### PR TITLE
API: export pubblici minimi per package toolkit

### DIFF
--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -1,3 +1,7 @@
+import toolkit.clean as clean_pkg
+import toolkit.plugins as plugins_pkg
+import toolkit.profile as profile_pkg
+import toolkit.raw as raw_pkg
 from toolkit.clean import run_clean, run_clean_validation, validate_clean
 from toolkit.plugins import CkanSource, HttpFileSource, LocalFileSource, SdmxSource
 from toolkit.profile import (
@@ -11,18 +15,21 @@ from toolkit.raw import run_raw, run_raw_validation, validate_raw_output
 
 
 def test_clean_exports() -> None:
+    assert clean_pkg.__all__ == ["run_clean", "validate_clean", "run_clean_validation"]
     assert callable(run_clean)
     assert callable(validate_clean)
     assert callable(run_clean_validation)
 
 
 def test_raw_exports() -> None:
+    assert raw_pkg.__all__ == ["run_raw", "validate_raw_output", "run_raw_validation"]
     assert callable(run_raw)
     assert callable(validate_raw_output)
     assert callable(run_raw_validation)
 
 
 def test_plugins_exports() -> None:
+    assert plugins_pkg.__all__ == ["LocalFileSource", "HttpFileSource", "CkanSource", "SdmxSource"]
     assert LocalFileSource.__name__ == "LocalFileSource"
     assert HttpFileSource.__name__ == "HttpFileSource"
     assert CkanSource.__name__ == "CkanSource"
@@ -30,6 +37,13 @@ def test_plugins_exports() -> None:
 
 
 def test_profile_exports() -> None:
+    assert profile_pkg.__all__ == [
+        "RawProfile",
+        "build_profile_hints",
+        "build_suggested_read_cfg",
+        "profile_raw",
+        "write_suggested_read_yml",
+    ]
     assert RawProfile.__name__ == "RawProfile"
     assert callable(profile_raw)
     assert callable(build_profile_hints)

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -1,0 +1,37 @@
+from toolkit.clean import run_clean, run_clean_validation, validate_clean
+from toolkit.plugins import CkanSource, HttpFileSource, LocalFileSource, SdmxSource
+from toolkit.profile import (
+    RawProfile,
+    build_profile_hints,
+    build_suggested_read_cfg,
+    profile_raw,
+    write_suggested_read_yml,
+)
+from toolkit.raw import run_raw, run_raw_validation, validate_raw_output
+
+
+def test_clean_exports() -> None:
+    assert callable(run_clean)
+    assert callable(validate_clean)
+    assert callable(run_clean_validation)
+
+
+def test_raw_exports() -> None:
+    assert callable(run_raw)
+    assert callable(validate_raw_output)
+    assert callable(run_raw_validation)
+
+
+def test_plugins_exports() -> None:
+    assert LocalFileSource.__name__ == "LocalFileSource"
+    assert HttpFileSource.__name__ == "HttpFileSource"
+    assert CkanSource.__name__ == "CkanSource"
+    assert SdmxSource.__name__ == "SdmxSource"
+
+
+def test_profile_exports() -> None:
+    assert RawProfile.__name__ == "RawProfile"
+    assert callable(profile_raw)
+    assert callable(build_profile_hints)
+    assert callable(build_suggested_read_cfg)
+    assert callable(write_suggested_read_yml)

--- a/toolkit/clean/__init__.py
+++ b/toolkit/clean/__init__.py
@@ -1,1 +1,10 @@
-__all__: list[str] = []
+"""Public clean-layer API."""
+
+from toolkit.clean.run import run_clean
+from toolkit.clean.validate import run_clean_validation, validate_clean
+
+__all__ = [
+    "run_clean",
+    "validate_clean",
+    "run_clean_validation",
+]

--- a/toolkit/plugins/__init__.py
+++ b/toolkit/plugins/__init__.py
@@ -9,3 +9,15 @@ Builtin stable sources exposed by the default runtime:
 - `ckan`
 - `sdmx`
 """
+
+from toolkit.plugins.ckan import CkanSource
+from toolkit.plugins.http_file import HttpFileSource
+from toolkit.plugins.local_file import LocalFileSource
+from toolkit.plugins.sdmx import SdmxSource
+
+__all__ = [
+    "LocalFileSource",
+    "HttpFileSource",
+    "CkanSource",
+    "SdmxSource",
+]

--- a/toolkit/profile/__init__.py
+++ b/toolkit/profile/__init__.py
@@ -1,5 +1,17 @@
-"""Advanced profiling helpers.
+"""Public profiling API for RAW diagnostics."""
 
-`toolkit.profile` is supported tooling for diagnostics and format inference on RAW
-inputs. It is not a first-class pipeline layer like `raw`, `clean`, or `mart`.
-"""
+from toolkit.profile.raw import (
+    RawProfile,
+    build_profile_hints,
+    build_suggested_read_cfg,
+    profile_raw,
+    write_suggested_read_yml,
+)
+
+__all__ = [
+    "RawProfile",
+    "build_profile_hints",
+    "build_suggested_read_cfg",
+    "profile_raw",
+    "write_suggested_read_yml",
+]

--- a/toolkit/raw/__init__.py
+++ b/toolkit/raw/__init__.py
@@ -1,0 +1,10 @@
+"""Public raw-layer API."""
+
+from toolkit.raw.run import run_raw
+from toolkit.raw.validate import run_raw_validation, validate_raw_output
+
+__all__ = [
+    "run_raw",
+    "validate_raw_output",
+    "run_raw_validation",
+]


### PR DESCRIPTION
## Obiettivo
Chiudere #123 definendo una surface API pubblica minima e intenzionale per i package principali.

## Cosa cambia
- `toolkit.clean`: export espliciti di `run_clean`, `validate_clean`, `run_clean_validation`
- `toolkit.raw`: export espliciti di `run_raw`, `validate_raw_output`, `run_raw_validation`
- `toolkit.plugins`: export delle classi plugin built-in (`LocalFileSource`, `HttpFileSource`, `CkanSource`, `SdmxSource`)
- `toolkit.profile`: export dei simboli pubblici di profiling (`RawProfile`, `profile_raw`, helper principali)

## Test
- nuovo `tests/test_package_exports.py` per bloccare regressioni sugli export package-level
- smoke test locale eseguito su:
  - `tests/test_package_exports.py`
  - `tests/test_mcp_server.py`
  - `tests/test_mcp_toolkit_client.py`

Closes #123
