### PR TITLE
fix(mcp): timeout subprocess, raw_profile fallback su suggested_read.yml

### DIFF
--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -4,6 +4,8 @@ import json
 import shutil
 from pathlib import Path
 
+import pytest
+
 from toolkit.mcp.toolkit_client import (
     blocker_hints,
     inspect_paths,
@@ -239,3 +241,48 @@ def test_review_readiness_needs_review_with_single_failure(tmp_path: Path, monke
     payload = review_readiness(str(config_path), 2022)
     assert payload["readiness"] == "needs-review"
     assert payload["fail_count"] == 1
+
+
+def test_mcp_raw_profile_handles_suggested_read_yaml(tmp_path: Path, monkeypatch) -> None:
+    """raw_profile deve cadere su suggested_read.yml quando raw_profile.json non esiste."""
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Crea solo suggested_read.yml, nessun raw_profile.json
+    raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022" / "_profile"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "suggested_read.yml").write_text(
+        "clean:\n  read:\n    delim: ','\n    encoding: 'utf-8'\n",
+        encoding="utf-8",
+    )
+
+    from toolkit.mcp.toolkit_client import raw_profile
+
+    payload = raw_profile(str(config_path), 2022)
+    assert payload["profile_exists"] is True
+    assert payload["read_hints"]["delimiter"] == ","
+    assert payload["read_hints"]["encoding"] == "utf-8"
+
+
+def test_mcp_raw_profile_error_when_no_profile_file(tmp_path: Path, monkeypatch) -> None:
+    """raw_profile deve fallire con errore chiaro quando non c'e' nessun profilo."""
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Crea la dir _profile ma lasciala vuota
+    raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022" / "_profile"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+
+    from toolkit.mcp.toolkit_client import raw_profile
+    from toolkit.mcp.errors import ToolkitClientError
+
+    with pytest.raises(ToolkitClientError, match="Nessun file raw_profile.json ne suggested_read.yml"):
+        raw_profile(str(config_path), 2022)

--- a/toolkit/mcp/cli_adapter.py
+++ b/toolkit/mcp/cli_adapter.py
@@ -30,7 +30,10 @@ def _toolkit_json(args: list[str]) -> dict[str, Any]:
             errors="replace",
             env=env,
             check=False,
+            timeout=60,
         )
+    except subprocess.TimeoutExpired as exc:
+        raise ToolkitClientError(f"toolkit CLI timeout (>60s): {exc}") from exc
     except Exception as exc:
         raise ToolkitClientError(f"Esecuzione toolkit CLI fallita: {exc}") from exc
 

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -112,7 +112,7 @@ def show_schema(config_path: str, layer: str = "clean", year: int | None = None)
 
 
 def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
-    """Restituisce il contenuto di _profile/raw_profile.json se presente.
+    """Restituisce il contenuto di _profile/raw_profile.json (o suggested_read.yml come fallback).
 
     Il profilo contiene encoding, delimitatore, decimal suggestion, nomi colonna,
     sample rows, missingness e mapping suggestions per il layer raw.
@@ -120,20 +120,48 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
     config = _safe_path(config_path)
     paths = inspect_paths(str(config), year)
     raw_dir = Path(paths["paths"]["raw"]["dir"])
-    profile_path = raw_dir / "_profile" / "raw_profile.json"
+    profile_path = raw_dir / "_profile"
+    raw_profile_json = profile_path / "raw_profile.json"
+    suggested_read_yml = profile_path / "suggested_read.yml"
 
-    if not profile_path.exists():
+    if raw_profile_json.exists():
+        try:
+            profile = json.loads(raw_profile_json.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ToolkitClientError(
+                f"raw_profile.json malformato in {raw_profile_json}: {exc}"
+            ) from exc
+    elif suggested_read_yml.exists():
+        # Fallback: suggested_read.yml contains the same hints in YAML form
+        import yaml
+
+        try:
+            raw_yaml = yaml.safe_load(suggested_read_yml.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise ToolkitClientError(
+                f"suggested_read.yml non valido in {suggested_read_yml}: {exc}"
+            ) from exc
+        clean_section = raw_yaml.get("clean", {}) if isinstance(raw_yaml, dict) else {}
+        read_section = clean_section.get("read", {}) if isinstance(clean_section, dict) else {}
+        profile = {
+            "dataset": None,
+            "year": None,
+            "encoding_suggested": read_section.get("encoding"),
+            "delim_suggested": read_section.get("delim"),
+            "decimal_suggested": read_section.get("decimal"),
+            "skip_suggested": read_section.get("skip"),
+            "robust_read_suggested": None,
+            "columns_raw": None,
+            "columns_norm": None,
+            "missingness_top": [],
+            "mapping_suggestions": {},
+            "warnings": [],
+        }
+    else:
         raise ToolkitClientError(
-            f"raw_profile.json non trovato in {profile_path}. "
-            "Esegui 'toolkit run raw' prima di accedere al profilo."
+            f"Profilo raw non trovato in {profile_path}. "
+            "Nessun file raw_profile.json ne suggested_read.yml."
         )
-
-    try:
-        profile = json.loads(profile_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise ToolkitClientError(
-            f"raw_profile.json malformato in {profile_path}: {exc}"
-        ) from exc
 
     # Ritorna un sottoinsieme leggibile: evita di restituire sample_rows intere
     # se sono troppe (già incluse nel profilo per reference).
@@ -152,9 +180,9 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
         },
         "header_line": profile.get("header_line"),
         "columns": {
-            "raw": profile.get("columns_raw", []),
-            "normalized": profile.get("columns_norm", []),
-            "count": len(profile.get("columns_raw", [])),
+            "raw": profile.get("columns_raw") or [],
+            "normalized": profile.get("columns_norm") or [],
+            "count": len(profile.get("columns_raw") or []),
         },
         "missingness_top": profile.get("missingness_top", []),
         "mapping_suggestions": profile.get("mapping_suggestions", {}),


### PR DESCRIPTION
## Summary

- **cli_adapter**: `timeout=60` al subprocess CLI + gestione esplicita `TimeoutExpired`
- **schema_ops**: `raw_profile` ora fallback su `suggested_read.yml` quando `raw_profile.json` non esiste (bug: il tool falliva su molti dataset che hanno solo lo scaffold YAML)
- **schema_ops**: `columns_raw/norm` con `or []` invece di default `[]` per gestire `None`
- **test**: 2 nuovi test per il fallback `suggested_read.yml` e l'errore chiaro senza profilo

## Test

17/17 passano.

## Breaking changes

Nessuna.