### PR TITLE
feat: aggiungi time_coverage al contract config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,6 +38,59 @@ mart: {}
     assert cfg.root_source == "base_dir_fallback"
 
 
+def test_load_config_exposes_optional_time_coverage(tmp_path: Path):
+    yml = tmp_path / "dataset.yml"
+    yml.write_text(
+        """
+root: null
+dataset:
+  name: demo
+  years: [2024]
+  time_coverage:
+    mode: full_series
+    start_year: 2020
+    end_year: 2025
+raw: {}
+clean: {}
+mart: {}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(yml)
+
+    assert cfg.years == [2024]
+    assert cfg.time_coverage is not None
+    assert cfg.time_coverage.mode == "full_series"
+    assert cfg.time_coverage.start_year == 2020
+    assert cfg.time_coverage.end_year == 2025
+
+
+def test_load_config_rejects_invalid_time_coverage_range(tmp_path: Path):
+    yml = tmp_path / "dataset.yml"
+    yml.write_text(
+        """
+root: null
+dataset:
+  name: demo
+  years: [2024]
+  time_coverage:
+    mode: full_series
+    start_year: 2025
+    end_year: 2020
+raw: {}
+clean: {}
+mart: {}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as e:
+        load_config(yml)
+
+    assert "dataset.time_coverage.end_year must be >= start_year" in str(e.value)
+
+
 def test_load_config_missing_dataset_name(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
     yml.write_text(

--- a/toolkit/core/config.py
+++ b/toolkit/core/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from toolkit.core.config_models import (
+    TimeCoverage,
     ToolkitConfigModel,
     ensure_str_list as _ensure_str_list,
     load_config_model,
@@ -20,6 +21,7 @@ class ToolkitConfig:
     root_source: str
     dataset: str
     years: list[int]
+    time_coverage: TimeCoverage | None
     raw: dict[str, Any]
     clean: dict[str, Any]
     mart: dict[str, Any]
@@ -96,6 +98,7 @@ def load_config(
         root_source=model.root_source,
         dataset=model.dataset.name,
         years=list(model.dataset.years),
+        time_coverage=model.dataset.time_coverage,
         raw=model.raw.model_dump(mode="python", exclude_none=True, exclude_unset=True),
         clean=_compat_clean(model),
         mart=_compat_mart(model),

--- a/toolkit/core/config_models.py
+++ b/toolkit/core/config_models.py
@@ -93,11 +93,31 @@ def ensure_str_list(value: Any, field_name: str) -> list[str]:
     raise ValueError(f"{field_name} must be a string or a list of strings")
 
 
+class TimeCoverage(BaseModel):
+    """Optional metadata per dichiarare la copertura temporale reale dei dati.
+    Questo campo e' puramente dichiarativo: non cambia il comportamento di run,
+    path o partizionamento del toolkit.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["full_series"] = "full_series"
+    start_year: int
+    end_year: int
+
+    @model_validator(mode="after")
+    def _validate_year_range(self) -> "TimeCoverage":
+        if self.end_year < self.start_year:
+            raise ValueError("dataset.time_coverage.end_year must be >= start_year")
+        return self
+
+
 class DatasetBlock(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str
     years: list[int]
+    time_coverage: TimeCoverage | None = None
 
 
 class SupportDatasetConfig(BaseModel):


### PR DESCRIPTION
Closes #96

## Cosa cambia

- aggiunge `dataset.time_coverage` come metadata opzionale nel contract `dataset.yml`
- espone `time_coverage` anche nel `ToolkitConfig` compat
- aggiunge test di parsing e una guardia minima sul range `start_year/end_year`

## Perche'

Serve a distinguere meglio tra:
- anno di runtime / partizione (`dataset.years`)
- copertura temporale reale dei dati

senza toccare il path contract o il comportamento di run.

## Verifica

- `pytest tests/test_config.py`

## Note

`time_coverage` resta puramente dichiarativo:
- non cambia run
- non cambia path
- non cambia partizionamento