### PR TITLE
Add direct tests for core/support.py

### DIFF
--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -108,14 +108,14 @@ class TestSupportExpectedMartOutputs:
         assert outputs[0].name == "alpha.parquet"
         assert outputs[1].name == "beta.parquet"
 
-    def test_no_tables_returns_empty(self):
-        ds = Path("/tmp/fake")
+    def test_no_tables_returns_empty(self, tmp_path: Path):
+        ds = tmp_path / "fake"
         cfg = FakeConfig(root=ds, dataset="ds", years=[2024], mart={"tables": []})
         outputs = _support_expected_mart_outputs(cfg, 2024)
         assert outputs == []
 
-    def test_malformed_table_entry_skipped(self):
-        ds = Path("/tmp/fake")
+    def test_malformed_table_entry_skipped(self, tmp_path: Path):
+        ds = tmp_path / "fake"
         cfg = FakeConfig(root=ds, dataset="ds", years=[2024], mart={"tables": ["not_a_dict", {}]})
         outputs = _support_expected_mart_outputs(cfg, 2024)
         assert outputs == []
@@ -233,7 +233,7 @@ class TestResolveSupportPayloadsErrors:
         assert "2023" in msg
 
     def test_multiple_years_first_missing_raises(self, tmp_path: Path):
-        """If first year has outputs but second doesn't, should raise on second."""
+        """If second year has outputs but first doesn't, should raise on first."""
         config_path = _make_support_dataset(tmp_path, years=[2023, 2024], create_mart_outputs=False)
         ds_dir = config_path.parent
         mart_dir_2024 = ds_dir / "data" / "mart" / "support_ds" / "2024"


### PR DESCRIPTION
## Problema

`toolkit/core/support.py` contiene logica non banale per risolvere payload e template context dei support dataset, ma non aveva copertura diretta.

## Cosa fa questa PR

Aggiunge **21 test** per `core/support.py`, organizzati in 4 classi:

| Classe | Test | Copertura |
|--------|------|-----------|
| `TestSupportExpectedMartOutputs` | 4 | Single/multiple tables, empty tables, malformed entries |
| `TestResolveSupportPayloadsHappy` | 6 | Single year, multiple years, multiple datasets, `require_exists=False`, None/empty |
| `TestResolveSupportPayloadsErrors` | 5 | Missing outputs, partial outputs, error message content (name, config path, year) |
| `TestFlattenSupportTemplateCtx` | 4 | Single/multiple payloads, empty, mart=None |
| `TestResolveAndFlatten` | 2 | End-to-end integration, empty resolve |

## Casi di errore coperti

- **Output mancanti**: `FileNotFoundError` con messaggio leggibile che include nome, config path e anno
- **Output parziali**: se una sola tabella su N esiste, fallisce
- **Anni multipli**: il primo anno senza output triggera l'errore corretto
- **Entry malformed**: non-dict e dict senza `name` sono silenziosamente skipati

## Non incluso

- Refactor architetturale del support layer
- Test per `cli/sql_dry_run.py` (issue separata)

## Verifica

```
pytest tests/test_support.py -v    # 21/21 pass
pytest tests/test_config.py -v     # 61/61 pass, nessuna regressione
```

Closes #90