### PR TITLE
Aggiungi Dependabot per le dipendenze Python di toolkit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Contesto

Quick win GitHub a basso costo per `toolkit`.

Il repo ha gia':
- `pyproject.toml`
- CI attiva
- una superficie tecnica abbastanza stabile da beneficiare di aggiornamenti automatici delle dipendenze

## Cosa cambia

Aggiunge `.github/dependabot.yml` con configurazione minima per:
- ecosystem: `pip`
- directory: `/`
- frequenza: settimanale
- massimo 5 PR aperte

## Boundary

- nessun cambiamento al codice runtime
- nessuna policy avanzata o grouping complesso
- rollout minimo e facile da mantenere

## Test

Nessun test runtime richiesto: cambio solo di config GitHub.