### PR TITLE
Valida i nomi delle tabelle mart e l'uso di clean_input

### DIFF
--- a/toolkit/core/config_models.py
+++ b/toolkit/core/config_models.py
@@ -14,6 +14,7 @@ from toolkit.core.csv_read import normalize_columns_spec
 
 logger = logging.getLogger("toolkit.core.config")
 _MANAGED_OUTPUT_ROOTS = {"_smoke_out", "_test_out"}
+_SAFE_SQL_IDENTIFIER_RE = r"^[A-Za-z_][A-Za-z0-9_]*$"
 
 
 @dataclass(frozen=True)
@@ -318,6 +319,21 @@ class MartTableConfig(BaseModel):
 
     name: str
     sql: Path
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        text = value.strip()
+        if not text:
+            raise ValueError("mart.tables[].name must not be empty")
+        import re
+
+        if not re.fullmatch(_SAFE_SQL_IDENTIFIER_RE, text):
+            raise ValueError(
+                "mart.tables[].name must be a safe SQL identifier "
+                "(letters, numbers, underscore; cannot start with a number)"
+            )
+        return text
 
 
 class CrossYearTableConfig(BaseModel):

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +10,9 @@ from toolkit.core.artifacts import ARTIFACT_POLICY_DEBUG, resolve_artifact_polic
 from toolkit.core.metadata import config_hash_for_year, file_record, write_layer_manifest, write_metadata
 from toolkit.core.paths import layer_year_dir, resolve_root, to_root_relative
 from toolkit.core.template import build_runtime_template_ctx, public_template_ctx, render_template
+
+
+_CLEAN_INPUT_TOKEN_RE = re.compile(r"\bclean_input\b", re.IGNORECASE)
 
 
 def _serialize_metadata_path(path: Path | None, rel_root: Path | None) -> str | None:
@@ -105,6 +109,11 @@ def run_mart(
 
             sql = sql_path.read_text(encoding="utf-8")
             sql = render_template(sql, template_ctx)
+
+            if not clean_sql_configured and _CLEAN_INPUT_TOKEN_RE.search(sql):
+                raise ValueError(
+                    "MART SQL references clean_input but clean.sql is not configured in dataset.yml"
+                )
 
             # Save rendered SQL for audit/debug
             rendered_sql_path: Path | None = None


### PR DESCRIPTION
﻿## Sintesi
- valida `mart.tables[].name` come identificatore SQL sicuro
- fallisce prima se un SQL MART usa `clean_input` ma `clean.sql` non e' configurato

## Perche'
Sono due fix piccoli di DX che evitano errori DuckDB opachi durante il run del mart.

## Note
- nessun lavoro su `support:` in questa PR
- la feature `support:` resta un follow-up separato
