### PR TITLE
feat: aggiungi supporto datastore al plugin CKAN

### DIFF
--- a/tests/test_ckan_plugin.py
+++ b/tests/test_ckan_plugin.py
@@ -267,3 +267,218 @@ def test_ckan_download_bytes_raises_on_http_error(monkeypatch):
         assert "HTTP 503" in str(exc)
     else:
         raise AssertionError("Expected DownloadError")
+
+
+def test_ckan_fetch_datastore_active_uses_datastore_search(monkeypatch):
+    calls = []
+
+    def _fake_get(url, params=None, timeout=None, headers=None):
+        calls.append((url, params))
+        if "resource_show" in url:
+            return _FakeResponse(
+                200,
+                json_data={
+                    "success": True,
+                    "result": {
+                        "id": "res-123",
+                        "url": "http://portal.example.org/api/3/dump.csv",
+                        "datastore_active": True,
+                    },
+                },
+                url=f"{url}?id=res-123",
+            )
+        if "datastore_search" in url:
+            return _FakeResponse(
+                200,
+                json_data={
+                    "success": True,
+                    "result": {
+                        "fields": [{"id": "nome"}, {"id": "valore"}],
+                        "records": [
+                            {"nome": "a", "valore": 1},
+                            {"nome": "b", "valore": 2},
+                        ],
+                    },
+                },
+                url=url,
+            )
+        return _FakeResponse(
+            200,
+            content=b"fallback csv content",
+            url="http://portal.example.org/api/3/dump.csv",
+        )
+
+    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+
+    payload, origin = CkanSource().fetch(
+        "https://portal.example.org/api/3", resource_id="res-123"
+    )
+
+    text = payload.decode("utf-8")
+    assert "nome,valore" in text
+    assert "a,1" in text
+    assert "b,2" in text
+    assert any("datastore_search" in str(c) for c in calls)
+
+
+def test_ckan_fetch_datastore_fallback_to_url_on_empty_records(monkeypatch):
+    calls = []
+
+    def _fake_get(url, params=None, timeout=None, headers=None):
+        calls.append((url, params))
+        if "resource_show" in url:
+            return _FakeResponse(
+                200,
+                json_data={
+                    "success": True,
+                    "result": {
+                        "id": "res-456",
+                        "url": "http://portal.example.org/api/3/dump.csv",
+                        "datastore_active": True,
+                    },
+                },
+                url=f"{url}?id=res-456",
+            )
+        if "datastore_search" in url:
+            return _FakeResponse(
+                200,
+                json_data={"success": True, "result": {"fields": [], "records": []}},
+                url=url,
+            )
+        return _FakeResponse(200, content=b"csv-from-url", url=url)
+
+    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+
+    payload, origin = CkanSource().fetch(
+        "https://portal.example.org/api/3", resource_id="res-456"
+    )
+
+    assert payload == b"csv-from-url"
+    assert "dump.csv" in origin
+
+
+def test_ckan_fetch_resource_no_url_no_datastore_raises(monkeypatch):
+    def _fake_get(url, params=None, timeout=None, headers=None):
+        if "resource_show" in url:
+            return _FakeResponse(
+                200,
+                json_data={
+                    "success": True,
+                    "result": {"id": "no-url-res", "datastore_active": False},
+                },
+                url=f"{url}?id=no-url-res",
+            )
+        if "package_show" in url:
+            return _FakeResponse(
+                200,
+                json_data={
+                    "success": True,
+                    "result": {"id": "no-url-res", "resources": []},
+                },
+                url=f"{url}?id=no-url-res",
+            )
+        raise AssertionError(f"Unexpected request to {url}")
+
+    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+
+    try:
+        CkanSource().fetch("https://portal.example.org/api/3", resource_id="no-url-res")
+    except DownloadError as exc:
+        assert "no URL" in str(exc) or "no resources" in str(exc).lower()
+    else:
+        raise AssertionError("Expected DownloadError")
+
+
+def test_ckan_fetch_malformed_json_falls_back_to_package_show(monkeypatch):
+    calls = []
+
+    def _fake_get(url, params=None, timeout=None, headers=None):
+        calls.append((url, params))
+        if "resource_show" in url:
+            return _FakeResponse(
+                200,
+                json_data=None,
+                content=b"not json at all",
+                url=f"{url}?id=malformed",
+            )
+        if "package_show" in url:
+            return _FakeResponse(
+                200,
+                json_data={
+                    "success": True,
+                    "result": {
+                        "id": "malformed",
+                        "resources": [
+                            {
+                                "id": "res-xyz",
+                                "name": "data",
+                                "format": "csv",
+                                "url": "http://portal.example.org/data.csv",
+                            }
+                        ],
+                    },
+                },
+                url=f"{url}?id=malformed",
+            )
+        return _FakeResponse(200, content=b"a,b\n1,2\n", url="http://portal.example.org/data.csv")
+
+    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+
+    payload, origin = CkanSource().fetch(
+        "https://portal.example.org/api/3", dataset_id="malformed"
+    )
+
+    assert payload == b"a,b\n1,2\n"
+
+
+def test_ckan_fetch_package_no_resources_raises(monkeypatch):
+    def _fake_get(url, params=None, timeout=None, headers=None):
+        if "package_show" in url:
+            return _FakeResponse(
+                200,
+                json_data={"success": True, "result": {"id": "empty-pkg", "resources": []}},
+                url=f"{url}?id=empty-pkg",
+            )
+        raise AssertionError(f"Unexpected request to {url}")
+
+    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+
+    try:
+        CkanSource().fetch("https://portal.example.org/api/3", dataset_id="empty-pkg")
+    except DownloadError as exc:
+        assert "no resources" in str(exc).lower()
+    else:
+        raise AssertionError("Expected DownloadError")
+
+
+def test_ckan_fetch_prefer_datastore_false_skips_datastore(monkeypatch):
+    calls = []
+
+    def _fake_get(url, params=None, timeout=None, headers=None):
+        calls.append((url, params))
+        if "resource_show" in url:
+            return _FakeResponse(
+                200,
+                json_data={
+                    "success": True,
+                    "result": {
+                        "id": "ds-res",
+                        "url": "http://portal.example.org/api/3/dump.csv",
+                        "datastore_active": True,
+                    },
+                },
+                url=f"{url}?id=ds-res",
+            )
+        return _FakeResponse(200, content=b"csv-via-url", url=url)
+
+    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+
+    payload, origin = CkanSource().fetch(
+        "https://portal.example.org/api/3",
+        resource_id="ds-res",
+        prefer_datastore=False,
+    )
+
+    assert payload == b"csv-via-url"
+    assert "csv-via-url" in origin or "dump.csv" in origin
+    assert not any("datastore_search" in str(c) for c in calls)

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -89,10 +89,15 @@ class CkanSource:
             raise DownloadError(
                 f"CKAN datastore_search for resource {resource_id} returned no records"
             )
+        # NOTE: other DownloadError from this method indicate empty-result only;
+        # HTTP/API errors surface as requests exceptions, caught by outer try-except in fetch()
         fields = [f["id"] for f in result.get("fields") or []]
         buffer = io.StringIO(newline="")
         writer = csv.DictWriter(buffer, fieldnames=fields)
         writer.writeheader()
+        # NOTE: CSV format does not distinguish None from empty string.
+        # row.get(k) returns None for missing keys; csv.DictWriter emits '' for None.
+        # If semantic distinction matters, a different format (JSONL) is needed.
         for row in records:
             writer.writerow({k: row.get(k) for k in fields})
         return buffer.getvalue().encode("utf-8")
@@ -180,6 +185,9 @@ class CkanSource:
                 if raw_url:
                     resolved_url = _force_https(str(raw_url))
                     return self._download_bytes(resolved_url), resolved_url
+                # Fallback: try datastore even if prefer_datastore=False, when URL is absent.
+                # Rationale: absent URL + active datastore means resource has no direct download;
+                # trying datastore is a reasonable fallback regardless of prefer_datastore flag.
                 if self._resource_is_datastore_active(result):
                     try:
                         return self._datastore_search(str(resource_id), portal_url), api_url

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
+import csv
+import io
 from urllib.parse import urlparse, urlunparse
 
 import requests
 
 from toolkit.core.exceptions import DownloadError
+
+
+def _normalize_datastore_search_url(portal_url: str) -> str:
+    base = portal_url.rstrip("/")
+    if base.endswith("/api/3/action"):
+        return f"{base}/datastore_search"
+    if base.endswith("/api/3"):
+        return f"{base}/action/datastore_search"
+    return f"{base}/api/3/action/datastore_search"
 
 
 def _normalize_resource_show_url(portal_url: str) -> str:
@@ -69,6 +80,23 @@ class CkanSource:
                 last_err = exc
         raise DownloadError(str(last_err) if last_err else f"Failed to fetch {url}")
 
+    def _datastore_search(self, resource_id: str, api_base: str) -> bytes:
+        url = _normalize_datastore_search_url(api_base)
+        payload = self._get_json(url, {"id": resource_id})
+        result = payload.get("result", {})
+        records = result.get("records") or []
+        if not records:
+            raise DownloadError(
+                f"CKAN datastore_search for resource {resource_id} returned no records"
+            )
+        fields = [f["id"] for f in result.get("fields") or []]
+        buffer = io.StringIO(newline="")
+        writer = csv.DictWriter(buffer, fieldnames=fields)
+        writer.writeheader()
+        for row in records:
+            writer.writerow({k: row.get(k) for k in fields})
+        return buffer.getvalue().encode("utf-8")
+
     def _select_resource_from_package(
         self,
         result: dict,
@@ -124,12 +152,17 @@ class CkanSource:
 
         return sorted(with_url, key=_score)[0]
 
+    def _resource_is_datastore_active(self, resource: dict) -> bool:
+        return str(resource.get("datastore_active") or "").lower() == "true"
+
     def fetch(
         self,
         portal_url: str,
         resource_id: str | None = None,
         dataset_id: str | None = None,
         resource_name: str | None = None,
+        *,
+        prefer_datastore: bool = True,
     ) -> tuple[bytes, str]:
         last_err: Exception | None = None
 
@@ -138,10 +171,20 @@ class CkanSource:
             try:
                 metadata = self._get_json(api_url, {"id": str(resource_id)})
                 result = metadata.get("result") or {}
+                if prefer_datastore and self._resource_is_datastore_active(result):
+                    try:
+                        return self._datastore_search(str(resource_id), portal_url), api_url
+                    except DownloadError:
+                        pass
                 raw_url = result.get("url")
                 if raw_url:
                     resolved_url = _force_https(str(raw_url))
                     return self._download_bytes(resolved_url), resolved_url
+                if self._resource_is_datastore_active(result):
+                    try:
+                        return self._datastore_search(str(resource_id), portal_url), api_url
+                    except DownloadError:
+                        pass
                 last_err = DownloadError(
                     f"CKAN resource_show returned no URL for resource_id={resource_id}"
                 )
@@ -155,6 +198,12 @@ class CkanSource:
                 metadata = self._get_json(api_url, {"id": str(package_identifier)})
                 result = metadata.get("result") or {}
                 resource = self._select_resource_from_package(result, resource_id, resource_name)
+                resource_id_for_ds = str(resource.get("id") or "")
+                if prefer_datastore and self._resource_is_datastore_active(resource):
+                    try:
+                        return self._datastore_search(resource_id_for_ds, portal_url), api_url
+                    except DownloadError:
+                        pass
                 resolved_url = _force_https(str(resource["url"]))
                 return self._download_bytes(resolved_url), resolved_url
             except Exception as exc:


### PR DESCRIPTION
## Contesto
Questo PR estende il plugin CKAN del toolkit per gestire meglio le risorse con `datastore_active=true` e copre alcuni edge case che oggi mancavano nei test.

## Cosa cambia
- aggiunge supporto base a `datastore_search` nel plugin CKAN
- se `prefer_datastore=True` e la risorsa ha `datastore_active=true`, prova prima il DataStore e poi cade sull'URL della risorsa se il DataStore non restituisce record o fallisce
- aggiunge il parametro `prefer_datastore=False` per forzare lo skip del DataStore
- aggiunge test su edge case reali: risorsa senza URL, package senza risorse, JSON malformed, fallback su DataStore vuoto

## Verifiche
- `pytest -q tests/test_ckan_plugin.py`
- `ruff check toolkit/plugins/ckan.py tests/test_ckan_plugin.py`

## Note
- questo PR non introduce ancora pre-download validation
- il supporto DataStore resta volutamente base (`datastore_search`), senza entrare in `datastore_search_sql`
