### PR TITLE
MCP toolkit: nuovo tool toolkit_blocker_hints

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16,6 +16,7 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_show_schema",
         "toolkit_run_state",
         "toolkit_summary",
+        "toolkit_blocker_hints",
     }
 
 

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -4,7 +4,7 @@ import json
 import shutil
 from pathlib import Path
 
-from toolkit.mcp.toolkit_client import inspect_paths, run_state, show_schema, summary
+from toolkit.mcp.toolkit_client import inspect_paths, run_state, show_schema, summary, blocker_hints
 
 
 def test_mcp_toolkit_client_works_from_repo_layout(tmp_path: Path, monkeypatch) -> None:
@@ -40,3 +40,109 @@ def test_mcp_toolkit_client_works_from_repo_layout(tmp_path: Path, monkeypatch) 
     assert "raw_output_missing" in warnings
     assert "clean_output_missing" in warnings
     assert "mart_outputs_missing" in warnings
+
+
+def test_mcp_blocker_hints_detects_missing_outputs(tmp_path: Path, monkeypatch) -> None:
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Arrange: solo raw manifest, nessun output reale
+    raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "manifest.json").write_text(
+        json.dumps({"primary_output_file": "missing.csv"}), encoding="utf-8"
+    )
+
+    hints_payload = blocker_hints(str(config_path), 2022)
+    assert hints_payload["hint_count"] > 0
+    codes = {h["code"] for h in hints_payload["hints"]}
+    assert "raw_output_missing" in codes
+    assert "clean_output_missing" in codes
+    assert hints_payload["blocker_count"] >= 2
+
+
+def test_mcp_blocker_hints_empty_when_all_present(tmp_path: Path, monkeypatch) -> None:
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Arrange: crea output fittizi per tutti i layer
+    raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    # Il filename risolto dal config e' "ispra_dettaglio_comunale_2022.csv"
+    (raw_dir / "ispra_dettaglio_comunale_2022.csv").write_bytes(b"a;b\n1;2\n")
+
+    clean_dir = dst / "_smoke_out" / "data" / "clean" / "project_example" / "2022"
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    (clean_dir / "project_example_2022_clean.parquet").write_bytes(b"")
+
+    mart_dir = dst / "_smoke_out" / "data" / "mart" / "project_example" / "2022"
+    mart_dir.mkdir(parents=True, exist_ok=True)
+    # Il config dichiara 2 tabelle mart
+    (mart_dir / "rd_by_regione.parquet").write_bytes(b"")
+    (mart_dir / "rd_by_provincia.parquet").write_bytes(b"")
+
+    hints_payload = blocker_hints(str(config_path), 2022)
+    assert hints_payload["hint_count"] == 0
+    assert hints_payload["blocker_count"] == 0
+    assert hints_payload["warning_count"] == 0
+
+
+def test_mcp_blocker_hints_run_says_clean_success_but_output_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Arrange: raw output presente, clean dir esiste ma output manca
+    raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "ispra_dettaglio_comunale_2022.csv").write_bytes(b"a;b\n1;2\n")
+    (raw_dir / "manifest.json").write_text(
+        json.dumps({"primary_output_file": "ispra_dettaglio_comunale_2022.csv"}),
+        encoding="utf-8",
+    )
+
+    clean_dir = dst / "_smoke_out" / "data" / "clean" / "project_example" / "2022"
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    # clean output NON creato di proposito
+
+    # Run record che dice clean SUCCESS ma il file non c'e'
+    # Rimuovo eventuali run record preesistenti copiati dal project-example
+    run_dir = dst / "_smoke_out" / "data" / "_runs" / "project_example" / "2022"
+    if run_dir.exists():
+        for f in run_dir.glob("*.json"):
+            f.unlink()
+    run_dir.mkdir(parents=True, exist_ok=True)
+    run_record = {
+        "dataset": "project_example",
+        "year": 2022,
+        "run_id": "20260101T000000Z_abc123",
+        "status": "FAILED",
+        "layers": {
+            "raw": {"status": "SUCCESS"},
+            "clean": {
+                "status": "SUCCESS",
+                "started_at": "2026-01-01T00:00:00Z",
+                "finished_at": "2026-01-01T00:00:01Z",
+            },
+        },
+    }
+    (run_dir / "20260101T000000Z_abc123.json").write_text(json.dumps(run_record), encoding="utf-8")
+
+    hints_payload = blocker_hints(str(config_path), 2022)
+    codes = {h["code"] for h in hints_payload["hints"]}
+    assert "run_says_clean_success_but_output_missing" in codes
+    blockers = [h for h in hints_payload["hints"] if h["severity"] == "blocker"]
+    assert len(blockers) >= 1

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -8,6 +8,7 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_show_schema(config_path, layer="clean", year=0)`
 - `toolkit_run_state(config_path, year=0)`
 - `toolkit_summary(config_path, year=0)`
+- `toolkit_blocker_hints(config_path, year=0)`
 
 ## Boundary
 
@@ -46,3 +47,4 @@ Sostituire il path del `command` con il Python reale del clone locale che usera'
   - `raw`: usa `toolkit inspect schema-diff --json`
   - `clean` / `mart`: legge schema reale dei parquet risolti via `inspect paths`
 - `toolkit_run_state` legge `latest_run` e il relativo record JSON se presente
+- `toolkit_blocker_hints` evidenzia mismatch pratici tra output risolti e stato run

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -6,6 +6,7 @@ from mcp.server.fastmcp import FastMCP
 
 from .toolkit_client import (
     ToolkitClientError,
+    blocker_hints as blocker_hints_impl,
     inspect_paths as inspect_paths_impl,
     run_state as run_state_impl,
     summary as summary_impl,
@@ -28,7 +29,9 @@ def _guard(fn, *args, **kwargs) -> dict[str, Any]:
         return {"error": str(exc)}
 
 
-@mcp.tool(description="Mostra il path contract risolto per un dataset config.", structured_output=True)
+@mcp.tool(
+    description="Mostra il path contract risolto per un dataset config.", structured_output=True
+)
 def toolkit_inspect_paths(config_path: str, year: int = 0) -> dict[str, Any]:
     return _guard(inspect_paths_impl, config_path, year or None)
 
@@ -38,14 +41,27 @@ def toolkit_show_schema(config_path: str, layer: str = "clean", year: int = 0) -
     return _guard(show_schema_impl, config_path, layer, year or None)
 
 
-@mcp.tool(description="Mostra lo stato minimo dei run per un dataset config.", structured_output=True)
+@mcp.tool(
+    description="Mostra lo stato minimo dei run per un dataset config.", structured_output=True
+)
 def toolkit_run_state(config_path: str, year: int = 0) -> dict[str, Any]:
     return _guard(run_state_impl, config_path, year or None)
 
 
-@mcp.tool(description="Mostra un riepilogo diagnostico minimo per un dataset config.", structured_output=True)
+@mcp.tool(
+    description="Mostra un riepilogo diagnostico minimo per un dataset config.",
+    structured_output=True,
+)
 def toolkit_summary(config_path: str, year: int = 0) -> dict[str, Any]:
     return _guard(summary_impl, config_path, year or None)
+
+
+@mcp.tool(
+    description="Segnala blocker e warning leggeri confrontando config dichiarata e output reali.",
+    structured_output=True,
+)
+def toolkit_blocker_hints(config_path: str, year: int = 0) -> dict[str, Any]:
+    return _guard(blocker_hints_impl, config_path, year or None)
 
 
 if __name__ == "__main__":

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -12,7 +12,9 @@ from toolkit.core.config import load_config
 
 
 TOOLKIT_ROOT = Path(__file__).resolve().parents[2]
-WORKSPACE_ROOT = Path(os.environ.get("DATACIVICLAB_WORKSPACE", str(TOOLKIT_ROOT.parent))).expanduser()
+WORKSPACE_ROOT = Path(
+    os.environ.get("DATACIVICLAB_WORKSPACE", str(TOOLKIT_ROOT.parent))
+).expanduser()
 TOOLKIT_PYTHON = Path(os.environ.get("DATACIVICLAB_TOOLKIT_PYTHON", sys.executable))
 
 
@@ -89,7 +91,9 @@ def _schema_from_parquet(parquet_path: Path) -> dict[str, Any]:
             conn.execute("PRAGMA disable_progress_bar")
             describe_rows = conn.execute(f"DESCRIBE SELECT * FROM {relation}").fetchall()
     except Exception as exc:
-        raise ToolkitClientError(f"Lettura schema parquet fallita per {parquet_path}: {exc}") from exc
+        raise ToolkitClientError(
+            f"Lettura schema parquet fallita per {parquet_path}: {exc}"
+        ) from exc
 
     columns = [{"name": row[0], "type": row[1]} for row in describe_rows]
     return {"path": str(parquet_path), "column_count": len(columns), "columns": columns}
@@ -176,6 +180,128 @@ def _exists(path: str | None) -> bool:
     if not path:
         return False
     return Path(path).exists()
+
+
+def blocker_hints(config_path: str, year: int | None = None) -> dict[str, Any]:
+    """Diagnostic hints that flag common mismatches between declared config and actual outputs."""
+    config = _safe_path(config_path)
+    s = summary(str(config), year)
+    layers = s.get("layers", {})
+    raw = layers.get("raw", {})
+    clean = layers.get("clean", {})
+    mart = layers.get("mart", {})
+    run = s.get("run", {})
+
+    # Get the full run record from run_state for layer status checks
+    rs = run_state(str(config), year)
+    run_record = rs.get("latest_run_record")
+
+    hints: list[dict[str, str]] = []
+
+    # clean output exists but mart outputs are all missing or empty
+    if (
+        clean.get("output_exists")
+        and mart.get("output_count", 0) > 0
+        and mart.get("output_exists_count", 0) == 0
+    ):
+        hints.append(
+            {
+                "code": "clean_but_no_mart",
+                "severity": "warning",
+                "message": "clean output esiste ma nessun mart output e' presente",
+            }
+        )
+
+    # clean dir missing entirely while mart dir exists
+    if not clean.get("dir_exists") and mart.get("dir_exists"):
+        hints.append(
+            {
+                "code": "clean_dir_missing",
+                "severity": "blocker",
+                "message": "mart dir esiste ma clean dir manca: run order incoerente",
+            }
+        )
+
+    # latest_run record exists but the actual run file is gone
+    latest = run.get("latest_run")
+    if latest and latest.get("path") and not _exists(latest.get("path")):
+        hints.append(
+            {
+                "code": "latest_run_record_missing",
+                "severity": "warning",
+                "message": "latest_run reference presente ma file non trovato",
+            }
+        )
+
+    # resolved output path declared but file missing
+    if raw.get("primary_output_file") and not raw.get("primary_output_exists"):
+        hints.append(
+            {
+                "code": "raw_output_missing",
+                "severity": "blocker",
+                "message": f"raw primary_output_file '{raw['primary_output_file']}' risolto ma file assente",
+            }
+        )
+
+    if clean.get("output") and not clean.get("output_exists"):
+        hints.append(
+            {
+                "code": "clean_output_missing",
+                "severity": "blocker",
+                "message": f"clean output '{clean['output']}' risolto ma file assente",
+            }
+        )
+
+    # mart with multiple outputs but only partial
+    if mart.get("output_count", 0) > 1 and mart.get("missing_outputs"):
+        missing = mart["missing_outputs"]
+        hints.append(
+            {
+                "code": "mart_partial_outputs",
+                "severity": "warning",
+                "message": f"{len(missing)} mart output su {mart['output_count']} mancanti: {', '.join(Path(o).name for o in missing[:3])}",
+            }
+        )
+
+    # run record references a layer status that contradicts file existence
+    if run_record:
+        layers_map = run_record.get("layers") or {}
+        for layer_name, layer_detail in layers_map.items():
+            layer_status = (
+                layer_detail.get("status") if isinstance(layer_detail, dict) else layer_detail
+            )
+            if layer_status == "SUCCESS":
+                layer_info = layers.get(layer_name, {})
+                if layer_name == "clean" and not layer_info.get("output_exists"):
+                    hints.append(
+                        {
+                            "code": "run_says_clean_success_but_output_missing",
+                            "severity": "blocker",
+                            "message": "run record dice clean SUCCESS ma output file manca",
+                        }
+                    )
+                elif (
+                    layer_name == "mart"
+                    and layer_info.get("output_exists_count", 0) == 0
+                    and layer_info.get("output_count", 0) > 0
+                ):
+                    hints.append(
+                        {
+                            "code": "run_says_mart_success_but_outputs_missing",
+                            "severity": "blocker",
+                            "message": "run record dice mart SUCCESS ma nessun output file presente",
+                        }
+                    )
+
+    return {
+        "dataset": s.get("dataset"),
+        "config_path": str(config),
+        "year": s.get("year"),
+        "hint_count": len(hints),
+        "hints": hints,
+        "blocker_count": sum(1 for h in hints if h.get("severity") == "blocker"),
+        "warning_count": sum(1 for h in hints if h.get("severity") == "warning"),
+    }
 
 
 def summary(config_path: str, year: int | None = None) -> dict[str, Any]:

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -192,9 +192,12 @@ def blocker_hints(config_path: str, year: int | None = None) -> dict[str, Any]:
     mart = layers.get("mart", {})
     run = s.get("run", {})
 
-    # Get the full run record from run_state for layer status checks
-    rs = run_state(str(config), year)
-    run_record = rs.get("latest_run_record")
+    latest_run = run.get("latest_run") if isinstance(run, dict) else None
+    run_record = None
+    if latest_run and latest_run.get("path"):
+        latest_path = Path(latest_run["path"])
+        if latest_path.exists():
+            run_record = json.loads(latest_path.read_text(encoding="utf-8"))
 
     hints: list[dict[str, str]] = []
 


### PR DESCRIPTION
## Obiettivo
Aggiungere un tool MCP dedicato ai blocker/warning operativi sui dataset, con check piu' chiari tra stato dichiarato e output reali.

## Modifiche
- aggiunta funzione `blocker_hints()` in `toolkit/mcp/toolkit_client.py`
- aggiunto tool MCP `toolkit_blocker_hints` in `toolkit/mcp/server.py`
- estesi test in `tests/test_mcp_toolkit_client.py` (incluso caso `run_says_*`)
- aggiornato test registrazione tool in `tests/test_mcp_server.py`

## Verifica
- test locali verdi (suite completa gia' verificata nella tua esecuzione: 347 passed)
- smoke mirato locale: `tests/test_mcp_toolkit_client.py` e `tests/test_mcp_server.py`

Closes #103