### PR TITLE
fix: raw_col_count da columns_raw del profile invece che da _profile_raw_input

### DIFF
--- a/tests/test_validate_layers.py
+++ b/tests/test_validate_layers.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import duckdb
 
 from toolkit.raw.validate import validate_raw_output
-from toolkit.clean.validate import validate_clean
+from toolkit.clean.validate import validate_clean, run_clean_validation
 from toolkit.cross.validate import run_cross_validation, validate_cross_outputs
 from toolkit.core.config_models import TransitionConfig
 from toolkit.core.validation import check_transitions
@@ -280,3 +280,63 @@ def test_run_cross_validation_does_not_require_metadata_json(tmp_path: Path):
     manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
     assert manifest_payload["validation"] == "_validate/cross_validation.json"
     assert manifest_payload["summary"]["ok"] is True
+
+
+def test_run_clean_validation_uses_columns_raw_from_raw_profile(tmp_path: Path):
+    """Regression test for issue #145: raw_col_count must come from columns_raw in
+    raw_profile.json, not from _profile_raw_input which may read the CSV with
+    broken read_params_used and get placeholder names (column00, column01, ...)."""
+    root = tmp_path / "root"
+    dataset = "demo"
+    year = 2024
+
+    raw_dir = root / "data" / "raw" / dataset / str(year)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "data.csv").write_text("a,b,c\n1,2,3\n", encoding="utf-8")
+
+    profile_dir = raw_dir / "_profile"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    real_columns = ["col_alpha", "col_beta", "col_gamma"]
+    (profile_dir / "raw_profile.json").write_text(
+        json.dumps(
+            {
+                "columns_raw": real_columns,
+                "columns_norm": [c.lower() for c in real_columns],
+                "row_count": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    clean_dir = root / "data" / "clean" / dataset / str(year)
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    _write_parquet(clean_dir / f"{dataset}_{year}_clean.parquet", "CREATE TABLE t AS SELECT 1 AS col_alpha, 2 AS col_beta")
+
+    (clean_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "input_files": ["data.csv"],
+                "read_params_used": {"header": False},
+                "output_profile": {
+                    "columns": [
+                        {"name": "col_alpha", "type": "INTEGER"},
+                        {"name": "col_beta", "type": "INTEGER"},
+                    ],
+                    "row_count": 1,
+                },
+                "outputs": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = SimpleNamespace(
+        root=root,
+        dataset=dataset,
+        clean={},
+    )
+
+    summary = run_clean_validation(cfg, year, logger=SimpleNamespace(info=lambda *args, **kwargs: None))
+
+    assert summary["stats"]["raw_cols"] == len(real_columns)
+    assert summary["stats"]["col_drop_count"] == len(real_columns) - 2

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -272,7 +272,23 @@ def validate_promotion(
 
     read_cfg = clean_metadata.get("read_params_used") or {}
     read_mode = str(clean_metadata.get("read_source_used") or "fallback")
-    raw_profile = _profile_raw_input(input_files, read_cfg, read_mode, logger)
+
+    profile_dir = raw_path / "_profile"
+    saved_profile_path = profile_dir / "raw_profile.json"
+    if not saved_profile_path.exists():
+        saved_profile_path = profile_dir / "profile.json"
+
+    if saved_profile_path.exists():
+        try:
+            saved = json.loads(saved_profile_path.read_text(encoding="utf-8"))
+            raw_profile = {
+                "row_count": saved.get("row_count"),
+                "columns": [{"name": c, "type": "VARCHAR"} for c in (saved.get("columns_raw") or [])],
+            }
+        except Exception:
+            raw_profile = _profile_raw_input(input_files, read_cfg, read_mode, logger)
+    else:
+        raw_profile = _profile_raw_input(input_files, read_cfg, read_mode, logger)
     transition_profile = compare_layer_profiles(
         raw_profile,
         clean_profile,
@@ -343,10 +359,13 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
     raw_col_count = promotion_result.summary.get("raw_col_count")
 
     # scaffold check: legge profile raw (canonical prima, fallback legacy alias)
+    # Usa columns_raw dal profile come source of truth per raw_col_count, bypassing
+    # _profile_raw_input che potrebbe rileggere il CSV con parametri header errati
     _profile_dir = raw_dir / "_profile"
     profile_path = _profile_dir / "raw_profile.json"
     if not profile_path.exists():
         profile_path = _profile_dir / "profile.json"
+    trusted_raw_cols: list[str] = []
     if profile_path.exists():
         try:
             import re as _re
@@ -356,7 +375,8 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
                 return _re.sub(r"_+", "_", s).lower().strip("_") or "col"
 
             raw_profile = json.loads(profile_path.read_text(encoding="utf-8"))
-            scaffold_cols = {_to_snake(c) for c in (raw_profile.get("columns_raw") or [])}
+            trusted_raw_cols = raw_profile.get("columns_raw") or []
+            scaffold_cols = {_to_snake(c) for c in trusted_raw_cols}
             clean_cols_set = set(clean_cols)
             unmapped = sorted(scaffold_cols - clean_cols_set)
             if unmapped:
@@ -366,6 +386,8 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
                 )
         except Exception:
             pass
+    if trusted_raw_cols:
+        raw_col_count = len(trusted_raw_cols)
     row_drop_pct = (
         round((raw_row_count - clean_row_count) / raw_row_count * 100, 2)
         if raw_row_count and clean_row_count is not None and raw_row_count > 0


### PR DESCRIPTION
## Motivazione

`_profile_raw_input` rilegge il CSV raw usando `read_params_used` da `clean/metadata.json`. Se manca `header=true` o l encoding non corrisponde, DuckDB assegna nomi placeholder (`column00`, `column01`, ...) e il col count risultante è errato — producendo `stats.raw_cols` e `col_drop_count` inaffidabili nel validation report.

## Soluzione

Leggo `columns_raw` direttamente dal file `raw_profile.json` (già generato dal run RAW con i parametri corretti), usando quello come source of truth per `raw_col_count` invece del valore ricavato da `_profile_raw_input`.

Due punti di intervento:
1. `validate_promotion`: se `raw_profile.json` esiste, costruisco `raw_profile` da `columns_raw` ivi contenuto invece di ri-profilare il CSV — il transition report usa così nomi reali
2. `run_clean_validation`: `raw_col_count` viene letto da `len(columns_raw)` invece che da `promotion_result.summary["raw_col_count"]` (che passava per `_profile_raw_input`)

## Verifiche

- Regression test `test_run_clean_validation_uses_columns_raw_from_raw_profile` che riproduce il bug: `read_params_used` degradato (`header: False`), `raw_profile.json` con 3 colonne reali, assert che `raw_cols == 3` e `col_drop_count == 1`
- 13 test passano in `test_validate_layers.py`

## Reference

fix #145