### PR TITLE
feat(plugin): aggiungi source plugin sparql (#149)

### DIFF
--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -3,7 +3,7 @@ import toolkit.plugins as plugins_pkg
 import toolkit.profile as profile_pkg
 import toolkit.raw as raw_pkg
 from toolkit.clean import run_clean, run_clean_validation, validate_clean
-from toolkit.plugins import CkanSource, HttpFileSource, LocalFileSource, SdmxSource
+from toolkit.plugins import CkanSource, HttpFileSource, LocalFileSource, SdmxSource, SparqlSource
 from toolkit.profile import (
     RawProfile,
     build_profile_hints,
@@ -36,11 +36,12 @@ def test_raw_exports() -> None:
 
 
 def test_plugins_exports() -> None:
-    assert plugins_pkg.__all__ == ["LocalFileSource", "HttpFileSource", "CkanSource", "SdmxSource"]
+    assert plugins_pkg.__all__ == ["LocalFileSource", "HttpFileSource", "CkanSource", "SdmxSource", "SparqlSource"]
     assert LocalFileSource.__name__ == "LocalFileSource"
     assert HttpFileSource.__name__ == "HttpFileSource"
     assert CkanSource.__name__ == "CkanSource"
     assert SdmxSource.__name__ == "SdmxSource"
+    assert SparqlSource.__name__ == "SparqlSource"
 
 
 def test_profile_exports() -> None:

--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -163,6 +163,16 @@ def test_sparql_fetch_unsupported_content_type_raises(monkeypatch: pytest.Monkey
         )
 
 
+def test_sparql_fetch_unsupported_accept_format_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="Unsupported accept_format"):
+        source.fetch(
+            "https://example.test/sparql",
+            "SELECT * WHERE { }",
+            accept_format="xml",
+        )
+
+
 def test_sparql_fetch_missing_endpoint_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     source = SparqlSource()
     with pytest.raises(DownloadError, match="requires endpoint URL"):

--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import pytest
+
+from toolkit.core.exceptions import DownloadError
+from toolkit.plugins.sparql import SparqlSource, _sparql_json_to_csv
+
+
+class _FakeSparqlResponse:
+    def __init__(
+        self,
+        status_code: int = 200,
+        text: str = "",
+        content: bytes | None = None,
+        headers: dict[str, str | bytes] | None = None,
+    ):
+        self.status_code = status_code
+        self.text = text
+        self.content = content if content is not None else text.encode("utf-8")
+        self.headers = headers or {}
+
+
+def test_sparql_fetch_csv_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[object, object]] = []
+
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
+        return _FakeSparqlResponse(
+            status_code=200,
+            text="name,value\nfoo,123\nbar,456\n",
+            headers={"Content-Type": "text/csv"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource(timeout=30)
+    payload, origin = source.fetch(
+        "https://example.test/sparql",
+        "SELECT ?name ?value WHERE { }",
+        accept_format="csv",
+    )
+
+    assert origin == "https://example.test/sparql"
+    assert b"name,value" in payload
+    assert b"foo,123" in payload
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://example.test/sparql"
+    assert calls[0]["timeout"] == 30
+
+
+def test_sparql_fetch_json_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    json_response = """{
+  "head": { "vars": ["name", "value"] },
+  "results": {
+    "bindings": [
+      { "name": { "type": "literal", "value": "Alice" }, "value": { "type": "literal", "value": "42" } },
+      { "name": { "type": "literal", "value": "Bob" }, "value": { "type": "literal", "value": "7" } }
+    ]
+  }
+}"""
+    calls: list[dict[object, object]] = []
+
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
+        return _FakeSparqlResponse(
+            status_code=200,
+            text=json_response,
+            headers={"Content-Type": "application/sparql-results+json"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    payload, origin = source.fetch(
+        "https://example.test/sparql",
+        "SELECT ?name ?value WHERE { }",
+        accept_format="sparql-results+json",
+    )
+
+    assert origin == "https://example.test/sparql"
+    lines = payload.decode("utf-8").splitlines()
+    assert lines[0] == "name,value"
+    assert "Alice,42" in payload.decode("utf-8")
+    assert "Bob,7" in payload.decode("utf-8")
+
+
+def test_sparql_fetch_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        return _FakeSparqlResponse(status_code=500, text="Internal Server Error")
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="HTTP 500"):
+        source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
+
+
+def test_sparql_fetch_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        raise Exception("connection refused")
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="connection refused"):
+        source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
+
+
+def test_sparql_fetch_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        return _FakeSparqlResponse(
+            status_code=200,
+            text='{"head":{"vars":["name"]},"results":{"bindings":[]}}',
+            headers={"Content-Type": "application/sparql-results+json"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="no results"):
+        source.fetch(
+            "https://example.test/sparql",
+            "SELECT ?name WHERE { }",
+            accept_format="sparql-results+json",
+        )
+
+
+def test_sparql_fetch_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        return _FakeSparqlResponse(
+            status_code=200,
+            text="not json at all",
+            headers={"Content-Type": "application/sparql-results+json"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="Invalid SPARQL JSON"):
+        source.fetch(
+            "https://example.test/sparql",
+            "SELECT * WHERE { }",
+            accept_format="sparql-results+json",
+        )
+
+
+def test_sparql_fetch_missing_endpoint_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="requires endpoint URL"):
+        source.fetch("", "SELECT * WHERE { }")
+
+
+def test_sparql_fetch_missing_query_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="requires a query"):
+        source.fetch("https://example.test/sparql", "")
+
+
+def test_sparql_json_to_csv_binding_types(monkeypatch: pytest.MonkeyPatch) -> None:
+    """URI and literal bindings are both converted to their string value."""
+    json_response = """{
+  "head": { "vars": ["person", "age"] },
+  "results": {
+    "bindings": [
+      {
+        "person": { "type": "uri", "value": "http://example.org/Alice" },
+        "age": { "type": "literal", "value": "30", "datatype": "http://www.w3.org/2001/XMLSchema#integer" }
+      }
+    ]
+  }
+}"""
+    csv_bytes = _sparql_json_to_csv(json_response)
+    csv_text = csv_bytes.decode("utf-8")
+    assert "person,age" in csv_text
+    assert "http://example.org/Alice,30" in csv_text

--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -144,6 +144,25 @@ def test_sparql_fetch_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
 
+def test_sparql_fetch_unsupported_content_type_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        return _FakeSparqlResponse(
+            status_code=200,
+            text="<xml>not supported</xml>",
+            headers={"Content-Type": "application/xml"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="Unsupported Content-Type"):
+        source.fetch(
+            "https://example.test/sparql",
+            "SELECT * WHERE { }",
+            accept_format="csv",
+        )
+
+
 def test_sparql_fetch_missing_endpoint_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     source = SparqlSource()
     with pytest.raises(DownloadError, match="requires endpoint URL"):

--- a/toolkit/core/registry.py
+++ b/toolkit/core/registry.py
@@ -68,7 +68,7 @@ _BUILTIN_PLUGINS: tuple[dict[str, Any], ...] = (
         "module": "toolkit.plugins.local_file",
         "class_name": "LocalFileSource",
         "optional": False,
-        "factory": lambda cls: (lambda **client: cls(**client)),
+        "factory": lambda cls: (lambda **client: cls()),
     },
     {
         "name": "sparql",

--- a/toolkit/core/registry.py
+++ b/toolkit/core/registry.py
@@ -68,7 +68,14 @@ _BUILTIN_PLUGINS: tuple[dict[str, Any], ...] = (
         "module": "toolkit.plugins.local_file",
         "class_name": "LocalFileSource",
         "optional": False,
-        "factory": lambda cls: (lambda **client: cls()),
+        "factory": lambda cls: (lambda **client: cls(**client)),
+    },
+    {
+        "name": "sparql",
+        "module": "toolkit.plugins.sparql",
+        "class_name": "SparqlSource",
+        "optional": False,
+        "factory": lambda cls: (lambda **client: cls(**client)),
     },
 )
 

--- a/toolkit/core/registry.py
+++ b/toolkit/core/registry.py
@@ -75,7 +75,7 @@ _BUILTIN_PLUGINS: tuple[dict[str, Any], ...] = (
         "module": "toolkit.plugins.sparql",
         "class_name": "SparqlSource",
         "optional": False,
-        "factory": lambda cls: (lambda **client: cls(**client)),
+        "factory": lambda cls: (lambda **client: cls(timeout=client.get("timeout", 60))),
     },
 )
 

--- a/toolkit/plugins/__init__.py
+++ b/toolkit/plugins/__init__.py
@@ -8,16 +8,19 @@ Builtin stable sources exposed by the default runtime:
 - `http_file`
 - `ckan`
 - `sdmx`
+- `sparql`
 """
 
 from toolkit.plugins.ckan import CkanSource
 from toolkit.plugins.http_file import HttpFileSource
 from toolkit.plugins.local_file import LocalFileSource
 from toolkit.plugins.sdmx import SdmxSource
+from toolkit.plugins.sparql import SparqlSource
 
 __all__ = [
     "LocalFileSource",
     "HttpFileSource",
     "CkanSource",
     "SdmxSource",
+    "SparqlSource",
 ]

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -44,6 +44,11 @@ class SparqlSource:
             raise DownloadError("SPARQL source requires endpoint URL")
         if not query:
             raise DownloadError("SPARQL source requires a query")
+        if accept_format not in {"csv", "sparql-results+json"}:
+            raise DownloadError(
+                f"Unsupported accept_format '{accept_format}'. "
+                "Supported values: 'csv', 'sparql-results+json'."
+            )
 
         headers: dict[str, str] = {
             "Accept": "application/sparql-results+json" if accept_format == "sparql-results+json" else "text/csv",
@@ -69,10 +74,7 @@ class SparqlSource:
         content_type = r.headers.get("Content-Type", "")
 
         if "text/csv" in content_type:
-            payload: bytes | str = r.content
-            if isinstance(payload, bytes):
-                payload = payload.decode("utf-8", errors="replace")
-            return payload.encode("utf-8"), endpoint
+            return r.content, endpoint
 
         if "sparql-results+json" in content_type:
             csv_bytes = _sparql_json_to_csv(r.text)
@@ -106,8 +108,8 @@ def _sparql_json_to_csv(json_text: str) -> bytes:
     if not bindings:
         raise DownloadError("SPARQL query returned no results")
 
-    # Collect all variable names from the first binding
-    var_names: list[str] = list(bindings[0].keys())
+    # Use head.vars as canonical column list; bindings may omit unbound variables.
+    var_names: list[str] = (payload.get("head") or {}).get("vars") or list(bindings[0].keys())
     rows: list[dict[str, str]] = []
 
     for binding in bindings:

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -1,0 +1,123 @@
+"""SPARQL source plugin.
+
+Fetches tabular data from a SPARQL endpoint via HTTP POST.
+Supports direct CSV responses and SPARQL Results JSON (converted to CSV).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Any
+
+import requests
+
+from toolkit.core.exceptions import DownloadError
+
+
+class SparqlSource:
+    """Query a SPARQL endpoint and return results as CSV bytes."""
+
+    def __init__(self, timeout: int = 60):
+        self.timeout = timeout
+
+    def fetch(
+        self,
+        endpoint: str,
+        query: str,
+        accept_format: str = "csv",
+    ) -> tuple[bytes, str]:
+        """Execute a SPARQL query and return CSV data.
+
+        Args:
+            endpoint: SPARQL endpoint URL.
+            query: SPARQL SELECT query string.
+            accept_format: 'csv' for direct CSV, 'sparql-results+json' for JSON conversion.
+
+        Returns:
+            (csv_bytes, endpoint) tuple.
+
+        Raises:
+            DownloadError: on network error, non-200 response, or empty results.
+        """
+        if not endpoint:
+            raise DownloadError("SPARQL source requires endpoint URL")
+        if not query:
+            raise DownloadError("SPARQL source requires a query")
+
+        headers: dict[str, str] = {
+            "Accept": "application/sparql-results+json" if accept_format == "sparql-results+json" else "text/csv",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        params: dict[str, Any] = {"query": query}
+
+        try:
+            r = requests.post(
+                endpoint,
+                data=params,
+                headers=headers,
+                timeout=self.timeout,
+            )
+        except Exception as e:
+            raise DownloadError(f"SPARQL request failed for {endpoint}: {e}") from e
+
+        if r.status_code != 200:
+            raise DownloadError(
+                f"SPARQL endpoint returned HTTP {r.status_code} for {endpoint}: {r.text[:200]}"
+            )
+
+        content_type = r.headers.get("Content-Type", "")
+
+        if "text/csv" in content_type or accept_format == "csv":
+            payload: bytes | str = r.content
+            if isinstance(payload, bytes):
+                payload = payload.decode("utf-8", errors="replace")
+            return payload.encode("utf-8"), endpoint
+
+        if "sparql-results+json" in content_type or accept_format == "sparql-results+json":
+            csv_bytes = _sparql_json_to_csv(r.text)
+            return csv_bytes, endpoint
+
+        # Fallback: treat as text
+        text = r.text
+        return text.encode("utf-8"), endpoint
+
+
+def _sparql_json_to_csv(json_text: str) -> bytes:
+    """Convert SPARQL Results JSON to CSV bytes."""
+    import json
+
+    try:
+        payload = json.loads(json_text)
+    except json.JSONDecodeError as e:
+        raise DownloadError(f"Invalid SPARQL JSON response: {e}") from e
+
+    bindings: list[dict[str, Any]] = (
+        (payload.get("results") or {}).get("bindings") or []
+    )
+    if not isinstance(bindings, list):
+        raise DownloadError("SPARQL JSON payload has unexpected structure")
+
+    if not bindings:
+        raise DownloadError("SPARQL query returned no results")
+
+    # Collect all variable names from the first binding
+    var_names: list[str] = list(bindings[0].keys())
+    rows: list[dict[str, str]] = []
+
+    for binding in bindings:
+        row: dict[str, str] = {}
+        for var in var_names:
+            cell = binding.get(var)
+            if cell and isinstance(cell, dict):
+                # SPARQL JSON binding: {"value": "...", "type": "..."}
+                row[var] = str(cell.get("value", ""))
+            else:
+                row[var] = str(cell if cell is not None else "")
+        rows.append(row)
+
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=var_names)
+    writer.writeheader()
+    writer.writerows(rows)
+    return buffer.getvalue().encode("utf-8")

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -68,23 +68,28 @@ class SparqlSource:
 
         content_type = r.headers.get("Content-Type", "")
 
-        if "text/csv" in content_type or accept_format == "csv":
+        if "text/csv" in content_type:
             payload: bytes | str = r.content
             if isinstance(payload, bytes):
                 payload = payload.decode("utf-8", errors="replace")
             return payload.encode("utf-8"), endpoint
 
-        if "sparql-results+json" in content_type or accept_format == "sparql-results+json":
+        if "sparql-results+json" in content_type:
             csv_bytes = _sparql_json_to_csv(r.text)
             return csv_bytes, endpoint
 
-        # Fallback: treat as text
-        text = r.text
-        return text.encode("utf-8"), endpoint
+        raise DownloadError(
+            f"Unsupported Content-Type '{content_type}' for SPARQL fetch. "
+            "Expected 'text/csv' or 'application/sparql-results+json'."
+        )
 
 
 def _sparql_json_to_csv(json_text: str) -> bytes:
-    """Convert SPARQL Results JSON to CSV bytes."""
+    """Convert SPARQL Results JSON to CSV bytes.
+
+    Assumes all bindings share the same set of variables (homogeneous schema).
+    Extra keys in later bindings or missing keys produce empty values silently.
+    """
     import json
 
     try:

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -86,6 +86,12 @@ def _fetch_payload(stype: str, client: dict, formatted_args: dict) -> tuple[byte
             str(formatted_args["version"]),
             formatted_args.get("filters"),
         )
+    elif stype == "sparql":
+        payload, origin = src.fetch(
+            str(formatted_args["endpoint"]),
+            str(formatted_args["query"]),
+            str(formatted_args.get("accept_format", "csv")),
+        )
     elif stype == "http_file":
         payload = src.fetch(formatted_args["url"])
         origin = formatted_args["url"]

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -26,7 +26,7 @@ def _format_args(args: dict, year: int) -> dict:
 
 
 def _infer_ext(stype: str, formatted_args: dict, origin: str | None = None) -> str:
-    if stype == "sdmx":
+    if stype in {"sdmx", "sparql"}:
         return ".csv"
     if stype in {"http_file", "ckan"}:
         url = origin or formatted_args.get("url", "")


### PR DESCRIPTION
Closes #149 
## Summary
- Nuovo source plugin built-in `sparql` per query a endpoint SPARQL
- Supporta risposte CSV dirette e `sparql-results+json` (convertito in CSV)
- Nessun cambio di contratto sui plugin esistenti

## Files
- `toolkit/plugins/sparql.py` — nuovo `SparqlSource`
- `toolkit/plugins/__init__.py` — export
- `toolkit/core/registry.py` — registrazione
- `toolkit/raw/run.py` — routing in `_fetch_payload`
- `tests/test_sparql_plugin.py` — 9 test
- `tests/test_package_exports.py` — aggiornato per SparqlSource

## Test
381 passed (1 pre-esistente xlrd skipped)