### PR TITLE
refactor: metadata.json canonico, manifest.json solo compat

### DIFF
--- a/toolkit/cli/cmd_inspect.py
+++ b/toolkit/cli/cmd_inspect.py
@@ -8,6 +8,7 @@ import typer
 
 from toolkit.cli.common import format_profile_preview, iter_years, load_layer_profile_summaries
 from toolkit.core.config import load_config
+from toolkit.core.metadata import read_layer_metadata
 from toolkit.core.paths import layer_year_dir
 from toolkit.core.support import resolve_support_payloads
 from toolkit.profile.raw import build_profile_hints
@@ -21,8 +22,8 @@ def _read_json(path: Path) -> dict[str, Any] | None:
         return None
 
 
-def _raw_primary_file(raw_dir: Path, manifest: dict[str, Any]) -> Path | None:
-    primary_output_file = manifest.get("primary_output_file")
+def _raw_primary_file(raw_dir: Path, metadata: dict[str, Any]) -> Path | None:
+    primary_output_file = metadata.get("primary_output_file")
     if isinstance(primary_output_file, str):
         candidate = raw_dir / primary_output_file
         if candidate.exists():
@@ -33,11 +34,10 @@ def _raw_primary_file(raw_dir: Path, manifest: dict[str, Any]) -> Path | None:
 def _raw_schema_payload(cfg, year: int) -> dict[str, Any]:
     root = Path(cfg.root)
     raw_dir = layer_year_dir(root, "raw", cfg.dataset, year)
-    manifest = _read_json(raw_dir / "manifest.json") or {}
-    metadata = _read_json(raw_dir / "metadata.json") or {}
-    primary_file = _raw_primary_file(raw_dir, manifest)
+    raw_meta = read_layer_metadata(raw_dir)
+    primary_file = _raw_primary_file(raw_dir, raw_meta)
 
-    profile_hints = metadata.get("profile_hints") or {}
+    profile_hints = raw_meta.get("profile_hints") or {}
     profile_source = "metadata" if profile_hints else None
     sniff_error: str | None = None
 
@@ -57,7 +57,7 @@ def _raw_schema_payload(cfg, year: int) -> dict[str, Any]:
         "year": year,
         "raw_dir": str(raw_dir),
         "raw_exists": raw_dir.exists(),
-        "primary_output_file": manifest.get("primary_output_file"),
+        "primary_output_file": raw_meta.get("primary_output_file"),
         "file_used": profile_hints.get("file_used"),
         "profile_source": profile_source,
         "encoding": profile_hints.get("encoding_suggested"),
@@ -94,8 +94,8 @@ def _raw_output_paths(root: Path, dataset: str, year: int) -> dict[str, str]:
     raw_dir = layer_year_dir(root, "raw", dataset, year)
     return {
         "dir": str(raw_dir),
-        "manifest": str(raw_dir / "manifest.json"),
         "metadata": str(raw_dir / "metadata.json"),
+        "manifest": str(raw_dir / "manifest.json"),
         "validation": str(raw_dir / "raw_validation.json"),
     }
 
@@ -109,8 +109,8 @@ def _clean_paths(root: Path, dataset: str, year: int) -> dict[str, str]:
     return {
         "dir": str(clean_dir),
         "output": str(_clean_output_path(root, dataset, year)),
-        "manifest": str(clean_dir / "manifest.json"),
         "metadata": str(clean_dir / "metadata.json"),
+        "manifest": str(clean_dir / "manifest.json"),
         "validation": str(clean_dir / "_validate" / "clean_validation.json"),
     }
 
@@ -130,8 +130,8 @@ def _mart_paths(
     return {
         "dir": str(mart_dir),
         "outputs": [str(path) for path in _mart_output_paths(root, mart_dir, tables)],
-        "manifest": str(mart_dir / "manifest.json"),
         "metadata": str(mart_dir / "metadata.json"),
+        "manifest": str(mart_dir / "manifest.json"),
         "validation": str(mart_dir / "_validate" / "mart_validation.json"),
     }
 
@@ -141,10 +141,9 @@ def _payload_for_year(cfg, year: int) -> dict[str, Any]:
     run_dir = get_run_dir(root, cfg.dataset, year)
     mart_tables = cfg.mart.get("tables") or []
     raw_dir = layer_year_dir(root, "raw", cfg.dataset, year)
-    raw_manifest = _read_json(raw_dir / "manifest.json") or {}
-    raw_metadata = _read_json(raw_dir / "metadata.json") or {}
+    raw_meta = read_layer_metadata(raw_dir)
     suggested_read_path = raw_dir / "_profile" / "suggested_read.yml"
-    profile_hints = raw_metadata.get("profile_hints") or {}
+    profile_hints = raw_meta.get("profile_hints") or {}
 
     latest_payload: dict[str, Any] | None = None
     try:
@@ -171,7 +170,7 @@ def _payload_for_year(cfg, year: int) -> dict[str, Any]:
             "run_dir": str(run_dir),
         },
         "raw_hints": {
-            "primary_output_file": raw_manifest.get("primary_output_file"),
+            "primary_output_file": raw_meta.get("primary_output_file"),
             "suggested_read_path": str(suggested_read_path),
             "suggested_read_exists": suggested_read_path.exists(),
             "encoding": profile_hints.get("encoding_suggested"),
@@ -213,8 +212,8 @@ def paths(
         typer.echo(f"config_path: {item['config_path']}")
         typer.echo(f"root: {item['root']}")
         typer.echo(f"raw_dir: {item['paths']['raw']['dir']}")
-        typer.echo(f"raw_manifest: {item['paths']['raw']['manifest']}")
         typer.echo(f"raw_metadata: {item['paths']['raw']['metadata']}")
+        typer.echo(f"raw_manifest: {item['paths']['raw']['manifest']}")
         typer.echo(f"raw_validation: {item['paths']['raw']['validation']}")
         typer.echo("raw_hints:")
         typer.echo(f"  - primary_output_file: {item['raw_hints']['primary_output_file']}")

--- a/toolkit/cli/cmd_resume.py
+++ b/toolkit/cli/cmd_resume.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import typer
@@ -8,8 +7,13 @@ import typer
 from toolkit.cli.cmd_run import run_year
 from toolkit.core.config import load_config
 from toolkit.core.logging import get_logger
+from toolkit.core.metadata import read_layer_metadata
 from toolkit.core.paths import layer_year_dir
 from toolkit.core.run_context import get_run_dir, latest_run, read_run_record
+
+
+def _artifact_exists(path: Path) -> bool:
+    return path.exists() and path.is_file()
 
 
 _LAYER_ORDER = ("raw", "clean", "mart")
@@ -24,28 +28,19 @@ def _resume_layer(record: dict[str, object]) -> str | None:
     return None
 
 
-def _artifact_exists(path: Path) -> bool:
-    return path.exists() and path.is_file()
-
-
 def _layer_artifacts_ok(root: Path, dataset: str, year: int, layer: str) -> tuple[bool, str]:
     layer_dir = layer_year_dir(root, layer, dataset, year)
-    manifest_path = layer_dir / "manifest.json"
     metadata_path = layer_dir / "metadata.json"
 
-    if not _artifact_exists(manifest_path):
-        return False, f"missing {layer}/manifest.json"
     if not _artifact_exists(metadata_path):
         return False, f"missing {layer}/metadata.json"
 
+    meta = read_layer_metadata(layer_dir)
+
     if layer == "raw":
-        try:
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except Exception as exc:
-            return False, f"cannot read raw manifest: {exc}"
-        primary_output = manifest.get("primary_output_file")
+        primary_output = meta.get("primary_output_file")
         if not isinstance(primary_output, str) or not primary_output:
-            return False, "raw manifest missing primary_output_file"
+            return False, "raw metadata missing primary_output_file"
         if not _artifact_exists(layer_dir / primary_output):
             return False, f"missing raw primary output: {primary_output}"
         return True, ""
@@ -57,18 +52,17 @@ def _layer_artifacts_ok(root: Path, dataset: str, year: int, layer: str) -> tupl
         return True, ""
 
     if layer == "mart":
-        try:
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except Exception as exc:
-            return False, f"cannot read mart manifest: {exc}"
-        outputs = manifest.get("outputs") or []
-        if not isinstance(outputs, list) or not outputs:
-            return False, "mart manifest missing outputs"
+        outputs = meta.get("outputs") or []
+        if not outputs:
+            manifest = _read_json(layer_dir / "manifest.json")
+            outputs = (manifest.get("outputs") or []) if manifest else []
+        if not outputs:
+            return False, "mart metadata missing outputs"
         for output in outputs:
             rel_file = (output or {}).get("file")
             if isinstance(rel_file, str) and rel_file and _artifact_exists(layer_dir / rel_file):
                 return True, ""
-        return False, "missing mart parquet outputs declared in manifest"
+        return False, "missing mart parquet outputs declared in metadata"
 
     raise ValueError(f"Unsupported layer: {layer}")
 

--- a/toolkit/cli/cmd_resume.py
+++ b/toolkit/cli/cmd_resume.py
@@ -54,9 +54,6 @@ def _layer_artifacts_ok(root: Path, dataset: str, year: int, layer: str) -> tupl
     if layer == "mart":
         outputs = meta.get("outputs") or []
         if not outputs:
-            manifest = _read_json(layer_dir / "manifest.json")
-            outputs = (manifest.get("outputs") or []) if manifest else []
-        if not outputs:
             return False, "mart metadata missing outputs"
         for output in outputs:
             rel_file = (output or {}).get("file")

--- a/toolkit/cli/cmd_resume.py
+++ b/toolkit/cli/cmd_resume.py
@@ -31,8 +31,9 @@ def _resume_layer(record: dict[str, object]) -> str | None:
 def _layer_artifacts_ok(root: Path, dataset: str, year: int, layer: str) -> tuple[bool, str]:
     layer_dir = layer_year_dir(root, layer, dataset, year)
     metadata_path = layer_dir / "metadata.json"
+    manifest_path = layer_dir / "manifest.json"
 
-    if not _artifact_exists(metadata_path):
+    if not _artifact_exists(metadata_path) and not _artifact_exists(manifest_path):
         return False, f"missing {layer}/metadata.json"
 
     meta = read_layer_metadata(layer_dir)

--- a/toolkit/cli/cmd_status.py
+++ b/toolkit/cli/cmd_status.py
@@ -8,21 +8,9 @@ import typer
 
 from toolkit.cli.common import format_profile_preview, load_layer_profile_summaries
 from toolkit.core.config import load_config
+from toolkit.core.metadata import read_layer_metadata
 from toolkit.core.paths import layer_dataset_dir, layer_year_dir
 from toolkit.core.run_context import get_run_dir, latest_run, read_run_record
-
-
-def _layer_row(record: dict[str, object], layer: str) -> str:
-    layer_info = (record.get("layers") or {}).get(layer, {})
-    validation = (record.get("validations") or {}).get(layer, {})
-    validation_passed = validation.get("passed")
-    return (
-        f"{layer:<5} "
-        f"{str(layer_info.get('status', 'PENDING')):<20} "
-        f"{str(validation_passed):<17} "
-        f"{str(validation.get('errors_count', 0)):<12} "
-        f"{str(validation.get('warnings_count', 0)):<14}"
-    )
 
 
 def _read_json(path: Path) -> dict[str, object] | None:
@@ -32,14 +20,13 @@ def _read_json(path: Path) -> dict[str, object] | None:
         return None
 
 
-def _raw_hints(root: Path, dataset: str, year: int) -> dict[str, object]:
+def _raw_hints(root: Path, dataset: str, year: int) -> dict[str, Any]:
     raw_dir = layer_year_dir(root, "raw", dataset, year)
-    raw_manifest = _read_json(raw_dir / "manifest.json") or {}
-    raw_metadata = _read_json(raw_dir / "metadata.json") or {}
-    profile_hints = raw_metadata.get("profile_hints") or {}
+    raw_meta = read_layer_metadata(raw_dir)
+    profile_hints = raw_meta.get("profile_hints") or {}
     suggested_read_path = raw_dir / "_profile" / "suggested_read.yml"
     return {
-        "primary_output_file": raw_manifest.get("primary_output_file"),
+        "primary_output_file": raw_meta.get("primary_output_file"),
         "suggested_read_exists": suggested_read_path.exists(),
         "suggested_read_path": str(suggested_read_path),
         "encoding": profile_hints.get("encoding_suggested"),
@@ -58,7 +45,7 @@ def _layer_artifacts_dir(root: Path, dataset: str, year: int, layer: str) -> Pat
 
 def _validation_counts(
     validation_payload: dict[str, Any] | None,
-    manifest_payload: dict[str, Any] | None,
+    meta_payload: dict[str, Any] | None,
     record_summary: dict[str, Any] | None,
 ) -> tuple[bool | None, int | None, int | None]:
     if validation_payload is not None:
@@ -68,12 +55,12 @@ def _validation_counts(
             len(validation_payload.get("warnings") or []),
         )
 
-    manifest_summary = (manifest_payload or {}).get("summary") or {}
-    if manifest_summary:
+    summary = (meta_payload or {}).get("summary") or {}
+    if summary:
         return (
-            manifest_summary.get("ok"),
-            manifest_summary.get("errors_count"),
-            manifest_summary.get("warnings_count"),
+            summary.get("ok"),
+            summary.get("errors_count"),
+            summary.get("warnings_count"),
         )
 
     record_summary = record_summary or {}
@@ -95,8 +82,8 @@ def _layer_validation_summary(
     record: dict[str, Any],
 ) -> dict[str, Any] | None:
     layer_dir = _layer_artifacts_dir(root, dataset, year, layer)
-    manifest_payload = _read_json(layer_dir / "manifest.json")
-    validation_rel = (manifest_payload or {}).get("validation")
+    meta_payload = read_layer_metadata(layer_dir)
+    validation_rel = meta_payload.get("validation")
     validation_payload = None
     validation_path = None
     if isinstance(validation_rel, str) and validation_rel.strip():
@@ -106,13 +93,13 @@ def _layer_validation_summary(
     record_summary = (record.get("validations") or {}).get(layer, {})
     ok, errors_count, warnings_count = _validation_counts(
         validation_payload,
-        manifest_payload,
+        meta_payload,
         record_summary if isinstance(record_summary, dict) else {},
     )
 
     has_any_data = any(
         [
-            manifest_payload is not None,
+            meta_payload is not None,
             validation_payload is not None,
             bool(record_summary),
             layer_dir.exists(),
@@ -131,7 +118,7 @@ def _layer_validation_summary(
     if validation_path is not None and validation_payload is None:
         details.append(f"validation_missing={validation_path.name}")
 
-    outputs = (manifest_payload or {}).get("outputs") or []
+    outputs = meta_payload.get("outputs") or []
     if isinstance(outputs, list):
         missing_outputs = []
         for entry in outputs:
@@ -167,7 +154,7 @@ def _layer_validation_summary(
         state = "passed"
     elif ok is False:
         state = "failed"
-    elif manifest_payload is not None:
+    elif meta_payload is not None:
         state = "not_validated"
     else:
         state = "unknown"
@@ -304,7 +291,16 @@ def status(
     typer.echo("")
     typer.echo("layer layer_status         validation_passed errors_count warnings_count")
     for layer in ("raw", "clean", "mart"):
-        typer.echo(_layer_row(record, layer))
+        layer_info = (record.get("layers") or {}).get(layer, {})
+        validation = (record.get("validations") or {}).get(layer, {})
+        validation_passed = validation.get("passed")
+        typer.echo(
+            f"{layer:<5} "
+            f"{str(layer_info.get('status', 'PENDING')):<20} "
+            f"{str(validation_passed):<17} "
+            f"{str(validation.get('errors_count', 0)):<12} "
+            f"{str(validation.get('warnings_count', 0)):<14}"
+        )
     _print_validation_summary(Path(cfg.root), dataset, year, record, has_cross_year)
     _print_layer_profiles(Path(cfg.root), dataset, year)
 

--- a/toolkit/core/manifest.py
+++ b/toolkit/core/manifest.py
@@ -4,11 +4,44 @@ from pathlib import Path
 from typing import Any
 
 from toolkit.core.io import read_json, write_json_atomic
+from toolkit.core.metadata import _read_metadata, merge_layer_manifest
 
 
 def write_raw_manifest(folder: Path, payload: dict[str, Any]) -> Path:
     path = folder / "manifest.json"
     write_json_atomic(path, payload)
+
+    outputs = payload.get("outputs")
+    summary = payload.get("summary")
+    validation = payload.get("validation")
+    ok = summary.get("ok") if isinstance(summary, dict) else None
+    errors_count = summary.get("errors_count") if isinstance(summary, dict) else None
+    warnings_count = summary.get("warnings_count") if isinstance(summary, dict) else None
+
+    merge_layer_manifest(
+        folder,
+        metadata_path="metadata.json",
+        validation_path=validation,
+        outputs=outputs,
+        ok=ok,
+        errors_count=errors_count,
+        warnings_count=warnings_count,
+    )
+
+    primary_output_file = payload.get("primary_output_file")
+    sources = payload.get("sources")
+    if primary_output_file or sources:
+        meta = _read_metadata(folder) or {}
+        changed = False
+        if primary_output_file and not meta.get("primary_output_file"):
+            meta["primary_output_file"] = primary_output_file
+            changed = True
+        if sources and not meta.get("sources"):
+            meta["sources"] = sources
+            changed = True
+        if changed:
+            write_json_atomic(folder / "metadata.json", meta)
+
     return path
 
 

--- a/toolkit/core/manifest.py
+++ b/toolkit/core/manifest.py
@@ -4,43 +4,25 @@ from pathlib import Path
 from typing import Any
 
 from toolkit.core.io import read_json, write_json_atomic
-from toolkit.core.metadata import _read_metadata, merge_layer_manifest
+from toolkit.core.metadata import merge_layer_manifest
 
 
 def write_raw_manifest(folder: Path, payload: dict[str, Any]) -> Path:
     path = folder / "manifest.json"
     write_json_atomic(path, payload)
 
-    outputs = payload.get("outputs")
     summary = payload.get("summary")
-    validation = payload.get("validation")
-    ok = summary.get("ok") if isinstance(summary, dict) else None
-    errors_count = summary.get("errors_count") if isinstance(summary, dict) else None
-    warnings_count = summary.get("warnings_count") if isinstance(summary, dict) else None
-
     merge_layer_manifest(
         folder,
         metadata_path="metadata.json",
-        validation_path=validation,
-        outputs=outputs,
-        ok=ok,
-        errors_count=errors_count,
-        warnings_count=warnings_count,
+        validation_path=payload.get("validation"),
+        outputs=payload.get("outputs"),
+        ok=summary.get("ok") if isinstance(summary, dict) else None,
+        errors_count=summary.get("errors_count") if isinstance(summary, dict) else None,
+        warnings_count=summary.get("warnings_count") if isinstance(summary, dict) else None,
+        primary_output_file=payload.get("primary_output_file"),
+        sources=payload.get("sources"),
     )
-
-    primary_output_file = payload.get("primary_output_file")
-    sources = payload.get("sources")
-    if primary_output_file or sources:
-        meta = _read_metadata(folder) or {}
-        changed = False
-        if primary_output_file and not meta.get("primary_output_file"):
-            meta["primary_output_file"] = primary_output_file
-            changed = True
-        if sources and not meta.get("sources"):
-            meta["sources"] = sources
-            changed = True
-        if changed:
-            write_json_atomic(folder / "metadata.json", meta)
 
     return path
 

--- a/toolkit/core/metadata.py
+++ b/toolkit/core/metadata.py
@@ -131,6 +131,8 @@ def merge_layer_manifest(
     ok: bool | None = None,
     errors_count: int | None = None,
     warnings_count: int | None = None,
+    primary_output_file: str | None = None,
+    sources: list[Any] | None = None,
 ) -> Path:
     meta = _read_metadata(folder, metadata_path) or {}
     if outputs is not None:
@@ -138,11 +140,18 @@ def merge_layer_manifest(
     if validation_path is not None:
         meta["validation"] = validation_path
     if ok is not None or errors_count is not None or warnings_count is not None:
-        meta["summary"] = {
-            "ok": ok,
-            "errors_count": errors_count,
-            "warnings_count": warnings_count,
-        }
+        summary: dict[str, Any] = {}
+        if ok is not None:
+            summary["ok"] = ok
+        if errors_count is not None:
+            summary["errors_count"] = errors_count
+        if warnings_count is not None:
+            summary["warnings_count"] = warnings_count
+        meta["summary"] = summary
+    if primary_output_file and not meta.get("primary_output_file"):
+        meta["primary_output_file"] = primary_output_file
+    if sources and not meta.get("sources"):
+        meta["sources"] = sources
     out = folder / metadata_path
     write_json_atomic(out, meta)
     return out

--- a/toolkit/core/metadata.py
+++ b/toolkit/core/metadata.py
@@ -46,7 +46,11 @@ def config_hash_for_year(base_dir: Path | None, year: int) -> str | None:
     return None
 
 
-def write_metadata(folder: Path, data: dict[str, Any], filename: str = "metadata.json") -> Path:
+def write_metadata(
+    folder: Path,
+    data: dict[str, Any],
+    filename: str = "metadata.json",
+) -> Path:
     meta = {
         "metadata_schema_version": 1,
         "timestamp_utc": datetime.now(timezone.utc).isoformat(),
@@ -60,16 +64,122 @@ def write_metadata(folder: Path, data: dict[str, Any], filename: str = "metadata
     return out
 
 
+def _read_metadata(folder: Path, filename: str = "metadata.json") -> dict[str, Any] | None:
+    path = folder / filename
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def read_layer_metadata(layer_dir: Path) -> dict[str, Any]:
+    """
+    Read layer metadata as the canonical source, with fallback to manifest.json
+    for fields that may not yet be migrated.
+
+    Migration path:
+    - metadata.json is the source of truth for: outputs, validation, summary,
+      primary_output_file (raw), sources (raw), and all standard metadata fields
+    - manifest.json is kept as a compat alias on write and as a fallback for
+      read when metadata.json does not yet contain the field
+    """
+    meta = _read_metadata(layer_dir) or {}
+
+    manifest = None
+    if not meta.get("primary_output_file"):
+        manifest = _read_json(layer_dir / "manifest.json") if manifest is None else manifest
+        pof = manifest.get("primary_output_file") if manifest else None
+        if isinstance(pof, str):
+            meta["primary_output_file"] = pof
+
+    if not meta.get("outputs"):
+        manifest = _read_json(layer_dir / "manifest.json") if manifest is None else manifest
+        outputs = manifest.get("outputs") if manifest else None
+        if isinstance(outputs, list):
+            meta["outputs"] = outputs
+
+    if not meta.get("summary"):
+        manifest = _read_json(layer_dir / "manifest.json") if manifest is None else manifest
+        summary = manifest.get("summary") if manifest else None
+        if isinstance(summary, dict):
+            meta["summary"] = summary
+
+    if not meta.get("validation"):
+        manifest = _read_json(layer_dir / "manifest.json") if manifest is None else manifest
+        validation = manifest.get("validation") if manifest else None
+        if isinstance(validation, str):
+            meta["validation"] = validation
+
+    return meta
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def merge_layer_manifest(
+    folder: Path,
+    *,
+    metadata_path: str = "metadata.json",
+    validation_path: str | None = None,
+    outputs: list[dict[str, Any]] | None = None,
+    ok: bool | None = None,
+    errors_count: int | None = None,
+    warnings_count: int | None = None,
+) -> Path:
+    meta = _read_metadata(folder, metadata_path) or {}
+    if outputs is not None:
+        meta["outputs"] = outputs
+    if validation_path is not None:
+        meta["validation"] = validation_path
+    if ok is not None or errors_count is not None or warnings_count is not None:
+        meta["summary"] = {
+            "ok": ok,
+            "errors_count": errors_count,
+            "warnings_count": warnings_count,
+        }
+    out = folder / metadata_path
+    write_json_atomic(out, meta)
+    return out
+
+
 def write_layer_manifest(
     folder: Path,
     *,
+    metadata_path: str = "metadata.json",
+    validation_path: str | None = None,
+    outputs: list[dict[str, Any]] | None = None,
+    ok: bool | None = None,
+    errors_count: int | None = None,
+    warnings_count: int | None = None,
+    filename: str = "manifest.json",
+) -> Path:
+    merge_layer_manifest(
+        folder,
+        metadata_path=metadata_path,
+        validation_path=validation_path,
+        outputs=outputs,
+        ok=ok,
+        errors_count=errors_count,
+        warnings_count=warnings_count,
+    )
+    return write_manifest_alias(folder, filename, metadata_path, validation_path, outputs, ok, errors_count, warnings_count)
+
+
+def write_manifest_alias(
+    folder: Path,
+    filename: str,
     metadata_path: str,
     validation_path: str | None,
-    outputs: list[dict[str, Any]],
+    outputs: list[dict[str, Any]] | None,
     ok: bool | None,
     errors_count: int | None,
     warnings_count: int | None,
-    filename: str = "manifest.json",
 ) -> Path:
     payload = {
         "metadata": metadata_path,
@@ -81,7 +191,6 @@ def write_layer_manifest(
         },
         "outputs": outputs,
     }
-
     out = folder / filename
     write_json_atomic(out, payload)
     return out


### PR DESCRIPTION
Closes #143 

## Sintesi

Questa PR chiude `#143` promuovendo `metadata.json` a source of truth canonico per gli artifact layer-level, senza introdurre nuovi file e mantenendo `manifest.json` come alias di compatibilita'.

## Cosa cambia

- `metadata.json` contiene ora anche i campi operativi usati dai consumer:
  - `outputs`
  - `validation`
  - `summary`
- per il layer `raw`, `metadata.json` include anche:
  - `primary_output_file`
  - `sources`
- `manifest.json` continua a essere scritto, ma resta solo compat di scrittura e fallback di lettura
- `status`, `inspect` e `resume` usano un helper canonico unico per leggere i metadata layer-level con fallback al manifest

## Risultato

- `metadata.json` diventa il file canonico per tutti i layer (`raw`, `clean`, `mart`, `cross`)
- `manifest.json` non e' piu' una seconda fonte di verita'
- nessun nuovo artifact introdotto
- zero duplicazione della logica di merge nei CLI

## Verifica

- `364` test passano
