### PR TITLE
smoke: riallineare i casi manuali al contratto attuale

### DIFF
--- a/smoke/README.md
+++ b/smoke/README.md
@@ -2,6 +2,18 @@
 
 Suite manuale di mini-progetti per verificare il toolkit end-to-end senza pytest.
 
+Questa cartella non definisce il core smoke contract del repository:
+
+- lo smoke offline canonico resta `project-example`
+- gli smoke tecnici deterministici restano in `tests/test_smoke_tiny_e2e.py`
+- i casi sotto `smoke/` sono playbook manuali, utili per controlli operativi su sorgenti locali o pubbliche
+
+Di conseguenza:
+
+- non sono CI gate
+- alcune sorgenti pubbliche possono cambiare formato o disponibilita`
+- eventuali output locali sotto `_smoke_out/` non vanno tenuti nella working tree
+
 Progetti inclusi:
 
 - `smoke/ispra_http_csv`: `http_file` contro server locale `http.server`

--- a/smoke/bdap_http_csv/dataset.yml
+++ b/smoke/bdap_http_csv/dataset.yml
@@ -5,11 +5,11 @@ dataset:
   years: [2022]
 
 raw:
-  source:
-    type: "http_file"
-    args:
-      url: "https://bdap-opendata.rgs.mef.gov.it/export/csv/Rendiconto-Pubblicato---Serie-storica---Saldi.csv"
-      filename: "bdap_rendiconto_saldi_{year}.csv"
+  sources:
+    - type: "http_file"
+      args:
+        url: "https://bdap-opendata.rgs.mef.gov.it/export/csv/Rendiconto-Pubblicato---Serie-storica---Saldi.csv"
+        filename: "bdap_rendiconto_saldi_{year}.csv"
 
 clean:
   sql: "sql/clean.sql"

--- a/smoke/finanze_http_zip_2023/dataset.yml
+++ b/smoke/finanze_http_zip_2023/dataset.yml
@@ -7,10 +7,10 @@ dataset:
 raw:
   extractor:
     type: "unzip_first_csv"
-  source:
-    type: "http_file"
-    args:
-      url: "https://www1.finanze.gov.it/finanze/analisi_stat/public/v_4_0_0/contenuti/Redditi_e_principali_variabili_IRPEF_su_base_comunale_CSV_2023.zip?d=1615465800"
+  sources:
+    - type: "http_file"
+      args:
+        url: "https://www1.finanze.gov.it/finanze/analisi_stat/public/v_4_0_0/contenuti/Redditi_e_principali_variabili_IRPEF_su_base_comunale_CSV_2023.zip?d=1615465800"
 
 clean:
   sql: "sql/clean.sql"

--- a/smoke/ispra_http_csv/dataset.yml
+++ b/smoke/ispra_http_csv/dataset.yml
@@ -5,11 +5,11 @@ dataset:
   years: [2022]
 
 raw:
-  source:
-    type: "http_file"
-    args:
-      url: "https://www.catasto-rifiuti.isprambiente.it/get/getDettaglioComunale.csv.php?&aa={year}"
-      filename: "ispra_http_sample_{year}.csv"
+  sources:
+    - type: "http_file"
+      args:
+        url: "https://www.catasto-rifiuti.isprambiente.it/get/getDettaglioComunale.csv.php?&aa={year}"
+        filename: "ispra_http_sample_{year}.csv"
 
 clean:
   sql: "sql/clean.sql"

--- a/smoke/local_file_csv/dataset.yml
+++ b/smoke/local_file_csv/dataset.yml
@@ -5,11 +5,11 @@ dataset:
   years: [2022]
 
 raw:
-  source:
-    type: "local_file"
-    args:
-      path: "fixtures/local_file_sample.csv"
-      filename: "local_file_sample_{year}.csv"
+  sources:
+    - type: "local_file"
+      args:
+        path: "fixtures/local_file_sample.csv"
+        filename: "local_file_sample_{year}.csv"
 
 clean:
   sql: "sql/clean.sql"

--- a/smoke/zip_http_csv/dataset.yml
+++ b/smoke/zip_http_csv/dataset.yml
@@ -7,10 +7,10 @@ dataset:
 raw:
   extractor:
     type: "unzip_first_csv"
-  source:
-    type: "http_file"
-    args:
-      url: "http://127.0.0.1:8000/fixtures/irpef_http_sample.zip"
+  sources:
+    - type: "http_file"
+      args:
+        url: "http://127.0.0.1:8000/fixtures/irpef_http_sample.zip"
 
 clean:
   sql: "sql/clean.sql"


### PR DESCRIPTION
## Sintesi

Questa PR riallinea i mini-progetti sotto smoke/ al contratto attuale del toolkit dopo la rimozione della compat interna su aw.source.

## Cosa cambia

- migra i dataset.yml sotto smoke/ da aw.source a aw.sources
- chiarisce nel README che smoke/ e' una raccolta di check manuali, non un CI gate
- esplicita che lo smoke offline canonico resta project-example
- richiama il ruolo dei test deterministici in 	ests/test_smoke_tiny_e2e.py

## Verifica

- py -m pytest tests\\test_smoke_tiny_e2e.py

## Note

- e' ancora presente localmente smoke/finanze_http_zip_2023/_smoke_out/, ma la directory e' ignorata e non fa parte del diff della PR

Closes #37