### PR TITLE
fix: stop injecting implicit __extra csv column

### DIFF
--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -89,6 +89,31 @@ def test_read_raw_to_relation_passes_parallel_flag(tmp_path: Path):
     con.close()
 
 
+def test_read_raw_to_relation_keeps_explicit_columns_unchanged(tmp_path: Path):
+    input_file = tmp_path / "ok.csv"
+    input_file.write_text("a;b\n1;2\n", encoding="utf-8")
+
+    con = duckdb.connect(":memory:")
+    logger = logging.getLogger("tests.clean.duckdb_read.columns")
+
+    info = duckdb_read.read_raw_to_relation(
+        con,
+        [input_file],
+        {
+            "delim": ";",
+            "encoding": "utf-8",
+            "header": True,
+            "columns": {"a": "VARCHAR", "b": "VARCHAR"},
+        },
+        "strict",
+        logger,
+    )
+
+    assert info.source == "strict"
+    assert info.params_used["columns"] == {"a": "VARCHAR", "b": "VARCHAR"}
+    con.close()
+
+
 def test_read_raw_to_relation_strict_error_message_uses_current_config_keys(tmp_path: Path):
     input_file = tmp_path / "bad.csv"
     input_file.write_text("a;b\n1;2;3\n", encoding="utf-8")
@@ -114,6 +139,39 @@ def test_read_raw_to_relation_strict_error_message_uses_current_config_keys(tmp_
     finally:
         duckdb_read._execute_csv_read = original_execute
 
+    con.close()
+
+
+def test_read_raw_to_relation_handles_no_header_fixed_schema_without_extra_column(tmp_path: Path):
+    input_file = tmp_path / "fixed.csv"
+    input_file.write_text("A,2024,1,123,45.6\nB,2024,2,456,78.9\n", encoding="utf-8")
+
+    con = duckdb.connect(":memory:")
+    logger = logging.getLogger("tests.clean.duckdb_read.fixed_schema")
+
+    info = duckdb_read.read_raw_to_relation(
+        con,
+        [input_file],
+        {
+            "delim": ",",
+            "encoding": "utf-8",
+            "header": False,
+            "auto_detect": False,
+            "columns": {
+                "col0": "VARCHAR",
+                "col1": "VARCHAR",
+                "col2": "VARCHAR",
+                "col3": "VARCHAR",
+                "col4": "VARCHAR",
+            },
+        },
+        "fallback",
+        logger,
+    )
+
+    rows = con.execute("SELECT col0, col1, col2, col3, col4 FROM raw_input ORDER BY col0").fetchall()
+    assert info.source == "strict"
+    assert rows == [("A", "2024", "1", "123", "45.6"), ("B", "2024", "2", "456", "78.9")]
     con.close()
 
 

--- a/toolkit/clean/duckdb_read.py
+++ b/toolkit/clean/duckdb_read.py
@@ -200,8 +200,6 @@ def _csv_read_options(read_cfg: dict[str, Any]) -> tuple[list[str], dict[str, An
     source_columns = None
     if columns:
         source_columns = dict(columns)
-        if "__extra" not in source_columns:
-            source_columns["__extra"] = "VARCHAR"
         cols_sql = ", ".join(
             [f"'{sql_str(name)}': '{sql_str(dtype)}'" for name, dtype in source_columns.items()]
         )


### PR DESCRIPTION
Closes #7 

## Summary

Questa PR rimuove l'aggiunta automatica della colonna `__extra` quando `clean.read.columns` e' gia' definito in modo esplicito.

In pratica, il reader ora usa esattamente lo schema dichiarato nel config, senza allargarlo implicitamente.

## Perche'

Il comportamento precedente rompeva casi reali a schema fisso:

- file no-header con numero di colonne stabile
- file sporchi con schema esplicito e `null_padding`

DuckDB riceveva una colonna in piu' rispetto a quelle presenti nel file e falliva in sniff/parsing.

## Cosa cambia

- rimosso l'inserimento automatico di `__extra` in `toolkit/clean/duckdb_read.py`
- aggiunti test mirati per:
  - mantenere invariato lo schema esplicito
  - leggere un CSV no-header a schema fisso senza colonna extra implicita

## Casi reali collegati

- `stress-local/cases/case_03_siope_no_header_schema`
- `stress-local/cases/case_08_pnrr_progetti_m1`

Questi casi hanno aiutato a identificare e validare il fix nel laboratorio locale.

## Testing

Eseguito:

```powershell
py -m pytest tests/test_clean_duckdb_read.py tests/test_clean_csv_columns.py tests/test_clean_input_selection.py -q
```

Esito:

- `26 passed`

## Note

Il laboratorio `stress-local` non fa parte di questa PR.

Il branch contiene solo:

- fix di prodotto
- test del reader
