### PR TITLE
refactor: consolida funzioni duplicate in core/

### DIFF
--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -7,26 +7,9 @@ from toolkit.clean.duckdb_read import SUPPORTED_INPUT_EXTS, resolve_clean_read_c
 from toolkit.clean.input_selection import select_raw_input
 from toolkit.core.artifacts import ARTIFACT_POLICY_DEBUG, resolve_artifact_policy, should_write
 from toolkit.core.metadata import config_hash_for_year, file_record, write_layer_manifest, write_metadata
-from toolkit.core.paths import layer_year_dir, resolve_root, to_root_relative
+from toolkit.core.paths import layer_year_dir, resolve_root, resolve_sql_path, serialize_metadata_path
 from toolkit.core.template import build_runtime_template_ctx, public_template_ctx, render_template
 from toolkit.clean.sql_execute import _normalize_output_profile, _run_sql
-
-
-def _serialize_metadata_path(path: Path | None, rel_root: Path | None) -> str | None:
-    if path is None:
-        return None
-    if rel_root is None:
-        return path.as_posix()
-    return to_root_relative(path, rel_root)
-
-
-def _resolve_sql_path(sql_ref: str | Path, *, base_dir: Path | None) -> Path:
-    path = Path(sql_ref)
-    if path.is_absolute():
-        return path
-    if base_dir is None:
-        return path
-    return base_dir / path
 
 
 def _load_clean_sql(
@@ -41,7 +24,7 @@ def _load_clean_sql(
     if not sql_ref:
         raise ValueError("clean.sql missing in dataset.yml (expected: clean: { sql: 'sql/clean.sql' })")
 
-    sql_path_obj = _resolve_sql_path(sql_ref, base_dir=base_dir)
+    sql_path_obj = resolve_sql_path(sql_ref, base_dir=base_dir)
     if not sql_path_obj.exists():
         raise FileNotFoundError(f"CLEAN SQL file not found: {sql_path_obj}")
 
@@ -158,8 +141,8 @@ def _clean_metadata_payload(
         "layer": "clean",
         "dataset": dataset,
         "year": year,
-        "sql": _serialize_metadata_path(sql_path_obj, base_dir),
-        "sql_rendered": _serialize_metadata_path(rendered_sql_path, root_dir),
+        "sql": serialize_metadata_path(sql_path_obj, base_dir),
+        "sql_rendered": serialize_metadata_path(rendered_sql_path, root_dir),
         "template_ctx": public_template_ctx(template_ctx),
         "read": clean_cfg.get("read"),
         "read_mode": read_mode,

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -11,6 +11,7 @@ from toolkit.core.config_models import CleanValidationSpec, RangeRuleConfig, Tra
 from toolkit.core.layer_profile import compare_layer_profiles, profile_relation
 from toolkit.core.metadata import write_layer_manifest
 from toolkit.core.paths import layer_year_dir, to_root_relative
+from toolkit.core.sql_utils import q_ident
 from toolkit.core.validation import (
     ValidationResult,
     build_validation_summary,
@@ -18,11 +19,6 @@ from toolkit.core.validation import (
     required_columns_check,
     write_validation_json,
 )
-
-
-def _q_ident(col: str) -> str:
-    """Quote identifier for DuckDB (handles reserved words / special chars)."""
-    return '"' + col.replace('"', '""') + '"'
 
 
 def _clean_validation_spec(
@@ -121,7 +117,7 @@ def validate_clean(
             if c not in cols:
                 warnings.append(f"Not-null rule column missing in data: '{c}'")
                 continue
-            qc = _q_ident(c)
+            qc = q_ident(c)
             nnull = int(con.execute(f"SELECT COUNT(*) FROM t WHERE {qc} IS NULL").fetchone()[0])
             if nnull > 0:
                 errors.append(f"Column '{c}' has NULLs: {nnull}")
@@ -131,7 +127,7 @@ def validate_clean(
                 if c not in cols:
                     warnings.append(f"Null-pct rule column missing in data: '{c}'")
                     continue
-                qc = _q_ident(c)
+                qc = q_ident(c)
                 nnull = int(con.execute(f"SELECT COUNT(*) FROM t WHERE {qc} IS NULL").fetchone()[0])
                 pct = nnull / row_count
                 if pct > thr:
@@ -141,7 +137,7 @@ def validate_clean(
             if not all(c in cols for c in primary_key):
                 warnings.append(f"Primary key columns not all present: {primary_key}")
             else:
-                key_expr = ", ".join(_q_ident(c) for c in primary_key)
+                key_expr = ", ".join(q_ident(c) for c in primary_key)
                 dup_groups = int(
                     con.execute(
                         f"""
@@ -162,7 +158,7 @@ def validate_clean(
                 warnings.append(f"Range rule column missing in data: '{c}'")
                 continue
 
-            qc = _q_ident(c)
+            qc = q_ident(c)
             violations: list[str] = []
             if rule.min is not None:
                 violations.append(f"{qc} < {rule.min}")

--- a/toolkit/cli/cmd_inspect.py
+++ b/toolkit/cli/cmd_inspect.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from toolkit.core.io import read_json_or_none as _read_json  # noqa: F401 — used by tests
+
 import requests
 import typer
 
@@ -27,13 +29,6 @@ from toolkit.profile.raw import build_profile_hints
 from toolkit.core.run_context import get_run_dir, latest_run
 from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.sparql import SparqlSource
-
-
-def _read_json(path: Path) -> dict[str, Any] | None:
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        return None
 
 
 def _raw_primary_file(raw_dir: Path, metadata: dict[str, Any]) -> Path | None:

--- a/toolkit/cli/cmd_status.py
+++ b/toolkit/cli/cmd_status.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
+
+from toolkit.core.io import read_json_or_none as _read_json
 
 import typer
 
@@ -11,13 +12,6 @@ from toolkit.core.config import load_config
 from toolkit.core.metadata import read_layer_metadata
 from toolkit.core.paths import layer_dataset_dir, layer_year_dir
 from toolkit.core.run_context import get_run_dir, latest_run, read_run_record
-
-
-def _read_json(path: Path) -> dict[str, object] | None:
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        return None
 
 
 def _raw_hints(root: Path, dataset: str, year: int) -> dict[str, Any]:

--- a/toolkit/cli/common.py
+++ b/toolkit/cli/common.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
+
+from toolkit.core.io import read_json_or_none as _read_json
 
 from toolkit.core.config import load_config
 from toolkit.core.logging import get_logger
@@ -70,13 +71,6 @@ def iter_selected_years(
         raise ValueError(f"Year(s) not configured in dataset.yml: {listed}")
 
     return requested
-
-
-def _read_json(path: Path) -> dict | None:
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        return None
 
 
 def _profile_summary(profile: dict | None, *, max_columns: int = 6) -> dict | None:

--- a/toolkit/cli/sql_dry_run.py
+++ b/toolkit/cli/sql_dry_run.py
@@ -6,10 +6,9 @@ from typing import Any
 import duckdb
 
 from toolkit.clean.run import _load_clean_sql
+from toolkit.core.paths import resolve_sql_path as _resolve_mart_sql_path
 from toolkit.core.support import flatten_support_template_ctx, resolve_support_payloads
-from toolkit.core.template import build_runtime_template_ctx
-from toolkit.core.template import render_template
-from toolkit.mart.run import _resolve_sql_path as _resolve_mart_sql_path
+from toolkit.core.template import build_runtime_template_ctx, render_template
 
 _QUOTED_IDENTIFIER_RE = re.compile(r'"([^"]+)"')
 _BINDER_MISSING_COLUMN_RE = re.compile(r'Referenced column "([^"]+)" not found in FROM clause')

--- a/toolkit/core/io.py
+++ b/toolkit/core/io.py
@@ -68,3 +68,14 @@ def write_json_atomic(path: Path, data: dict[str, Any]) -> None:
 
 def read_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_json_or_none(path: Path) -> dict[str, Any] | None:
+    """Read JSON file, returning None on any parse or I/O error.
+
+    Use for optional config files where absence is a valid state.
+    """
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None

--- a/toolkit/core/layer_profile.py
+++ b/toolkit/core/layer_profile.py
@@ -5,13 +5,11 @@ from typing import Any
 
 import duckdb
 
-
-def _q_ident(value: str) -> str:
-    return '"' + value.replace('"', '""') + '"'
+from toolkit.core.sql_utils import q_ident
 
 
 def profile_relation(con: duckdb.DuckDBPyConnection, relation_name: str) -> dict[str, Any]:
-    q_relation = _q_ident(relation_name)
+    q_relation = q_ident(relation_name)
     row_count = int(con.execute(f"SELECT COUNT(*) FROM {q_relation}").fetchone()[0])
     described = con.execute(f"DESCRIBE {q_relation}").fetchall()
     columns = [{"name": row[0], "type": row[1]} for row in described]

--- a/toolkit/core/metadata.py
+++ b/toolkit/core/metadata.py
@@ -7,7 +7,7 @@ import hashlib
 from pathlib import Path
 from typing import Any
 
-from toolkit.core.io import write_json_atomic
+from toolkit.core.io import write_json_atomic, read_json_or_none as _read_json
 from toolkit.version import __version__
 
 
@@ -115,11 +115,7 @@ def read_layer_metadata(layer_dir: Path) -> dict[str, Any]:
     return meta
 
 
-def _read_json(path: Path) -> dict[str, Any] | None:
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        return None
+
 
 
 def merge_layer_manifest(

--- a/toolkit/core/paths.py
+++ b/toolkit/core/paths.py
@@ -49,3 +49,31 @@ def run_dir(root: str | os.PathLike[str], layer: str, dataset: str, year: int | 
 def ensure_dir(p: Path) -> Path:
     p.mkdir(parents=True, exist_ok=True)
     return p
+
+
+def serialize_metadata_path(path: Path | None, rel_root: Path | None) -> str | None:
+    """Serialize a Path relative to rel_root for storage in metadata JSON.
+
+    Returns None if path is None.
+    Returns the path as posix string if rel_root is None (absolute path).
+    Returns the path relative to rel_root otherwise.
+    """
+    if path is None:
+        return None
+    if rel_root is None:
+        return path.as_posix()
+    return to_root_relative(path, rel_root)
+
+
+def resolve_sql_path(sql_ref: str | Path, *, base_dir: Path | None) -> Path:
+    """Resolve a SQL file reference to an absolute Path.
+
+    - Absolute Path: returned as-is.
+    - Relative Path: resolved relative to base_dir (if provided).
+    """
+    path = Path(sql_ref)
+    if path.is_absolute():
+        return path
+    if base_dir is None:
+        return path
+    return base_dir / path

--- a/toolkit/core/sql_utils.py
+++ b/toolkit/core/sql_utils.py
@@ -1,0 +1,12 @@
+"""SQL/DuckDB utility functions shared across layers."""
+
+from __future__ import annotations
+
+
+def q_ident(value: str) -> str:
+    """Quote a SQL identifier for DuckDB (handles reserved words / special chars).
+
+    Replaces double quotes with escaped double quotes and wraps in double quotes.
+    This is safe for any identifier including those containing spaces or special chars.
+    """
+    return '"' + value.replace('"', '""') + '"'

--- a/toolkit/cross/run.py
+++ b/toolkit/cross/run.py
@@ -7,25 +7,8 @@ import duckdb
 
 from toolkit.core.artifacts import ARTIFACT_POLICY_DEBUG, resolve_artifact_policy, should_write
 from toolkit.core.metadata import file_record, sha256_bytes, write_layer_manifest, write_metadata
-from toolkit.core.paths import layer_dataset_dir, layer_year_dir, resolve_root, to_root_relative
+from toolkit.core.paths import layer_dataset_dir, layer_year_dir, resolve_root, resolve_sql_path, serialize_metadata_path
 from toolkit.core.template import render_template
-
-
-def _serialize_metadata_path(path: Path | None, rel_root: Path | None) -> str | None:
-    if path is None:
-        return None
-    if rel_root is None:
-        return path.as_posix()
-    return to_root_relative(path, rel_root)
-
-
-def _resolve_sql_path(sql_ref: str | Path, *, base_dir: Path | None) -> Path:
-    path = Path(sql_ref)
-    if path.is_absolute():
-        return path
-    if base_dir is None:
-        return path
-    return base_dir / path
 
 
 def _config_hash(base_dir: Path | None) -> str | None:
@@ -130,7 +113,7 @@ def run_cross_year(
             files = _source_files(root, dataset, years, table)
             _bind_source_view(con, files, source_layer)
 
-            sql_path = _resolve_sql_path(sql_rel, base_dir=base_dir)
+            sql_path = resolve_sql_path(sql_rel, base_dir=base_dir)
             if not sql_path.exists():
                 raise FileNotFoundError(f"CROSS_YEAR SQL file not found: {sql_path}")
 
@@ -149,12 +132,12 @@ def run_cross_year(
             executed.append(
                 {
                     "name": name,
-                    "sql": _serialize_metadata_path(sql_path, base_dir),
-                    "sql_rendered": _serialize_metadata_path(rendered_sql_path, root_dir),
-                    "output": _serialize_metadata_path(out, root_dir),
+                    "sql": serialize_metadata_path(sql_path, base_dir),
+                    "sql_rendered": serialize_metadata_path(rendered_sql_path, root_dir),
+                    "output": serialize_metadata_path(out, root_dir),
                     "source_layer": source_layer,
                     "source_table": table.get("source_table"),
-                    "source_inputs": [_serialize_metadata_path(path, root_dir) for path in files],
+                    "source_inputs": [serialize_metadata_path(path, root_dir) for path in files],
                 }
             )
             if policy == ARTIFACT_POLICY_DEBUG:
@@ -176,7 +159,7 @@ def run_cross_year(
         "years": years,
         "config_hash": _config_hash(base_dir),
         "outputs": outputs,
-        "output_paths": [_serialize_metadata_path(path, root_dir) for path in written],
+        "output_paths": [serialize_metadata_path(path, root_dir) for path in written],
         "tables": executed,
     }
     if policy == ARTIFACT_POLICY_DEBUG:

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -9,29 +9,12 @@ import duckdb
 from toolkit.core.artifacts import ARTIFACT_POLICY_DEBUG, resolve_artifact_policy, should_write
 from toolkit.core.layer_profile import compare_layer_profiles, profile_relation, profile_parquet_files
 from toolkit.core.metadata import config_hash_for_year, file_record, write_layer_manifest, write_metadata
-from toolkit.core.paths import layer_year_dir, resolve_root, to_root_relative
+from toolkit.core.paths import layer_year_dir, resolve_root, resolve_sql_path, serialize_metadata_path
 from toolkit.core.support import flatten_support_template_ctx, resolve_support_payloads
 from toolkit.core.template import build_runtime_template_ctx, public_template_ctx, render_template
 
 
 _CLEAN_INPUT_TOKEN_RE = re.compile(r"\bclean_input\b", re.IGNORECASE)
-
-
-def _serialize_metadata_path(path: Path | None, rel_root: Path | None) -> str | None:
-    if path is None:
-        return None
-    if rel_root is None:
-        return path.as_posix()
-    return to_root_relative(path, rel_root)
-
-
-def _resolve_sql_path(sql_ref: str | Path, *, base_dir: Path | None) -> Path:
-    path = Path(sql_ref)
-    if path.is_absolute():
-        return path
-    if base_dir is None:
-        return path
-    return base_dir / path
 
 
 def run_mart(
@@ -111,7 +94,7 @@ def run_mart(
             if not name or not sql_rel:
                 raise ValueError("Each mart.tables entry must include: name, sql")
 
-            sql_path = _resolve_sql_path(sql_rel, base_dir=base_dir)
+            sql_path = resolve_sql_path(sql_rel, base_dir=base_dir)
             if not sql_path.exists():
                 raise FileNotFoundError(f"MART SQL file not found: {sql_path}")
 
@@ -152,9 +135,9 @@ def run_mart(
             executed.append(
                 {
                     "name": name,
-                    "sql": _serialize_metadata_path(sql_path, base_dir),
-                    "sql_rendered": _serialize_metadata_path(rendered_sql_path, root_dir),
-                    "output": _serialize_metadata_path(out, root_dir),
+                    "sql": serialize_metadata_path(sql_path, base_dir),
+                    "sql_rendered": serialize_metadata_path(rendered_sql_path, root_dir),
+                    "output": serialize_metadata_path(out, root_dir),
                 }
             )
             if policy == ARTIFACT_POLICY_DEBUG:
@@ -178,7 +161,7 @@ def run_mart(
         "config_hash": config_hash_for_year(base_dir, year),
         "inputs": [file_record(p) for p in clean_files],
         "outputs": outputs,
-        "output_paths": [_serialize_metadata_path(p, root_dir) for p in written],
+        "output_paths": [serialize_metadata_path(p, root_dir) for p in written],
         "template_ctx": public_template_ctx(template_ctx),
         "tables": executed,
         "clean_input_profile": clean_input_profile,

--- a/toolkit/mart/validate.py
+++ b/toolkit/mart/validate.py
@@ -9,6 +9,7 @@ import duckdb
 from toolkit.core.config_models import MartTableRuleConfig, MartValidationSpec
 from toolkit.core.metadata import write_layer_manifest
 from toolkit.core.paths import layer_year_dir, to_root_relative
+from toolkit.core.sql_utils import q_ident
 from toolkit.core.validation import (
     ValidationResult,
     build_validation_summary,
@@ -16,11 +17,6 @@ from toolkit.core.validation import (
     required_columns_check,
     write_validation_json,
 )
-
-
-def _q_ident(col: str) -> str:
-    """Quote identifier for DuckDB (handles reserved words / special chars)."""
-    return '"' + col.replace('"', '""') + '"'
 
 
 def validate_mart(
@@ -118,7 +114,7 @@ def validate_mart(
             if c not in cols:
                 warnings.append(f"[{name}] Not-null rule column missing: '{c}'")
                 continue
-            qc = _q_ident(c)
+            qc = q_ident(c)
             nnull = int(con.execute(f"SELECT COUNT(*) FROM t WHERE {qc} IS NULL").fetchone()[0])
             if nnull > 0:
                 errors.append(f"[{name}] Column '{c}' has NULLs: {nnull}")
@@ -129,7 +125,7 @@ def validate_mart(
             if not all(c in cols for c in pk):
                 warnings.append(f"[{name}] Primary key columns not all present: {pk}")
             else:
-                key_expr = ", ".join(_q_ident(c) for c in pk)
+                key_expr = ", ".join(q_ident(c) for c in pk)
                 dup_groups = int(
                     con.execute(
                         f"""
@@ -151,7 +147,7 @@ def validate_mart(
                 warnings.append(f"[{name}] Range rule column missing: '{c}'")
                 continue
 
-            qc = _q_ident(c)
+            qc = q_ident(c)
             violations: list[str] = []
             if rule.min is not None:
                 violations.append(f"{qc} < {rule.min}")


### PR DESCRIPTION
## Summary

- `_read_json` (4 copie) → `core/io.read_json_or_none()`
- `_q_ident` (3 copie) → `core/sql_utils.q_ident()` (nuovo file)
- `_serialize_metadata_path` (3 copie) → `core/paths.serialize_metadata_path()`
- `_resolve_sql_path` (3 copie) → `core/paths.resolve_sql_path()`
- `cmd_run._resolve_sql_path` resta intenzionalmente divergente (accetta cfg object e valida presenza path)

**Netto**: `-119 +89` righe, 437/437 test passano.

## Files toccati

- `toolkit/core/io.py` — aggiunto `read_json_or_none()`
- `toolkit/core/sql_utils.py` — **nuovo**, canonical per `q_ident()`
- `toolkit/core/paths.py` — aggiunto `serialize_metadata_path()` e `resolve_sql_path()`
- `toolkit/clean/run.py`, `toolkit/mart/run.py`, `toolkit/cross/run.py` — rimossi copy locali, import da paths
- `toolkit/clean/validate.py`, `toolkit/mart/validate.py`, `toolkit/core/layer_profile.py` — rimossi copy locali, import da sql_utils
- `toolkit/cli/cmd_inspect.py`, `toolkit/cli/cmd_status.py`, `toolkit/cli/common.py`, `toolkit/core/metadata.py` — rimossi copy locali, import da io
- `toolkit/cli/sql_dry_run.py` — aggiornato import dopo rimozione da mart/run