### PR TITLE
docs: clarify rerun workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ toolkit run all --config dataset.yml --dry-run --strict-config
 
 `resume`, `profile raw`, `run raw|clean|mart` e la policy completa degli artifacts restano disponibili, ma sono tooling avanzato: vedi [docs/advanced-workflows.md](docs/advanced-workflows.md).
 
+In particolare, [docs/advanced-workflows.md](docs/advanced-workflows.md)
+chiarisce quando restare su `run all`, quando preferire rerun parziali
+(`run clean`, `run mart`, `run cross_year`) e quando usare `resume` senza
+rilanciare l'intera pipeline.
+
 ## Notebook locali
 
 Nei repo dataset clonati dal template, i notebook dovrebbero leggere gli output reali gia` scritti dal toolkit, non ricostruire logica di path.

--- a/docs/advanced-workflows.md
+++ b/docs/advanced-workflows.md
@@ -15,6 +15,38 @@ Questa categoria include anche tooling di supporto che non va confuso con il run
 - `resume`
 - run parziali per layer
 
+## Quando usare cosa
+
+Regola pratica:
+
+- se stai eseguendo un dataset per la prima volta o hai cambiato fonte, anni,
+  `dataset.yml` o logica `clean.sql`, parti da `toolkit run all`
+- se hai toccato solo SQL `mart`, preferisci `toolkit run mart`
+- se hai aggiunto o modificato solo output multi-anno, preferisci
+  `toolkit run cross_year`
+- se un run si interrompe ma il run record e gli artefatti precedenti sono
+  ancora coerenti, usa `toolkit resume`
+- se hai toccato solo notebook, docs o script locali del repo dataset, non
+  rilanciare la pipeline per default
+
+Matrice minima:
+
+| Tipo di modifica | Comando consigliato |
+|---|---|
+| prima esecuzione del dataset | `toolkit run all --config dataset.yml` |
+| cambio fonte o perimetro anni | `toolkit run all --config dataset.yml` |
+| cambio `dataset.yml` con impatto su input/layer | `toolkit run all --config dataset.yml` |
+| cambio `clean.sql` | `toolkit run clean --config dataset.yml` poi `toolkit run mart --config dataset.yml` |
+| cambio solo `mart.sql` | `toolkit run mart --config dataset.yml` |
+| cambio solo `cross_year` | `toolkit run cross_year --config dataset.yml` |
+| run interrotto a meta' | `toolkit resume ... --config dataset.yml` |
+| cambio solo notebook/docs | nessun rerun automatico |
+
+Il toolkit non impone di cancellare `raw/`, `clean/`, `mart/` o `cross/` tra un
+run e l'altro. Negli ambienti di lavoro questi output possono restare come
+cache locale finche' il loro perimetro e' ancora coerente con la config e con
+il layer che stai rieseguendo.
+
 ## Step singoli
 
 Utili per debug o per ripetere solo una parte della pipeline:


### PR DESCRIPTION
## Cosa cambia

Aggiunge chiarezza operativa su quando usare i diversi comandi di run, senza toccare la CLI o il contratto tecnico.

- `docs/advanced-workflows.md`: nuova sezione "Quando usare cosa" con regola pratica e matrice minima (run all / run clean / run mart / run cross_year / resume / nessun rerun)
- `docs/advanced-workflows.md`: nota esplicita che raw/clean/mart/cross possono restare come cache locale coerente tra un run e l'altro
- `README.md`: richiamo diretto alla sezione decision rule in advanced-workflows

## Tipo

docs-only — nessuna modifica CLI, nessun cambio di contratto tecnico.