### PR TITLE
refactor(run_context): split in run_records.py + run_record_portability.py

### DIFF
--- a/toolkit/core/run_context.py
+++ b/toolkit/core/run_context.py
@@ -1,24 +1,35 @@
+"""Run context lifecycle management.
+
+This module is the public facade for run lifecycle. Storage/query and portability
+have been migrated to dedicated sub-modules:
+- run_records: path resolution, write, read, query
+- run_record_portability: absolute-to-relative path migration
+"""
+
 from __future__ import annotations
 
 import json
 import re
-import time
 import uuid
 from datetime import datetime, timezone
-from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
+from pathlib import Path
 from typing import Any, Dict, Optional
 
+from toolkit.core.run_records import get_run_dir, write_run_record
 from toolkit.core.paths import to_root_relative
 from toolkit.version import __version__ as _toolkit_version
 
+
+# --- Backward-compat re-exports (consumers import from run_context) ---
+# ruff: noqa: F401
+from toolkit.core.run_records import latest_run, list_runs, read_run_record
+
+
+# --- Module-level constants ---
 _LAYER_NAMES = ("raw", "clean", "mart")
-_WINDOWS_ABS_RE = re.compile(r"^[A-Za-z]:[\\/]")
-_RUN_RECORD_RENAME_RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2)
-_PORTABLE_RUN_PATH_FIELDS: set[tuple[str, ...]] = {
-    ("layers", "raw", "artifact_path"),
-    ("layers", "clean", "artifact_path"),
-    ("layers", "mart", "artifact_path"),
-}
+
+
+# --- Lifecycle helpers (remain here, tight coupling with RunContext) ---
 
 
 def _now_iso() -> str:
@@ -40,134 +51,7 @@ def _empty_layer_metrics() -> Dict[str, Any]:
     return {"output_rows": None, "output_bytes": None, "col_count": None, "tables_count": None}
 
 
-def get_run_dir(root: Path, dataset: str, year: int) -> Path:
-    return root / "data" / "_runs" / dataset / str(year)
-
-
-def _run_record_path(run_dir: Path, run_id: str) -> Path:
-    return run_dir / f"{run_id}.json"
-
-
-def _root_from_run_dir(run_dir: Path) -> Path:
-    return run_dir.parents[3]
-
-
-def _to_pure_path(path: str) -> PurePath:
-    if "\\" in path or _WINDOWS_ABS_RE.match(path):
-        return PureWindowsPath(path)
-    return PurePosixPath(path)
-
-
-def _is_absolute_path_string(value: str) -> bool:
-    return value.startswith("/") or value.startswith("\\\\") or _WINDOWS_ABS_RE.match(value) is not None
-
-
-def _migrate_path_value(value: str, root: Path) -> tuple[str, bool]:
-    if not _is_absolute_path_string(value):
-        return value, False
-
-    try:
-        relative = to_root_relative(_to_pure_path(value), _to_pure_path(str(root)))
-        return relative, True
-    except Exception:
-        return value, False
-
-
-def _migrate_whitelisted_path_fields(payload: dict[str, Any], root: Path, warnings: list[str]) -> dict[str, Any]:
-    migrated = json.loads(json.dumps(payload))
-
-    for field_path in _PORTABLE_RUN_PATH_FIELDS:
-        current: Any = migrated
-        for token in field_path[:-1]:
-            if not isinstance(current, dict) or token not in current:
-                current = None
-                break
-            current = current[token]
-
-        if not isinstance(current, dict):
-            continue
-
-        leaf = field_path[-1]
-        value = current.get(leaf)
-        if not isinstance(value, str):
-            continue
-
-        normalized, portable = _migrate_path_value(value, root)
-        if portable:
-            current[leaf] = normalized
-        elif _is_absolute_path_string(value):
-            warnings.append(value)
-
-    return migrated
-
-
-def _load_run_record(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    run_dir = path.parent
-    root = _root_from_run_dir(run_dir)
-    warnings: list[str] = []
-    migrated = _migrate_whitelisted_path_fields(payload, root, warnings)
-    migrated["_portability"] = {
-        "portable": not warnings,
-        "warnings": warnings,
-    }
-    return migrated
-
-
-def write_run_record(run_dir: Path, run_id: str, payload: dict[str, Any]) -> Path:
-    run_dir.mkdir(parents=True, exist_ok=True)
-    path = _run_record_path(run_dir, run_id)
-    tmp = run_dir / f".{run_id}.json.tmp"
-    tmp.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False),
-        encoding="utf-8",
-    )
-
-    last_error: PermissionError | None = None
-    for attempt in range(len(_RUN_RECORD_RENAME_RETRY_DELAYS_SECONDS) + 1):
-        try:
-            tmp.replace(path)
-            return path
-        except PermissionError as exc:
-            # On Windows, AV/indexing can transiently hold the tmp/target handle.
-            # Retrying keeps run tracking resilient without changing record format.
-            last_error = exc
-            if attempt >= len(_RUN_RECORD_RENAME_RETRY_DELAYS_SECONDS):
-                raise
-            time.sleep(_RUN_RECORD_RENAME_RETRY_DELAYS_SECONDS[attempt])
-
-    if last_error is not None:
-        raise last_error
-    return path
-
-
-def list_runs(run_dir: Path) -> list[Path]:
-    if not run_dir.exists():
-        return []
-    return sorted(run_dir.glob("*.json"))
-
-
-def read_run_record(run_dir: Path, run_id: str) -> dict[str, Any]:
-    path = _run_record_path(run_dir, run_id)
-    if not path.exists():
-        raise FileNotFoundError(f"Run record not found: {path}")
-    return _load_run_record(path)
-
-
-def latest_run(run_dir: Path) -> dict[str, Any]:
-    runs = list_runs(run_dir)
-    if not runs:
-        dataset = run_dir.parent.name if run_dir.parent != run_dir else "(unknown)"
-        year = run_dir.name
-        raise FileNotFoundError(f"No run records found for dataset={dataset} year={year}")
-    latest = max(
-        runs,
-        key=lambda path: (
-            _load_run_record(path).get("started_at", ""),
-            path.stat().st_mtime,
-        ),
-    )
-    return _load_run_record(latest)
+# --- RunContext ---------------------------------------------------------------
 
 
 class RunContext:

--- a/toolkit/core/run_record_portability.py
+++ b/toolkit/core/run_record_portability.py
@@ -1,0 +1,96 @@
+"""Portability layer for run records.
+
+Handles:
+- Conversion between absolute and portable (relative) paths in run records
+- Path normalization for cross-platform compatibility
+- Migration of legacy absolute paths to relative paths
+- Loading run records with portability metadata attached
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
+from typing import Any
+
+from toolkit.core.paths import to_root_relative
+
+
+_WINDOWS_ABS_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+_PORTABLE_RUN_PATH_FIELDS: set[tuple[str, ...]] = {
+    ("layers", "raw", "artifact_path"),
+    ("layers", "clean", "artifact_path"),
+    ("layers", "mart", "artifact_path"),
+}
+
+
+def _root_from_run_dir(run_dir: Path) -> Path:
+    return run_dir.parents[3]
+
+
+def _to_pure_path(path: str) -> PurePath:
+    if "\\" in path or _WINDOWS_ABS_RE.match(path):
+        return PureWindowsPath(path)
+    return PurePosixPath(path)
+
+
+def _is_absolute_path_string(value: str) -> bool:
+    return value.startswith("/") or value.startswith("\\\\") or _WINDOWS_ABS_RE.match(value) is not None
+
+
+def _migrate_path_value(value: str, root: Path) -> tuple[str, bool]:
+    if not _is_absolute_path_string(value):
+        return value, False
+
+    try:
+        relative = to_root_relative(_to_pure_path(value), _to_pure_path(str(root)))
+        return relative, True
+    except Exception:
+        return value, False
+
+
+def _migrate_whitelisted_path_fields(
+    payload: dict[str, Any],
+    root: Path,
+    warnings: list[str],
+) -> dict[str, Any]:
+    migrated = json.loads(json.dumps(payload))
+
+    for field_path in _PORTABLE_RUN_PATH_FIELDS:
+        current: Any = migrated
+        for token in field_path[:-1]:
+            if not isinstance(current, dict) or token not in current:
+                current = None
+                break
+            current = current[token]
+
+        if not isinstance(current, dict):
+            continue
+
+        leaf = field_path[-1]
+        value = current.get(leaf)
+        if not isinstance(value, str):
+            continue
+
+        normalized, portable = _migrate_path_value(value, root)
+        if portable:
+            current[leaf] = normalized
+        elif _is_absolute_path_string(value):
+            warnings.append(value)
+
+    return migrated
+
+
+def _load_run_record(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    run_dir = path.parent
+    root = _root_from_run_dir(run_dir)
+    warnings: list[str] = []
+    migrated = _migrate_whitelisted_path_fields(payload, root, warnings)
+    migrated["_portability"] = {
+        "portable": not warnings,
+        "warnings": warnings,
+    }
+    return migrated

--- a/toolkit/core/run_records.py
+++ b/toolkit/core/run_records.py
@@ -1,0 +1,89 @@
+"""Storage and query layer for run records.
+
+Provides:
+- Run record path resolution (get_run_dir, _run_record_path)
+- Write with Windows-safe retry (write_run_record)
+- Read with portability migration (read_run_record)
+- Query (list_runs, latest_run)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from toolkit.core.run_record_portability import _load_run_record
+
+
+# --- Path resolution ----------------------------------------------------------
+
+
+def get_run_dir(root: Path, dataset: str, year: int) -> Path:
+    return root / "data" / "_runs" / dataset / str(year)
+
+
+def _run_record_path(run_dir: Path, run_id: str) -> Path:
+    return run_dir / f"{run_id}.json"
+
+
+# --- Write -------------------------------------------------------------------
+
+
+def write_run_record(run_dir: Path, run_id: str, payload: dict) -> Path:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    path = _run_record_path(run_dir, run_id)
+    tmp = run_dir / f".{run_id}.json.tmp"
+    tmp.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    last_error: PermissionError | None = None
+    _RUN_RECORD_RENAME_RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2)
+    for attempt in range(len(_RUN_RECORD_RENAME_RETRY_DELAYS_SECONDS) + 1):
+        try:
+            tmp.replace(path)
+            return path
+        except PermissionError as exc:
+            # On Windows, AV/indexing can transiently hold the tmp/target handle.
+            last_error = exc
+            if attempt >= len(_RUN_RECORD_RENAME_RETRY_DELAYS_SECONDS):
+                raise
+            time.sleep(_RUN_RECORD_RENAME_RETRY_DELAYS_SECONDS[attempt])
+
+    if last_error is not None:
+        raise last_error
+    return path
+
+
+# --- Query ------------------------------------------------------------------
+
+
+def list_runs(run_dir: Path) -> list[Path]:
+    if not run_dir.exists():
+        return []
+    return sorted(run_dir.glob("*.json"))
+
+
+def read_run_record(run_dir: Path, run_id: str) -> dict:
+    path = _run_record_path(run_dir, run_id)
+    if not path.exists():
+        raise FileNotFoundError(f"Run record not found: {path}")
+    return _load_run_record(path)
+
+
+def latest_run(run_dir: Path) -> dict:
+    runs = list_runs(run_dir)
+    if not runs:
+        dataset = run_dir.parent.name if run_dir.parent != run_dir else "(unknown)"
+        year = run_dir.name
+        raise FileNotFoundError(f"No run records found for dataset={dataset} year={year}")
+    latest = max(
+        runs,
+        key=lambda path: (
+            _load_run_record(path).get("started_at", ""),
+            path.stat().st_mtime,
+        ),
+    )
+    return _load_run_record(latest)


### PR DESCRIPTION
## Summary

Refactoring di `toolkit/core/run_context.py` in due sub-moduli专项ati, come da issue #155.

### Cosa è cambiato

- **`toolkit/core/run_records.py`** (nuovo): path resolution, write, read, query per run record
  - `get_run_dir`, `_run_record_path`: risoluzione path
  - `write_run_record`: write con Windows-safe rename retry (già esistente, spostata)
  - `read_run_record`, `list_runs`, `latest_run`: query (portability migration inclusa)

- **`toolkit/core/run_record_portability.py`** (nuovo): portability layer
  - `_load_run_record`: carica e migra paths assoluti → relativi
  - `_PORTABLE_RUN_PATH_FIELDS`: whitelist campi da migrare (`layers.{raw,clean,mart}.artifact_path`)
  - `_migrate_path_value`, `_migrate_whitelisted_path_fields`, `_to_pure_path`, `_is_absolute_path_string`

- **`toolkit/core/run_context.py`**: diventa thin facade
  - `RunContext` resta qui (lifecycle boundary pubblico)
  - `_now_iso`, `_duration_seconds`, `_empty_layer_metrics` restano qui
  - re-export di `latest_run`, `list_runs`, `read_run_record` per backward compat

### Cosa NON è cambiato

- API pubblica di `RunContext`
- Formato JSON dei run record
- Contratto di `save()` e `path`
- Behavior di `complete_run`, `fail_run`, `mark_dry_run`, layer lifecycle

### Test

- 371/371 test passano
- ruff clean
- Backward compat: tutti i consumer esistenti (`cmd_run`, `cmd_status`, `cmd_inspect`, `cmd_resume`, `input_selection`) continuano a funzionare senza modifiche

Closes #155