### PR TITLE
test+cleanup lean: ckan coverage e piccoli cleanup plugin/registry

### DIFF
--- a/tests/test_ckan_plugin.py
+++ b/tests/test_ckan_plugin.py
@@ -131,3 +131,55 @@ def test_ckan_fetch_rejects_package_fallback_when_resource_id_missing(monkeypatc
         assert "resource_id=99999" in str(exc)
     else:
         raise AssertionError("Expected DownloadError")
+
+
+def test_ckan_download_bytes_retries_then_succeeds(monkeypatch):
+    calls = {"n": 0}
+
+    def _fake_get(url, params=None, timeout=None, headers=None):
+        calls["n"] += 1
+        if "resource_show" in url:
+            return _FakeResponse(
+                200,
+                json_data={
+                    "success": True,
+                    "result": {"url": "https://portal.example.org/export/retry.csv"},
+                },
+                url=f"{url}?id=abc",
+            )
+        if calls["n"] < 3:
+            raise RuntimeError("temporary network error")
+        return _FakeResponse(200, content=b"ok-after-retry", url=url)
+
+    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+
+    payload, origin = CkanSource(retries=3).fetch(
+        "https://portal.example.org/api/3", resource_id="abc"
+    )
+
+    assert payload == b"ok-after-retry"
+    assert origin == "https://portal.example.org/export/retry.csv"
+    assert calls["n"] == 3
+
+
+def test_ckan_download_bytes_raises_on_http_error(monkeypatch):
+    def _fake_get(url, params=None, timeout=None, headers=None):
+        if "resource_show" in url:
+            return _FakeResponse(
+                200,
+                json_data={
+                    "success": True,
+                    "result": {"url": "https://portal.example.org/export/unavailable.csv"},
+                },
+                url=f"{url}?id=abc",
+            )
+        return _FakeResponse(503, content=b"", url=url)
+
+    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+
+    try:
+        CkanSource(retries=1).fetch("https://portal.example.org/api/3", resource_id="abc")
+    except DownloadError as exc:
+        assert "HTTP 503" in str(exc)
+    else:
+        raise AssertionError("Expected DownloadError")

--- a/toolkit/core/registry.py
+++ b/toolkit/core/registry.py
@@ -2,11 +2,8 @@
 from __future__ import annotations
 
 import importlib
-import logging
 from collections.abc import Callable
 from typing import Any
-
-logger = logging.getLogger("toolkit.core.registry")
 
 
 class PluginRegistrationError(RuntimeError):

--- a/toolkit/plugins/local_file.py
+++ b/toolkit/plugins/local_file.py
@@ -6,9 +6,6 @@ from toolkit.core.exceptions import DownloadError
 class LocalFileSource:
     """Read a local file (offline, deterministic)."""
 
-    def __init__(self):
-        pass
-
     def fetch(self, path: str) -> bytes:
         p = Path(path)
         if not p.exists():


### PR DESCRIPTION
Tranche lean di miglioramenti su test e cleanup minimo.

### Cosa cambia
- estesa copertura test su `plugins/ckan.py` (retry download + errore HTTP)
- rimosso `logging` inutilizzato in `core/registry.py`
- rimosso `__init__` no-op in `plugins/local_file.py`

### Verifiche locali
- `pytest -q tests/test_ckan_plugin.py`
- `pytest -q tests/test_registry.py tests/test_config.py -k "registry or local_file"`
