### PR TITLE
feat: source plugin sparql + inspect probe SPARQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ toolkit status --dataset project_example --year 2022 --latest --config project-e
 
 Il toolkit risolve `dataset.yml` + `sql/` per produrre output auditabili.
 - **`root`**: Directory di output (fallback su cartella config).
-- **`raw`**: Sorgenti (local, generic_https, ckan, sdmx) e strategie di download.
+- **`raw`**: Sorgenti (local_file, http_file, ckan, sdmx, sparql) e strategie di download.
 - **`clean`**: Normalizzazione tramite `sql/clean.sql`.
 - **`mart`**: Tabelle analitiche aggregate via `sql/mart/*.sql`.
 - **`validation`**: Quality check per layer (`fail_on_error: true`).
@@ -38,6 +38,8 @@ Il toolkit risolve `dataset.yml` + `sql/` per produrre output auditabili.
 
 - `toolkit inspect paths --config dataset.yml --year 2024 --json`: Contratto path per notebook e script.
 - `toolkit inspect schema-diff`: Analisi diagnostica di drift tra anni nel RAW.
+- `toolkit inspect url <url>`: Probe URL pubblico e generazione scaffold YAML.
+- `toolkit inspect probe --source sparql --endpoint <url> --query <query>`: Probe schema e stats di un endpoint SPARQL.
 - `toolkit run all --config dataset.yml --dry-run --strict-config`: Valida config/SQL in modo stretto.
 - `toolkit status --dataset <name> --year <year> --latest --config dataset.yml`: Recupera l'ultimo run.
 - `toolkit batch`: esecuzione batch quando devi orchestrare più config.

--- a/docs/feature-stability.md
+++ b/docs/feature-stability.md
@@ -18,7 +18,9 @@ Questa matrice serve a chiarire cosa il toolkit considera percorso canonico, cos
 | artifact policy `minimal|standard|debug` | supported / advanced | tuning operativo |
 | `legacy_aliases` | compatibility only | non promuovere nei repo nuovi |
 | config legacy | compatibility only | usare `--strict-config` nei repo nuovi |
-| `scout_url` | experimental | scouting rapido di un URL pubblico — non fa parte del workflow canonico |
+| `scout_url` | deprecated | sostituito da `inspect url` |
+| `inspect url` | experimental | scouting rapido di un URL pubblico e generazione scaffold YAML |
+| `inspect probe` | experimental | probe schema+stats di un endpoint SPARQL pre-candidate |
 
 Lettura equivalente a livello package:
 
@@ -26,7 +28,7 @@ Lettura equivalente a livello package:
 - advanced tooling: `toolkit.profile`, `resume`, run parziali, `cross_year`, `inspect schema-diff`
 - compatibility only: config legacy e alias storici
 
-Sorgenti builtin supportate dal runtime canonico: `local_file`, `http_file`. Il runtime può conservare `.xlsx` e `.xls` in RAW e leggerli in CLEAN — il file originale resta l'artefatto sorgente.
+Sorgenti builtin supportate dal runtime canonico: `local_file`, `http_file`, `ckan`, `sdmx`, `sparql`. Il runtime può conservare `.xlsx` e `.xls` in RAW e leggerli in CLEAN — il file originale resta l'artefatto sorgente.
 
 Regola pratica:
 

--- a/tests/test_cli_scout_url.py
+++ b/tests/test_cli_scout_url.py
@@ -81,7 +81,7 @@ def test_scout_url_reports_file_headers_after_redirect() -> None:
     server, base_url = _serve()
     runner = CliRunner()
     try:
-        result = runner.invoke(app, ["scout-url", f"{base_url}/redirect-file"])
+        result = runner.invoke(app, ["inspect", "url", f"{base_url}/redirect-file"])
     finally:
         server.shutdown()
         server.server_close()
@@ -100,7 +100,7 @@ def test_scout_url_extracts_candidate_links_from_html() -> None:
     server, base_url = _serve()
     runner = CliRunner()
     try:
-        result = runner.invoke(app, ["scout-url", f"{base_url}/html"])
+        result = runner.invoke(app, ["inspect", "url", f"{base_url}/html"])
     finally:
         server.shutdown()
         server.server_close()
@@ -121,7 +121,7 @@ def test_scout_url_marks_opaque_non_html_response() -> None:
     server, base_url = _serve()
     runner = CliRunner()
     try:
-        result = runner.invoke(app, ["scout-url", f"{base_url}/opaque"])
+        result = runner.invoke(app, ["inspect", "url", f"{base_url}/opaque"])
     finally:
         server.shutdown()
         server.server_close()
@@ -332,7 +332,7 @@ def test_scout_url_scaffold_flag_http_file() -> None:
     server, base_url = _serve()
     runner = CliRunner()
     try:
-        result = runner.invoke(app, ["scout-url", "--scaffold", f"{base_url}/files/demo.csv"])
+        result = runner.invoke(app, ["inspect", "url", "--scaffold", f"{base_url}/files/demo.csv"])
     finally:
         server.shutdown()
         server.server_close()
@@ -349,7 +349,7 @@ def test_scout_url_scaffold_flag_html_uses_candidate_links() -> None:
     server, base_url = _serve()
     runner = CliRunner()
     try:
-        result = runner.invoke(app, ["scout-url", "--scaffold", f"{base_url}/html"])
+        result = runner.invoke(app, ["inspect", "url", "--scaffold", f"{base_url}/html"])
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -3,7 +3,7 @@ import toolkit.plugins as plugins_pkg
 import toolkit.profile as profile_pkg
 import toolkit.raw as raw_pkg
 from toolkit.clean import run_clean, run_clean_validation, validate_clean
-from toolkit.plugins import CkanSource, HttpFileSource, LocalFileSource, SdmxSource
+from toolkit.plugins import CkanSource, HttpFileSource, LocalFileSource, SdmxSource, SparqlSource
 from toolkit.profile import (
     RawProfile,
     build_profile_hints,
@@ -36,11 +36,12 @@ def test_raw_exports() -> None:
 
 
 def test_plugins_exports() -> None:
-    assert plugins_pkg.__all__ == ["LocalFileSource", "HttpFileSource", "CkanSource", "SdmxSource"]
+    assert plugins_pkg.__all__ == ["LocalFileSource", "HttpFileSource", "CkanSource", "SdmxSource", "SparqlSource"]
     assert LocalFileSource.__name__ == "LocalFileSource"
     assert HttpFileSource.__name__ == "HttpFileSource"
     assert CkanSource.__name__ == "CkanSource"
     assert SdmxSource.__name__ == "SdmxSource"
+    assert SparqlSource.__name__ == "SparqlSource"
 
 
 def test_profile_exports() -> None:

--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import pytest
+
+from toolkit.core.exceptions import DownloadError
+from toolkit.plugins.sparql import SparqlSource, _sparql_json_to_csv
+
+
+class _FakeSparqlResponse:
+    def __init__(
+        self,
+        status_code: int = 200,
+        text: str = "",
+        content: bytes | None = None,
+        headers: dict[str, str | bytes] | None = None,
+    ):
+        self.status_code = status_code
+        self.text = text
+        self.content = content if content is not None else text.encode("utf-8")
+        self.headers = headers or {}
+
+
+def test_sparql_fetch_csv_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[object, object]] = []
+
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
+        return _FakeSparqlResponse(
+            status_code=200,
+            text="name,value\nfoo,123\nbar,456\n",
+            headers={"Content-Type": "text/csv"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource(timeout=30)
+    payload, origin = source.fetch(
+        "https://example.test/sparql",
+        "SELECT ?name ?value WHERE { }",
+        accept_format="csv",
+    )
+
+    assert origin == "https://example.test/sparql"
+    assert b"name,value" in payload
+    assert b"foo,123" in payload
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://example.test/sparql"
+    assert calls[0]["timeout"] == 30
+
+
+def test_sparql_fetch_json_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    json_response = """{
+  "head": { "vars": ["name", "value"] },
+  "results": {
+    "bindings": [
+      { "name": { "type": "literal", "value": "Alice" }, "value": { "type": "literal", "value": "42" } },
+      { "name": { "type": "literal", "value": "Bob" }, "value": { "type": "literal", "value": "7" } }
+    ]
+  }
+}"""
+    calls: list[dict[object, object]] = []
+
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
+        return _FakeSparqlResponse(
+            status_code=200,
+            text=json_response,
+            headers={"Content-Type": "application/sparql-results+json"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    payload, origin = source.fetch(
+        "https://example.test/sparql",
+        "SELECT ?name ?value WHERE { }",
+        accept_format="sparql-results+json",
+    )
+
+    assert origin == "https://example.test/sparql"
+    lines = payload.decode("utf-8").splitlines()
+    assert lines[0] == "name,value"
+    assert "Alice,42" in payload.decode("utf-8")
+    assert "Bob,7" in payload.decode("utf-8")
+
+
+def test_sparql_fetch_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        return _FakeSparqlResponse(status_code=500, text="Internal Server Error")
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="HTTP 500"):
+        source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
+
+
+def test_sparql_fetch_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        raise Exception("connection refused")
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="connection refused"):
+        source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
+
+
+def test_sparql_fetch_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        return _FakeSparqlResponse(
+            status_code=200,
+            text='{"head":{"vars":["name"]},"results":{"bindings":[]}}',
+            headers={"Content-Type": "application/sparql-results+json"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="no results"):
+        source.fetch(
+            "https://example.test/sparql",
+            "SELECT ?name WHERE { }",
+            accept_format="sparql-results+json",
+        )
+
+
+def test_sparql_fetch_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        return _FakeSparqlResponse(
+            status_code=200,
+            text="not json at all",
+            headers={"Content-Type": "application/sparql-results+json"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="Invalid SPARQL JSON"):
+        source.fetch(
+            "https://example.test/sparql",
+            "SELECT * WHERE { }",
+            accept_format="sparql-results+json",
+        )
+
+
+def test_sparql_fetch_unsupported_content_type_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        return _FakeSparqlResponse(
+            status_code=200,
+            text="<xml>not supported</xml>",
+            headers={"Content-Type": "application/xml"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="Unsupported Content-Type"):
+        source.fetch(
+            "https://example.test/sparql",
+            "SELECT * WHERE { }",
+            accept_format="csv",
+        )
+
+
+def test_sparql_fetch_unsupported_accept_format_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="Unsupported accept_format"):
+        source.fetch(
+            "https://example.test/sparql",
+            "SELECT * WHERE { }",
+            accept_format="xml",
+        )
+
+
+def test_sparql_fetch_missing_endpoint_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="requires endpoint URL"):
+        source.fetch("", "SELECT * WHERE { }")
+
+
+def test_sparql_fetch_missing_query_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="requires a query"):
+        source.fetch("https://example.test/sparql", "")
+
+
+def test_sparql_json_to_csv_binding_types(monkeypatch: pytest.MonkeyPatch) -> None:
+    """URI and literal bindings are both converted to their string value."""
+    json_response = """{
+  "head": { "vars": ["person", "age"] },
+  "results": {
+    "bindings": [
+      {
+        "person": { "type": "uri", "value": "http://example.org/Alice" },
+        "age": { "type": "literal", "value": "30", "datatype": "http://www.w3.org/2001/XMLSchema#integer" }
+      }
+    ]
+  }
+}"""
+    csv_bytes = _sparql_json_to_csv(json_response)
+    csv_text = csv_bytes.decode("utf-8")
+    assert "person,age" in csv_text
+    assert "http://example.org/Alice,30" in csv_text
+
+
+def test_sparql_probe_returns_schema_and_stats(monkeypatch: pytest.MonkeyPatch) -> None:
+    json_response = """{
+  "head": { "vars": ["name", "value"] },
+  "results": {
+    "bindings": [
+      { "name": { "type": "literal", "value": "Alice" }, "value": { "type": "literal", "value": "42" } },
+      { "name": { "type": "literal", "value": "Bob" }, "value": { "type": "literal", "value": null } },
+      { "name": { "type": "literal", "value": "Charlie" }, "value": { "type": "literal", "value": "7" } }
+    ]
+  }
+}"""
+    calls: list[dict[object, object]] = []
+
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
+        return _FakeSparqlResponse(
+            status_code=200,
+            text=json_response,
+            headers={"Content-Type": "application/sparql-results+json"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource(timeout=30)
+    result = source.probe(
+        "https://example.test/sparql",
+        "SELECT ?name ?value WHERE { }",
+        limit=10,
+    )
+
+    assert result["endpoint"] == "https://example.test/sparql"
+    assert result["variables"] == ["name", "value"]
+    assert result["row_count"] == 3
+    assert result["null_counts"]["name"] == 0
+    assert result["null_counts"]["value"] == 1
+    assert result["distinct_counts"]["name"] == 3
+    assert result["distinct_counts"]["value"] == 2
+    assert len(result["sample_rows"]) == 3
+    assert any("variable 'value'" in w and "null" in w for w in result["warnings"])
+    assert result["query_time_ms"] >= 0
+
+
+def test_sparql_probe_adds_limit_if_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[object, object]] = []
+
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
+        return _FakeSparqlResponse(
+            status_code=200,
+            text='{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"literal","value":"1"}}]}}',
+            headers={"Content-Type": "application/sparql-results+json"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    source.probe("https://example.test/sparql", "SELECT ?x WHERE { }", limit=50)
+
+    sent_query = calls[0]["data"]["query"]
+    assert "LIMIT 50" in sent_query.upper()
+
+
+def test_sparql_probe_preserves_existing_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[object, object]] = []
+
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
+        return _FakeSparqlResponse(
+            status_code=200,
+            text='{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"literal","value":"1"}}]}}',
+            headers={"Content-Type": "application/sparql-results+json"},
+        )
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    source.probe("https://example.test/sparql", "SELECT ?x WHERE { } LIMIT 10", limit=50)
+
+    sent_query = calls[0]["data"]["query"]
+    # Should not double-limit
+    assert sent_query.upper().count("LIMIT") == 1
+
+
+def test_sparql_probe_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, data: dict, headers: dict, timeout: int):
+        return _FakeSparqlResponse(status_code=500, text="Internal Server Error")
+
+    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
+
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="HTTP 500"):
+        source.probe("https://example.test/sparql", "SELECT * WHERE { }")
+
+
+def test_sparql_probe_missing_endpoint_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="requires endpoint URL"):
+        source.probe("", "SELECT * WHERE { }")
+
+
+def test_sparql_probe_missing_query_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = SparqlSource()
+    with pytest.raises(DownloadError, match="requires a query"):
+        source.probe("https://example.test/sparql", "")

--- a/toolkit/cli/app.py
+++ b/toolkit/cli/app.py
@@ -5,6 +5,7 @@ import typer
 from toolkit.cli.cmd_run import register as register_run
 from toolkit.cli.cmd_profile import register as register_profile
 from toolkit.cli.cmd_resume import register as register_resume
+from toolkit.cli.cmd_scout_url import register as register_scout_url
 from toolkit.cli.cmd_status import register as register_status
 from toolkit.cli.cmd_validate import register as register_validate
 from toolkit.cli.cmd_inspect import register as register_inspect
@@ -17,6 +18,7 @@ app = typer.Typer(no_args_is_help=True, add_completion=False)
 register_run(app)
 register_profile(app)
 register_resume(app)
+register_scout_url(app)
 register_status(app)
 register_validate(app)
 register_inspect(app)

--- a/toolkit/cli/app.py
+++ b/toolkit/cli/app.py
@@ -5,7 +5,6 @@ import typer
 from toolkit.cli.cmd_run import register as register_run
 from toolkit.cli.cmd_profile import register as register_profile
 from toolkit.cli.cmd_resume import register as register_resume
-from toolkit.cli.cmd_scout_url import register as register_scout_url
 from toolkit.cli.cmd_status import register as register_status
 from toolkit.cli.cmd_validate import register as register_validate
 from toolkit.cli.cmd_inspect import register as register_inspect
@@ -18,7 +17,6 @@ app = typer.Typer(no_args_is_help=True, add_completion=False)
 register_run(app)
 register_profile(app)
 register_resume(app)
-register_scout_url(app)
 register_status(app)
 register_validate(app)
 register_inspect(app)

--- a/toolkit/cli/cmd_inspect.py
+++ b/toolkit/cli/cmd_inspect.py
@@ -4,9 +4,24 @@ import json
 from pathlib import Path
 from typing import Any
 
+import requests
 import typer
 
 from toolkit.cli.common import format_profile_preview, iter_years, load_layer_profile_summaries
+from toolkit.cli.cmd_scout_url import (  # noqa: F401 — re-exported for compatibility
+    _EXTENDED_EXTENSIONS,
+    _MAX_PRINTED_LINKS,
+    _candidate_links,
+    _DEFAULT_TIMEOUT,
+    _DEFAULT_USER_AGENT,
+    _detect_ckan,
+    _discover_ckan_resources,
+    _extract_ckan_dataset_id,
+    _generate_yaml_scaffold,
+    _is_file_like,
+    _is_html,
+    probe_url,
+)
 from toolkit.core.config import load_config
 from toolkit.core.metadata import read_layer_metadata
 from toolkit.core.paths import layer_year_dir
@@ -360,8 +375,75 @@ def schema_diff(
         typer.echo("comparisons: none")
 
 
+def url(
+    url: str = typer.Argument(..., help="URL da ispezionare"),
+    scaffold: bool = typer.Option(False, "--scaffold", help="Genera scaffold YAML (blocchi dataset + raw)"),
+    timeout: int = typer.Option(_DEFAULT_TIMEOUT, "--timeout", min=1, help="Timeout HTTP in secondi"),
+    user_agent: str = typer.Option(_DEFAULT_USER_AGENT, "--user-agent"),
+    as_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+) -> None:
+    """
+    Ispeziona un URL per dataset scouting: probe HTTP e generazione scaffold YAML.
+    """
+    try:
+        result = probe_url(url, timeout=timeout, user_agent=user_agent, capture_html=scaffold)
+    except requests.RequestException as exc:
+        typer.echo(f"error: {type(exc).__name__}: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if scaffold:
+        ckan_resources: list[dict[str, Any]] | None = None
+        candidate_file_links: list[str] | None = None
+
+        if result["kind"] == "html":
+            html_content = result.get("html_content", b"")
+            html_text = html_content.decode("utf-8", errors="replace") if html_content else ""
+            dataset_id = _extract_ckan_dataset_id(result["final_url"], html_text)
+            is_ckan = _detect_ckan(html_content) if html_content else False
+
+            if dataset_id and html_content and is_ckan:
+                ckan_resources = _discover_ckan_resources(
+                    result["final_url"],
+                    dataset_id,
+                    timeout=timeout,
+                    user_agent=user_agent,
+                )
+
+            if not ckan_resources and html_content:
+                candidate_file_links = [
+                    link for link in result.get("candidate_links", [])
+                    if any(ext in link.lower() for ext in _EXTENDED_EXTENSIONS)
+                ]
+
+        yaml_scaffold = _generate_yaml_scaffold(result, ckan_resources, candidate_file_links)
+        typer.echo(yaml_scaffold)
+        return
+
+    if as_json:
+        typer.echo(json.dumps(result, indent=2, ensure_ascii=False))
+        return
+
+    typer.echo(f"requested_url: {result['requested_url']}")
+    typer.echo(f"final_url: {result['final_url']}")
+    typer.echo(f"status_code: {result['status_code']}")
+    typer.echo(f"content_type: {result['content_type']}")
+    typer.echo(f"content_disposition: {result['content_disposition']}")
+    typer.echo(f"kind: {result['kind']}")
+
+    if result["candidate_links"]:
+        typer.echo("candidate_links:")
+        for link in result["candidate_links"][:_MAX_PRINTED_LINKS]:
+            typer.echo(f"  - {link}")
+        remaining = len(result["candidate_links"]) - _MAX_PRINTED_LINKS
+        if remaining > 0:
+            typer.echo(f"candidate_links_more: {remaining}")
+    else:
+        typer.echo("candidate_links: none")
+
+
 def register(app: typer.Typer) -> None:
     inspect_app = typer.Typer(no_args_is_help=True, add_completion=False)
     inspect_app.command("paths")(paths)
     inspect_app.command("schema-diff")(schema_diff)
+    inspect_app.command("url")(url)
     app.add_typer(inspect_app, name="inspect")

--- a/toolkit/cli/cmd_inspect.py
+++ b/toolkit/cli/cmd_inspect.py
@@ -8,18 +8,15 @@ import requests
 import typer
 
 from toolkit.cli.common import format_profile_preview, iter_years, load_layer_profile_summaries
-from toolkit.cli.cmd_scout_url import (  # noqa: F401 — re-exported for compatibility
+from toolkit.cli.cmd_scout_url import (
     _EXTENDED_EXTENSIONS,
     _MAX_PRINTED_LINKS,
-    _candidate_links,
     _DEFAULT_TIMEOUT,
     _DEFAULT_USER_AGENT,
     _detect_ckan,
     _discover_ckan_resources,
     _extract_ckan_dataset_id,
     _generate_yaml_scaffold,
-    _is_file_like,
-    _is_html,
     probe_url,
 )
 from toolkit.core.config import load_config

--- a/toolkit/cli/cmd_inspect.py
+++ b/toolkit/cli/cmd_inspect.py
@@ -28,6 +28,8 @@ from toolkit.core.paths import layer_year_dir
 from toolkit.core.support import resolve_support_payloads
 from toolkit.profile.raw import build_profile_hints
 from toolkit.core.run_context import get_run_dir, latest_run
+from toolkit.core.exceptions import DownloadError
+from toolkit.plugins.sparql import SparqlSource
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:
@@ -441,9 +443,67 @@ def url(
         typer.echo("candidate_links: none")
 
 
+def probe(
+    source: str = typer.Option(..., "--source", "-s", help="Source type (e.g. sparql)"),
+    endpoint: str | None = typer.Option(None, "--endpoint", help="SPARQL endpoint URL"),
+    query: str | None = typer.Option(None, "--query", "-q", help="SPARQL SELECT query"),
+    timeout: int = typer.Option(60, "--timeout", min=1, help="Timeout in seconds"),
+    limit: int = typer.Option(100, "--limit", min=1, help="Max rows for probe sample"),
+    as_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+) -> None:
+    """
+    Probe a source endpoint to infer schema and basic statistics.
+    Currently supports SPARQL endpoints.
+    """
+    if source != "sparql":
+        typer.echo(f"error: source '{source}' not supported. Only 'sparql' is available.", err=True)
+        raise typer.Exit(code=1)
+
+    if not endpoint:
+        typer.echo("error: --endpoint is required for sparql source.", err=True)
+        raise typer.Exit(code=1)
+
+    if not query:
+        typer.echo("error: --query/-q is required for sparql source.", err=True)
+        raise typer.Exit(code=1)
+
+    src = SparqlSource(timeout=timeout)
+    try:
+        result = src.probe(endpoint, query, limit=limit)
+    except DownloadError as exc:
+        typer.echo(f"error: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if as_json:
+        typer.echo(json.dumps(result, indent=2, ensure_ascii=False))
+        return
+
+    typer.echo(f"endpoint: {result['endpoint']}")
+    typer.echo(f"query_time_ms: {result['query_time_ms']}")
+    typer.echo(f"variables ({len(result['variables'])}): {', '.join(result['variables'])}")
+    typer.echo(f"row_count: {result['row_count']}")
+    typer.echo("null_counts:")
+    for var, count in result["null_counts"].items():
+        if count > 0:
+            typer.echo(f"  {var}: {count}")
+    if not any(c > 0 for c in result["null_counts"].values()):
+        typer.echo("  (none)")
+
+    if result["warnings"]:
+        typer.echo("warnings:")
+        for w in result["warnings"]:
+            typer.echo(f"  - {w}")
+
+    if result["sample_rows"]:
+        typer.echo("sample_rows:")
+        for row in result["sample_rows"]:
+            typer.echo(f"  {row}")
+
+
 def register(app: typer.Typer) -> None:
     inspect_app = typer.Typer(no_args_is_help=True, add_completion=False)
     inspect_app.command("paths")(paths)
     inspect_app.command("schema-diff")(schema_diff)
     inspect_app.command("url")(url)
+    inspect_app.command("probe")(probe)
     app.add_typer(inspect_app, name="inspect")

--- a/toolkit/cli/cmd_scout_url.py
+++ b/toolkit/cli/cmd_scout_url.py
@@ -348,5 +348,10 @@ def scout_url(
         DeprecationWarning,
         stacklevel=2,
     )
-    typer.echo("[DEPRECATO] Usa 'toolkit inspect url' invece.", err=True)
+    typer.echo("[DEPRECATO] Usa 'toolkit inspect url' invece. Vedi: toolkit inspect url --help", err=True)
     raise typer.Exit(code=1)
+
+
+def register(app: typer.Typer) -> None:
+    """Deprecated: use 'toolkit inspect url' instead. Registration kept for deprecation message."""
+    app.command("scout-url")(scout_url)

--- a/toolkit/cli/cmd_scout_url.py
+++ b/toolkit/cli/cmd_scout_url.py
@@ -337,63 +337,16 @@ def scout_url(
     scaffold: bool = typer.Option(False, "--scaffold", help="Genera scaffold YAML (blocchi dataset + raw)"),
 ) -> None:
     """
-    Ispeziona un URL per dataset scouting minimale.
+    [DEPRECATO] Usa 'toolkit inspect url' invece.
+    Questo comando sarà rimosso in una versione futura.
     """
-    try:
-        result = probe_url(url, timeout=timeout, user_agent=user_agent, capture_html=scaffold)
-    except requests.RequestException as exc:
-        typer.echo(f"error: {type(exc).__name__}: {exc}")
-        raise typer.Exit(code=1) from exc
+    import warnings
 
-    if scaffold:
-        ckan_resources: list[dict[str, Any]] | None = None
-        candidate_file_links: list[str] | None = None
-
-        if result["kind"] == "html":
-            html_content = result.get("html_content", b"")
-            html_text = html_content.decode("utf-8", errors="replace") if html_content else ""
-            dataset_id = _extract_ckan_dataset_id(result["final_url"], html_text)
-            is_ckan = _detect_ckan(html_content) if html_content else False
-
-            if dataset_id and html_content and is_ckan:
-                ckan_resources = _discover_ckan_resources(
-                    result["final_url"],
-                    dataset_id,
-                    timeout=timeout,
-                    user_agent=user_agent,
-                )
-
-            # Se CKAN discovery ha trovato risorse, usa quelle.
-            # Altrimenti se è HTML (anche CKAN-like ma senza API funzionante),
-            # usa candidate_links per generare http_file per ogni link a file.
-            if not ckan_resources and html_content:
-                # Filtra candidate_links per estensioni file (non solo data links)
-                candidate_file_links = [
-                    link for link in result.get("candidate_links", [])
-                    if any(ext in link.lower() for ext in _EXTENDED_EXTENSIONS)
-                ]
-
-        yaml_scaffold = _generate_yaml_scaffold(result, ckan_resources, candidate_file_links)
-        typer.echo(yaml_scaffold)
-        return
-
-    typer.echo(f"requested_url: {result['requested_url']}")
-    typer.echo(f"final_url: {result['final_url']}")
-    typer.echo(f"status_code: {result['status_code']}")
-    typer.echo(f"content_type: {result['content_type']}")
-    typer.echo(f"content_disposition: {result['content_disposition']}")
-    typer.echo(f"kind: {result['kind']}")
-
-    if result["candidate_links"]:
-        typer.echo("candidate_links:")
-        for link in result["candidate_links"][:_MAX_PRINTED_LINKS]:
-            typer.echo(f"  - {link}")
-        remaining = len(result["candidate_links"]) - _MAX_PRINTED_LINKS
-        if remaining > 0:
-            typer.echo(f"candidate_links_more: {remaining}")
-    else:
-        typer.echo("candidate_links: none")
-
-
-def register(app: typer.Typer) -> None:
-    app.command("scout-url")(scout_url)
+    warnings.warn(
+        "scout-url è deprecato. Usa 'toolkit inspect url' invece. "
+        "Vedere 'toolkit inspect url --help'.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    typer.echo("[DEPRECATO] Usa 'toolkit inspect url' invece.", err=True)
+    raise typer.Exit(code=1)

--- a/toolkit/core/registry.py
+++ b/toolkit/core/registry.py
@@ -70,6 +70,13 @@ _BUILTIN_PLUGINS: tuple[dict[str, Any], ...] = (
         "optional": False,
         "factory": lambda cls: (lambda **client: cls()),
     },
+    {
+        "name": "sparql",
+        "module": "toolkit.plugins.sparql",
+        "class_name": "SparqlSource",
+        "optional": False,
+        "factory": lambda cls: (lambda **client: cls(timeout=client.get("timeout", 60))),
+    },
 )
 
 

--- a/toolkit/plugins/__init__.py
+++ b/toolkit/plugins/__init__.py
@@ -8,16 +8,19 @@ Builtin stable sources exposed by the default runtime:
 - `http_file`
 - `ckan`
 - `sdmx`
+- `sparql`
 """
 
 from toolkit.plugins.ckan import CkanSource
 from toolkit.plugins.http_file import HttpFileSource
 from toolkit.plugins.local_file import LocalFileSource
 from toolkit.plugins.sdmx import SdmxSource
+from toolkit.plugins.sparql import SparqlSource
 
 __all__ = [
     "LocalFileSource",
     "HttpFileSource",
     "CkanSource",
     "SdmxSource",
+    "SparqlSource",
 ]

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -1,0 +1,250 @@
+"""SPARQL source plugin.
+
+Fetches tabular data from a SPARQL endpoint via HTTP POST.
+Supports direct CSV responses and SPARQL Results JSON (converted to CSV).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Any
+
+import requests
+
+from toolkit.core.exceptions import DownloadError
+
+
+class SparqlSource:
+    """Query a SPARQL endpoint and return results as CSV bytes."""
+
+    def __init__(self, timeout: int = 60):
+        self.timeout = timeout
+
+    def fetch(
+        self,
+        endpoint: str,
+        query: str,
+        accept_format: str = "csv",
+    ) -> tuple[bytes, str]:
+        """Execute a SPARQL query and return CSV data.
+
+        Args:
+            endpoint: SPARQL endpoint URL.
+            query: SPARQL SELECT query string.
+            accept_format: 'csv' for direct CSV, 'sparql-results+json' for JSON conversion.
+
+        Returns:
+            (csv_bytes, endpoint) tuple.
+
+        Raises:
+            DownloadError: on network error, non-200 response, or empty results.
+        """
+        if not endpoint:
+            raise DownloadError("SPARQL source requires endpoint URL")
+        if not query:
+            raise DownloadError("SPARQL source requires a query")
+        if accept_format not in {"csv", "sparql-results+json"}:
+            raise DownloadError(
+                f"Unsupported accept_format '{accept_format}'. "
+                "Supported values: 'csv', 'sparql-results+json'."
+            )
+
+        headers: dict[str, str] = {
+            "Accept": "application/sparql-results+json" if accept_format == "sparql-results+json" else "text/csv",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        params: dict[str, Any] = {"query": query}
+
+        try:
+            r = requests.post(
+                endpoint,
+                data=params,
+                headers=headers,
+                timeout=self.timeout,
+            )
+        except Exception as e:
+            raise DownloadError(f"SPARQL request failed for {endpoint}: {e}") from e
+
+        if r.status_code != 200:
+            raise DownloadError(
+                f"SPARQL endpoint returned HTTP {r.status_code} for {endpoint}: {r.text[:200]}"
+            )
+
+        content_type = r.headers.get("Content-Type", "")
+
+        if "text/csv" in content_type:
+            return r.content, endpoint
+
+        if "sparql-results+json" in content_type:
+            csv_bytes = _sparql_json_to_csv(r.text)
+            return csv_bytes, endpoint
+
+        raise DownloadError(
+            f"Unsupported Content-Type '{content_type}' for SPARQL fetch. "
+            "Expected 'text/csv' or 'application/sparql-results+json'."
+        )
+
+    def probe(
+        self,
+        endpoint: str,
+        query: str,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        """Probe a SPARQL endpoint: execute query and return schema + stats.
+
+        Does NOT save any file. Use for inspection before creating a candidate.
+
+        Args:
+            endpoint: SPARQL endpoint URL.
+            query: SPARQL SELECT query. A LIMIT will be appended if not present.
+            limit: Maximum rows to sample for stats (default 100).
+
+        Returns:
+            dict with keys: variables, row_count, null_counts, distinct_counts,
+            sample_rows, warnings, query_time_ms, endpoint.
+        """
+        import json
+        import time
+
+        if not endpoint:
+            raise DownloadError("SPARQL probe requires endpoint URL")
+        if not query:
+            raise DownloadError("SPARQL probe requires a query")
+
+        # Ensure LIMIT is present in query
+        safe_query = query.strip()
+        if "limit" not in safe_query.lower():
+            safe_query = f"{safe_query.rstrip(';')} LIMIT {limit}"
+
+        headers: dict[str, str] = {
+            "Accept": "application/sparql-results+json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        params: dict[str, Any] = {"query": safe_query}
+
+        start = time.monotonic()
+        try:
+            r = requests.post(
+                endpoint,
+                data=params,
+                headers=headers,
+                timeout=self.timeout,
+            )
+        except Exception as e:
+            raise DownloadError(f"SPARQL probe failed for {endpoint}: {e}") from e
+
+        query_time_ms = int((time.monotonic() - start) * 1000)
+
+        if r.status_code != 200:
+            raise DownloadError(
+                f"SPARQL endpoint returned HTTP {r.status_code} for {endpoint}: {r.text[:200]}"
+            )
+
+        try:
+            payload = json.loads(r.text)
+        except json.JSONDecodeError as e:
+            raise DownloadError(f"Invalid SPARQL JSON response during probe: {e}") from e
+
+        bindings: list[dict[str, Any]] = (
+            (payload.get("results") or {}).get("bindings") or []
+        )
+        if not isinstance(bindings, list):
+            raise DownloadError("SPARQL probe: unexpected payload structure")
+
+        vars_list: list[str] = (payload.get("head") or {}).get("vars") or []
+        if not bindings and not vars_list:
+            raise DownloadError("SPARQL probe: query returned no variables")
+
+        # If vars_list is empty but we have bindings, infer from first binding
+        if not vars_list and bindings:
+            vars_list = list(bindings[0].keys())
+
+        row_count = len(bindings)
+
+        # Compute null and distinct counts per variable
+        null_counts: dict[str, int] = {v: 0 for v in vars_list}
+        distinct_counts: dict[str, set[str]] = {v: set() for v in vars_list}
+        sample_rows: list[dict[str, str]] = []
+
+        for i, binding in enumerate(bindings):
+            row: dict[str, str] = {}
+            for var in vars_list:
+                cell = binding.get(var)
+                value: str
+                if cell and isinstance(cell, dict):
+                    raw_value = cell.get("value")
+                    # SPARQL JSON can have null values as JSON null
+                    if raw_value is None:
+                        value = ""
+                    else:
+                        value = str(raw_value)
+                else:
+                    value = str(cell if cell is not None else "")
+                row[var] = value
+                if not value:
+                    null_counts[var] = null_counts.get(var, 0) + 1
+                else:
+                    distinct_counts[var].add(value)
+            if i < 5:
+                sample_rows.append(row)
+
+        warnings: list[str] = []
+        for var in vars_list:
+            if null_counts.get(var, 0) > 0:
+                warnings.append(f"variable '{var}' has {null_counts[var]} null/unbound value(s)")
+
+        return {
+            "endpoint": endpoint,
+            "variables": vars_list,
+            "row_count": row_count,
+            "null_counts": null_counts,
+            "distinct_counts": {v: len(s) for v, s in distinct_counts.items()},
+            "sample_rows": sample_rows,
+            "warnings": warnings,
+            "query_time_ms": query_time_ms,
+        }
+
+
+def _sparql_json_to_csv(json_text: str) -> bytes:
+    """Convert SPARQL Results JSON to CSV bytes.
+
+    Assumes all bindings share the same set of variables (homogeneous schema).
+    Extra keys in later bindings or missing keys produce empty values silently.
+    """
+    import json
+
+    try:
+        payload = json.loads(json_text)
+    except json.JSONDecodeError as e:
+        raise DownloadError(f"Invalid SPARQL JSON response: {e}") from e
+
+    bindings: list[dict[str, Any]] = (
+        (payload.get("results") or {}).get("bindings") or []
+    )
+    if not isinstance(bindings, list):
+        raise DownloadError("SPARQL JSON payload has unexpected structure")
+
+    if not bindings:
+        raise DownloadError("SPARQL query returned no results")
+
+    # Use head.vars as canonical column list; bindings may omit unbound variables.
+    var_names: list[str] = (payload.get("head") or {}).get("vars") or list(bindings[0].keys())
+    rows: list[dict[str, str]] = []
+
+    for binding in bindings:
+        row: dict[str, str] = {}
+        for var in var_names:
+            cell = binding.get(var)
+            if cell and isinstance(cell, dict):
+                # SPARQL JSON binding: {"value": "...", "type": "..."}
+                row[var] = str(cell.get("value", ""))
+            else:
+                row[var] = str(cell if cell is not None else "")
+        rows.append(row)
+
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=var_names)
+    writer.writeheader()
+    writer.writerows(rows)
+    return buffer.getvalue().encode("utf-8")

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -98,7 +98,8 @@ class SparqlSource:
         Args:
             endpoint: SPARQL endpoint URL.
             query: SPARQL SELECT query. A LIMIT will be appended if not present.
-            limit: Maximum rows to sample for stats (default 100).
+            limit: Maximum rows to fetch for stats (default 100). sample_rows is
+                capped at 5 regardless of this value.
 
         Returns:
             dict with keys: variables, row_count, null_counts, distinct_counts,

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -26,7 +26,7 @@ def _format_args(args: dict, year: int) -> dict:
 
 
 def _infer_ext(stype: str, formatted_args: dict, origin: str | None = None) -> str:
-    if stype == "sdmx":
+    if stype in {"sdmx", "sparql"}:
         return ".csv"
     if stype in {"http_file", "ckan"}:
         url = origin or formatted_args.get("url", "")
@@ -85,6 +85,12 @@ def _fetch_payload(stype: str, client: dict, formatted_args: dict) -> tuple[byte
             str(formatted_args["flow"]),
             str(formatted_args["version"]),
             formatted_args.get("filters"),
+        )
+    elif stype == "sparql":
+        payload, origin = src.fetch(
+            str(formatted_args["endpoint"]),
+            str(formatted_args["query"]),
+            str(formatted_args.get("accept_format", "csv")),
         )
     elif stype == "http_file":
         payload = src.fetch(formatted_args["url"])


### PR DESCRIPTION
## Summary
- **Source plugin `sparql`**: fetch CSV e sparql-results+json da endpoint SPARQL, registrato in registry
- **`SparqlSource.probe()`**: schema + stats senza file output (null_counts, distinct_counts, sample_rows)
- **`inspect probe --source sparql`**: CLI wrapper per probe SPARQL endpoint pre-candidate
- `scout-url` deprecato: usa `toolkit inspect url`

## Usage
```bash
# Probe SPARQL endpoint
toolkit inspect probe --source sparql \
  --endpoint https://dati.camera.it/sparql \
  --query "SELECT * WHERE { ?s a ocd:deputato } LIMIT 50"

# Output JSON
toolkit inspect probe --source sparql --endpoint ... --query ... --json
```

## Files
- `toolkit/plugins/sparql.py` — nuovo plugin
- `toolkit/plugins/__init__.py` — export
- `toolkit/core/registry.py` — registrazione
- `toolkit/raw/run.py` — routing in `_fetch_payload` + `_infer_ext` fix
- `toolkit/cli/cmd_inspect.py` — `inspect probe` subcommand
- `tests/test_sparql_plugin.py` — 17 test

## Test
406 passed (1 pre-esistente xlrd skipped)

## Review status
- PR #175 chiusa (contenuto già in main via #169)
- `feat/sparql-source-plugin` branch chiuso