### PR TITLE
fix: CKAN plugin — due lows pre-merge

### DIFF
--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -94,7 +94,7 @@ class CkanSource:
         writer = csv.DictWriter(buffer, fieldnames=fields)
         writer.writeheader()
         for row in records:
-            writer.writerow({k: row.get(k) for k in fields})
+            writer.writerow({k: (row.get(k) if row.get(k) is not None else "") for k in fields})
         return buffer.getvalue().encode("utf-8")
 
     def _select_resource_from_package(
@@ -180,7 +180,12 @@ class CkanSource:
                 if raw_url:
                     resolved_url = _force_https(str(raw_url))
                     return self._download_bytes(resolved_url), resolved_url
-                if self._resource_is_datastore_active(result):
+                if prefer_datastore and self._resource_is_datastore_active(result):
+                    try:
+                        return self._datastore_search(str(resource_id), portal_url), api_url
+                    except DownloadError:
+                        pass
+                elif self._resource_is_datastore_active(result):
                     try:
                         return self._datastore_search(str(resource_id), portal_url), api_url
                     except DownloadError:


### PR DESCRIPTION
## Summary
- **Low riga 183**: secondo blocco datastore ora usa `elif` invece di `if` — rispetta `prefer_datastore=False` anche quando URL manca
- **Low riga 97**: `row.get(k)` → cast esplicito `None` → stringa vuota nel CSV writer

## Verifiche
- `ruff check toolkit/plugins/ckan.py`
- `pytest -q tests/test_ckan_plugin.py`