### PR TITLE
chore: esplicitare regole lint Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,6 @@ version = { attr = "toolkit.version.__version__" }
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
Aggiunge configurazione lint Ruff esplicita in .

- aggiunta sezione 
- regole impostate a  per coerenza con CI attuale

Verifica:  verde in locale.

Closes #115
