### PR TITLE
[codex] aggiunge batch runner sequenziale

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,20 @@ toolkit run all --config dataset.yml
 toolkit validate all --config dataset.yml
 ```
 
+Per eseguire piu` `dataset.yml` in sequenza:
+
+```bash
+toolkit batch --configs configs.txt --step all
+```
+
+Dove `configs.txt` contiene un path a `dataset.yml` per riga, con path relativi
+risolti rispetto alla directory del file lista.
+
+Output finale:
+
+- tabella con `dataset`, `years`, `step`, `status`, `duration`
+- blocco `Failures` se almeno una config fallisce
+
 Per il percorso base:
 
 - `run all` esegue RAW -> CLEAN -> MART

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import shutil
+from typer.testing import CliRunner
+
+from toolkit.cli.app import app
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content).strip() + "\n", encoding="utf-8")
+
+
+def _write_batch_project(project_dir: Path, dataset: str, year: int) -> Path:
+    (project_dir / "data").mkdir(parents=True, exist_ok=True)
+    shutil.copy(FIXTURES_DIR / "it_small.csv", project_dir / "data" / "it_small.csv")
+
+    _write_text(
+        project_dir / "sql" / "clean.sql",
+        """
+        SELECT
+          comune,
+          CAST(anno AS INTEGER) AS anno,
+          CAST(valore AS DOUBLE) AS valore
+        FROM raw_input
+        """,
+    )
+    _write_text(
+        project_dir / "sql" / "mart.sql",
+        """
+        SELECT
+          anno,
+          SUM(valore) AS totale
+        FROM clean_input
+        GROUP BY anno
+        """,
+    )
+    _write_text(
+        project_dir / "dataset.yml",
+        f"""
+        schema_version: 1
+        root: out
+        dataset:
+          name: {dataset}
+          years: [{year}]
+        raw:
+          output_policy: overwrite
+          sources:
+            - name: csv_it
+              type: local_file
+              primary: "true"
+              args:
+                path: data/it_small.csv
+                filename: {dataset}_{year}.csv
+        clean:
+          sql: sql/clean.sql
+          read_mode: strict
+          read:
+            source: config_only
+            header: true
+            delim: ";"
+            decimal: ","
+            mode: explicit
+            include: {dataset}_{year}.csv
+          required_columns: comune
+          validate:
+            not_null: valore
+        mart:
+          tables:
+            - name: mart_totali
+              sql: sql/mart.sql
+          required_tables: mart_totali
+          validate:
+            table_rules:
+              mart_totali:
+                required_columns: [anno, totale]
+        """,
+    )
+    return project_dir / "dataset.yml"
+
+
+def test_batch_runs_configs_in_sequence_and_prints_report(tmp_path: Path) -> None:
+    project_a = tmp_path / "project_a"
+    project_b = tmp_path / "project_b"
+    _write_batch_project(project_a, "batch_a", 2022)
+    _write_batch_project(project_b, "batch_b", 2023)
+
+    configs_file = tmp_path / "configs.txt"
+    configs_file.write_text(
+        "\n".join(
+            [
+                "project_a/dataset.yml",
+                "project_b/dataset.yml",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "all"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "Batch Report" in result.output
+    assert "dataset" in result.output
+    assert "years" in result.output
+    assert "status" in result.output
+    assert "batch_a" in result.output
+    assert "batch_b" in result.output
+    assert "SUCCESS" in result.output
+
+    assert (project_a / "out" / "data" / "mart" / "batch_a" / "2022" / "mart_totali.parquet").exists()
+    assert (project_b / "out" / "data" / "mart" / "batch_b" / "2023" / "mart_totali.parquet").exists()

--- a/toolkit/cli/app.py
+++ b/toolkit/cli/app.py
@@ -10,6 +10,7 @@ from toolkit.cli.cmd_status import register as register_status
 from toolkit.cli.cmd_validate import register as register_validate
 from toolkit.cli.cmd_inspect import register as register_inspect
 from toolkit.cli.cmd_scaffold import register as register_scaffold
+from toolkit.cli.cmd_batch import register as register_batch
 
 app = typer.Typer(no_args_is_help=True, add_completion=False)
 
@@ -22,6 +23,7 @@ register_status(app)
 register_validate(app)
 register_inspect(app)
 register_scaffold(app)
+register_batch(app)
 
 
 def main():

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from pathlib import Path
+from time import perf_counter
+
+import typer
+
+from toolkit.cli.common import load_cfg_and_logger
+from toolkit.cli.cmd_run import run_cross_year_step, run_year
+
+_ALLOWED_STEPS = {"raw", "clean", "mart", "cross_year", "all"}
+
+
+def _read_config_list(configs_file: Path) -> list[Path]:
+    if not configs_file.exists():
+        raise FileNotFoundError(f"Config list not found: {configs_file}")
+
+    config_paths: list[Path] = []
+    for raw_line in configs_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        config_path = Path(line)
+        if not config_path.is_absolute():
+            config_path = (configs_file.parent / config_path).resolve()
+        config_paths.append(config_path)
+
+    if not config_paths:
+        raise ValueError(f"No config paths found in {configs_file}")
+
+    return config_paths
+
+
+def _format_years(years: list[int] | None) -> str:
+    if not years:
+        return "-"
+    return ",".join(str(year) for year in years)
+
+
+def _format_duration(seconds: float | None) -> str:
+    if seconds is None:
+        return "-"
+    return f"{seconds:.3f}s"
+
+
+def _print_table(rows: list[dict[str, str]]) -> None:
+    headers = ["dataset", "years", "step", "status", "duration"]
+    widths = {header: len(header) for header in headers}
+    for row in rows:
+        for header in headers:
+            widths[header] = max(widths[header], len(str(row.get(header, ""))))
+
+    def _render(row: dict[str, str]) -> str:
+        return "  ".join(str(row.get(header, "")).ljust(widths[header]) for header in headers)
+
+    typer.echo("Batch Report")
+    typer.echo(_render({header: header for header in headers}))
+    typer.echo("  ".join("-" * widths[header] for header in headers))
+    for row in rows:
+        typer.echo(_render(row))
+
+
+def batch(
+    configs: str = typer.Option(
+        ..., "--configs", help="Path to a text file with one dataset.yml path per line"
+    ),
+    step: str = typer.Option("all", "--step", help="raw | clean | mart | cross_year | all"),
+    strict_config: bool = typer.Option(
+        False, "--strict-config", help="Treat deprecated config forms as errors"
+    ),
+):
+    """
+    Esegue più config in sequenza e stampa un report aggregato finale.
+    """
+    if step not in _ALLOWED_STEPS:
+        raise typer.BadParameter("step must be one of: raw, clean, mart, cross_year, all")
+
+    configs_file = Path(configs)
+    config_paths = _read_config_list(configs_file)
+    strict_config_flag = strict_config if isinstance(strict_config, bool) else False
+
+    rows: list[dict[str, str]] = []
+    failures: list[dict[str, str]] = []
+
+    for config_path in config_paths:
+        config_started_at = perf_counter()
+        dataset_label = config_path.stem
+        try:
+            cfg, logger = load_cfg_and_logger(str(config_path), strict_config=strict_config_flag)
+            dataset_label = cfg.dataset
+
+            if step == "cross_year":
+                run_started_at = perf_counter()
+                status = "FAILED"
+                try:
+                    run_cross_year_step(cfg, logger=logger)
+                    status = "SUCCESS"
+                except Exception as exc:
+                    failures.append(
+                        {
+                            "config": str(config_path),
+                            "dataset": dataset_label,
+                            "years": _format_years(list(cfg.years)),
+                            "error": str(exc),
+                        }
+                    )
+                finally:
+                    rows.append(
+                        {
+                            "dataset": dataset_label,
+                            "years": _format_years(list(cfg.years)),
+                            "step": step,
+                            "status": status,
+                            "duration": _format_duration(perf_counter() - run_started_at),
+                        }
+                    )
+            else:
+                for year in cfg.years:
+                    run_started_at = perf_counter()
+                    status = "FAILED"
+                    try:
+                        context = run_year(cfg, year, step=step, logger=logger)
+                        status = context.status
+                    except Exception as exc:
+                        failures.append(
+                            {
+                                "config": str(config_path),
+                                "dataset": dataset_label,
+                                "years": str(year),
+                                "error": str(exc),
+                            }
+                        )
+                    finally:
+                        rows.append(
+                            {
+                                "dataset": dataset_label,
+                                "years": str(year),
+                                "step": step,
+                                "status": status,
+                                "duration": _format_duration(perf_counter() - run_started_at),
+                            }
+                        )
+        except Exception as exc:
+            failures.append(
+                {
+                    "config": str(config_path),
+                    "dataset": dataset_label,
+                    "years": "-",
+                    "error": str(exc),
+                }
+            )
+            rows.append(
+                {
+                    "dataset": dataset_label,
+                    "years": "-",
+                    "step": step,
+                    "status": "FAILED",
+                    "duration": _format_duration(perf_counter() - config_started_at),
+                }
+            )
+
+    _print_table(rows)
+
+    if failures:
+        typer.echo("")
+        typer.echo("Failures")
+        for failure in failures:
+            typer.echo(
+                f"- config={failure['config']} dataset={failure['dataset']} "
+                f"years={failure['years']} error={failure['error']}"
+            )
+        raise typer.Exit(code=1)
+
+
+def register(app: typer.Typer) -> None:
+    app.command("batch")(batch)


### PR DESCRIPTION
## Cosa cambia
- Aggiunto il comando `toolkit batch` per leggere una lista di `dataset.yml` e lanciarli in sequenza.
- Il comando stampa un report finale aggregato con `dataset`, `years`, `step`, `status` e `duration`.
- In caso di errore continua con i config successivi e mostra una sezione `Failures` a fine esecuzione.
- Comando collegato alla CLI principale e documentato nel README.

## Perché
Closes #51: serve un batch runner semplice e sequenziale per rebuild completi di più config senza introdurre parallelismo o orchestrazione.

## Impatto
- Permette di eseguire più config dataset in una sola invocazione.
- Mantiene invariato il comportamento del runner singolo.
- Rende i fallimenti visibili nel riepilogo finale senza interrompere lintera sequenza.

## Verifica
- `python3 -m py_compile` sui file Python toccati
- `toolkit/.venv/bin/pytest tests/test_batch_cli.py -q`
- `toolkit/.venv/bin/pytest tests/test_run_dry_run.py -q`
- Run manuale del batch su tre config candidate in `dataset-incubator`, con un caso di failure e prosecuzione sequenziale