### PR TITLE
fix: preserve year templates in local raw paths

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -124,6 +124,35 @@ mart:
     assert cfg.mart["label_path"] == "labels/mart.txt"
 
 
+def test_load_config_preserves_year_template_in_raw_local_file_path(tmp_path: Path):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    yml = project_dir / "dataset.yml"
+    yml.write_text(
+        """
+root: "./out"
+dataset:
+  name: demo
+  years: [2022, 2023]
+raw:
+  sources:
+    - type: local_file
+      args:
+        path: "data/raw_{year}.csv"
+        filename: "raw_{year}.csv"
+clean: {}
+mart: {}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(yml)
+
+    assert cfg.raw["sources"][0]["args"]["path"] == str((project_dir / "data" / "raw_{year}.csv").resolve())
+    assert cfg.raw["sources"][0]["args"]["filename"] == "raw_{year}.csv"
+
+
 def test_load_config_logs_normalized_whitelist_fields(tmp_path: Path, caplog, monkeypatch):
     project_dir = tmp_path / "project"
     project_dir.mkdir()

--- a/tests/test_smoke_tiny_e2e.py
+++ b/tests/test_smoke_tiny_e2e.py
@@ -253,3 +253,83 @@ def test_smoke_e2e_local_zip_extractor(tmp_path: Path) -> None:
     raw_dir = Path(cfg.root) / "data" / "raw" / cfg.dataset / str(year)
     raw_manifest = json.loads((raw_dir / "manifest.json").read_text(encoding="utf-8"))
     assert raw_manifest["primary_output_file"] == "zip_payload.csv"
+
+
+def test_smoke_e2e_local_file_path_year_template(tmp_path: Path) -> None:
+    project_dir = tmp_path / "templated_local_project"
+    data_dir = project_dir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(FIXTURES_DIR / "it_small.csv", data_dir / "it_small_2024.csv")
+
+    _write_text(
+        project_dir / "sql" / "clean.sql",
+        """
+        SELECT
+          comune,
+          CAST(anno AS INTEGER) AS anno,
+          CAST(valore AS DOUBLE) AS valore
+        FROM raw_input
+        """,
+    )
+    _write_text(
+        project_dir / "sql" / "mart_totali.sql",
+        """
+        SELECT
+          anno,
+          SUM(valore) AS totale
+        FROM clean_input
+        GROUP BY anno
+        """,
+    )
+    _write_text(
+        project_dir / "dataset.yml",
+        """
+        schema_version: 1
+        root: out
+        dataset:
+          name: tiny_csv_it_templated
+          years: [2024]
+        raw:
+          output_policy: overwrite
+          sources:
+            - name: csv_it
+              type: local_file
+              primary: true
+              args:
+                path: data/it_small_{year}.csv
+                filename: tiny_it_{year}.csv
+        clean:
+          sql: sql/clean.sql
+          read_mode: strict
+          read:
+            source: config_only
+            header: true
+            delim: ";"
+            decimal: ","
+            mode: explicit
+            include: tiny_it_2024.csv
+          required_columns: comune
+          validate:
+            not_null: valore
+        mart:
+          tables:
+            - name: mart_totali
+              sql: sql/mart_totali.sql
+          required_tables: mart_totali
+          validate:
+            table_rules:
+              mart_totali:
+                required_columns: [anno, totale]
+        """,
+    )
+
+    cfg = load_config(project_dir / "dataset.yml")
+    year = cfg.years[0]
+    context = run_year(cfg, year, step="all", logger=_project_logger())
+
+    _assert_run_success(context.path)
+    _assert_common_outputs(Path(cfg.root), cfg.dataset, year, ["mart_totali"])
+
+    raw_dir = Path(cfg.root) / "data" / "raw" / cfg.dataset / str(year)
+    raw_manifest = json.loads((raw_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert raw_manifest["primary_output_file"] == "tiny_it_2024.csv"

--- a/toolkit/core/config_models.py
+++ b/toolkit/core/config_models.py
@@ -463,6 +463,13 @@ def _resolve_path_value(value: Any, *, base_dir: Path) -> Any:
     text = value.strip()
     if not text:
         return value
+    if "{year}" in text:
+        sentinel = "__DCL_YEAR_PLACEHOLDER__"
+        templated = text.replace("{year}", sentinel)
+        path = Path(templated).expanduser()
+        if path.is_absolute():
+            return str(path.resolve()).replace(sentinel, "{year}")
+        return str((base_dir / path).resolve()).replace(sentinel, "{year}")
     path = Path(text).expanduser()
     if path.is_absolute():
         return path.resolve()


### PR DESCRIPTION
## Sintesi

Closes #17

Questa PR corregge un bug nel caricamento config: i path RAW `local_file` con `{year}` venivano normalizzati troppo presto e il placeholder non arrivava fino a `run raw`.

## Problema

Prima del fix:

- `raw.sources[].args.path` con `{year}` veniva convertito in `Path`
- `_format_args()` in `run_raw()` applicava la sostituzione solo alle stringhe
- il placeholder restava letterale
- `local_file` falliva su path tipo `demo_{year}.csv`

## Cosa cambia

Durante la normalizzazione config:

- i path RAW con `{year}` restano stringhe
- vengono comunque risolti rispetto alla directory del `dataset.yml`
- il template `{year}` resta disponibile fino al run

## Scope

Dentro il perimetro:

- fix dei path templated per `raw.sources[].args.path`
- copertura test dedicata

Fuori scope:

- cambi al comportamento di CLEAN o MART
- nuove feature di templating oltre `{year}`

## Test

Eseguiti:

```powershell
py -m pytest tests/test_config.py tests/test_smoke_tiny_e2e.py -q
```

Esito:

- `54 passed`

## Verifica reale

Usato su due dataset multi-anno locali:

1. `RU Comunali 2018-2024`
   - `run raw` corretto su tutti gli anni
   - `inspect schema-diff` mostra schema stabile

2. `IRPEF comunale 2018-2023`
   - `run raw` corretto su tutti gli anni
   - `inspect schema-diff` rileva drift reale:
     - `2020 -> 2021`
       - `Bonus spettante` -> `Trattamento spettante`
     - `2022 -> 2023`
       - aggiunte le colonne `Reddito complessivo - Frequenza`
       - aggiunte le colonne `Reddito complessivo - Ammontare in euro`

## Nota

Il fix trova il suo posto nel workflow per dataset storici e multi-anno:

`dataset.yml -> run raw -> inspect schema-diff -> clean`
