### PR TITLE
feat(mcp): aggiungi tool toolkit_raw_profile

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14,6 +14,7 @@ def test_mcp_server_registers_expected_tools() -> None:
     assert tool_names == {
         "toolkit_inspect_paths",
         "toolkit_show_schema",
+        "toolkit_raw_profile",
         "toolkit_run_state",
         "toolkit_summary",
         "toolkit_blocker_hints",
@@ -89,3 +90,19 @@ def test_toolkit_json_includes_cmd_in_error_on_empty_output(monkeypatch: pytest.
         cli_adapter._toolkit_json(["inspect", "paths", "--config", "dataset.yml"])
 
     assert "toolkit.cli.app" in str(exc_info.value)
+
+
+def test_toolkit_raw_profile_passes_config_and_year(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_impl(config_path: str, year: int | None) -> dict[str, object]:
+        calls["config_path"] = config_path
+        calls["year"] = year
+        return {"profile_exists": True}
+
+    monkeypatch.setattr(mcp_server, "raw_profile_impl", fake_impl)
+
+    payload = mcp_server.toolkit_raw_profile("dataset.yml", 2024)
+
+    assert payload == {"profile_exists": True}
+    assert calls == {"config_path": "dataset.yml", "year": 2024}

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -2,6 +2,7 @@
 
 Provides read-only diagnostics on config, layers, and run records:
 - show_schema: schema of a raw/clean/mart layer
+- raw_profile: content of _profile/raw_profile.json
 - run_state: run directory state and latest run record
 - summary: layer-level overview with existence checks
 - blocker_hints: common mismatches between config and outputs
@@ -108,6 +109,58 @@ def show_schema(config_path: str, layer: str = "clean", year: int | None = None)
         }
     )
     return payload
+
+
+def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
+    """Restituisce il contenuto di _profile/raw_profile.json se presente.
+
+    Il profilo contiene encoding, delimitatore, decimal suggestion, nomi colonna,
+    sample rows, missingness e mapping suggestions per il layer raw.
+    """
+    config = _safe_path(config_path)
+    paths = inspect_paths(str(config), year)
+    raw_dir = Path(paths["paths"]["raw"]["dir"])
+    profile_path = raw_dir / "_profile" / "raw_profile.json"
+
+    if not profile_path.exists():
+        raise ToolkitClientError(
+            f"raw_profile.json non trovato in {profile_path}. "
+            "Esegui 'toolkit run raw' prima di accedere al profilo."
+        )
+
+    try:
+        profile = json.loads(profile_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ToolkitClientError(
+            f"raw_profile.json malformato in {profile_path}: {exc}"
+        ) from exc
+
+    # Ritorna un sottoinsieme leggibile: evita di restituire sample_rows intere
+    # se sono troppe (già incluse nel profilo per reference).
+    return {
+        "dataset": profile.get("dataset"),
+        "year": profile.get("year"),
+        "config_path": str(config),
+        "profile_path": str(profile_path),
+        "file_used": profile.get("file_used"),
+        "read_hints": {
+            "encoding": profile.get("encoding_suggested"),
+            "delimiter": profile.get("delim_suggested"),
+            "decimal": profile.get("decimal_suggested"),
+            "skip": profile.get("skip_suggested"),
+            "robust": profile.get("robust_read_suggested"),
+        },
+        "header_line": profile.get("header_line"),
+        "columns": {
+            "raw": profile.get("columns_raw", []),
+            "normalized": profile.get("columns_norm", []),
+            "count": len(profile.get("columns_raw", [])),
+        },
+        "missingness_top": profile.get("missingness_top", []),
+        "mapping_suggestions": profile.get("mapping_suggestions", {}),
+        "warnings": profile.get("warnings", []),
+        "profile_exists": True,
+    }
 
 
 def run_state(config_path: str, year: int | None = None) -> dict[str, Any]:

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -8,6 +8,7 @@ from .toolkit_client import (
     ToolkitClientError,
     blocker_hints as blocker_hints_impl,
     inspect_paths as inspect_paths_impl,
+    raw_profile as raw_profile_impl,
     review_readiness as review_readiness_impl,
     run_state as run_state_impl,
     summary as summary_impl,
@@ -40,6 +41,14 @@ def toolkit_inspect_paths(config_path: str, year: int = 0) -> dict[str, Any]:
 @mcp.tool(description="Mostra lo schema di raw, clean o mart.", structured_output=True)
 def toolkit_show_schema(config_path: str, layer: str = "clean", year: int = 0) -> dict[str, Any]:
     return _guard(show_schema_impl, config_path, layer, year or None)
+
+
+@mcp.tool(
+    description="Mostra il profilo raw: encoding, delimiter, colonne, missingness e mapping suggestions.",
+    structured_output=True,
+)
+def toolkit_raw_profile(config_path: str, year: int = 0) -> dict[str, Any]:
+    return _guard(raw_profile_impl, config_path, year or None)
 
 
 @mcp.tool(

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -5,7 +5,7 @@ This module is a thin facade. The actual implementation lives in dedicated sub-m
 - errors: ToolkitClientError
 - path_safety: _safe_path, _load_cfg
 - cli_adapter: _toolkit_json, inspect_paths
-- schema_ops: show_schema, run_state, summary, blocker_hints, review_readiness
+- schema_ops: show_schema, raw_profile, run_state, summary, blocker_hints, review_readiness
 """
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.cli_adapter import inspect_paths
 from toolkit.mcp.schema_ops import (
     blocker_hints,
+    raw_profile,
     review_readiness,
     run_state,
     show_schema,


### PR DESCRIPTION
## Summary

Nuovo tool MCP `toolkit_raw_profile` che legge `_profile/raw_profile.json` e restituisce un dict strutturato con:

- **read_hints**: encoding, delimiter, decimal, skip, robust
- **columns**: nomi raw e normalized delle colonne
- **missingness_top**: prime N colonne con missing values
- **mapping_suggestions**: suggerimenti di normalizzazione
- **warnings**: eventuali warning dal profiling

## Motivazione

Il profilo raw contiene informazioni preziose per chi fa intake/review di un candidate:
encoding rilevato, delimiter, nomi colonne — informazioni già generate da `toolkit run raw` ma non accessibili via MCP.

## Output esempio

```json
{
  "dataset": "inps_cig",
  "year": 2024,
  "read_hints": {
    "encoding": "latin-1",
    "delimiter": ";",
    "decimal": null,
    "skip": 0,
    "robust": false
  },
  "columns": {
    "raw": ["Anno", "CodEnte", "Denominazione", ...],
    "normalized": ["anno", "cod_ente", "denominazione", ...],
    "count": 42
  },
  "missingness_top": [...],
  "mapping_suggestions": {...},
  "warnings": []
}
```

## Check

- [x] Ruff clean
- [x] 383 test passano (383 = 381 originali + 2 nuovi)
- [x] Test MCP aggiornato: `test_mcp_server_registers_expected_tools`
- [x] Nuovo test: `test_toolkit_raw_profile_passes_config_and_year`

ref TASK_toolkit_mcp_followup