### PR TITLE
qualità: tranche 1 su test, robustezza CLI e CI (py3.12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/tests/test_cli_json_helpers.py
+++ b/tests/test_cli_json_helpers.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from toolkit.cli import cmd_inspect, cmd_status, common
+
+
+def test_cmd_status_read_json_returns_none_on_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "broken.json"
+    path.write_text("{ invalid", encoding="utf-8")
+
+    assert cmd_status._read_json(path) is None
+
+
+def test_cmd_inspect_read_json_returns_none_on_missing_file(tmp_path: Path) -> None:
+    path = tmp_path / "missing.json"
+
+    assert cmd_inspect._read_json(path) is None
+
+
+def test_common_read_json_returns_payload_on_valid_json(tmp_path: Path) -> None:
+    path = tmp_path / "ok.json"
+    path.write_text('{"k": 1}', encoding="utf-8")
+
+    assert common._read_json(path) == {"k": 1}

--- a/tests/test_cli_profile.py
+++ b/tests/test_cli_profile.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from toolkit.cli.app import app
+from toolkit.cli.cmd_profile import render_profile_md
+
+
+def test_render_profile_md_includes_expected_sections() -> None:
+    profile = {
+        "dataset": "demo_ds",
+        "year": 2024,
+        "file_used": "demo.csv",
+        "encoding_suggested": "utf-8",
+        "header_line": "col1;col2",
+        "columns_raw": ["col1", "col2"],
+        "missingness_top": [{"column": "col2", "missing_pct": 12.5}],
+        "warnings": ["warning uno"],
+        "mapping_suggestions": {
+            "col1_clean": {"type": "text"},
+            "col2_clean": {"type": "number", "parse": {"kind": "int"}},
+        },
+        "robust_read_suggested": True,
+    }
+
+    md = render_profile_md(profile)
+
+    assert "# RAW Profile - demo_ds (2024)" in md
+    assert "## Suggested read options" in md
+    assert "## Header (first line)" in md
+    assert "## Missingness (top)" in md
+    assert "## Mapping suggestions (first 15)" in md
+    assert "## Warnings" in md
+    assert "`col2`: 12.5%" in md
+
+
+def test_cli_profile_raw_happy_path(tmp_path: Path, monkeypatch) -> None:
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    shutil.rmtree(dst / "_smoke_out", ignore_errors=True)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    run_result = runner.invoke(
+        app,
+        ["run", "raw", "--config", str(config_path), "--strict-config"],
+    )
+    assert run_result.exit_code == 0, run_result.output
+
+    profile_result = runner.invoke(
+        app,
+        ["profile", "raw", "--config", str(config_path), "--strict-config"],
+    )
+    assert profile_result.exit_code == 0, profile_result.output
+    assert "PROFILE RAW ->" in profile_result.output
+
+    profile_dir = (
+        dst
+        / "_smoke_out"
+        / "data"
+        / "raw"
+        / "project_example"
+        / "2022"
+        / "_profile"
+    )
+    assert (profile_dir / "raw_profile.json").exists()

--- a/tests/test_cli_profile.py
+++ b/tests/test_cli_profile.py
@@ -38,7 +38,7 @@ def test_render_profile_md_includes_expected_sections() -> None:
 
 
 def test_cli_profile_raw_happy_path(tmp_path: Path, monkeypatch) -> None:
-    src = Path("project-example")
+    src = Path(__file__).resolve().parents[1] / "project-example"
     dst = tmp_path / "project-example"
     shutil.copytree(src, dst)
     shutil.rmtree(dst / "_smoke_out", ignore_errors=True)

--- a/tests/test_http_file_plugin.py
+++ b/tests/test_http_file_plugin.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import requests
+
+import pytest
+
+from toolkit.core.exceptions import DownloadError
+from toolkit.plugins.http_file import HttpFileSource
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, content: bytes = b"ok") -> None:
+        self.status_code = status_code
+        self.content = content
+
+
+def test_http_file_fetch_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_get(url: str, timeout: int, headers: dict[str, str]):
+        calls.append({"url": url, "timeout": timeout, "headers": headers})
+        return _FakeResponse(200, b"payload")
+
+    monkeypatch.setattr("toolkit.plugins.http_file.requests.get", fake_get)
+
+    source = HttpFileSource(timeout=15, retries=2, user_agent="ua-test")
+    payload = source.fetch("https://example.test/data.csv")
+
+    assert payload == b"payload"
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://example.test/data.csv"
+    assert calls[0]["timeout"] == 15
+    assert calls[0]["headers"] == {"User-Agent": "ua-test"}
+
+
+def test_http_file_fetch_retries_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {"n": 0}
+
+    def fake_get(url: str, timeout: int, headers: dict[str, str]):
+        state["n"] += 1
+        if state["n"] < 3:
+            raise requests.exceptions.Timeout("timeout")
+        return _FakeResponse(200, b"ok-after-retry")
+
+    monkeypatch.setattr("toolkit.plugins.http_file.requests.get", fake_get)
+
+    source = HttpFileSource(retries=3)
+    payload = source.fetch("https://example.test/retry")
+
+    assert payload == b"ok-after-retry"
+    assert state["n"] == 3
+
+
+def test_http_file_fetch_raises_after_retries_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, timeout: int, headers: dict[str, str]):
+        raise requests.exceptions.ConnectionError("conn-down")
+
+    monkeypatch.setattr("toolkit.plugins.http_file.requests.get", fake_get)
+
+    source = HttpFileSource(retries=2)
+    with pytest.raises(DownloadError, match="conn-down"):
+        source.fetch("https://example.test/fail")
+
+
+def test_http_file_fetch_http_status_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, timeout: int, headers: dict[str, str]):
+        return _FakeResponse(503, b"service unavailable")
+
+    monkeypatch.setattr("toolkit.plugins.http_file.requests.get", fake_get)
+
+    source = HttpFileSource(retries=1)
+    with pytest.raises(DownloadError, match="HTTP 503"):
+        source.fetch("https://example.test/unavailable")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from toolkit.mcp import server as mcp_server
+from toolkit.mcp.toolkit_client import ToolkitClientError
+
+
+def test_mcp_server_registers_expected_tools() -> None:
+    tools = mcp_server.mcp._tool_manager._tools
+    assert set(tools) == {
+        "toolkit_inspect_paths",
+        "toolkit_show_schema",
+        "toolkit_run_state",
+        "toolkit_summary",
+    }
+
+
+def test_guard_returns_payload_on_success() -> None:
+    assert mcp_server._guard(lambda x: {"ok": x}, 123) == {"ok": 123}
+
+
+def test_guard_wraps_toolkit_client_error() -> None:
+    def boom() -> dict[str, str]:
+        raise ToolkitClientError("errore client")
+
+    assert mcp_server._guard(boom) == {"error": "errore client"}
+
+
+def test_guard_does_not_swallow_unexpected_errors() -> None:
+    def boom() -> dict[str, str]:
+        raise ValueError("unexpected")
+
+    with pytest.raises(ValueError, match="unexpected"):
+        mcp_server._guard(boom)
+
+
+def test_toolkit_inspect_paths_passes_none_when_year_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_impl(config_path: str, year: int | None) -> dict[str, object]:
+        calls["config_path"] = config_path
+        calls["year"] = year
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_server, "inspect_paths_impl", fake_impl)
+
+    payload = mcp_server.toolkit_inspect_paths("dataset.yml", 0)
+
+    assert payload == {"ok": True}
+    assert calls == {"config_path": "dataset.yml", "year": None}
+
+
+def test_toolkit_show_schema_passes_layer_and_year(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_impl(config_path: str, layer: str, year: int | None) -> dict[str, object]:
+        calls["config_path"] = config_path
+        calls["layer"] = layer
+        calls["year"] = year
+        return {"layer": layer, "year": year}
+
+    monkeypatch.setattr(mcp_server, "show_schema_impl", fake_impl)
+
+    payload = mcp_server.toolkit_show_schema("dataset.yml", "mart", 2024)
+
+    assert payload == {"layer": "mart", "year": 2024}
+    assert calls == {"config_path": "dataset.yml", "layer": "mart", "year": 2024}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from toolkit.mcp import server as mcp_server
@@ -7,8 +9,9 @@ from toolkit.mcp.toolkit_client import ToolkitClientError
 
 
 def test_mcp_server_registers_expected_tools() -> None:
-    tools = mcp_server.mcp._tool_manager._tools
-    assert set(tools) == {
+    tools = asyncio.run(mcp_server.mcp.list_tools())
+    tool_names = {tool.name for tool in tools}
+    assert tool_names == {
         "toolkit_inspect_paths",
         "toolkit_show_schema",
         "toolkit_run_state",

--- a/toolkit/cli/cmd_inspect.py
+++ b/toolkit/cli/cmd_inspect.py
@@ -17,7 +17,7 @@ from toolkit.core.run_context import get_run_dir, latest_run
 def _read_json(path: Path) -> dict[str, Any] | None:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return None
 
 

--- a/toolkit/cli/cmd_status.py
+++ b/toolkit/cli/cmd_status.py
@@ -28,7 +28,7 @@ def _layer_row(record: dict[str, object], layer: str) -> str:
 def _read_json(path: Path) -> dict[str, object] | None:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return None
 
 

--- a/toolkit/cli/common.py
+++ b/toolkit/cli/common.py
@@ -75,7 +75,7 @@ def iter_selected_years(
 def _read_json(path: Path) -> dict | None:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return None
 
 


### PR DESCRIPTION
## Cosa include questa PR

Prima tranche di miglioramenti qualitativi (test + robustezza + CI), in un'unica PR:

- test MCP server (`toolkit/mcp/server.py`): registrazione tool + comportamento `_guard`
- test CLI profile (`toolkit/cli/cmd_profile.py`): rendering markdown + happy path `profile raw`
- test plugin HTTP (`toolkit/plugins/http_file.py`): successo, retry con recupero, retry esaurito, errore HTTP
- hardening helper JSON CLI: `except` generici ristretti a eccezioni specifiche in
  - `toolkit/cli/cmd_status.py`
  - `toolkit/cli/cmd_inspect.py`
  - `toolkit/cli/common.py`
- CI matrix aggiornata con Python `3.12`

## Verifica locale eseguita

- `pytest -q tests/test_mcp_server.py tests/test_mcp_toolkit_client.py`
- `pytest -q tests/test_cli_profile.py tests/test_mcp_server.py`
- `pytest -q tests/test_http_file_plugin.py tests/test_ckan_plugin.py tests/test_sdmx_plugin.py`
- `pytest -q tests/test_cli_json_helpers.py tests/test_cli_status.py tests/test_cli_inspect_paths.py`

Tutti verdi nella sessione di lavoro.

## Chiusura issue

Closes #109
Closes #110
Closes #111
Closes #112
Closes #113
