### PR TITLE
refactor(clean): separare responsabilità in duckdb_read.py

### DIFF
--- a/tests/test_clean_csv_columns.py
+++ b/tests/test_clean_csv_columns.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import duckdb
 import pytest
 
-from toolkit.clean.duckdb_read import (
+from toolkit.clean.read_csv_normalized import (
     _execute_normalized_csv_read,
     _load_normalized_csv_frame,
 )

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -2,7 +2,7 @@ import toolkit.clean as clean_pkg
 import toolkit.plugins as plugins_pkg
 import toolkit.profile as profile_pkg
 import toolkit.raw as raw_pkg
-from toolkit.clean import resolve_clean_read_cfg, run_clean, run_clean_validation, validate_clean
+from toolkit.clean import run_clean, run_clean_validation, validate_clean
 from toolkit.plugins import CkanSource, HttpFileSource, LocalFileSource, SdmxSource
 from toolkit.profile import (
     RawProfile,

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -2,7 +2,7 @@ import toolkit.clean as clean_pkg
 import toolkit.plugins as plugins_pkg
 import toolkit.profile as profile_pkg
 import toolkit.raw as raw_pkg
-from toolkit.clean import run_clean, run_clean_validation, validate_clean
+from toolkit.clean import resolve_clean_read_cfg, run_clean, run_clean_validation, validate_clean
 from toolkit.plugins import CkanSource, HttpFileSource, LocalFileSource, SdmxSource
 from toolkit.profile import (
     RawProfile,
@@ -16,7 +16,13 @@ from toolkit.raw import run_raw, run_raw_validation, validate_raw_output
 
 
 def test_clean_exports() -> None:
-    assert clean_pkg.__all__ == ["run_clean", "validate_clean", "run_clean_validation"]
+    assert clean_pkg.__all__ == [
+        "resolve_clean_read_cfg",
+        "run_clean",
+        "validate_clean",
+        "run_clean_validation",
+    ]
+    assert callable(clean_pkg.resolve_clean_read_cfg)
     assert callable(run_clean)
     assert callable(validate_clean)
     assert callable(run_clean_validation)

--- a/toolkit/clean/__init__.py
+++ b/toolkit/clean/__init__.py
@@ -1,9 +1,11 @@
 """Public clean-layer API."""
 
+from toolkit.clean.duckdb_read import resolve_clean_read_cfg
 from toolkit.clean.run import run_clean
 from toolkit.clean.validate import run_clean_validation, validate_clean
 
 __all__ = [
+    "resolve_clean_read_cfg",
     "run_clean",
     "validate_clean",
     "run_clean_validation",

--- a/toolkit/clean/duckdb_read.py
+++ b/toolkit/clean/duckdb_read.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import csv
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,9 +15,9 @@ from toolkit.clean.read_config import (
     load_suggested_read,
     resolve_clean_read_cfg,
 )
+from toolkit.clean.read_csv_normalized import _execute_normalized_csv_read
 from toolkit.core.csv_read import (
     csv_read_option_strings,
-    normalize_encoding,
     normalize_read_cfg,
     robust_preset,
 )
@@ -170,92 +169,6 @@ def _execute_csv_read(
             f"CREATE OR REPLACE VIEW raw_input AS SELECT * FROM read_csv([{paths}], {opt_sql});"
         )
     params_used["trim_whitespace"] = bool(trim_whitespace)
-    return params_used
-
-
-def _normalized_csv_reader_kwargs(read_cfg: dict[str, Any]) -> dict[str, Any]:
-    kwargs: dict[str, Any] = {
-        "delimiter": read_cfg.get("delim") or ",",
-    }
-    quote = read_cfg.get("quote")
-    if quote is not None:
-        kwargs["quotechar"] = quote
-    escape = read_cfg.get("escape")
-    if escape is not None:
-        kwargs["escapechar"] = escape
-    return kwargs
-
-
-def _load_normalized_csv_frame(
-    input_file: Path,
-    read_cfg: dict[str, Any],
-    columns: dict[str, str],
-) -> pd.DataFrame:
-    encoding = normalize_encoding(read_cfg.get("encoding")) or "utf-8"
-    trim_whitespace = bool(read_cfg.get("trim_whitespace", True))
-    header = bool(read_cfg.get("header", True))
-    skip = int(read_cfg.get("skip") or 0)
-    expected_names = list(columns.keys())
-    expected_len = len(expected_names)
-    skip_rows = skip + (1 if header else 0)
-
-    rows: list[list[Any]] = []
-    with input_file.open("r", encoding=encoding, newline="") as handle:
-        reader = csv.reader(handle, **_normalized_csv_reader_kwargs(read_cfg))
-        for _ in range(skip_rows):
-            try:
-                next(reader)
-            except StopIteration:
-                break
-        for row_number, row in enumerate(reader, start=skip_rows + 1):
-            if len(row) > expected_len:
-                raise ValueError(
-                    "CSV row wider than configured columns while normalize_rows_to_columns=true. "
-                    f"file={input_file} row={row_number} configured={expected_len} actual={len(row)}"
-                )
-            if len(row) < expected_len:
-                row = list(row) + [""] * (expected_len - len(row))
-            else:
-                row = list(row)
-            if trim_whitespace:
-                row = [value.strip() if isinstance(value, str) else value for value in row]
-            rows.append(row)
-
-    return pd.DataFrame(rows, columns=expected_names)
-
-
-def _execute_normalized_csv_read(
-    con: duckdb.DuckDBPyConnection,
-    input_files: list[Path],
-    read_cfg: dict[str, Any],
-) -> dict[str, Any]:
-    columns = read_cfg.get("columns")
-    if not columns:
-        raise ValueError("clean.read.normalize_rows_to_columns=true requires clean.read.columns")
-
-    frames = [
-        _load_normalized_csv_frame(input_file, read_cfg, columns) for input_file in input_files
-    ]
-    combined = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
-    con.register("raw_input_df", combined)
-    con.execute("CREATE OR REPLACE VIEW raw_input AS SELECT * FROM raw_input_df;")
-
-    params_used: dict[str, Any] = {
-        "columns": dict(columns),
-        "normalize_rows_to_columns": True,
-        "trim_whitespace": bool(read_cfg.get("trim_whitespace", True)),
-        "header": bool(read_cfg.get("header", True)),
-    }
-    if read_cfg.get("delim") is not None:
-        params_used["delim"] = read_cfg.get("delim")
-    if read_cfg.get("encoding") is not None:
-        params_used["encoding"] = normalize_encoding(read_cfg.get("encoding"))
-    if read_cfg.get("skip") is not None:
-        params_used["skip"] = int(read_cfg.get("skip"))
-    if read_cfg.get("quote") is not None:
-        params_used["quote"] = read_cfg.get("quote")
-    if read_cfg.get("escape") is not None:
-        params_used["escape"] = read_cfg.get("escape")
     return params_used
 
 

--- a/toolkit/clean/duckdb_read.py
+++ b/toolkit/clean/duckdb_read.py
@@ -16,6 +16,13 @@ from toolkit.clean.read_config import (
     resolve_clean_read_cfg,
 )
 from toolkit.clean.read_csv_normalized import _execute_normalized_csv_read
+from toolkit.clean.read_sql_utils import (
+    csv_trim_projection,
+    q_ident,
+    quote_list,
+    sql_path,
+)
+from toolkit.clean.read_excel import _execute_excel_read
 from toolkit.core.csv_read import (
     csv_read_option_strings,
     normalize_read_cfg,
@@ -43,31 +50,6 @@ class ReadInfo:
 
 
 
-
-
-def q_ident(name: str) -> str:
-    return '"' + name.replace('"', '""') + '"'
-
-
-def sql_path(p: Path) -> str:
-    s = p.resolve().as_posix()
-    return s.replace("'", "''")
-
-
-def quote_list(paths: list[Path]) -> str:
-    return ", ".join([f"'{sql_path(p)}'" for p in paths])
-
-
-def csv_trim_projection(columns: dict[str, str]) -> str:
-    exprs: list[str] = []
-    for name, dtype in columns.items():
-        qname = q_ident(name)
-        dtype_upper = dtype.upper()
-        if "CHAR" in dtype_upper or "TEXT" in dtype_upper or "STRING" in dtype_upper:
-            exprs.append(f"TRIM({qname}, ' \t\r\n') AS {qname}")
-        else:
-            exprs.append(qname)
-    return ", ".join(exprs)
 
 
 def _csv_read_options(
@@ -186,99 +168,6 @@ def _execute_parquet_read(
     return ReadInfo(source="parquet", params_used={})
 
 
-def _normalize_excel_sheet_name(value: Any) -> str | int:
-    if value is None:
-        return 0
-    if isinstance(value, bool):
-        raise ValueError("clean.read.sheet_name must be a string, integer, or null")
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            return 0
-        return text
-    raise ValueError("clean.read.sheet_name must be a string, integer, or null")
-
-
-def _trim_excel_dataframe(df: pd.DataFrame) -> pd.DataFrame:
-    return df.apply(
-        lambda column: column.map(lambda value: value.strip() if isinstance(value, str) else value)
-    )
-
-
-def _load_excel_frame(
-    input_file: Path,
-    read_cfg: dict[str, Any],
-) -> tuple[pd.DataFrame, dict[str, Any]]:
-    header = bool(read_cfg.get("header", True))
-    skip = int(read_cfg["skip"]) if read_cfg.get("skip") is not None else 0
-    trim_whitespace = read_cfg.get("trim_whitespace", True)
-    columns = read_cfg.get("columns")
-    sheet_name = _normalize_excel_sheet_name(read_cfg.get("sheet_name"))
-
-    df = pd.read_excel(
-        input_file,
-        sheet_name=sheet_name,
-        header=0 if header else None,
-        skiprows=skip,
-        dtype=object,
-        engine="openpyxl",
-    )
-
-    if columns:
-        expected_columns = list(columns.keys())
-        if len(expected_columns) != len(df.columns):
-            raise ValueError(
-                "Excel input columns mismatch. "
-                f"Configured={len(expected_columns)} detected={len(df.columns)} file={input_file}"
-            )
-        df.columns = expected_columns
-    elif not header:
-        df.columns = [f"col{i}" for i in range(len(df.columns))]
-
-    if trim_whitespace:
-        df = _trim_excel_dataframe(df)
-
-    return df, {
-        "sheet_name": sheet_name,
-        "header": header,
-        "skip": skip,
-        "trim_whitespace": bool(trim_whitespace),
-        "columns": dict(columns) if columns else None,
-    }
-
-
-def _execute_excel_read(
-    con: duckdb.DuckDBPyConnection,
-    input_files: list[Path],
-    read_cfg: dict[str, Any],
-    *,
-    logger,
-) -> ReadInfo:
-    frames: list[pd.DataFrame] = []
-    params_used: dict[str, Any] | None = None
-
-    for input_file in input_files:
-        frame, frame_params = _load_excel_frame(input_file, read_cfg)
-        frames.append(frame)
-        if params_used is None:
-            params_used = frame_params
-
-    combined = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
-    con.register("raw_input_df", combined)
-    con.execute("CREATE OR REPLACE VIEW raw_input AS SELECT * FROM raw_input_df;")
-
-    used = dict(params_used or {})
-    if used.get("columns") is None:
-        used.pop("columns", None)
-    logger.info(
-        "read_excel params used: source=excel params=%s",
-        json.dumps(used, ensure_ascii=False, sort_keys=True),
-    )
-    return ReadInfo(source="excel", params_used=used)
-
-
 def _validate_read_mode(mode: str) -> str:
     normalized_mode = str(mode or "fallback")
     if normalized_mode not in {"strict", "fallback", "robust"}:
@@ -389,7 +278,8 @@ def read_raw_to_relation(
         logger.info("read_csv params used: source=parquet params={}")
         return info
     if exts <= {".xlsx"}:
-        return _execute_excel_read(con, input_files, read_cfg, logger=logger)
+        result = _execute_excel_read(con, input_files, read_cfg, logger=logger)
+        return ReadInfo(source=result["source"], params_used=result["params_used"])
 
     normalized_mode = _validate_read_mode(mode)
     return _read_csv_relation(

--- a/toolkit/clean/duckdb_read.py
+++ b/toolkit/clean/duckdb_read.py
@@ -9,12 +9,15 @@ from typing import Any
 import duckdb
 import pandas as pd
 import yaml
+from toolkit.clean.read_config import (
+    _read_source_mode,
+    _split_read_cfg,
+    filter_suggested_read,
+    load_suggested_read,
+    resolve_clean_read_cfg,
+)
 from toolkit.core.csv_read import (
-    READ_SELECTION_KEYS,
-    READ_SOURCE_MODES,
     csv_read_option_strings,
-    filter_suggested_format_keys,
-    merge_read_cfg,
     normalize_encoding,
     normalize_read_cfg,
     robust_preset,
@@ -40,83 +43,7 @@ class ReadInfo:
     params_used: dict[str, Any]
 
 
-def _read_source_mode(clean_cfg: dict[str, Any], logger=None) -> tuple[str, dict[str, Any]]:
-    raw_read_cfg = clean_cfg.get("read")
-    read_source = clean_cfg.get("read_source")
-    explicit_cfg: dict[str, Any] = {}
 
-    if raw_read_cfg is None:
-        pass
-    elif isinstance(raw_read_cfg, dict):
-        explicit_cfg = dict(raw_read_cfg)
-        nested_source = explicit_cfg.pop("source", None)
-        if nested_source is not None:
-            read_source = nested_source
-    else:
-        raise ValueError("clean.read must be a mapping (dict)")
-
-    normalized_source = str(read_source or "auto")
-    if normalized_source not in READ_SOURCE_MODES:
-        raise ValueError("clean.read source must be one of: auto, config_only")
-
-    return normalized_source, explicit_cfg
-
-
-def _split_read_cfg(explicit_cfg: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
-    selection_cfg = dict(explicit_cfg)
-    relation_overrides = {
-        key: value for key, value in explicit_cfg.items() if key not in READ_SELECTION_KEYS
-    }
-    return selection_cfg, relation_overrides
-
-
-def load_suggested_read(raw_year_dir: Path) -> dict[str, Any] | None:
-    suggested_path = raw_year_dir / "_profile" / "suggested_read.yml"
-    if not suggested_path.exists():
-        return None
-
-    payload = yaml.safe_load(suggested_path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        return None
-
-    clean_cfg = payload.get("clean")
-    if not isinstance(clean_cfg, dict):
-        return None
-
-    read_cfg = clean_cfg.get("read")
-    if not isinstance(read_cfg, dict):
-        return None
-
-    return dict(read_cfg)
-
-
-def filter_suggested_read(cfg: dict[str, Any] | None) -> dict[str, Any]:
-    return filter_suggested_format_keys(cfg)
-
-
-def resolve_clean_read_cfg(
-    raw_year_dir: Path,
-    clean_cfg: dict[str, Any],
-    logger=None,
-) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
-    normalized_source, explicit_cfg = _read_source_mode(clean_cfg, logger)
-    selection_cfg, relation_overrides = _split_read_cfg(explicit_cfg)
-
-    suggested_cfg = load_suggested_read(raw_year_dir)
-    filtered_suggested = filter_suggested_read(suggested_cfg)
-    if normalized_source == "auto" and filtered_suggested and logger is not None:
-        logger.info(
-            "CLEAN read hints loaded from suggested_read.yml: %s",
-            json.dumps(filtered_suggested, ensure_ascii=False, sort_keys=True),
-        )
-
-    merged_relation_cfg, params_source = merge_read_cfg(
-        source=normalized_source,
-        suggested=suggested_cfg,
-        overrides=relation_overrides,
-    )
-
-    return selection_cfg, merged_relation_cfg, params_source
 
 
 def q_ident(name: str) -> str:

--- a/toolkit/clean/duckdb_read.py
+++ b/toolkit/clean/duckdb_read.py
@@ -6,15 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import duckdb
-import pandas as pd
-import yaml
-from toolkit.clean.read_config import (
-    _read_source_mode,
-    _split_read_cfg,
-    filter_suggested_read,
-    load_suggested_read,
-    resolve_clean_read_cfg,
-)
+from toolkit.clean.read_config import resolve_clean_read_cfg as _resolve_clean_read_cfg
 from toolkit.clean.read_csv_normalized import _execute_normalized_csv_read
 from toolkit.clean.read_sql_utils import (
     csv_trim_projection,
@@ -22,12 +14,16 @@ from toolkit.clean.read_sql_utils import (
     quote_list,
     sql_path,
 )
+
 from toolkit.clean.read_excel import _execute_excel_read
 from toolkit.core.csv_read import (
     csv_read_option_strings,
     normalize_read_cfg,
     robust_preset,
 )
+
+# Re-exported for backward compat — consumers import resolve_clean_read_cfg from duckdb_read
+resolve_clean_read_cfg = _resolve_clean_read_cfg
 
 
 SUPPORTED_INPUT_EXTS = {

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -20,8 +20,6 @@ from toolkit.core.csv_read import (
     READ_SOURCE_MODES,
     filter_suggested_format_keys,
     merge_read_cfg,
-    normalize_encoding,
-    normalize_read_cfg,
 )
 
 

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -1,0 +1,104 @@
+"""Clean read configuration resolution.
+
+Responsible for resolving clean.read contract from:
+- explicit clean.read config
+- suggested_read.yml hints from raw profiling
+- merging and normalising into a unified read config
+
+Does NOT handle runtime read execution (see duckdb_read.py).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+from toolkit.core.csv_read import (
+    READ_SELECTION_KEYS,
+    READ_SOURCE_MODES,
+    filter_suggested_format_keys,
+    merge_read_cfg,
+    normalize_encoding,
+    normalize_read_cfg,
+)
+
+
+def _read_source_mode(clean_cfg: dict[str, Any], logger=None) -> tuple[str, dict[str, Any]]:
+    raw_read_cfg = clean_cfg.get("read")
+    read_source = clean_cfg.get("read_source")
+    explicit_cfg: dict[str, Any] = {}
+
+    if raw_read_cfg is None:
+        pass
+    elif isinstance(raw_read_cfg, dict):
+        explicit_cfg = dict(raw_read_cfg)
+        nested_source = explicit_cfg.pop("source", None)
+        if nested_source is not None:
+            read_source = nested_source
+    else:
+        raise ValueError("clean.read must be a mapping (dict)")
+
+    normalized_source = str(read_source or "auto")
+    if normalized_source not in READ_SOURCE_MODES:
+        raise ValueError("clean.read source must be one of: auto, config_only")
+
+    return normalized_source, explicit_cfg
+
+
+def _split_read_cfg(explicit_cfg: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    selection_cfg = dict(explicit_cfg)
+    relation_overrides = {
+        key: value for key, value in explicit_cfg.items() if key not in READ_SELECTION_KEYS
+    }
+    return selection_cfg, relation_overrides
+
+
+def load_suggested_read(raw_year_dir: Path) -> dict[str, Any] | None:
+    suggested_path = raw_year_dir / "_profile" / "suggested_read.yml"
+    if not suggested_path.exists():
+        return None
+
+    payload = yaml.safe_load(suggested_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return None
+
+    clean_cfg = payload.get("clean")
+    if not isinstance(clean_cfg, dict):
+        return None
+
+    read_cfg = clean_cfg.get("read")
+    if not isinstance(read_cfg, dict):
+        return None
+
+    return dict(read_cfg)
+
+
+def filter_suggested_read(cfg: dict[str, Any] | None) -> dict[str, Any]:
+    return filter_suggested_format_keys(cfg)
+
+
+def resolve_clean_read_cfg(
+    raw_year_dir: Path,
+    clean_cfg: dict[str, Any],
+    logger=None,
+) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    normalized_source, explicit_cfg = _read_source_mode(clean_cfg, logger)
+    selection_cfg, relation_overrides = _split_read_cfg(explicit_cfg)
+
+    suggested_cfg = load_suggested_read(raw_year_dir)
+    filtered_suggested = filter_suggested_read(suggested_cfg)
+    if normalized_source == "auto" and filtered_suggested and logger is not None:
+        logger.info(
+            "CLEAN read hints loaded from suggested_read.yml: %s",
+            json.dumps(filtered_suggested, ensure_ascii=False, sort_keys=True),
+        )
+
+    merged_relation_cfg, params_source = merge_read_cfg(
+        source=normalized_source,
+        suggested=suggested_cfg,
+        overrides=relation_overrides,
+    )
+
+    return selection_cfg, merged_relation_cfg, params_source

--- a/toolkit/clean/read_csv_normalized.py
+++ b/toolkit/clean/read_csv_normalized.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from toolkit.core.csv_read import normalize_encoding
+
+
+def _normalized_csv_reader_kwargs(read_cfg: dict[str, Any]) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "delimiter": read_cfg.get("delim") or ",",
+    }
+    quote = read_cfg.get("quote")
+    if quote is not None:
+        kwargs["quotechar"] = quote
+    escape = read_cfg.get("escape")
+    if escape is not None:
+        kwargs["escapechar"] = escape
+    return kwargs
+
+
+def _load_normalized_csv_frame(
+    input_file: Path,
+    read_cfg: dict[str, Any],
+    columns: dict[str, str],
+) -> pd.DataFrame:
+    encoding = normalize_encoding(read_cfg.get("encoding")) or "utf-8"
+    trim_whitespace = bool(read_cfg.get("trim_whitespace", True))
+    header = bool(read_cfg.get("header", True))
+    skip = int(read_cfg.get("skip") or 0)
+    expected_names = list(columns.keys())
+    expected_len = len(expected_names)
+    skip_rows = skip + (1 if header else 0)
+
+    rows: list[list[Any]] = []
+    with input_file.open("r", encoding=encoding, newline="") as handle:
+        reader = csv.reader(handle, **_normalized_csv_reader_kwargs(read_cfg))
+        for _ in range(skip_rows):
+            try:
+                next(reader)
+            except StopIteration:
+                break
+        for row_number, row in enumerate(reader, start=skip_rows + 1):
+            if len(row) > expected_len:
+                raise ValueError(
+                    "CSV row wider than configured columns while normalize_rows_to_columns=true. "
+                    f"file={input_file} row={row_number} configured={expected_len} actual={len(row)}"
+                )
+            if len(row) < expected_len:
+                row = list(row) + [""] * (expected_len - len(row))
+            else:
+                row = list(row)
+            if trim_whitespace:
+                row = [value.strip() if isinstance(value, str) else value for value in row]
+            rows.append(row)
+
+    return pd.DataFrame(rows, columns=expected_names)
+
+
+def _execute_normalized_csv_read(
+    con,
+    input_files: list[Path],
+    read_cfg: dict[str, Any],
+) -> dict[str, Any]:
+    """Execute CSV read with normalize_rows_to_columns=true.
+
+    Reads each input file with the CSV reader into a pandas DataFrame,
+    concatenates if multiple files, registers as DuckDB view ``raw_input``.
+    """
+    import duckdb
+
+    columns = read_cfg.get("columns")
+    if not columns:
+        raise ValueError("clean.read.normalize_rows_to_columns=true requires clean.read.columns")
+
+    frames = [
+        _load_normalized_csv_frame(input_file, read_cfg, columns) for input_file in input_files
+    ]
+    combined = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
+    con.register("raw_input_df", combined)
+    con.execute("CREATE OR REPLACE VIEW raw_input AS SELECT * FROM raw_input_df;")
+
+    params_used: dict[str, Any] = {
+        "columns": dict(columns),
+        "normalize_rows_to_columns": True,
+        "trim_whitespace": bool(read_cfg.get("trim_whitespace", True)),
+        "header": bool(read_cfg.get("header", True)),
+    }
+    if read_cfg.get("delim") is not None:
+        params_used["delim"] = read_cfg.get("delim")
+    if read_cfg.get("encoding") is not None:
+        params_used["encoding"] = normalize_encoding(read_cfg.get("encoding"))
+    if read_cfg.get("skip") is not None:
+        params_used["skip"] = int(read_cfg.get("skip"))
+    if read_cfg.get("quote") is not None:
+        params_used["quote"] = read_cfg.get("quote")
+    if read_cfg.get("escape") is not None:
+        params_used["escape"] = read_cfg.get("escape")
+    return params_used

--- a/toolkit/clean/read_csv_normalized.py
+++ b/toolkit/clean/read_csv_normalized.py
@@ -70,7 +70,6 @@ def _execute_normalized_csv_read(
     Reads each input file with the CSV reader into a pandas DataFrame,
     concatenates if multiple files, registers as DuckDB view ``raw_input``.
     """
-    import duckdb
 
     columns = read_cfg.get("columns")
     if not columns:

--- a/toolkit/clean/read_excel.py
+++ b/toolkit/clean/read_excel.py
@@ -78,7 +78,7 @@ def _execute_excel_read(
     read_cfg: dict[str, Any],
     *,
     logger,
-) -> ReadInfo:
+) -> dict[str, Any]:
     """Execute Excel read: load each file, concatenate, register as DuckDB view ``raw_input``."""
     import json
 

--- a/toolkit/clean/read_excel.py
+++ b/toolkit/clean/read_excel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -80,8 +81,6 @@ def _execute_excel_read(
     logger,
 ) -> dict[str, Any]:
     """Execute Excel read: load each file, concatenate, register as DuckDB view ``raw_input``."""
-    import json
-
     frames: list[pd.DataFrame] = []
     params_used: dict[str, Any] | None = None
 

--- a/toolkit/clean/read_excel.py
+++ b/toolkit/clean/read_excel.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+def _normalize_excel_sheet_name(value: Any) -> str | int:
+    """Normalize sheet_name config value to a string or integer for pd.read_excel."""
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        raise ValueError("clean.read.sheet_name must be a string, integer, or null")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return 0
+        return text
+    raise ValueError("clean.read.sheet_name must be a string, integer, or null")
+
+
+def _trim_excel_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Strip whitespace from all string values in a DataFrame."""
+    return df.apply(
+        lambda column: column.map(lambda value: value.strip() if isinstance(value, str) else value)
+    )
+
+
+def _load_excel_frame(
+    input_file: Path,
+    read_cfg: dict[str, Any],
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    """Load a single Excel file into a DataFrame with configured columns / header / skip."""
+    header = bool(read_cfg.get("header", True))
+    skip = int(read_cfg["skip"]) if read_cfg.get("skip") is not None else 0
+    trim_whitespace = read_cfg.get("trim_whitespace", True)
+    columns = read_cfg.get("columns")
+    sheet_name = _normalize_excel_sheet_name(read_cfg.get("sheet_name"))
+
+    df = pd.read_excel(
+        input_file,
+        sheet_name=sheet_name,
+        header=0 if header else None,
+        skiprows=skip,
+        dtype=object,
+        engine="openpyxl",
+    )
+
+    if columns:
+        expected_columns = list(columns.keys())
+        if len(expected_columns) != len(df.columns):
+            raise ValueError(
+                "Excel input columns mismatch. "
+                f"Configured={len(expected_columns)} detected={len(df.columns)} file={input_file}"
+            )
+        df.columns = expected_columns
+    elif not header:
+        df.columns = [f"col{i}" for i in range(len(df.columns))]
+
+    if trim_whitespace:
+        df = _trim_excel_dataframe(df)
+
+    return df, {
+        "sheet_name": sheet_name,
+        "header": header,
+        "skip": skip,
+        "trim_whitespace": bool(trim_whitespace),
+        "columns": dict(columns) if columns else None,
+    }
+
+
+def _execute_excel_read(
+    con,
+    input_files: list[Path],
+    read_cfg: dict[str, Any],
+    *,
+    logger,
+) -> ReadInfo:
+    """Execute Excel read: load each file, concatenate, register as DuckDB view ``raw_input``."""
+    import json
+
+    frames: list[pd.DataFrame] = []
+    params_used: dict[str, Any] | None = None
+
+    for input_file in input_files:
+        frame, frame_params = _load_excel_frame(input_file, read_cfg)
+        frames.append(frame)
+        if params_used is None:
+            params_used = frame_params
+
+    combined = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
+    con.register("raw_input_df", combined)
+    con.execute("CREATE OR REPLACE VIEW raw_input AS SELECT * FROM raw_input_df;")
+
+    used = dict(params_used or {})
+    if used.get("columns") is None:
+        used.pop("columns", None)
+    logger.info(
+        "read_excel params used: source=excel params=%s",
+        json.dumps(used, ensure_ascii=False, sort_keys=True),
+    )
+    return {"source": "excel", "params_used": used}

--- a/toolkit/clean/read_sql_utils.py
+++ b/toolkit/clean/read_sql_utils.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def q_ident(name: str) -> str:
+    """Quote a SQL identifier, escaping embedded double quotes."""
+    return '"' + name.replace('"', '""') + '"'
+
+
+def sql_path(p: Path) -> str:
+    """Quote a file-system path for use in a DuckDB SQL string literal."""
+    s = p.resolve().as_posix()
+    return s.replace("'", "''")
+
+
+def quote_list(paths: list[Path]) -> str:
+    """Return a SQL comma-separated list of quoted path literals."""
+    return ", ".join([f"'{sql_path(p)}'" for p in paths])
+
+
+def csv_trim_projection(columns: dict[str, str]) -> str:
+    """Build a SQL projection that trims CHAR/TEXT/STRING columns."""
+    exprs: list[str] = []
+    for name, dtype in columns.items():
+        qname = q_ident(name)
+        dtype_upper = dtype.upper()
+        if "CHAR" in dtype_upper or "TEXT" in dtype_upper or "STRING" in dtype_upper:
+            exprs.append(f"TRIM({qname}, ' \t\r\n') AS {qname}")
+        else:
+            exprs.append(qname)
+    return ", ".join(exprs)


### PR DESCRIPTION
Closes #153 

## Summary

Refactoring di `toolkit/clean/duckdb_read.py` — split in moduli专项ati senza cambiare il contract esterno.

## Cosa è cambiato

### Nuovi moduli estratti

| Modulo | Funzioni | Rischio |
|---|---|---|
| `read_config.py` | `_read_source_mode`, `_split_read_cfg`, `load_suggested_read`, `filter_suggested_read`, `resolve_clean_read_cfg` | Basso |
| `read_csv_normalized.py` | `_normalized_csv_reader_kwargs`, `_load_normalized_csv_frame`, `_execute_normalized_csv_read` | Basso-medio |
| `read_sql_utils.py` | `q_ident`, `sql_path`, `quote_list`, `csv_trim_projection` | Molto basso |
| `read_excel.py` | `_normalize_excel_sheet_name`, `_trim_excel_dataframe`, `_load_excel_frame`, `_execute_excel_read` | Basso |

### `duckdb_read.py` dopo il refactor

- ~291 righe (era 561, **‑270 righe**)
- Entrypoint pubblico `read_raw_to_relation` invariato
- `ReadInfo` dataclass invariata
- Policy strict/fallback/robust inclusa (cuore legittimo del file)

### Note tecniche

- `read_excel.py` restituisce `dict`; `duckdb_read.py` wrappa in `ReadInfo` per evitare circular import
- Nessuna logica nuova, solo risistemazione dei confini tra moduli
- 25/25 test passati

## Perché

Il file miscolava 6 responsabilità diverse (contract resolution, helper SQL, adapter CSV/Excel/parquet, policy strict/fallback). Il refactor le separa per famiglie funzionali omogenee, come indicato nel piano di audit.

## Test

```bash
pytest tests/test_clean_duckdb_read.py tests/test_package_exports.py tests/test_clean_csv_columns.py -v
# 25 passed
```

## Checklist pre-merge

- [x] Branch aggiornato da `main`
- [x] 25/25 test passati
- [x] Nessun contract esterno cambiato (`read_raw_to_relation`, `ReadInfo`)
- [x] Circular import evitato