### PR TITLE
feat(scout-url): scaffold YAML dataset+raw da URL

### DIFF
--- a/tests/test_cli_scout_url.py
+++ b/tests/test_cli_scout_url.py
@@ -7,7 +7,12 @@ from typing import Any
 from typer.testing import CliRunner
 
 from toolkit.cli.app import app
-from toolkit.cli.cmd_scout_url import probe_url
+from toolkit.cli.cmd_scout_url import (
+    _detect_ckan,
+    _extract_ckan_dataset_id,
+    _generate_yaml_scaffold,
+    probe_url,
+)
 
 
 class _ScoutHandler(BaseHTTPRequestHandler):
@@ -204,3 +209,154 @@ def test_probe_url_passes_custom_user_agent(monkeypatch) -> None:
 
     assert len(calls) == 1
     assert calls[0]["headers"] == {"User-Agent": custom_ua}
+
+
+# ── Tests for CKAN detection and scaffold ───────────────────────────────────────
+
+class TestExtractCkanDatasetId:
+    def test_uuid_from_id_param(self) -> None:
+        url = "https://www.dati.gov.it/view-dataset/dataset?id=bef11a2c-300b-4578-8143-c1ce08f46fff"
+        assert _extract_ckan_dataset_id(url) == "bef11a2c-300b-4578-8143-c1ce08f46fff"
+
+    def test_dataset_path_with_uuid(self) -> None:
+        url = "https://example.com/dataset/bef11a2c-300b-4578-8143-c1ce08f46fff"
+        assert _extract_ckan_dataset_id(url) == "bef11a2c-300b-4578-8143-c1ce08f46fff"
+
+    def test_dataset_path_with_slug(self) -> None:
+        url = "https://example.com/dataset/mio-dataset-slug"
+        assert _extract_ckan_dataset_id(url) == "mio-dataset-slug"
+
+    def test_non_ckan_url_returns_none(self) -> None:
+        url = "https://example.com/data/file.csv"
+        assert _extract_ckan_dataset_id(url) is None
+
+    def test_html_api_reference(self) -> None:
+        html = '<a href="/api/3/action/package_show?id=abc-123">Package</a>'
+        url = "https://example.com/other"
+        assert _extract_ckan_dataset_id(url, html) == "abc-123"
+
+
+class TestDetectCkan:
+    def test_detects_data_view_embed(self) -> None:
+        html = b'<div data-view-embed="/dataset/...">CKAN</div>'
+        assert _detect_ckan(html) is True
+
+    def test_detects_api_action(self) -> None:
+        html = b'/api/3/action/package_show'
+        assert _detect_ckan(html) is True
+
+    def test_detects_ckan_css_class(self) -> None:
+        html = b'<div class="ckan-1000">Content</div>'
+        assert _detect_ckan(html) is True
+
+    def test_detects_package_id(self) -> None:
+        html = b'{"package_id": "abc-123"}'
+        assert _detect_ckan(html) is True
+
+    def test_rejects_non_ckan_html(self) -> None:
+        html = b'<html><body><p>Plain HTML page</p></body></html>'
+        assert _detect_ckan(html) is False
+
+
+class TestGenerateYamlScaffold:
+    def test_http_file_scaffold(self) -> None:
+        probe_result = {
+            "final_url": "https://example.com/data/file.csv",
+            "requested_url": "https://example.com/data/file.csv",
+        }
+        yaml = _generate_yaml_scaffold(probe_result)
+        assert 'name: "file_source"' in yaml
+        assert 'type: "http_file"' in yaml
+        assert 'url: "https://example.com/data/file.csv"' in yaml
+        assert 'filename: "file.csv"' in yaml
+        assert 'years: [2024]' in yaml
+        assert "root:" in yaml
+
+    def test_http_file_scaffold_with_datastore_url(self) -> None:
+        probe_result = {
+            "final_url": "https://portal.com/api/3/datastore/dump/uuid.csv",
+            "requested_url": "https://portal.com/api/3/datastore/dump/uuid.csv",
+        }
+        yaml = _generate_yaml_scaffold(probe_result)
+        assert 'type: "ckan"' in yaml
+
+    def test_http_file_scaffold_with_sdmx_url(self) -> None:
+        probe_result = {
+            "final_url": "https://example.com/data/flow/sdmx",
+            "requested_url": "https://example.com/data/flow/sdmx",
+        }
+        yaml = _generate_yaml_scaffold(probe_result)
+        assert 'type: "sdmx"' in yaml
+
+    def test_ckan_resources_scaffold(self) -> None:
+        probe_result = {
+            "final_url": "https://portal.it/dataset/uuid",
+            "requested_url": "https://portal.it/dataset/uuid",
+        }
+        ckan_resources = [
+            {
+                "id": "res-uuid-1",
+                "name": "Main CSV",
+                "format": "csv",
+                "url": "https://portal.it/files/data.csv",
+            },
+            {
+                "id": "res-uuid-2",
+                "name": "Backup XLS",
+                "format": "xls",
+                "url": "https://portal.it/files/data.xls",
+            },
+        ]
+        yaml = _generate_yaml_scaffold(probe_result, ckan_resources)
+        assert "type: \"ckan\"" in yaml
+        assert 'resource_id: "res-uuid-1"' in yaml
+        assert 'resource_id: "res-uuid-2"' in yaml
+        assert 'filename: "data.csv"' in yaml
+
+    def test_candidate_links_fallback(self) -> None:
+        probe_result = {
+            "final_url": "https://portal.it/page",
+            "requested_url": "https://portal.it/page",
+        }
+        links = [
+            "https://portal.it/download/data.csv",
+            "https://portal.it/download/report.xlsx",
+        ]
+        yaml = _generate_yaml_scaffold(probe_result, None, links)
+        assert 'type: "http_file"' in yaml
+        assert 'url: "https://portal.it/download/data.csv"' in yaml
+        assert 'url: "https://portal.it/download/report.xlsx"' in yaml
+
+
+def test_scout_url_scaffold_flag_http_file() -> None:
+    server, base_url = _serve()
+    runner = CliRunner()
+    try:
+        result = runner.invoke(app, ["scout-url", "--scaffold", f"{base_url}/files/demo.csv"])
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.exit_code == 0
+    assert "root:" in result.output
+    assert 'name: "demo_source"' in result.output
+    assert 'type: "http_file"' in result.output
+    assert "dataset:" in result.output
+    assert "raw:" in result.output
+
+
+def test_scout_url_scaffold_flag_html_uses_candidate_links() -> None:
+    server, base_url = _serve()
+    runner = CliRunner()
+    try:
+        result = runner.invoke(app, ["scout-url", "--scaffold", f"{base_url}/html"])
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.exit_code == 0
+    assert "root:" in result.output
+    assert 'type: "http_file"' in result.output
+    # HTML page has links to CSV, XLSX in test server
+    assert "seriestoricheannualiinps" not in result.output  # uses data.csv stem
+    assert "data_source" in result.output or "csv" in result.output

--- a/toolkit/cli/cmd_scout_url.py
+++ b/toolkit/cli/cmd_scout_url.py
@@ -1,17 +1,30 @@
 from __future__ import annotations
 
+import re
 from html.parser import HTMLParser
+from pathlib import Path
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import parse_qs, urljoin, urlparse
 
 import requests
 import typer
 
 
-_CANDIDATE_EXTENSIONS = (".csv", ".xlsx", ".xls", ".zip", ".json")
+_CANDIDATE_EXTENSIONS = (".csv", ".xlsx", ".xls", ".zip", ".json", ".parquet", ".geojson")
+_EXTENDED_EXTENSIONS = _CANDIDATE_EXTENSIONS + (".sdmx", ".tds", ".xml")
 _DEFAULT_USER_AGENT = "dataciviclab-toolkit/scout-url"
 _DEFAULT_TIMEOUT = 10
 _MAX_PRINTED_LINKS = 20
+
+# CKAN detection patterns
+_CKAN_ID_PARAM_RE = re.compile(r"[?&]id=([a-f0-9-]{36,})", re.IGNORECASE)
+_CKAN_DATASET_PATH_RE = re.compile(r"/dataset/([^/?#]+)", re.IGNORECASE)
+_CKAN_HTML_SIGNATURES = (
+    b"data-view-embed",
+    b"/api/3/action",
+    b"ckan-",
+    b'"package_id"',
+)
 
 
 class _AnchorParser(HTMLParser):
@@ -72,7 +85,214 @@ def _candidate_links(base_url: str, html_text: str) -> list[str]:
     return links
 
 
-def probe_url(url: str, *, timeout: int = _DEFAULT_TIMEOUT, user_agent: str = _DEFAULT_USER_AGENT) -> dict[str, Any]:
+# ── CKAN detection ──────────────────────────────────────────────────────────────
+
+def _extract_ckan_dataset_id(url: str, html_text: str = "") -> str | None:
+    """Estrae il dataset_id CKAN da URL o HTML. Ritorna None se non è un URL CKAN."""
+    # Pattern 1: ?id=UUID nell'URL (UUID = 36+ char con hyphens)
+    match = _CKAN_ID_PARAM_RE.search(url)
+    if match:
+        return match.group(1)
+
+    # Pattern 2: /dataset/slug nell'URL
+    match = _CKAN_DATASET_PATH_RE.search(url)
+    if match:
+        slug = match.group(1)
+        # Se lo slug sembra un UUID (CKAN: a volte il path e' /dataset/<uuid>)
+        if len(slug) >= 32 and "-" in slug:
+            return slug
+        # Altrimenti è uno slug testuale — CKAN non espone l'UUID direttamente.
+        # In questo caso torna lo slug come dataset_id e si farà package_show
+        # che accetta anche gli slug al posto degli UUID.
+        return slug
+
+    # Pattern 3: cerca nell'HTML un riferimento a /api/3/action/package_show
+    if html_text:
+        api_match = re.search(r'["\']?(/api/3/action/package_show\?id=[^"\'<>\s]+)', html_text)
+        if api_match:
+            qs = api_match.group(1).split("?", 1)[-1]
+            parsed = parse_qs(qs)
+            if "id" in parsed:
+                return parsed["id"][0]
+
+    return None
+
+
+def _detect_ckan(html_content: bytes) -> bool:
+    """Ritorna True se l'HTML sembra essere una pagina portale CKAN."""
+    return any(sig in html_content for sig in _CKAN_HTML_SIGNATURES)
+
+
+def _discover_ckan_resources(
+    portal_url: str,
+    dataset_id: str,
+    *,
+    timeout: int = _DEFAULT_TIMEOUT,
+    user_agent: str = _DEFAULT_USER_AGENT,
+) -> list[dict[str, Any]]:
+    """
+    Chiama CKAN package_show API e ritorna la lista delle risorse.
+    Prova diversi pattern di URL CKAN comuni (standard e non).
+    """
+    parsed = urlparse(portal_url)
+    root = f"{parsed.scheme}://{parsed.netloc}"
+
+    # Proberò questi API base in ordine di priorità.
+    # Tutti i branch costruiscono l'endpoint package_show.
+    api_bases = []
+    if parsed.path.startswith("/api/3/action"):
+        api_bases.append(f"{root}/api/3/action/package_show")
+    elif parsed.path.startswith("/api/3"):
+        api_bases.append(f"{root}/api/3/action/package_show")
+    elif parsed.path.startswith("/dataset/"):
+        api_bases.append(f"{root}/api/3/action/package_show")
+    else:
+        # Portali con path non-standard (es. /view-dataset/dataset?id=UUID).
+        # Prova prima l'endpoint standard, poi la variante esplicita.
+        api_bases.append(f"{root}/api/3/action/package_show")
+        api_bases.append(f"{root}/package_show")
+
+    headers = {"User-Agent": user_agent}
+
+    for api_base in api_bases:
+        pkg_url = f"{api_base}?id={dataset_id}"
+        try:
+            resp = requests.get(pkg_url, timeout=timeout, headers=headers)
+            if resp.status_code != 200:
+                continue
+            data = resp.json()
+            if not data.get("success"):
+                continue
+            result = data.get("result") or {}
+        except Exception:
+            continue
+
+        resources: list[dict[str, Any]] = result.get("resources") or []
+        discovered: list[dict[str, Any]] = []
+        for res in resources:
+            res_url = res.get("url") or ""
+            if not res_url or not res_url.startswith("http"):
+                continue
+            discovered.append({
+                "id": res.get("id") or "",
+                "name": res.get("name") or res.get("description") or res.get("id") or "",
+                "format": (res.get("format") or "").lower(),
+                "url": res_url,
+            })
+        if discovered:
+            return discovered
+
+    return []
+
+
+def _generate_yaml_scaffold(
+    probe_result: dict[str, Any],
+    ckan_resources: list[dict[str, Any]] | None = None,
+    candidate_links: list[str] | None = None,
+) -> str:
+    """
+    Genera un YAML scaffold (blocchi dataset + raw) per il dataset.yml.
+
+    Priorità:
+      1. ckan_resources (discoveribili): genera blocco ckan per ogni risorsa
+      2. candidate_links (pagine HTML con link a file): genera http_file per ogni link
+      3. Fallback: genera http_file dalla URL del probe_result
+    """
+    url = probe_result["final_url"]
+    parsed = urlparse(url)
+    slug = Path(parsed.path).stem or "dataset"
+    slug = re.sub(r"[^a-z0-9_]", "_", slug.lower())
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    if not slug:
+        slug = "dataset"
+
+    lines = [
+        "# Scaffold generato da scout-url --scaffold",
+        "# Verifica e modifica prima di usare",
+        "",
+        "root: \"../../out\"",
+        "schema_version: 1",
+        "",
+        "dataset:",
+        f'  name: "{slug}"',
+        "  years: [2024]  # TBD: inferito da URL o sorgente",
+        "",
+        "raw:",
+        "  output_policy: overwrite",
+        "  sources:",
+    ]
+
+    def _make_source_name(link: str) -> str:
+        stem = Path(urlparse(link).path).stem
+        return re.sub(r"[^a-z0-9_]", "_", (stem or "resource").lower())
+
+    def _infer_type_from_url(u: str) -> str:
+        if "/datastore/dump/" in u or "/datastore_search" in u:
+            return "ckan"
+        if "sdmx" in u.lower() or "/dataflow/" in u.lower():
+            return "sdmx"
+        return "http_file"
+
+    if ckan_resources:
+        for res in ckan_resources:
+            res_name = re.sub(r"[^a-z0-9_]", "_", (res["name"] or "resource").lower())
+            res_url = res["url"]
+            fmt = res["format"]
+            fname = Path(urlparse(res_url).path).name or f"{res_name}.{fmt}"
+            portal_base = f"{parsed.scheme}://{parsed.netloc}"
+            lines.append(f"    - name: \"{res_name}\"")
+            lines.append('      type: "ckan"')
+            lines.append("      args:")
+            lines.append(f"        portal_url: \"{portal_base}\"")
+            lines.append(f"        resource_id: \"{res.get('id') or ''}\"")
+            lines.append(f"        filename: \"{fname}\"")
+            lines.append("      primary: true")
+    elif candidate_links:
+        # Pagina HTML con link a file scaricabili: genera un source per ogni link
+        seen: set[str] = set()
+        for link in candidate_links:
+            if link in seen:
+                continue
+            seen.add(link)
+            link_name = _make_source_name(link)
+            fname = Path(urlparse(link).path).name
+            stype = _infer_type_from_url(link)
+            lines.append(f"    - name: \"{link_name}\"")
+            lines.append(f"      type: \"{stype}\"")
+            lines.append("      args:")
+            lines.append(f"        url: \"{link}\"")
+            if fname:
+                lines.append(f"        filename: \"{fname}\"")
+            lines.append("      primary: true")
+    else:
+        fname = Path(parsed.path).name
+        stype = _infer_type_from_url(url)
+        lines.append(f"    - name: \"{slug}_source\"")
+        lines.append(f"      type: \"{stype}\"")
+        lines.append("      args:")
+        lines.append(f"        url: \"{url}\"")
+        if fname:
+            lines.append(f"        filename: \"{fname}\"")
+        lines.append("      primary: true")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def probe_url(
+    url: str,
+    *,
+    timeout: int = _DEFAULT_TIMEOUT,
+    user_agent: str = _DEFAULT_USER_AGENT,
+    capture_html: bool = False,
+) -> dict[str, Any]:
+    """
+    Probe di un URL. Restituisce metadata e candidate_links.
+
+    Parametri:
+        capture_html: se True e kind=html, include html_content nel dict
+                     (necessario per CKAN detection in scaffold mode).
+    """
     headers = {"User-Agent": user_agent}
     with requests.get(url, allow_redirects=True, timeout=timeout, headers=headers, stream=True) as response:
         content_type = response.headers.get("Content-Type")
@@ -80,10 +300,15 @@ def probe_url(url: str, *, timeout: int = _DEFAULT_TIMEOUT, user_agent: str = _D
         final_url = response.url
         is_html = _is_html(content_type)
 
+        raw_html: bytes = b""
+
         if is_html:
             response.encoding = response.encoding or response.apparent_encoding or "utf-8"
-            candidate_links = _candidate_links(final_url, response.text)
+            text = response.text
+            candidate_links = _candidate_links(final_url, text)
             kind = "html"
+            if capture_html:
+                raw_html = text.encode(response.encoding or "utf-8", errors="replace")
         elif _is_file_like(final_url, content_type, content_disposition):
             candidate_links = []
             kind = "file"
@@ -91,7 +316,7 @@ def probe_url(url: str, *, timeout: int = _DEFAULT_TIMEOUT, user_agent: str = _D
             candidate_links = []
             kind = "opaque"
 
-        return {
+        result: dict[str, Any] = {
             "requested_url": url,
             "final_url": final_url,
             "status_code": response.status_code,
@@ -100,21 +325,57 @@ def probe_url(url: str, *, timeout: int = _DEFAULT_TIMEOUT, user_agent: str = _D
             "kind": kind,
             "candidate_links": candidate_links,
         }
+        if capture_html and raw_html:
+            result["html_content"] = raw_html
+        return result
 
 
 def scout_url(
     url: str = typer.Argument(..., help="URL da ispezionare"),
     timeout: int = typer.Option(_DEFAULT_TIMEOUT, "--timeout", min=1, help="Timeout HTTP in secondi"),
     user_agent: str = typer.Option(_DEFAULT_USER_AGENT, "--user-agent", help="User-Agent da usare per la richiesta"),
+    scaffold: bool = typer.Option(False, "--scaffold", help="Genera scaffold YAML (blocchi dataset + raw)"),
 ) -> None:
     """
     Ispeziona un URL per dataset scouting minimale.
     """
     try:
-        result = probe_url(url, timeout=timeout, user_agent=user_agent)
+        result = probe_url(url, timeout=timeout, user_agent=user_agent, capture_html=scaffold)
     except requests.RequestException as exc:
         typer.echo(f"error: {type(exc).__name__}: {exc}")
         raise typer.Exit(code=1) from exc
+
+    if scaffold:
+        ckan_resources: list[dict[str, Any]] | None = None
+        candidate_file_links: list[str] | None = None
+
+        if result["kind"] == "html":
+            html_content = result.get("html_content", b"")
+            html_text = html_content.decode("utf-8", errors="replace") if html_content else ""
+            dataset_id = _extract_ckan_dataset_id(result["final_url"], html_text)
+            is_ckan = _detect_ckan(html_content) if html_content else False
+
+            if dataset_id and html_content and is_ckan:
+                ckan_resources = _discover_ckan_resources(
+                    result["final_url"],
+                    dataset_id,
+                    timeout=timeout,
+                    user_agent=user_agent,
+                )
+
+            # Se CKAN discovery ha trovato risorse, usa quelle.
+            # Altrimenti se è HTML (anche CKAN-like ma senza API funzionante),
+            # usa candidate_links per generare http_file per ogni link a file.
+            if not ckan_resources and html_content:
+                # Filtra candidate_links per estensioni file (non solo data links)
+                candidate_file_links = [
+                    link for link in result.get("candidate_links", [])
+                    if any(ext in link.lower() for ext in _EXTENDED_EXTENSIONS)
+                ]
+
+        yaml_scaffold = _generate_yaml_scaffold(result, ckan_resources, candidate_file_links)
+        typer.echo(yaml_scaffold)
+        return
 
     typer.echo(f"requested_url: {result['requested_url']}")
     typer.echo(f"final_url: {result['final_url']}")


### PR DESCRIPTION
## Summary

- Nuovo flag `--scaffold` su `toolkit scout-url` che genera blocchi `dataset` + `raw` del `dataset.yml` a partire da un URL.
- Estensioni file riconosciute: aggiunto `.parquet`, `.geojson`, `.sdmx`, `.tds`, `.xml`.
- CKAN detection: riconosce portali CKAN dall'HTML e tenta discovery delle risorse via `package_show` API.
- Fallback intelligente: se CKAN API non funziona (es. dati.gov.it), usa i `candidate_links` per generare `http_file`.

## Usage

```bash
# File diretto
toolkit scout-url --scaffold https://example.com/data.csv

# Portale CKAN con API funzionante
toolkit scout-url --scaffold https://portal.it/dataset/id-del-dataset

# Portale CKAN-like senza API (dati.gov.it, etc.)
toolkit scout-url --scaffold https://dati.gov.it/view-dataset/dataset?id=UUID
```

## Logica di decisione

```
URL -> probe -> kind=html?
  ├─ yes -> CKAN detect?
  │    ├─ yes + API OK -> ckan source per ogni risorsa
  │    └─ yes + API ko -> candidate_links -> http_file per ogni link file
  │    └─ no -> candidate_links -> http_file per ogni link file
  └─ no (file) -> http_file diretto (o ckan se datastore dump URL)
```

## Limitazioni note

1. CKAN discovery: dati.gov.it ha signature CKAN ma API ko -> fallback su candidate_links (comportamento atteso)
2. SDMX detection: basato solo su URL (`/dataflow/`), non probing content-type (miglioramento futuro)
3. `years: [2024]` sempre placeholder - inferenza anni e' miglioramento futuro

## Test

17 nuovi test + 5 esistenti = 22 totali su `test_cli_scout_url.py`.
399 test passano sulla suite completa.

## Files

- `toolkit/cli/cmd_scout_url.py` (+210 righe)
- `tests/test_cli_scout_url.py` (+130 righe)

## Check

- [x] Test passano
- [x] Nessuna regressione su 399 test
- [x] CKAN detection testata con URL reali (dati.gov.it)
- [x] Output YAML verificato con candidati reali (INPS, BDAP, Terna)

ref #151 