### PR TITLE
feat(mcp): add toolkit_summary diagnostic tool

### DIFF
--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
-from toolkit.mcp.toolkit_client import inspect_paths, run_state, show_schema
+from toolkit.mcp.toolkit_client import inspect_paths, run_state, show_schema, summary
 
 
 def test_mcp_toolkit_client_works_from_repo_layout(tmp_path: Path, monkeypatch) -> None:
@@ -26,3 +27,16 @@ def test_mcp_toolkit_client_works_from_repo_layout(tmp_path: Path, monkeypatch) 
     state_payload = run_state(str(config_path), 2022)
     assert state_payload["dataset"] == "project_example"
     assert Path(state_payload["run_dir"]).parts[-2:] == ("project_example", "2022")
+
+    # Arrange raw manifest without creating the primary output file.
+    raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "manifest.json").write_text(
+        json.dumps({"primary_output_file": "missing.csv"}), encoding="utf-8"
+    )
+
+    summary_payload = summary(str(config_path), 2022)
+    warnings = summary_payload["warnings"]
+    assert "raw_output_missing" in warnings
+    assert "clean_output_missing" in warnings
+    assert "mart_outputs_missing" in warnings

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -7,6 +7,7 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_inspect_paths(config_path, year=0)`
 - `toolkit_show_schema(config_path, layer="clean", year=0)`
 - `toolkit_run_state(config_path, year=0)`
+- `toolkit_summary(config_path, year=0)`
 
 ## Boundary
 

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -8,6 +8,7 @@ from .toolkit_client import (
     ToolkitClientError,
     inspect_paths as inspect_paths_impl,
     run_state as run_state_impl,
+    summary as summary_impl,
     show_schema as show_schema_impl,
 )
 
@@ -42,6 +43,10 @@ def toolkit_run_state(config_path: str, year: int = 0) -> dict[str, Any]:
     return _guard(run_state_impl, config_path, year or None)
 
 
+@mcp.tool(description="Mostra un riepilogo diagnostico minimo per un dataset config.", structured_output=True)
+def toolkit_summary(config_path: str, year: int = 0) -> dict[str, Any]:
+    return _guard(summary_impl, config_path, year or None)
+
+
 if __name__ == "__main__":
     mcp.run()
-

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -170,3 +170,85 @@ def run_state(config_path: str, year: int | None = None) -> dict[str, Any]:
         "latest_run": latest_run,
         "latest_run_record": latest_payload,
     }
+
+
+def _exists(path: str | None) -> bool:
+    if not path:
+        return False
+    return Path(path).exists()
+
+
+def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
+    config = _safe_path(config_path)
+    paths = inspect_paths(str(config), year)
+    raw_paths = paths["paths"]["raw"]
+    clean_paths = paths["paths"]["clean"]
+    mart_paths = paths["paths"]["mart"]
+    run_dir = Path(paths["paths"]["run_dir"])
+
+    raw_dir = Path(raw_paths["dir"])
+    clean_dir = Path(clean_paths["dir"])
+    mart_dir = Path(mart_paths["dir"])
+    mart_outputs = list(mart_paths.get("outputs") or [])
+    missing_mart_outputs = [output for output in mart_outputs if not _exists(output)]
+
+    primary_output_file = (paths.get("raw_hints") or {}).get("primary_output_file")
+    primary_output_path = str(raw_dir / primary_output_file) if primary_output_file else None
+
+    latest_run = paths.get("latest_run") or {}
+    latest_run_path = latest_run.get("path")
+
+    run_files = sorted(run_dir.glob("*.json")) if run_dir.exists() else []
+
+    warnings: list[str] = []
+    if not _exists(clean_paths.get("output")):
+        warnings.append("clean_output_missing")
+    if mart_outputs and missing_mart_outputs:
+        warnings.append("mart_outputs_missing")
+    if latest_run_path and not _exists(latest_run_path):
+        warnings.append("latest_run_record_missing")
+
+    return {
+        "dataset": paths.get("dataset"),
+        "config_path": str(config),
+        "year": paths.get("year"),
+        "layers": {
+            "raw": {
+                "dir": str(raw_dir),
+                "dir_exists": raw_dir.exists(),
+                "manifest_exists": _exists(raw_paths.get("manifest")),
+                "metadata_exists": _exists(raw_paths.get("metadata")),
+                "primary_output_file": primary_output_file,
+                "primary_output_exists": _exists(primary_output_path),
+                "suggested_read_exists": (paths.get("raw_hints") or {}).get(
+                    "suggested_read_exists"
+                ),
+            },
+            "clean": {
+                "dir": str(clean_dir),
+                "dir_exists": clean_dir.exists(),
+                "output": clean_paths.get("output"),
+                "output_exists": _exists(clean_paths.get("output")),
+                "manifest_exists": _exists(clean_paths.get("manifest")),
+                "metadata_exists": _exists(clean_paths.get("metadata")),
+            },
+            "mart": {
+                "dir": str(mart_dir),
+                "dir_exists": mart_dir.exists(),
+                "outputs": mart_outputs,
+                "output_count": len(mart_outputs),
+                "output_exists_count": len(mart_outputs) - len(missing_mart_outputs),
+                "missing_outputs": missing_mart_outputs,
+                "manifest_exists": _exists(mart_paths.get("manifest")),
+                "metadata_exists": _exists(mart_paths.get("metadata")),
+            },
+        },
+        "run": {
+            "run_dir": str(run_dir),
+            "run_dir_exists": run_dir.exists(),
+            "run_file_count": len(run_files),
+            "latest_run": latest_run or None,
+            "latest_run_record_exists": _exists(latest_run_path),
+        },
+        "warnings": warnings,
+    }

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -201,6 +201,8 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
     run_files = sorted(run_dir.glob("*.json")) if run_dir.exists() else []
 
     warnings: list[str] = []
+    if primary_output_file and not _exists(primary_output_path):
+        warnings.append("raw_output_missing")
     if not _exists(clean_paths.get("output")):
         warnings.append("clean_output_missing")
     if mart_outputs and missing_mart_outputs:


### PR DESCRIPTION
## Sintesi
- aggiunge il tool MCP 	oolkit_summary per diagnosi compatta (raw/clean/mart + stato run)
- espone warning minimi per output o record run mancanti
- documenta il nuovo tool nel README MCP

## Perche'
Il MCP espone gia' pezzi tecnici (inspect_paths, show_schema, un_state), ma in review/triage serve una vista unica e veloce. Questo tool fornisce uno snapshot read-only senza introdurre logica di workflow.

## Come verificare
- chiamare 	oolkit_summary(config_path, year=0) su un dataset.yml noto
- verificare presenza raw/clean/mart, outputs e info run

Closes #102