### PR TITLE
feat(raw): aggiunge campo year opzionale nei source args per filtro in run_raw (#190)

### DIFF
--- a/tests/test_raw_ext_inference.py
+++ b/tests/test_raw_ext_inference.py
@@ -233,3 +233,81 @@ def test_multisource_primary_selection(monkeypatch, tmp_path: Path):
         {"name": "beta", "output_file": "b.csv"},
     ]
     assert manifest["primary_output_file"] == "b.csv"
+
+
+def test_multisource_year_filter_skips_non_matching(monkeypatch, tmp_path: Path):
+    """Sources with a year field that doesn't match the requested year are skipped."""
+
+    def _fake_fetch_payload(_stype: str, _client: dict, formatted_args: dict):
+        return f"payload:{formatted_args['filename']}\n".encode("utf-8"), formatted_args["filename"]
+
+    monkeypatch.setattr("toolkit.raw.run._fetch_payload", _fake_fetch_payload)
+
+    raw_cfg = {
+        "sources": [
+            {
+                "name": "source_2020",
+                "type": "http_file",
+                "year": 2020,
+                "args": {"url": "https://example.org/2020.csv", "filename": "source_2020.csv"},
+            },
+            {
+                "name": "source_2021",
+                "type": "http_file",
+                "year": 2021,
+                "args": {"url": "https://example.org/2021.csv", "filename": "source_2021.csv"},
+            },
+            {
+                "name": "source_2022",
+                "type": "http_file",
+                "year": 2022,
+                "args": {"url": "https://example.org/2022.csv", "filename": "source_2022.csv"},
+            },
+        ]
+    }
+
+    run_raw("demo", 2022, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-2022")
+
+    out_dir = tmp_path / "data" / "raw" / "demo" / "2022"
+    manifest = read_raw_manifest(out_dir)
+    assert manifest is not None
+    # Only the source with year=2022 should be fetched
+    assert manifest["sources"] == [{"name": "source_2022", "output_file": "source_2022.csv"}]
+    assert manifest["primary_output_file"] == "source_2022.csv"
+    # Other files must not exist
+    assert not (out_dir / "source_2020.csv").exists()
+    assert not (out_dir / "source_2021.csv").exists()
+
+
+def test_multisource_year_filter_all_matching(monkeypatch, tmp_path: Path):
+    """When no source has a year field, all sources are fetched (backward compatible)."""
+
+    def _fake_fetch_payload(_stype: str, _client: dict, formatted_args: dict):
+        return f"payload:{formatted_args['filename']}\n".encode("utf-8"), formatted_args["filename"]
+
+    monkeypatch.setattr("toolkit.raw.run._fetch_payload", _fake_fetch_payload)
+
+    raw_cfg = {
+        "sources": [
+            {
+                "name": "alpha",
+                "type": "http_file",
+                "args": {"url": "https://example.org/a.csv", "filename": "a.csv"},
+            },
+            {
+                "name": "beta",
+                "type": "http_file",
+                "args": {"url": "https://example.org/b.csv", "filename": "b.csv"},
+            },
+        ]
+    }
+
+    run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-all")
+
+    out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
+    manifest = read_raw_manifest(out_dir)
+    assert manifest is not None
+    assert manifest["sources"] == [
+        {"name": "alpha", "output_file": "a.csv"},
+        {"name": "beta", "output_file": "b.csv"},
+    ]

--- a/toolkit/core/config_models/raw.py
+++ b/toolkit/core/config_models/raw.py
@@ -50,6 +50,7 @@ class RawSourceConfig(BaseModel):
 
     name: str | None = None
     type: str = "http_file"
+    year: int | None = None
     client: ClientConfig = Field(default_factory=ClientConfig)
     args: dict[str, Any] = Field(default_factory=dict)
     extractor: ExtractorConfig | None = None

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -215,6 +215,12 @@ def run_raw(
         name = source.get("name") or source.get("id") or f"source_{i + 1}"
         source_written: list[str] = []
 
+        # Skip source if year is specified and doesn't match the requested year
+        source_year = source.get("year")
+        if source_year is not None and int(source_year) != year:
+            logger.info(f"SKIP source '{name}' (year={source_year} != requested year={year})")
+            continue
+
         formatted_args = _format_args(args, year)
         payload, origin = _fetch_payload(stype, client, formatted_args)
         inputs.append(


### PR DESCRIPTION
Closes #190
## Summary

Aggiunge campo opzionale `raw.sources[].year` — quando specificato, `run_raw` salta le source il cui anno non corrisponde all'anno richiesto.

## Fix per issue #190

Quando si fa `run raw --year 2022` su un candidate con source multi-anno url-independent (es. MEF partecipazioni con URL separati per 2020/2021/2022/2023), prima venivano scaricate tutte le source. Ora vengono scaricate solo quelle con `year` matching.

## Changes

- `toolkit/raw/run.py`: skip source se `source.year != requested year`
- `tests/test_raw_ext_inference.py`: 2 nuovi test (filtro per anno, backward compat senza year field)

## Test

24/24 passano nei test raw.

## Breaking changes

Nessuna — campo opzionale, backward compatible. Source senza `year` field vengono processate come prima.