### PR TITLE
MCP toolkit: aggiunto tool toolkit_review_readiness

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,6 +17,7 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_run_state",
         "toolkit_summary",
         "toolkit_blocker_hints",
+        "toolkit_review_readiness",
     }
 
 

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -4,7 +4,14 @@ import json
 import shutil
 from pathlib import Path
 
-from toolkit.mcp.toolkit_client import inspect_paths, run_state, show_schema, summary, blocker_hints
+from toolkit.mcp.toolkit_client import (
+    blocker_hints,
+    inspect_paths,
+    review_readiness,
+    run_state,
+    show_schema,
+    summary,
+)
 
 
 def test_mcp_toolkit_client_works_from_repo_layout(tmp_path: Path, monkeypatch) -> None:
@@ -146,3 +153,60 @@ def test_mcp_blocker_hints_run_says_clean_success_but_output_missing(
     assert "run_says_clean_success_but_output_missing" in codes
     blockers = [h for h in hints_payload["hints"] if h["severity"] == "blocker"]
     assert len(blockers) >= 1
+
+
+def test_review_readiness_incomplete_when_no_outputs(tmp_path: Path, monkeypatch) -> None:
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Nessun output creato
+    payload = review_readiness(str(config_path), 2022)
+    assert payload["readiness"] == "incomplete"
+    assert payload["fail_count"] >= 2  # raw, clean, mart tutti mancanti
+    check_names = {c["check"] for c in payload["checks"]}
+    assert "config_valid" in check_names
+    assert "raw_output_present" in check_names
+    assert "clean_output_readable" in check_names
+    assert "mart_outputs_readable" in check_names
+    assert "run_record_coherent" in check_names
+
+
+def test_review_readiness_ready_when_all_layers_present(tmp_path: Path, monkeypatch) -> None:
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Crea output fittizi per tutti i layer
+    raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "ispra_dettaglio_comunale_2022.csv").write_bytes(b"a;b\n1;2\n")
+
+    clean_dir = dst / "_smoke_out" / "data" / "clean" / "project_example" / "2022"
+    clean_dir.mkdir(parents=True, exist_ok=True)
+
+    # Crea un parquet minimale leggibile
+    import duckdb
+
+    clean_parquet = clean_dir / "project_example_2022_clean.parquet"
+    with duckdb.connect(":memory:") as conn:
+        conn.execute("CREATE TABLE t AS SELECT 1 AS x")
+        conn.execute(f"COPY t TO '{clean_parquet}' (FORMAT PARQUET)")
+
+    mart_dir = dst / "_smoke_out" / "data" / "mart" / "project_example" / "2022"
+    mart_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("rd_by_regione.parquet", "rd_by_provincia.parquet"):
+        with duckdb.connect(":memory:") as conn:
+            conn.execute("CREATE TABLE t AS SELECT 1 AS x")
+            conn.execute(f"COPY t TO '{mart_dir / name}' (FORMAT PARQUET)")
+
+    payload = review_readiness(str(config_path), 2022)
+    assert payload["readiness"] == "ready"
+    assert payload["fail_count"] == 0
+    assert payload["ok_count"] == len(payload["checks"])

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -210,3 +210,32 @@ def test_review_readiness_ready_when_all_layers_present(tmp_path: Path, monkeypa
     assert payload["readiness"] == "ready"
     assert payload["fail_count"] == 0
     assert payload["ok_count"] == len(payload["checks"])
+
+
+def test_review_readiness_needs_review_with_single_failure(tmp_path: Path, monkeypatch) -> None:
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # raw presente
+    raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "ispra_dettaglio_comunale_2022.csv").write_bytes(b"a;b\n1;2\n")
+
+    # clean presente e leggibile
+    clean_dir = dst / "_smoke_out" / "data" / "clean" / "project_example" / "2022"
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    import duckdb
+
+    clean_parquet = clean_dir / "project_example_2022_clean.parquet"
+    with duckdb.connect(":memory:") as conn:
+        conn.execute("CREATE TABLE t AS SELECT 1 AS x")
+        conn.execute(f"COPY t TO '{clean_parquet}' (FORMAT PARQUET)")
+
+    # mart volutamente mancante -> unico fail atteso
+    payload = review_readiness(str(config_path), 2022)
+    assert payload["readiness"] == "needs-review"
+    assert payload["fail_count"] == 1

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -9,6 +9,7 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_run_state(config_path, year=0)`
 - `toolkit_summary(config_path, year=0)`
 - `toolkit_blocker_hints(config_path, year=0)`
+- `toolkit_review_readiness(config_path, year=0)`
 
 ## Boundary
 
@@ -17,6 +18,7 @@ Questo MCP resta nel repo `toolkit` perche' espone solo introspezione tecnica de
 - path contract risolto
 - schema `raw`, `clean`, `mart`
 - stato minimo dei run
+- readiness check per review candidate
 
 Non espone:
 
@@ -48,3 +50,4 @@ Sostituire il path del `command` con il Python reale del clone locale che usera'
   - `clean` / `mart`: legge schema reale dei parquet risolti via `inspect paths`
 - `toolkit_run_state` legge `latest_run` e il relativo record JSON se presente
 - `toolkit_blocker_hints` evidenzia mismatch pratici tra output risolti e stato run
+- `toolkit_review_readiness` esegue check di readiness per review candidate: config valida, layer presenti, output leggibili, coerenza run record

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -8,6 +8,7 @@ from .toolkit_client import (
     ToolkitClientError,
     blocker_hints as blocker_hints_impl,
     inspect_paths as inspect_paths_impl,
+    review_readiness as review_readiness_impl,
     run_state as run_state_impl,
     summary as summary_impl,
     show_schema as show_schema_impl,
@@ -62,6 +63,14 @@ def toolkit_summary(config_path: str, year: int = 0) -> dict[str, Any]:
 )
 def toolkit_blocker_hints(config_path: str, year: int = 0) -> dict[str, Any]:
     return _guard(blocker_hints_impl, config_path, year or None)
+
+
+@mcp.tool(
+    description="Check di readiness per review candidate: config, layer, output e coerenza run record.",
+    structured_output=True,
+)
+def toolkit_review_readiness(config_path: str, year: int = 0) -> dict[str, Any]:
+    return _guard(review_readiness_impl, config_path, year or None)
 
 
 if __name__ == "__main__":

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -182,6 +182,159 @@ def _exists(path: str | None) -> bool:
     return Path(path).exists()
 
 
+def _read_parquet_row_count(parquet_path: Path) -> int | None:
+    """Return row count of a parquet file, or None if unreadable."""
+    if not parquet_path.exists():
+        return None
+    try:
+        with duckdb.connect(database=":memory:") as conn:
+            conn.execute("PRAGMA disable_progress_bar")
+            result = conn.execute(
+                f"SELECT COUNT(*) FROM read_parquet('{_sql_literal(str(parquet_path))}')"
+            ).fetchone()
+            return int(result[0]) if result else None
+    except Exception:
+        return None
+
+
+def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any]:
+    """Check minimale di readiness per review di intake/run candidate.
+
+    Risponde a:
+    - il candidate e' runnable almeno al minimo?
+    - i layer attesi esistono davvero?
+    - c'e' almeno un output leggibile?
+    - il run record e' coerente con gli output presenti?
+    """
+    config = _safe_path(config_path)
+    _, cfg = _load_cfg(config)
+
+    years = getattr(cfg, "years", []) if hasattr(cfg, "years") else []
+    target_year = year or (years[0] if years else None)
+
+    checks: list[dict[str, Any]] = []
+
+    # --- Config check ---
+    checks.append(
+        {
+            "check": "config_valid",
+            "ok": True,
+            "detail": "config parse ok",
+        }
+    )
+
+    # --- Raw layer ---
+    s = summary(str(config), target_year)
+    raw = s.get("layers", {}).get("raw", {})
+    raw_primary = raw.get("primary_output_file")
+    if raw_primary:
+        raw_ok = raw.get("primary_output_exists")
+    else:
+        # Nessun manifest: fallback su esistenza dir e presenza file
+        raw_dir_path = Path(raw.get("dir", ""))
+        raw_ok = raw_dir_path.exists() and any(raw_dir_path.iterdir())
+    checks.append(
+        {
+            "check": "raw_output_present",
+            "ok": raw_ok,
+            "detail": f"primary_output={raw.get('primary_output_file', 'unknown')}"
+            if raw_ok
+            else "raw output mancante",
+        }
+    )
+
+    # --- Clean layer ---
+    clean = s.get("layers", {}).get("clean", {})
+    clean_path_str = clean.get("output")
+    clean_path = Path(clean_path_str) if clean_path_str else None
+    clean_rows = _read_parquet_row_count(clean_path) if clean_path else None
+    clean_ok = clean.get("output_exists") and (clean_rows is not None)
+    checks.append(
+        {
+            "check": "clean_output_readable",
+            "ok": clean_ok,
+            "detail": f"{clean_rows} rows"
+            if clean_rows is not None
+            else "clean output mancante o illeggibile",
+        }
+    )
+
+    # --- Mart layer ---
+    mart = s.get("layers", {}).get("mart", {})
+    mart_outputs = mart.get("outputs", [])
+    mart_checks: list[dict[str, Any]] = []
+    for output_name in mart_outputs:
+        o_path = Path(output_name)
+        rows = _read_parquet_row_count(o_path)
+        mart_checks.append({"name": o_path.name, "exists": o_path.exists(), "rows": rows})
+    mart_ok = len(mart_outputs) > 0 and all(m.get("exists") for m in mart_checks)
+    checks.append(
+        {
+            "check": "mart_outputs_readable",
+            "ok": mart_ok,
+            "detail": mart_checks,
+        }
+    )
+
+    # --- Run record coherence ---
+    rs = run_state(str(config), target_year)
+    run_record = rs.get("latest_run_record")
+    run_coherent = True
+    run_detail: str | None = None
+    if run_record:
+        layers_map = run_record.get("layers") or {}
+        for layer_name, layer_detail in layers_map.items():
+            layer_status = (
+                layer_detail.get("status") if isinstance(layer_detail, dict) else layer_detail
+            )
+            if layer_status == "SUCCESS":
+                layer_info = s.get("layers", {}).get(layer_name, {})
+                if layer_name == "clean" and not layer_info.get("output_exists"):
+                    run_coherent = False
+                    run_detail = f"run dice {layer_name} SUCCESS ma output manca"
+                elif layer_name == "mart":
+                    if (
+                        layer_info.get("output_exists_count", 0) == 0
+                        and layer_info.get("output_count", 0) > 0
+                    ):
+                        run_coherent = False
+                        run_detail = f"run dice {layer_name} SUCCESS ma nessun output presente"
+        if run_coherent:
+            run_detail = f"run record coerente ({run_record.get('status', 'unknown')})"
+    else:
+        # Nessun run record: non e' un fallimento di readiness se i file esistono
+        run_detail = "nessun run record (ok se output presenti)"
+
+    checks.append(
+        {
+            "check": "run_record_coherent",
+            "ok": run_coherent,
+            "detail": run_detail,
+        }
+    )
+
+    ok_count = sum(1 for c in checks if c["ok"])
+    fail_count = sum(1 for c in checks if not c["ok"])
+
+    if fail_count == 0:
+        readiness = "ready"
+    elif ok_count >= len(checks) - 1:
+        readiness = "needs-review"
+    else:
+        readiness = "incomplete"
+
+    return {
+        "dataset": s.get("dataset"),
+        "config_path": str(config),
+        "year": target_year,
+        "readiness": readiness,
+        "check_count": len(checks),
+        "ok_count": ok_count,
+        "fail_count": fail_count,
+        "checks": checks,
+    }
+
+
 def blocker_hints(config_path: str, year: int | None = None) -> dict[str, Any]:
     """Diagnostic hints that flag common mismatches between declared config and actual outputs."""
     config = _safe_path(config_path)

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -266,8 +266,17 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
     for output_name in mart_outputs:
         o_path = Path(output_name)
         rows = _read_parquet_row_count(o_path)
-        mart_checks.append({"name": o_path.name, "exists": o_path.exists(), "rows": rows})
-    mart_ok = len(mart_outputs) > 0 and all(m.get("exists") for m in mart_checks)
+        mart_checks.append(
+            {
+                "name": o_path.name,
+                "exists": o_path.exists(),
+                "readable": rows is not None,
+                "rows": rows,
+            }
+        )
+    mart_ok = len(mart_outputs) > 0 and all(
+        m.get("exists") and m.get("readable") for m in mart_checks
+    )
     checks.append(
         {
             "check": "mart_outputs_readable",
@@ -326,7 +335,7 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
     return {
         "dataset": s.get("dataset"),
         "config_path": str(config),
-        "year": target_year,
+        "year": s.get("year"),
         "readiness": readiness,
         "check_count": len(checks),
         "ok_count": ok_count,


### PR DESCRIPTION
## Obiettivo
Chiudere #104 aggiungendo nel MCP `toolkit` un check di readiness tecnico per review di intake/run candidate.

## Cosa cambia
- nuovo helper `review_readiness()` in `toolkit/mcp/toolkit_client.py`
- nuovo tool MCP `toolkit_review_readiness` in `toolkit/mcp/server.py`
- nuovo helper `_read_parquet_row_count()` per verificare leggibilita' output parquet
- README MCP aggiornato con il nuovo tool
- test estesi in `tests/test_mcp_toolkit_client.py`
- test registrazione tool aggiornato in `tests/test_mcp_server.py`

## Readiness checks inclusi
- `config_valid`
- `raw_output_present`
- `clean_output_readable`
- `mart_outputs_readable`
- `run_record_coherent`

Output sintetico:
- `readiness`: `ready | needs-review | incomplete`
- `check_count`, `ok_count`, `fail_count`
- dettaglio check in `checks[]`

## Verifica
- test locali verdi: `349 passed, 0 failed` (suite completa)
- smoke mirato locale:
  - `tests/test_mcp_toolkit_client.py`
  - `tests/test_mcp_server.py`

Closes #104
