### PR TITLE
feat(ckan): supporta la selezione della resource per nome

### DIFF
--- a/tests/test_ckan_plugin.py
+++ b/tests/test_ckan_plugin.py
@@ -95,6 +95,90 @@ def test_ckan_fetch_requires_identifier():
         raise AssertionError("Expected DownloadError")
 
 
+def test_ckan_fetch_package_show_by_resource_name(monkeypatch):
+    calls = []
+
+    def _fake_get(url, params=None, timeout=None, headers=None):
+        calls.append((url, params))
+        if "package_show" in url:
+            return _FakeResponse(
+                200,
+                json_data={
+                    "success": True,
+                    "result": {
+                        "resources": [
+                            {
+                                "id": "other",
+                                "name": "auxiliary export",
+                                "format": "CSV",
+                                "url": "https://portal.example.org/export/aux.csv",
+                            },
+                            {
+                                "id": "wanted",
+                                "name": "target csv export",
+                                "format": "CSV",
+                                "url": "http://portal.example.org/export/target.csv",
+                            },
+                        ]
+                    },
+                },
+                url=f"{url}?id=dataset-id",
+            )
+        return _FakeResponse(
+            200,
+            content=b"a,b\n1,2\n",
+            url="https://portal.example.org/export/target.csv",
+        )
+
+    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+
+    payload, origin = CkanSource().fetch(
+        "https://portal.example.org/api/3",
+        dataset_id="dataset-id",
+        resource_name="target csv export",
+    )
+
+    assert payload == b"a,b\n1,2\n"
+    assert origin == "https://portal.example.org/export/target.csv"
+    assert any("package_show" in call[0] for call in calls)
+
+
+def test_ckan_fetch_package_show_by_resource_name_raises_when_missing(monkeypatch):
+    def _fake_get(url, params=None, timeout=None, headers=None):
+        if "package_show" in url:
+            return _FakeResponse(
+                200,
+                json_data={
+                    "success": True,
+                    "result": {
+                        "resources": [
+                            {
+                                "id": "other",
+                                "name": "auxiliary export",
+                                "format": "CSV",
+                                "url": "https://portal.example.org/export/aux.csv",
+                            }
+                        ]
+                    },
+                },
+                url=f"{url}?id=dataset-id",
+            )
+        raise AssertionError(f"Unexpected download request to {url}")
+
+    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+
+    try:
+        CkanSource().fetch(
+            "https://portal.example.org/api/3",
+            dataset_id="dataset-id",
+            resource_name="target csv export",
+        )
+    except DownloadError as exc:
+        assert "resource_name=target csv export" in str(exc)
+    else:
+        raise AssertionError("Expected DownloadError")
+
+
 def test_ckan_fetch_rejects_package_fallback_when_resource_id_missing(monkeypatch):
     def _fake_get(url, params=None, timeout=None, headers=None):
         if "resource_show" in url:

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -69,7 +69,12 @@ class CkanSource:
                 last_err = exc
         raise DownloadError(str(last_err) if last_err else f"Failed to fetch {url}")
 
-    def _select_resource_from_package(self, result: dict, resource_id: str | None) -> dict:
+    def _select_resource_from_package(
+        self,
+        result: dict,
+        resource_id: str | None,
+        resource_name: str | None = None,
+    ) -> dict:
         resources = result.get("resources") or []
         if not resources:
             raise DownloadError("CKAN package_show returned no resources")
@@ -80,6 +85,20 @@ class CkanSource:
                     return item
             raise DownloadError(
                 f"CKAN package_show did not contain requested resource_id={resource_id}"
+            )
+
+        if resource_name:
+            wanted = str(resource_name).strip().lower()
+            for item in resources:
+                candidate = str(item.get("name") or "").strip().lower()
+                if candidate == wanted:
+                    return item
+            for item in resources:
+                candidate = str(item.get("name") or "").strip().lower()
+                if wanted in candidate:
+                    return item
+            raise DownloadError(
+                f"CKAN package_show did not contain requested resource_name={resource_name}"
             )
 
         with_url = [item for item in resources if item.get("url")]
@@ -110,6 +129,7 @@ class CkanSource:
         portal_url: str,
         resource_id: str | None = None,
         dataset_id: str | None = None,
+        resource_name: str | None = None,
     ) -> tuple[bytes, str]:
         last_err: Exception | None = None
 
@@ -134,7 +154,7 @@ class CkanSource:
             try:
                 metadata = self._get_json(api_url, {"id": str(package_identifier)})
                 result = metadata.get("result") or {}
-                resource = self._select_resource_from_package(result, resource_id)
+                resource = self._select_resource_from_package(result, resource_id, resource_name)
                 resolved_url = _force_https(str(resource["url"]))
                 return self._download_bytes(resolved_url), resolved_url
             except Exception as exc:

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -76,6 +76,7 @@ def _fetch_payload(stype: str, client: dict, formatted_args: dict) -> tuple[byte
             formatted_args["portal_url"],
             str(formatted_args["resource_id"]) if formatted_args.get("resource_id") is not None else None,
             str(formatted_args["dataset_id"]) if formatted_args.get("dataset_id") is not None else None,
+            str(formatted_args["resource_name"]) if formatted_args.get("resource_name") is not None else None,
         )
     elif stype == "sdmx":
         payload, origin = src.fetch(


### PR DESCRIPTION
## Riepilogo

- aggiunge il supporto a `resource_name` nella source `ckan` quando la resource viene risolta via `package_show`
- propaga il nuovo argomento nel raw runner
- aggiunge test generici per la selezione per nome e per il caso di resource mancante

## Perché serve

Alcuni dataset esposti via CKAN hanno un package/dataset id stabile ma cambiano `resource_id` tra release o annualita'. In questi casi, selezionare il file target per nome della resource e' piu stabile che hardcodare gli id nel `dataset.yml`.

## Scope

La modifica e' intenzionalmente limitata al plugin `ckan`.

Non cambia `http_file`, `local_file` o altri source type che non risolvono package con piu resources.

## Validazione

- `pytest -q toolkit/tests/test_ckan_plugin.py`
