### PR TITLE
sdmx: add minimal ISTAT endpoint fallback

### DIFF
--- a/tests/test_sdmx_plugin.py
+++ b/tests/test_sdmx_plugin.py
@@ -269,3 +269,48 @@ def test_sdmx_fetch_does_not_fallback_on_404(monkeypatch):
         assert "HTTP 404" in str(exc)
     else:
         raise AssertionError("Expected DownloadError")
+
+
+def test_sdmx_fetch_does_not_fallback_on_connection_error(monkeypatch):
+    calls = []
+
+    def _fake_get(url, params=None, timeout=None, headers=None):
+        calls.append(url)
+        if url == "https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
+            return _FakeResponse(200, DATAFLOW_XML, url)
+        if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
+            return _FakeResponse(200, PREVIEW_JSON, url)
+        if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
+            raise requests.exceptions.ConnectionError("tls handshake failed")
+        raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr("toolkit.plugins.sdmx.requests.get", _fake_get)
+
+    try:
+        SdmxSource(
+            retries=1,
+            data_base_url="https://esploradati.istat.it/SDMXWS/rest",
+            metadata_base_url="https://sdmx.istat.it/SDMXWS/rest",
+        ).fetch(
+            "IT1",
+            "22_289",
+            "1.5",
+            {
+                "FREQ": "A",
+                "REF_AREA": "001001",
+                "DATA_TYPE": "JAN",
+                "SEX": "9",
+                "AGE": "TOTAL",
+                "MARITAL_STATUS": "99",
+            },
+        )
+    except DownloadError as exc:
+        assert "connection error" in str(exc).lower()
+    else:
+        raise AssertionError("Expected DownloadError")
+
+    assert calls == [
+        "https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/22_289",
+        "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all",
+        "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99",
+    ]

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -125,7 +125,9 @@ class SdmxSource:
             except requests.exceptions.Timeout as exc:
                 last_err = DownloadError(f"SDMX endpoint timeout for {url}: {exc}")
             except requests.exceptions.ConnectionError as exc:
-                last_err = DownloadError(f"SDMX endpoint timeout for {url}: {exc}")
+                last_err = DownloadError(
+                    f"SDMX endpoint connection error for {url}: {exc}"
+                )
             except Exception as exc:
                 if isinstance(exc, DownloadError):
                     last_err = exc


### PR DESCRIPTION
Closes #75.

## Contesto

Il primo pilot reale SDMX su `istat-housing-crowding` ha mostrato che il plugin `sdmx` regge sul caso stretto, ma resta fragile quando gli endpoint ISTAT si comportano in modo incoerente tra metadata e data.

## Cosa cambia

- aggiunge un fallback minimo tra i due endpoint ISTAT per `agency=IT1`
- il fallback si attiva solo su:
  - timeout / connect timeout
  - errori `5xx`
- non si attiva su `404`, che resta trattato come query/filtro non supportato
- migliora i messaggi di errore per distinguere meglio:
  - timeout endpoint
  - `5xx` lato fonte
  - `404` query non trovata

## Test

Aggiunti test per:
- metadata endpoint A fail -> fallback endpoint B
- data endpoint A fail -> fallback endpoint B
- `404` non deve attivare fallback

Test eseguiti:
- `tests/test_sdmx_plugin.py`
- `tests/test_ckan_plugin.py`
- `tests/test_raw_ext_inference.py`
- `tests/test_registry.py`

Totale locale: `24 passed`

## Note

Questo PR non introduce caching, backoff sofisticato o failover complesso.
Punta solo a un hardening minimo e difendibile del plugin SDMX contro l'instabilita' degli endpoint ISTAT.