### PR TITLE
fix(cli_adapter): includi cmd nell'errore quando stdout/stderr vuoti (#167)

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -71,3 +71,21 @@ def test_toolkit_show_schema_passes_layer_and_year(monkeypatch: pytest.MonkeyPat
 
     assert payload == {"layer": "mart", "year": 2024}
     assert calls == {"config_path": "dataset.yml", "layer": "mart", "year": 2024}
+
+
+def test_toolkit_json_includes_cmd_in_error_on_empty_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When CLI fails with no stdout/stderr, error should include the command."""
+    import subprocess
+    from toolkit.mcp.toolkit_client import ToolkitClientError
+
+    def fake_run(*args: object, **kwargs: object) -> object:
+        fake_result = subprocess.CompletedProcess(args=[], returncode=127)
+        return fake_result
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(ToolkitClientError, match="exit code 127") as exc_info:
+        from toolkit.mcp import cli_adapter  # re-import to apply monkeypatch
+        cli_adapter._toolkit_json(["inspect", "paths", "--config", "dataset.yml"])
+
+    assert "toolkit.cli.app" in str(exc_info.value)

--- a/toolkit/mcp/cli_adapter.py
+++ b/toolkit/mcp/cli_adapter.py
@@ -37,7 +37,12 @@ def _toolkit_json(args: list[str]) -> dict[str, Any]:
     if result.returncode != 0:
         stderr = (result.stderr or "").strip()
         stdout = (result.stdout or "").strip()
-        detail = stderr or stdout or f"exit code {result.returncode}"
+        if stderr:
+            detail = stderr
+        elif stdout:
+            detail = stdout
+        else:
+            detail = f"exit code {result.returncode}: {' '.join(cmd)}"
         raise ToolkitClientError(f"toolkit CLI fallita: {detail}")
 
     try:


### PR DESCRIPTION
## Summary

- `_toolkit_json` in `cli_adapter.py`: quando stderr e stdout sono entrambi vuoti ma exit code != 0, il messaggio di errore ora include il comando eseguito (`cmd`)
- Prima: `"exit code 127"`
- Dopo: `"exit code 127: /path/to/python -m toolkit.cli.app inspect paths ..."`

## Motivazione

Un crash CLI che produce exit code non-zero ma nessun output (es. segfault, kill esterno) rendeva il debug impossibile perché il messaggio non conteneva il comando fallito.

## Fix

Branching esplicito `if/elif/else`:
- `stderr` non vuoto → usa stderr
- `stdout` non vuoto → usa stdout
- entrambi vuoti → `f"exit code N: {cmd}"` con il comando completo

## Test

- `test_toolkit_json_includes_cmd_in_error_on_empty_output`: monkeypatch `subprocess.run` per simulare exit 127 senza output, verifica che errore contenga `"exit code 127"` e `"toolkit.cli.app"`

## Check

- [x] 385 test passano (nessuna regressione)
- [x] Ruff clean

ref #167