### PR TITLE
docs: allineare feature stability e default del project-example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Documentation now classifies `run cross_year` and `inspect schema-diff` as supported advanced tooling in the feature stability matrix.
+- Changelog/docs references to config warning codes now reflect the current implemented range through `DCL013`.
+
 ### Removed
 
 - Legacy config forms below no longer emit deprecation warnings and now fail with explicit config errors:
@@ -23,7 +28,7 @@ All notable changes to this project will be documented in this file.
 - End-to-end smoke tests for tiny CSV and local ZIP extraction flows.
 - Install and CLI smoke script for clean-environment verification.
 - Configuration schema documentation with minimal and full examples.
-- Centralized config deprecation policy with `DCL001` to `DCL008` warning codes.
+- Centralized config deprecation policy with `DCL001` to `DCL013` warning codes.
 - `--strict-config` CLI option and `config.strict` config switch.
 - Explicit built-in plugin registry with strict/non-strict handling for optional plugins.
 - Coverage reporting in CI with XML artifact upload and fail-under threshold.

--- a/docs/feature-stability.md
+++ b/docs/feature-stability.md
@@ -13,13 +13,15 @@ Questa matrice serve a chiarire cosa il toolkit considera percorso canonico, cos
 | `resume` | supported / advanced | debug operativo e recovery |
 | `profile raw` | supported / advanced | diagnostica su RAW sporchi o ambigui |
 | `run raw|clean|mart` | supported / advanced | debug e re-run parziali |
+| `run cross_year` | supported / advanced | output multi-anno e workflow non canonici |
+| `inspect schema-diff` | supported / advanced | confronto rapido segnali schema RAW tra anni |
 | artifact policy `minimal|standard|debug` | supported / advanced | tuning operativo |
 | `legacy_aliases` | compatibility only | non promuovere nei repo nuovi |
 | config legacy | compatibility only | usare `--strict-config` nei repo nuovi |
 Lettura equivalente a livello package:
 
 - core runtime: `toolkit.raw`, `toolkit.clean`, `toolkit.mart`, `toolkit.cli` (`run`, `validate`, `status`, `inspect`)
-- advanced tooling: `toolkit.profile`, `resume`, run parziali
+- advanced tooling: `toolkit.profile`, `resume`, run parziali, `cross_year`, `inspect schema-diff`
 - compatibility only: config legacy e alias storici
 
 Regola pratica:

--- a/project-example/dataset.yml
+++ b/project-example/dataset.yml
@@ -15,6 +15,7 @@ raw:
 clean:
   sql: "sql/clean.sql"
   read:
+    mode: "largest"
     header: true
     delim: ";"
     quote: "\""


### PR DESCRIPTION
﻿## Sintesi

- classificare `run cross_year` e `inspect schema-diff` nella matrice di stabilita'
- allineare il changelog al range attuale dei codici warning DCL
- rendere esplicito `clean.read.mode` nel `project-example` per evitare il warning legacy rumoroso

## Issue collegate

Closes #26
Closes #30

## Note

PR piccola, limitata a documentazione ed esempio di configurazione.
Non introduce cambi di comportamento nel runtime, salvo rendere esplicito il default usato dal progetto di esempio.
