### PR TITLE
fix: _format_args only format strings containing {year}

### DIFF
--- a/tests/test_raw_run_format_args.py
+++ b/tests/test_raw_run_format_args.py
@@ -80,3 +80,14 @@ class TestFormatArgs:
         result = _format_args(args, 2023)
         assert result["other"] == "value"
         assert "url" not in result
+
+    def test_format_args_sparql_query_with_braces_no_year(self) -> None:
+        """SPARQL query containing {} but no {year} must not be formatted.
+
+        Regression test for issue #186: Python .format() treats {s} as a placeholder
+        and raises KeyError. Only strings containing {year} should be formatted.
+        """
+        sparql_query = "SELECT ?s WHERE { ?s ?p ?o }"
+        args = {"query": sparql_query}
+        result = _format_args(args, 2024)
+        assert result["query"] == sparql_query

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -21,7 +21,7 @@ from toolkit.raw.validate import validate_raw_output
 def _format_args(args: dict, year: int) -> dict:
     formatted = {}
     for k, v in (args or {}).items():
-        formatted[k] = v.format(year=year) if isinstance(v, str) else v
+        formatted[k] = v.format(year=year) if isinstance(v, str) and "{year}" in v else v
     # Handle url_suffix_by_year: append per-year suffix to the formatted URL
     if "url" in formatted and "url_suffix_by_year" in (args or {}):
         suffix_map = args["url_suffix_by_year"]


### PR DESCRIPTION
## Summary

`_format_args` formattava ogni stringa con `.format(year=year)`, anche quelle senza `{year}`. Questo rompeva query SPARQL che contengono `{}` (syntax valida) — Python interpreta `{s}` come placeholder e solleva `KeyError`.

## Fix

```python
# Prima
formatted[k] = v.format(year=year) if isinstance(v, str) else v

# Dopo
formatted[k] = v.format(year=year) if isinstance(v, str) and "{year}" in v else v
```

Solo le stringhe contenenti `{year}` vengono formattate.

## Check

- [x] 431 test passano (430 originali + 1 nuovo)
- [x] Test: query SPARQL con `{}` senza `{year}` lasciato intatto
- [x] Test: URL con `{year}` continua a funzionare
- [x] Retrocompatibile — nessun contract rotto

Closes #186