### PR TITLE
Refactor: decomporre toolkit.profile.raw in moduli interni (#122)

### DIFF
--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -9,6 +9,7 @@ from toolkit.profile import (
     build_profile_hints,
     build_suggested_read_cfg,
     profile_raw,
+    write_raw_profile,
     write_suggested_read_yml,
 )
 from toolkit.raw import run_raw, run_raw_validation, validate_raw_output
@@ -42,10 +43,12 @@ def test_profile_exports() -> None:
         "build_profile_hints",
         "build_suggested_read_cfg",
         "profile_raw",
+        "write_raw_profile",
         "write_suggested_read_yml",
     ]
     assert RawProfile.__name__ == "RawProfile"
     assert callable(profile_raw)
     assert callable(build_profile_hints)
     assert callable(build_suggested_read_cfg)
+    assert callable(write_raw_profile)
     assert callable(write_suggested_read_yml)

--- a/toolkit/profile/__init__.py
+++ b/toolkit/profile/__init__.py
@@ -5,6 +5,7 @@ from toolkit.profile.raw import (
     build_profile_hints,
     build_suggested_read_cfg,
     profile_raw,
+    write_raw_profile,
     write_suggested_read_yml,
 )
 
@@ -13,5 +14,6 @@ __all__ = [
     "build_profile_hints",
     "build_suggested_read_cfg",
     "profile_raw",
+    "write_raw_profile",
     "write_suggested_read_yml",
 ]

--- a/toolkit/profile/_column_profile.py
+++ b/toolkit/profile/_column_profile.py
@@ -1,0 +1,112 @@
+"""Column profiling and mapping suggestion utilities."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+# tokens tipici che vogliamo suggerire come nullify
+NULL_TOKENS_DEFAULT = ["", "-", "n.d.", "n.d", "ND", "NA", "N/A", "null", "NULL"]
+
+
+def _normalize_colname(c: str) -> str:
+    c = c.strip()
+    c = re.sub(r"\s+", " ", c)
+    return c
+
+
+def _sample_values(sample_rows: List[Dict[str, Any]], col: str, limit: int = 25) -> List[str]:
+    vals: List[str] = []
+    for r in sample_rows:
+        if col not in r:
+            continue
+        v = r.get(col)
+        if v is None:
+            continue
+        s = str(v).strip()
+        if s == "":
+            continue
+        vals.append(s)
+        if len(vals) >= limit:
+            break
+    return vals
+
+
+def _detect_parse_kind(values: List[str]) -> Optional[str]:
+    pct = sum(1 for v in values if "%" in v)
+    if pct >= max(2, int(len(values) * 0.3)):
+        return "percent_it"
+
+    it_like = 0
+    for v in values:
+        v2 = v.replace(" ", "")
+        if re.search(r"\d{1,3}(\.\d{3})+,\d+", v2):
+            it_like += 1
+        elif re.search(r"\d+,\d{1,3}\b", v2):
+            it_like += 1
+    if it_like >= max(2, int(len(values) * 0.3)):
+        return "number_it"
+
+    return None
+
+
+def _detect_type(values: List[str], parse_kind: Optional[str]) -> str:
+    if parse_kind in ("percent_it", "number_it"):
+        return "float"
+
+    int_like = 0
+    float_like = 0
+    for v in values:
+        v2 = v.replace(" ", "")
+        if re.fullmatch(r"-?\d+", v2):
+            int_like += 1
+        elif re.fullmatch(r"-?\d+\.\d+", v2) or re.fullmatch(r"-?\d+,\d+", v2):
+            float_like += 1
+
+    if int_like >= max(2, int(len(values) * 0.6)):
+        return "int"
+    if (int_like + float_like) >= max(2, int(len(values) * 0.6)):
+        return "float"
+
+    return "str"
+
+
+def _suggest_nullify(values: List[str]) -> List[str]:
+    hits = set()
+    for v in values:
+        if v in NULL_TOKENS_DEFAULT:
+            hits.add(v)
+    out = [t for t in NULL_TOKENS_DEFAULT if t in hits]
+    return out
+
+
+def _suggest_normalize(colname: str, detected_type: str) -> Optional[List[str]]:
+    if detected_type == "str":
+        if any(k in colname.lower() for k in ["comune", "prov", "reg", "nome", "citt"]):
+            return ["trim", "title", "collapse_spaces"]
+        return ["trim", "collapse_spaces"]
+    return None
+
+
+def _build_mapping_suggestions(
+    columns: List[str], sample_rows: List[Dict[str, Any]]
+) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for col in columns:
+        vals = _sample_values(sample_rows, col, limit=30)
+        parse_kind = _detect_parse_kind(vals)
+        dtype = _detect_type(vals, parse_kind)
+        nullify = _suggest_nullify(vals)
+        normalize = _suggest_normalize(col, dtype)
+
+        spec: Dict[str, Any] = {"from": col, "type": dtype}
+
+        if nullify:
+            spec["nullify"] = nullify
+        if normalize:
+            spec["normalize"] = normalize
+        if parse_kind:
+            spec["parse"] = {"kind": parse_kind}
+
+        out[col] = spec
+    return out

--- a/toolkit/profile/_sniff_delimiter.py
+++ b/toolkit/profile/_sniff_delimiter.py
@@ -1,0 +1,49 @@
+"""Delimiter and decimal sniffing utilities for CSV profiling."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+COMMON_DELIMS = [";", ",", "\t", "|"]
+
+
+def sniff_delim(sample_text: str) -> Optional[str]:
+    lines = [ln for ln in sample_text.splitlines() if ln.strip()][:25]
+    if not lines:
+        return None
+    scores = {}
+    for d in COMMON_DELIMS:
+        counts = [ln.count(d) for ln in lines]
+        non_zero = [c for c in counts if c > 0]
+        if not non_zero:
+            continue
+        variance = max(non_zero) - min(non_zero)
+        scores[d] = (len(non_zero), -variance, sum(non_zero))
+    if not scores:
+        return None
+    return sorted(scores.items(), key=lambda kv: (kv[1][0], kv[1][1], kv[1][2]), reverse=True)[0][0]
+
+
+def sniff_decimal(sample_text: str) -> Optional[str]:
+    chunk = sample_text[:200_000]
+    comma_dec = len(re.findall(r"\d+,\d{1,3}\b", chunk))
+    dot_dec = len(re.findall(r"\d+\.\d{1,3}\b", chunk))
+    if comma_dec == 0 and dot_dec == 0:
+        return None
+    return "," if comma_dec >= dot_dec else "."
+
+
+def suggest_skip(sample_text: str, delim: Optional[str]) -> int:
+    if not delim:
+        return 0
+    lines = [ln for ln in sample_text.splitlines() if ln.strip()][:5]
+    if len(lines) < 2:
+        return 0
+    first_count = lines[0].count(delim)
+    second_count = lines[1].count(delim)
+    if first_count == 0 and second_count > 0:
+        return 1
+    if first_count < second_count and first_count <= 1 and second_count >= 3:
+        return 1
+    return 0

--- a/toolkit/profile/_sniff_encoding.py
+++ b/toolkit/profile/_sniff_encoding.py
@@ -1,0 +1,25 @@
+"""Encoding sniffing utilities for CSV profiling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Tuple
+
+COMMON_ENCODINGS = ["utf-8", "latin-1", "windows-1252", "CP1252"]
+
+
+def _try_decode(filepath: Path, enc: str) -> Optional[str]:
+    try:
+        with filepath.open("r", encoding=enc, errors="strict") as f:
+            return f.read(200_000)
+    except Exception:
+        return None
+
+
+def sniff_encoding(filepath: Path) -> Tuple[str, str]:
+    for enc in COMMON_ENCODINGS:
+        txt = _try_decode(filepath, enc)
+        if txt is not None:
+            return enc, txt
+    with filepath.open("r", encoding="utf-8", errors="replace") as f:
+        return "utf-8", f.read(200_000)

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -1,11 +1,18 @@
+"""RAW profiling entry point.
+
+Orchestrates encoding/delimiter sniffing, DuckDB-based column profiling,
+and mapping suggestion generation. Internal sniffing logic lives in
+``_sniff_encoding``, ``_sniff_delimiter``, and ``_column_profile``.
+"""
+
 from __future__ import annotations
 
-import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import duckdb
+
 from toolkit.core.csv_read import (
     csv_read_option_strings,
     normalize_read_cfg,
@@ -13,12 +20,9 @@ from toolkit.core.csv_read import (
     sql_str,
 )
 from toolkit.core.io import write_json_atomic
-
-COMMON_DELIMS = [";", ",", "\t", "|"]
-COMMON_ENCODINGS = ["utf-8", "latin-1", "windows-1252", "CP1252"]
-
-# tokens tipici che vogliamo suggerire come nullify
-NULL_TOKENS_DEFAULT = ["", "-", "n.d.", "n.d", "ND", "NA", "N/A", "null", "NULL"]
+from toolkit.profile._sniff_encoding import sniff_encoding
+from toolkit.profile._sniff_delimiter import sniff_decimal, sniff_delim, suggest_skip
+from toolkit.profile._column_profile import _build_mapping_suggestions, _normalize_colname
 
 
 def _safe_mkdir(p: Path) -> None:
@@ -27,78 +31,6 @@ def _safe_mkdir(p: Path) -> None:
 
 def _raw_files(raw_dir: Path) -> list[Path]:
     return sorted([p for p in raw_dir.glob("*") if p.is_file()])
-
-
-def _try_decode(filepath: Path, enc: str) -> Optional[str]:
-    try:
-        with filepath.open("r", encoding=enc, errors="strict") as f:
-            return f.read(200_000)
-    except Exception:
-        return None
-
-
-def sniff_encoding(filepath: Path) -> Tuple[str, str]:
-    for enc in COMMON_ENCODINGS:
-        txt = _try_decode(filepath, enc)
-        if txt is not None:
-            return enc, txt
-    with filepath.open("r", encoding="utf-8", errors="replace") as f:
-        return "utf-8", f.read(200_000)
-
-
-def sniff_delim(sample_text: str) -> Optional[str]:
-    lines = [ln for ln in sample_text.splitlines() if ln.strip()][:25]
-    if not lines:
-        return None
-    scores = {}
-    for d in COMMON_DELIMS:
-        counts = [ln.count(d) for ln in lines]
-        non_zero = [c for c in counts if c > 0]
-        if not non_zero:
-            continue
-        variance = max(non_zero) - min(non_zero)
-        scores[d] = (len(non_zero), -variance, sum(non_zero))
-    if not scores:
-        return None
-    return sorted(scores.items(), key=lambda kv: (kv[1][0], kv[1][1], kv[1][2]), reverse=True)[0][0]
-
-
-def sniff_decimal(sample_text: str) -> Optional[str]:
-    chunk = sample_text[:200_000]
-    comma_dec = len(re.findall(r"\d+,\d{1,3}\b", chunk))
-    dot_dec = len(re.findall(r"\d+\.\d{1,3}\b", chunk))
-    if comma_dec == 0 and dot_dec == 0:
-        return None
-    return "," if comma_dec >= dot_dec else "."
-
-
-def _normalize_colname(c: str) -> str:
-    c = c.strip()
-    c = re.sub(r"\s+", " ", c)
-    return c
-
-
-def suggest_skip(sample_text: str, delim: Optional[str]) -> int:
-    if not delim:
-        return 0
-    lines = [ln for ln in sample_text.splitlines() if ln.strip()][:5]
-    if len(lines) < 2:
-        return 0
-    first_count = lines[0].count(delim)
-    second_count = lines[1].count(delim)
-    if first_count == 0 and second_count > 0:
-        return 1
-    if first_count < second_count and first_count <= 1 and second_count >= 3:
-        return 1
-    return 0
-
-
-def _sniff_file_profile(file0: Path) -> tuple[str, str, Optional[str], Optional[str], int]:
-    enc, txt = sniff_encoding(file0)
-    delim = sniff_delim(txt)
-    dec = sniff_decimal(txt)
-    skip = suggest_skip(txt, delim)
-    return enc, txt, delim, dec, skip
 
 
 def _preview_columns(header_line: str | None, delim: str | None) -> list[str]:
@@ -142,13 +74,6 @@ def build_profile_hints(filepath: Path) -> Dict[str, Any]:
 
 
 def _build_read_csv_opts(read_cfg: Dict[str, Any]) -> str:
-    """Build DuckDB read_csv option string from a config dict.
-
-    Delegates to the shared ``csv_read_option_strings`` in ``core/csv_read.py``
-    for the common option set, then appends ``header`` and ``skip`` which are
-    intentionally excluded from the shared function (they are call-site
-    specific — see ``duckdb_read._csv_read_options``).
-    """
     opts = ["union_by_name=true"] + csv_read_option_strings(read_cfg)
 
     header = read_cfg.get("header", True)
@@ -233,11 +158,9 @@ def write_suggested_read_yml(out_dir: Path, profile: "RawProfile | Dict[str, Any
 
 
 def _pick_data_file(files: List[Path]) -> Path:
-    # prefer csv-like, exclude metadata/validation json
     preferred = [p for p in files if p.suffix.lower() in {".csv", ".tsv", ".txt", ".php", ".gz"}]
     if preferred:
         return preferred[0]
-    # fallback: first non-json/yml/md
     for p in files:
         if p.suffix.lower() not in {".json", ".md", ".yml", ".yaml"}:
             return p
@@ -274,110 +197,6 @@ def _read_header_line(file0: Path, *, encoding: str, skip_n: int) -> str | None:
             return f.readline().rstrip("\n\r")
     except Exception:
         return None
-
-
-def _sample_values(sample_rows: List[Dict[str, Any]], col: str, limit: int = 25) -> List[str]:
-    vals: List[str] = []
-    for r in sample_rows:
-        if col not in r:
-            continue
-        v = r.get(col)
-        if v is None:
-            continue
-        s = str(v).strip()
-        if s == "":
-            continue
-        vals.append(s)
-        if len(vals) >= limit:
-            break
-    return vals
-
-
-def _detect_parse_kind(values: List[str]) -> Optional[str]:
-    # percent if many values include '%'
-    pct = sum(1 for v in values if "%" in v)
-    if pct >= max(2, int(len(values) * 0.3)):
-        return "percent_it"
-
-    # number_it if we see patterns like 1.234,56 or 123,45
-    it_like = 0
-    for v in values:
-        v2 = v.replace(" ", "")
-        if re.search(r"\d{1,3}(\.\d{3})+,\d+", v2):  # 1.234,56
-            it_like += 1
-        elif re.search(r"\d+,\d{1,3}\b", v2):  # 123,4
-            it_like += 1
-    if it_like >= max(2, int(len(values) * 0.3)):
-        return "number_it"
-
-    return None
-
-
-def _detect_type(values: List[str], parse_kind: Optional[str]) -> str:
-    # If parse_kind is numeric-ish, it will be float
-    if parse_kind in ("percent_it", "number_it"):
-        return "float"
-
-    # try int
-    int_like = 0
-    float_like = 0
-    for v in values:
-        v2 = v.replace(" ", "")
-        if re.fullmatch(r"-?\d+", v2):
-            int_like += 1
-        elif re.fullmatch(r"-?\d+\.\d+", v2) or re.fullmatch(r"-?\d+,\d+", v2):
-            float_like += 1
-
-    if int_like >= max(2, int(len(values) * 0.6)):
-        return "int"
-    if (int_like + float_like) >= max(2, int(len(values) * 0.6)):
-        return "float"
-
-    return "str"
-
-
-def _suggest_nullify(values: List[str]) -> List[str]:
-    hits = set()
-    for v in values:
-        if v in NULL_TOKENS_DEFAULT:
-            hits.add(v)
-    # mantieni ordine “standard”
-    out = [t for t in NULL_TOKENS_DEFAULT if t in hits]
-    return out
-
-
-def _suggest_normalize(colname: str, detected_type: str) -> Optional[List[str]]:
-    # su stringhe suggeriamo sempre trim + collapse_spaces
-    if detected_type == "str":
-        # title utile su nomi geografici
-        if any(k in colname.lower() for k in ["comune", "prov", "reg", "nome", "citt"]):
-            return ["trim", "title", "collapse_spaces"]
-        return ["trim", "collapse_spaces"]
-    return None
-
-
-def _build_mapping_suggestions(
-    columns: List[str], sample_rows: List[Dict[str, Any]]
-) -> Dict[str, Any]:
-    out: Dict[str, Any] = {}
-    for col in columns:
-        vals = _sample_values(sample_rows, col, limit=30)
-        parse_kind = _detect_parse_kind(vals)
-        dtype = _detect_type(vals, parse_kind)
-        nullify = _suggest_nullify(vals)
-        normalize = _suggest_normalize(col, dtype)
-
-        spec: Dict[str, Any] = {"from": col, "type": dtype}
-
-        if nullify:
-            spec["nullify"] = nullify
-        if normalize:
-            spec["normalize"] = normalize
-        if parse_kind:
-            spec["parse"] = {"kind": parse_kind}
-
-        out[col] = spec
-    return out
 
 
 def _profile_view(
@@ -454,7 +273,10 @@ def profile_raw(
         raise FileNotFoundError(f"No RAW files found in {raw_dir}")
 
     file0 = _pick_data_file(files)
-    enc, txt, delim, dec, skip = _sniff_file_profile(file0)
+    enc, txt = sniff_encoding(file0)
+    delim = sniff_delim(txt)
+    dec = sniff_decimal(txt)
+    skip = suggest_skip(txt, delim)
     effective_read_cfg = _effective_profile_read_cfg(
         read_cfg,
         encoding=enc,


### PR DESCRIPTION
## Summary
- scompone `toolkit/profile/raw.py` in moduli interni focalizzati
- mantiene invariata l'API pubblica di `toolkit.profile`
- aggiorna export package e test di export

## Modifiche
- aggiunti i moduli interni:
  - `toolkit/profile/_sniff_encoding.py`
  - `toolkit/profile/_sniff_delimiter.py`
  - `toolkit/profile/_column_profile.py`
- `toolkit/profile/raw.py` resta orchestratore/API pubblica
- aggiornato `toolkit/profile/__init__.py`
- aggiornato `tests/test_package_exports.py`

## Validazione
- test suite locale verde (come da run condiviso)

Closes #122