### PR TITLE
fix: MCP tools consolidation, validation enrichment, parallel tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
   "build>=1.4.3",
   "pytest>=8.0",
   "pytest-cov>=5.0.0",
+  "pytest-xdist>=3.0",
   "ruff>=0.3.0",
   "twine>=5.0.0",
   "xlwt>=1.0.0",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15,7 +15,6 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_inspect_paths",
         "toolkit_show_schema",
         "toolkit_raw_profile",
-        "toolkit_run_state",
         "toolkit_run_summary",
         "toolkit_summary",
         "toolkit_blocker_hints",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16,6 +16,7 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_show_schema",
         "toolkit_raw_profile",
         "toolkit_run_state",
+        "toolkit_run_summary",
         "toolkit_summary",
         "toolkit_blocker_hints",
         "toolkit_review_readiness",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -19,6 +19,7 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_summary",
         "toolkit_blocker_hints",
         "toolkit_review_readiness",
+        "toolkit_list_runs",
     }
 
 

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -12,6 +12,7 @@ from toolkit.mcp.toolkit_client import (
     list_runs,
     review_readiness,
     run_state,
+    run_summary,
     show_schema,
     summary,
 )
@@ -331,3 +332,60 @@ def test_list_runs_accepts_naive_datetime_filter(tmp_path: Path, monkeypatch) ->
     payload3 = list_runs(str(config_path), 2022, since="2025-12-01T00:00:00+00:00", limit=5)
     run_ids3 = [r["run_id"] for r in payload3["runs"]]
     assert "20260101T120000Z_abc123" in run_ids3
+
+
+def test_run_summary_accepts_since_until_filters(tmp_path: Path, monkeypatch) -> None:
+    """run_summary with since/until filters must normalize naive datetimes to UTC."""
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Clear any pre-existing run records
+    run_dir = dst / "_smoke_out" / "data" / "_runs" / "project_example" / "2022"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    for f in run_dir.glob("*.json"):
+        f.unlink()
+
+    # Create runs: Oct 10, Oct 20, Oct 25 — 2 SUCCESS, 1 FAILED
+    records = [
+        {"started_at": "2025-10-10T12:00:00+00:00", "status": "SUCCESS"},
+        {"started_at": "2025-10-20T12:00:00+00:00", "status": "SUCCESS"},
+        {"started_at": "2025-10-25T12:00:00+00:00", "status": "FAILED"},
+    ]
+    for i, rec in enumerate(records):
+        run_id = f"run_{i+1}"
+        run_record = {
+            "dataset": "project_example",
+            "year": 2022,
+            "run_id": run_id,
+            "status": rec["status"],
+            "started_at": rec["started_at"],
+            "finished_at": rec["started_at"].replace("T12:00", "T12:01"),
+            "duration_seconds": 60.0,
+            "layers": {"raw": {"status": "SUCCESS"}, "clean": {"status": "SUCCESS"}},
+        }
+        (run_dir / f"{run_id}.json").write_text(json.dumps(run_record), encoding="utf-8")
+
+    # Without filters — all 3 runs
+    p = run_summary(str(config_path), 2022)
+    assert p["total_runs"] == 3
+    assert p["success_count"] == 2
+
+    # Naive since — must not crash; Oct 16+ keeps Oct 20 and Oct 25 (2 runs, 1 SUCCESS)
+    p2 = run_summary(str(config_path), 2022, since="2025-10-16T00:00:00")
+    assert p2["total_runs"] == 2
+    assert p2["success_count"] == 1
+    assert p2["filters"]["since"] == "2025-10-16T00:00:00"
+
+    # Naive until — Oct 25 00:00 excludes Oct 25 (12:00 > 00:00), keeps Oct 10 and Oct 20
+    p3 = run_summary(str(config_path), 2022, until="2025-10-25T00:00:00")
+    assert p3["total_runs"] == 2
+    assert p3["success_count"] == 2
+    assert p3["filters"]["until"] == "2025-10-25T00:00:00"
+
+    # Aware datetime — same result as naive
+    p4 = run_summary(str(config_path), 2022, since="2025-10-16T00:00:00+00:00")
+    assert p4["total_runs"] == 2

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -9,6 +9,7 @@ import pytest
 from toolkit.mcp.toolkit_client import (
     blocker_hints,
     inspect_paths,
+    list_runs,
     review_readiness,
     run_state,
     show_schema,
@@ -286,3 +287,47 @@ def test_mcp_raw_profile_error_when_no_profile_file(tmp_path: Path, monkeypatch)
 
     with pytest.raises(ToolkitClientError, match="Nessun file raw_profile.json ne suggested_read.yml"):
         raw_profile(str(config_path), 2022)
+
+
+def test_list_runs_accepts_naive_datetime_filter(tmp_path: Path, monkeypatch) -> None:
+    """Naive datetime in since/until must be normalized to UTC, not crash with TypeError."""
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Create a run record with UTC-aware started_at
+    run_dir = dst / "_smoke_out" / "data" / "_runs" / "project_example" / "2022"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    run_record = {
+        "dataset": "project_example",
+        "year": 2022,
+        "run_id": "20260101T120000Z_abc123",
+        "status": "SUCCESS",
+        "started_at": "2026-01-01T12:00:00+00:00",
+        "finished_at": "2026-01-01T12:01:00+00:00",
+        "layers": {
+            "raw": {"status": "SUCCESS"},
+            "clean": {"status": "SUCCESS"},
+        },
+    }
+    (run_dir / "20260101T120000Z_abc123.json").write_text(
+        json.dumps(run_record), encoding="utf-8"
+    )
+
+    # Naive datetime filter — must NOT raise TypeError
+    payload = list_runs(str(config_path), 2022, since="2025-12-01T00:00:00", limit=5)
+    run_ids = [r["run_id"] for r in payload["runs"]]
+    assert "20260101T120000Z_abc123" in run_ids
+
+    # Naive until — filter should exclude this run
+    payload2 = list_runs(str(config_path), 2022, until="2025-12-01T00:00:00", limit=5)
+    run_ids2 = [r["run_id"] for r in payload2["runs"]]
+    assert "20260101T120000Z_abc123" not in run_ids2
+
+    # Aware datetime still works
+    payload3 = list_runs(str(config_path), 2022, since="2025-12-01T00:00:00+00:00", limit=5)
+    run_ids3 = [r["run_id"] for r in payload3["runs"]]
+    assert "20260101T120000Z_abc123" in run_ids3

--- a/toolkit/clean/input_selection.py
+++ b/toolkit/clean/input_selection.py
@@ -78,20 +78,21 @@ def _is_usable_input_file(path: Path) -> bool:
     )
 
 
-def _run_record_paths(root: str | None, dataset: str, year: int) -> list[Path]:
+def _run_record_paths(root: str | None, dataset: str, year: int) -> list[dict]:
+    """Return run records for the given dataset/year, most recent first."""
     return list_runs(get_run_dir(resolve_root(root), dataset, year))
 
 
-def _raw_layer_succeeded(run_path: Path) -> bool:
-    record = json.loads(run_path.read_text(encoding="utf-8"))
+def _raw_layer_succeeded(record: dict) -> bool:
     raw_layer = (record.get("layers") or {}).get("raw") or {}
     return raw_layer.get("status") == "SUCCESS"
 
 
 def _latest_raw_success_exists(root: str | None, dataset: str, year: int) -> bool:
-    runs = _run_record_paths(root, dataset, year)
-    for run_path in sorted(runs, key=lambda item: item.stat().st_mtime, reverse=True):
-        if _raw_layer_succeeded(run_path):
+    records = _run_record_paths(root, dataset, year)
+    # list_runs already returns records sorted by started_at desc
+    for record in records:
+        if _raw_layer_succeeded(record):
             return True
     return False
 

--- a/toolkit/cli/cmd_inspect.py
+++ b/toolkit/cli/cmd_inspect.py
@@ -154,6 +154,13 @@ def _payload_for_year(cfg, year: int) -> dict[str, Any]:
     suggested_read_path = raw_dir / "_profile" / "suggested_read.yml"
     profile_hints = raw_meta.get("profile_hints") or {}
 
+    run_files = sorted(run_dir.glob("*.json")) if run_dir.exists() else []
+    years_seen = (
+        sorted({p.parent.name for p in run_dir.parent.glob("*/*.json") if p.parent.name.isdigit()})
+        if run_dir.parent.exists()
+        else []
+    )
+
     latest_payload: dict[str, Any] | None = None
     try:
         latest_record = latest_run(run_dir)
@@ -178,6 +185,8 @@ def _payload_for_year(cfg, year: int) -> dict[str, Any]:
             "support": resolve_support_payloads(cfg.support, require_exists=False),
             "run_dir": str(run_dir),
         },
+        "run_file_count": len(run_files),
+        "years_seen": years_seen,
         "raw_hints": {
             "primary_output_file": raw_meta.get("primary_output_file"),
             "suggested_read_path": str(suggested_read_path),

--- a/toolkit/core/metadata.py
+++ b/toolkit/core/metadata.py
@@ -164,16 +164,23 @@ def write_layer_manifest(
     warnings_count: int | None = None,
     filename: str = "manifest.json",
 ) -> Path:
-    merge_layer_manifest(
-        folder,
-        metadata_path=metadata_path,
-        validation_path=validation_path,
-        outputs=outputs,
-        ok=ok,
-        errors_count=errors_count,
-        warnings_count=warnings_count,
-    )
-    return write_manifest_alias(folder, filename, metadata_path, validation_path, outputs, ok, errors_count, warnings_count)
+    # Single write: compute payload once, write only manifest.json.
+    # metadata.json is NOT updated here — it stays as the run-time source of truth
+    # written by the run step. manifest.json is the validation-time alias that
+    # always reflects the latest validation outcome.
+    payload = {
+        "metadata": metadata_path,
+        "validation": validation_path,
+        "summary": {
+            "ok": ok,
+            "errors_count": errors_count,
+            "warnings_count": warnings_count,
+        },
+        "outputs": outputs,
+    }
+    out = folder / filename
+    write_json_atomic(out, payload)
+    return out
 
 
 def write_manifest_alias(

--- a/toolkit/core/run_records.py
+++ b/toolkit/core/run_records.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
 
@@ -64,7 +64,25 @@ def write_run_record(run_dir: Path, run_id: str, payload: dict) -> Path:
     return path
 
 
-# --- Query ------------------------------------------------------------------
+# --- Query helpers -----------------------------------------------------------
+
+
+def _is_cross_year_run_dir(run_dir: Path) -> bool:
+    """Detect if run_dir is dataset-level (cross-year) vs year-level.
+
+    True when run_dir is data/_runs/{dataset} (no year subdir).
+    False when run_dir is data/_runs/{dataset}/{year}.
+    """
+    parts = run_dir.parts
+    try:
+        runs_idx = parts.index("_runs")
+    except ValueError:
+        return False
+    # dataset-level: data/_runs/{dataset} with no year subdir after
+    if len(parts) <= runs_idx + 2:
+        return True
+    after_dataset = parts[runs_idx + 2] if len(parts) > runs_idx + 2 else None
+    return after_dataset is not None and not after_dataset.isdigit()
 
 
 def list_runs(
@@ -88,7 +106,10 @@ def list_runs(
         return []
 
     all_records: list[dict[str, Any]] = []
-    for path in sorted(run_dir.glob("*.json")):
+    # cross_year=True: run_dir is dataset-level (data/_runs/{dataset}),
+    # need rglob to find JSON in year subdirectories
+    pattern = "**/*.json" if _is_cross_year_run_dir(run_dir) else "*.json"
+    for path in sorted(run_dir.glob(pattern)):
         try:
             record = _load_run_record(path)
         except Exception:

--- a/toolkit/core/run_records.py
+++ b/toolkit/core/run_records.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 

--- a/toolkit/core/run_records.py
+++ b/toolkit/core/run_records.py
@@ -81,8 +81,8 @@ def _is_cross_year_run_dir(run_dir: Path) -> bool:
     # dataset-level: data/_runs/{dataset} with no year subdir after
     if len(parts) <= runs_idx + 2:
         return True
-    after_dataset = parts[runs_idx + 2] if len(parts) > runs_idx + 2 else None
-    return after_dataset is not None and not after_dataset.isdigit()
+    after_dataset = parts[runs_idx + 2]
+    return not after_dataset.isdigit()
 
 
 def list_runs(
@@ -118,6 +118,8 @@ def list_runs(
         if started:
             try:
                 started_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+                if started_dt.tzinfo is None:
+                    started_dt = started_dt.replace(tzinfo=timezone.utc)
             except ValueError:
                 started_dt = None
         else:

--- a/toolkit/core/run_records.py
+++ b/toolkit/core/run_records.py
@@ -1,17 +1,19 @@
 """Storage and query layer for run records.
 
 Provides:
-- Run record path resolution (get_run_dir, _run_record_path)
+- Run record path resolution (get_run_dir, get_run_dir_dataset, _run_record_path)
 - Write with Windows-safe retry (write_run_record)
 - Read with portability migration (read_run_record)
-- Query (list_runs, latest_run)
+- Query with filters (list_runs, latest_run)
 """
 
 from __future__ import annotations
 
 import json
 import time
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Literal
 
 from toolkit.core.run_record_portability import _load_run_record
 
@@ -21,6 +23,11 @@ from toolkit.core.run_record_portability import _load_run_record
 
 def get_run_dir(root: Path, dataset: str, year: int) -> Path:
     return root / "data" / "_runs" / dataset / str(year)
+
+
+def get_run_dir_dataset(root: Path, dataset: str) -> Path:
+    """Return the dataset-level run directory (above year). Used for cross-year queries."""
+    return root / "data" / "_runs" / dataset
 
 
 def _run_record_path(run_dir: Path, run_id: str) -> Path:
@@ -60,10 +67,57 @@ def write_run_record(run_dir: Path, run_id: str, payload: dict) -> Path:
 # --- Query ------------------------------------------------------------------
 
 
-def list_runs(run_dir: Path) -> list[Path]:
+def list_runs(
+    run_dir: Path,
+    *,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    status: Literal["SUCCESS", "FAILED", "RUNNING", "DRY_RUN"] | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """List run records from a run directory, with optional filters.
+
+    Args:
+        run_dir: directory containing run JSON files (data/_runs/{dataset}/{year})
+        since: only runs started at or after this datetime (UTC)
+        until: only runs started at or before this datetime (UTC)
+        status: filter by run status
+        limit: maximum number of runs to return (most recent first)
+    """
     if not run_dir.exists():
         return []
-    return sorted(run_dir.glob("*.json"))
+
+    all_records: list[dict[str, Any]] = []
+    for path in sorted(run_dir.glob("*.json")):
+        try:
+            record = _load_run_record(path)
+        except Exception:
+            continue
+        started = record.get("started_at", "")
+        if started:
+            try:
+                started_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+            except ValueError:
+                started_dt = None
+        else:
+            started_dt = None
+
+        if since and started_dt and started_dt < since:
+            continue
+        if until and started_dt and started_dt > until:
+            continue
+        if status and record.get("status") != status:
+            continue
+
+        all_records.append(record)
+
+    # Sort descending by started_at
+    all_records.sort(key=lambda r: r.get("started_at", ""), reverse=True)
+
+    if limit is not None:
+        all_records = all_records[:limit]
+
+    return all_records
 
 
 def read_run_record(run_dir: Path, run_id: str) -> dict:
@@ -79,11 +133,4 @@ def latest_run(run_dir: Path) -> dict:
         dataset = run_dir.parent.name if run_dir.parent != run_dir else "(unknown)"
         year = run_dir.name
         raise FileNotFoundError(f"No run records found for dataset={dataset} year={year}")
-    latest = max(
-        runs,
-        key=lambda path: (
-            _load_run_record(path).get("started_at", ""),
-            path.stat().st_mtime,
-        ),
-    )
-    return _load_run_record(latest)
+    return runs[0]

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -187,5 +187,6 @@ def run_mart(
         warnings_count=None,
     )
     total_bytes = sum(p.stat().st_size for p in written if p.exists())
+    col_count = sum(len(tp.get("columns", [])) for tp in table_profiles.values()) if table_profiles else None
     logger.info(f"MART -> {mart_dir}")
-    return {"output_rows": total_rows, "output_bytes": total_bytes, "tables_count": len(written)}
+    return {"output_rows": total_rows, "output_bytes": total_bytes, "tables_count": len(written), "col_count": col_count}

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -4,11 +4,10 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 
 ## Tool esposti
 
-- `toolkit_inspect_paths(config_path, year=0)`
+- `toolkit_inspect_paths(config_path, year=0)` — path contract + run metadata (run_file_count, years_seen, latest_run)
 - `toolkit_show_schema(config_path, layer="clean", year=0)`
-- `toolkit_run_state(config_path, year=0)`
 - `toolkit_run_summary(config_path, year=0)` — statistiche aggregate (totali, successi, durata media)
-- `toolkit_summary(config_path, year=0)`
+- `toolkit_summary(config_path, year=0)` — dashboard diagnostico (layer + run + warnings)
 - `toolkit_blocker_hints(config_path, year=0)`
 - `toolkit_review_readiness(config_path, year=0)`
 - `toolkit_list_runs(config_path, year=0, since=None, until=None, status=None, limit=20, cross_year=False)`
@@ -46,10 +45,11 @@ Sostituire il path del `command` con il Python reale del clone locale che usera'
 
 ## Note tecniche
 
-- `toolkit_inspect_paths` usa `toolkit inspect paths --json`
+- `toolkit_inspect_paths` usa `toolkit inspect paths --json`; arricchito con run_file_count e years_seen dalla CLI
 - `toolkit_show_schema`
   - `raw`: usa `toolkit inspect schema-diff --json`
   - `clean` / `mart`: legge schema reale dei parquet risolti via `inspect paths`
-- `toolkit_run_state` legge `latest_run` e il relativo record JSON se presente
+- `toolkit_run_summary` aggrega tutti i run record per dataset/year
+- `toolkit_summary` include `run.latest_run_record` (payload completo dell'ultimo run)
 - `toolkit_blocker_hints` evidenzia mismatch pratici tra output risolti e stato run
 - `toolkit_review_readiness` esegue check di readiness per review candidate: config valida, layer presenti, output leggibili, coerenza run record

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -7,6 +7,7 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_inspect_paths(config_path, year=0)`
 - `toolkit_show_schema(config_path, layer="clean", year=0)`
 - `toolkit_run_state(config_path, year=0)`
+- `toolkit_run_summary(config_path, year=0)` — statistiche aggregate (totali, successi, durata media)
 - `toolkit_summary(config_path, year=0)`
 - `toolkit_blocker_hints(config_path, year=0)`
 - `toolkit_review_readiness(config_path, year=0)`

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -10,6 +10,7 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_summary(config_path, year=0)`
 - `toolkit_blocker_hints(config_path, year=0)`
 - `toolkit_review_readiness(config_path, year=0)`
+- `toolkit_list_runs(config_path, year=0, since=None, until=None, status=None, limit=20, cross_year=False)`
 
 ## Boundary
 

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -369,8 +369,20 @@ def list_runs(
     }
 
 
-def run_summary(config_path: str, year: int | None = None) -> dict[str, Any]:
+def run_summary(
+    config_path: str,
+    year: int | None = None,
+    *,
+    since: str | None = None,
+    until: str | None = None,
+) -> dict[str, Any]:
     """Aggregated run statistics for a dataset/year.
+
+    Args:
+        config_path: path to dataset.yml
+        year: filter to specific year (default: first year in config)
+        since: ISO datetime string — only runs started after this moment
+        until: ISO datetime string — only runs started before this moment
 
     Returns: total_runs, success_count, failed_count, run_rate,
     avg_duration_seconds, last_30d_runs, status_breakdown.
@@ -386,9 +398,46 @@ def run_summary(config_path: str, year: int | None = None) -> dict[str, Any]:
         year = cfg.years[0] if cfg.years else 0
     run_dir = get_run_dir(Path(root), cfg.dataset, year)
 
+    since_dt: datetime | None = None
+    if since:
+        try:
+            raw = since.replace("Z", "+00:00")
+            since_dt = datetime.fromisoformat(raw)
+            if since_dt.tzinfo is None:
+                since_dt = since_dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            raise ToolkitClientError(f"since must be a valid ISO datetime, got: {since}")
+
+    until_dt: datetime | None = None
+    if until:
+        try:
+            raw = until.replace("Z", "+00:00")
+            until_dt = datetime.fromisoformat(raw)
+            if until_dt.tzinfo is None:
+                until_dt = until_dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            raise ToolkitClientError(f"until must be a valid ISO datetime, got: {until}")
+
     all_records = list_runs(run_dir, limit=None)
 
-    if not all_records:
+    # Apply datetime filters (same logic as list_runs core)
+    filtered_records: list[dict[str, Any]] = []
+    for record in all_records:
+        started = record.get("started_at", "")
+        if started:
+            try:
+                started_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+            except ValueError:
+                started_dt = None
+        else:
+            started_dt = None
+        if since_dt and started_dt and started_dt < since_dt:
+            continue
+        if until_dt and started_dt and started_dt > until_dt:
+            continue
+        filtered_records.append(record)
+
+    if not filtered_records:
         return {
             "dataset": cfg.dataset,
             "year": year,
@@ -402,15 +451,15 @@ def run_summary(config_path: str, year: int | None = None) -> dict[str, Any]:
             "status_breakdown": {},
         }
 
-    total = len(all_records)
-    success = sum(1 for r in all_records if r.get("status") == "SUCCESS")
-    failed = sum(1 for r in all_records if r.get("status") == "FAILED")
-    durations = [r.get("duration_seconds") for r in all_records if r.get("duration_seconds") is not None]
+    total = len(filtered_records)
+    success = sum(1 for r in filtered_records if r.get("status") == "SUCCESS")
+    failed = sum(1 for r in filtered_records if r.get("status") == "FAILED")
+    durations = [r.get("duration_seconds") for r in filtered_records if r.get("duration_seconds") is not None]
     avg_duration = round(sum(durations) / len(durations), 1) if durations else None
 
     thirty_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
     last_30d = 0
-    for r in all_records:
+    for r in filtered_records:
         started = r.get("started_at", "")
         if started:
             try:
@@ -421,7 +470,7 @@ def run_summary(config_path: str, year: int | None = None) -> dict[str, Any]:
                 pass
 
     status_breakdown: dict[str, int] = {}
-    for r in all_records:
+    for r in filtered_records:
         s = r.get("status", "UNKNOWN")
         status_breakdown[s] = status_breakdown.get(s, 0) + 1
 
@@ -429,6 +478,7 @@ def run_summary(config_path: str, year: int | None = None) -> dict[str, Any]:
         "dataset": cfg.dataset,
         "year": year,
         "run_dir": str(run_dir),
+        "filters": {"since": since, "until": until},
         "total_runs": total,
         "success_count": success,
         "failed_count": failed,

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -454,6 +454,15 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
     latest_run_path = latest_run.get("path")
 
     run_files = sorted(run_dir.glob("*.json")) if run_dir.exists() else []
+    run_file_count = paths.get("run_file_count", len(run_files))
+    years_seen = paths.get("years_seen", [])
+
+    latest_run_record: dict[str, Any] | None = None
+    if latest_run_path and Path(latest_run_path).exists():
+        try:
+            latest_run_record = json.loads(Path(latest_run_path).read_text(encoding="utf-8"))
+        except Exception:
+            pass
 
     warnings: list[str] = []
     if primary_output_file and not _exists(primary_output_path):
@@ -506,9 +515,10 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
         "run": {
             "run_dir": str(run_dir),
             "run_dir_exists": run_dir.exists(),
-            "run_file_count": len(run_files),
+            "run_file_count": run_file_count,
+            "years_seen": years_seen,
             "latest_run": latest_run or None,
-            "latest_run_record_exists": _exists(latest_run_path),
+            "latest_run_record": latest_run_record,
         },
         "warnings": warnings,
     }

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -20,6 +20,7 @@ import duckdb
 from toolkit.mcp.cli_adapter import _toolkit_json, inspect_paths
 from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.path_safety import _load_cfg, _safe_path
+from toolkit.core.run_records import get_run_dir_dataset, list_runs
 
 
 def _sql_literal(value: str) -> str:
@@ -265,6 +266,85 @@ def run_state(config_path: str, year: int | None = None) -> dict[str, Any]:
         "years_seen": years_seen,
         "latest_run": latest_run,
         "latest_run_record": latest_payload,
+    }
+
+
+def list_runs(
+    config_path: str,
+    year: int | None = None,
+    *,
+    since: str | None = None,
+    until: str | None = None,
+    status: str | None = None,
+    limit: int | None = None,
+    cross_year: bool = False,
+) -> dict[str, Any]:
+    """List run records with optional filters.
+
+    Args:
+        config_path: path to dataset.yml
+        year: filter to specific year (default: all years)
+        since: ISO datetime string — only runs started after this moment
+        until: ISO datetime string — only runs started before this moment
+        status: filter by status (SUCCESS, FAILED, RUNNING, DRY_RUN)
+        limit: max records to return (default 20, None for all)
+        cross_year: if True, list runs across all years for this dataset
+    """
+    from datetime import datetime, timezone
+
+    config = _safe_path(config_path)
+    cfg, _ = _load_cfg(config)
+    root = cfg.root
+
+    if cross_year:
+        run_dir = get_run_dir_dataset(Path(root), cfg.dataset)
+    else:
+        if year is None:
+            year = cfg.years[0] if cfg.years else 0
+        run_dir = Path(root) / "data" / "_runs" / cfg.dataset / str(year)
+
+    since_dt = None
+    if since:
+        try:
+            since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        except ValueError:
+            raise ToolkitClientError(f"since must be a valid ISO datetime, got: {since}")
+
+    until_dt = None
+    if until:
+        try:
+            until_dt = datetime.fromisoformat(until.replace("Z", "+00:00"))
+        except ValueError:
+            raise ToolkitClientError(f"until must be a valid ISO datetime, got: {until}")
+
+    valid_statuses = {"SUCCESS", "FAILED", "RUNNING", "DRY_RUN"}
+    if status and status not in valid_statuses:
+        raise ToolkitClientError(f"status must be one of: {', '.join(sorted(valid_statuses))}")
+
+    limit = limit if limit is not None else 20
+
+    records = list_runs(
+        run_dir,
+        since=since_dt,
+        until=until_dt,
+        status=status if status else None,
+        limit=limit,
+    )
+
+    return {
+        "dataset": cfg.dataset,
+        "config_path": str(config),
+        "requested_year": year,
+        "cross_year": cross_year,
+        "filters": {
+            "since": since,
+            "until": until,
+            "status": status,
+            "limit": limit,
+        },
+        "run_dir": str(run_dir),
+        "total_matches": len(records),
+        "runs": records,
     }
 
 

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -306,7 +306,7 @@ def list_runs(
         limit: max records to return (default 20, None for all)
         cross_year: if True, list runs across all years for this dataset
     """
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     _, cfg = _load_cfg(str(config_path))
     root = cfg.root
@@ -321,14 +321,20 @@ def list_runs(
     since_dt = None
     if since:
         try:
-            since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+            raw = since.replace("Z", "+00:00")
+            since_dt = datetime.fromisoformat(raw)
+            if since_dt.tzinfo is None:
+                since_dt = since_dt.replace(tzinfo=timezone.utc)
         except ValueError:
             raise ToolkitClientError(f"since must be a valid ISO datetime, got: {since}")
 
     until_dt = None
     if until:
         try:
-            until_dt = datetime.fromisoformat(until.replace("Z", "+00:00"))
+            raw = until.replace("Z", "+00:00")
+            until_dt = datetime.fromisoformat(raw)
+            if until_dt.tzinfo is None:
+                until_dt = until_dt.replace(tzinfo=timezone.utc)
         except ValueError:
             raise ToolkitClientError(f"until must be a valid ISO datetime, got: {until}")
 

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -418,26 +418,9 @@ def run_summary(
         except ValueError:
             raise ToolkitClientError(f"until must be a valid ISO datetime, got: {until}")
 
-    all_records = list_runs(run_dir, limit=None)
+    all_records = list_runs(run_dir, since=since_dt, until=until_dt, limit=None)
 
-    # Apply datetime filters (same logic as list_runs core)
-    filtered_records: list[dict[str, Any]] = []
-    for record in all_records:
-        started = record.get("started_at", "")
-        if started:
-            try:
-                started_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
-            except ValueError:
-                started_dt = None
-        else:
-            started_dt = None
-        if since_dt and started_dt and started_dt < since_dt:
-            continue
-        if until_dt and started_dt and started_dt > until_dt:
-            continue
-        filtered_records.append(record)
-
-    if not filtered_records:
+    if not all_records:
         return {
             "dataset": cfg.dataset,
             "year": year,
@@ -451,15 +434,15 @@ def run_summary(
             "status_breakdown": {},
         }
 
-    total = len(filtered_records)
-    success = sum(1 for r in filtered_records if r.get("status") == "SUCCESS")
-    failed = sum(1 for r in filtered_records if r.get("status") == "FAILED")
-    durations = [r.get("duration_seconds") for r in filtered_records if r.get("duration_seconds") is not None]
+    total = len(all_records)
+    success = sum(1 for r in all_records if r.get("status") == "SUCCESS")
+    failed = sum(1 for r in all_records if r.get("status") == "FAILED")
+    durations = [r.get("duration_seconds") for r in all_records if r.get("duration_seconds") is not None]
     avg_duration = round(sum(durations) / len(durations), 1) if durations else None
 
     thirty_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
     last_30d = 0
-    for r in filtered_records:
+    for r in all_records:
         started = r.get("started_at", "")
         if started:
             try:
@@ -470,7 +453,7 @@ def run_summary(
                 pass
 
     status_breakdown: dict[str, int] = {}
-    for r in filtered_records:
+    for r in all_records:
         s = r.get("status", "UNKNOWN")
         status_breakdown[s] = status_breakdown.get(s, 0) + 1
 

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -64,6 +64,54 @@ def _exists(path: str | None) -> bool:
     return Path(path).exists()
 
 
+def _read_validation_content(path: str | None) -> dict[str, Any] | None:
+    """Read a validation JSON file and return its content, or None if missing."""
+    if not path or not _exists(path):
+        return None
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _validation_summary_for_layer(layer_dir: Path, validation_filename: str) -> dict[str, Any] | None:
+    """Extract summary + sections from a layer's validation JSON.
+
+    Adds: ok, errors_count, warnings_count, row_count, col_count, profile sections.
+    Returns None if the validation file does not exist.
+    """
+    validation_path = layer_dir / validation_filename
+    content = _read_validation_content(str(validation_path))
+    if not content:
+        return None
+
+    result = {
+        "ok": content.get("ok"),
+        "errors_count": len(content.get("errors", [])),
+        "warnings_count": len(content.get("warnings", [])),
+        "row_count": None,
+        "col_count": None,
+    }
+
+    # Extract stats from sections (set by clean/mart validation)
+    sections = content.get("sections", {})
+    if "stats" in sections:
+        result["row_count"] = sections["stats"].get("row_count")
+        result["col_count"] = sections["stats"].get("col_count")
+
+    # Extract column profile from transition section (clean validation)
+    if "transition" in sections:
+        t = sections["transition"]
+        if "clean_cols" in t:
+            result["col_count"] = t.get("clean_cols")
+        if "raw_row_count" in t:
+            result["raw_row_count"] = t.get("raw_row_count")
+        if "clean_row_count" in t:
+            result["clean_row_count"] = t.get("clean_row_count")
+
+    return result
+
+
 def show_schema(config_path: str, layer: str = "clean", year: int | None = None) -> dict[str, Any]:
     config, _cfg = _load_cfg(config_path)
     safe_layer = (layer or "clean").strip().lower()
@@ -267,6 +315,7 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
                 "suggested_read_exists": (paths.get("raw_hints") or {}).get(
                     "suggested_read_exists"
                 ),
+                "validation": _validation_summary_for_layer(raw_dir, "_validate/raw_validation.json"),
             },
             "clean": {
                 "dir": str(clean_dir),
@@ -275,6 +324,7 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
                 "output_exists": _exists(clean_paths.get("output")),
                 "manifest_exists": _exists(clean_paths.get("manifest")),
                 "metadata_exists": _exists(clean_paths.get("metadata")),
+                "validation": _validation_summary_for_layer(clean_dir, "_validate/clean_validation.json"),
             },
             "mart": {
                 "dir": str(mart_dir),
@@ -285,6 +335,7 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
                 "missing_outputs": missing_mart_outputs,
                 "manifest_exists": _exists(mart_paths.get("manifest")),
                 "metadata_exists": _exists(mart_paths.get("metadata")),
+                "validation": _validation_summary_for_layer(mart_dir, "_validate/mart_validation.json"),
             },
         },
         "run": {

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -76,9 +76,11 @@ def _read_validation_content(path: str | None) -> dict[str, Any] | None:
 
 
 def _validation_summary_for_layer(layer_dir: Path, validation_filename: str) -> dict[str, Any] | None:
-    """Extract summary + sections from a layer's validation JSON.
+    """Extract summary from a layer's validation JSON.
 
-    Adds: ok, errors_count, warnings_count, row_count, col_count, profile sections.
+    Adds: ok, errors_count, warnings_count, row_count, col_count, raw_row_count, clean_row_count.
+    Reads row/col counts from summary.stats (clean) or summary.row_counts (mart).
+    Falls back to sections.stats for layers that use that path.
     Returns None if the validation file does not exist.
     """
     validation_path = layer_dir / validation_filename
@@ -94,13 +96,19 @@ def _validation_summary_for_layer(layer_dir: Path, validation_filename: str) -> 
         "col_count": None,
     }
 
-    # Extract stats from sections (set by clean/mart validation)
+    # Extract stats from summary (clean layer: summary.stats.clean_rows/clean_cols)
+    summary = content.get("summary", {})
+    stats = summary.get("stats", {})
+    result["row_count"] = stats.get("clean_rows") or stats.get("row_count")
+    result["col_count"] = stats.get("clean_cols")
+
+    # Fallback: sections.stats (mart layer uses sections differently)
     sections = content.get("sections", {})
-    if "stats" in sections:
+    if result["row_count"] is None and "stats" in sections:
         result["row_count"] = sections["stats"].get("row_count")
         result["col_count"] = sections["stats"].get("col_count")
 
-    # Extract column profile from transition section (clean validation)
+    # Extract transition metadata (clean validation)
     if "transition" in sections:
         t = sections["transition"]
         if "clean_cols" in t:
@@ -109,6 +117,14 @@ def _validation_summary_for_layer(layer_dir: Path, validation_filename: str) -> 
             result["raw_row_count"] = t.get("raw_row_count")
         if "clean_row_count" in t:
             result["clean_row_count"] = t.get("clean_row_count")
+
+    # Extract row_counts from mart summary (mart layer)
+    if result["row_count"] is None:
+        row_counts = summary.get("row_counts", {})
+        if row_counts:
+            first_key = next(iter(row_counts), None)
+            if first_key:
+                result["row_count"] = row_counts[first_key]
 
     return result
 

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -355,7 +355,7 @@ def run_summary(config_path: str, year: int | None = None) -> dict[str, Any]:
     avg_duration_seconds, last_30d_runs, status_breakdown.
     """
     config = _safe_path(config_path)
-    cfg, _ = _load_cfg(config)
+    _, cfg = _load_cfg(config)
     root = cfg.root
 
     from datetime import datetime, timezone, timedelta

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -20,7 +20,7 @@ import duckdb
 from toolkit.mcp.cli_adapter import _toolkit_json, inspect_paths
 from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.path_safety import _load_cfg, _safe_path
-from toolkit.core.run_records import get_run_dir_dataset, list_runs
+from toolkit.core.run_records import get_run_dir_dataset, list_runs as _list_runs_records
 
 
 def _sql_literal(value: str) -> str:
@@ -154,7 +154,7 @@ def show_schema(config_path: str, layer: str = "clean", year: int | None = None)
             "dataset": paths.get("dataset"),
             "year": paths.get("year"),
             "layer": safe_layer,
-            "config_path": str(config),
+"config_path": str(config_path),
         }
     )
     return payload
@@ -217,7 +217,7 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
     return {
         "dataset": profile.get("dataset"),
         "year": profile.get("year"),
-        "config_path": str(config),
+        "config_path": str(config_path),
         "profile_path": str(profile_path),
         "file_used": profile.get("file_used"),
         "read_hints": {
@@ -258,7 +258,7 @@ def run_state(config_path: str, year: int | None = None) -> dict[str, Any]:
     )
     return {
         "dataset": paths.get("dataset"),
-        "config_path": str(config),
+        "config_path": str(config_path),
         "requested_year": year,
         "run_dir": str(run_dir),
         "run_dir_exists": run_dir.exists(),
@@ -292,8 +292,7 @@ def list_runs(
     """
     from datetime import datetime, timezone
 
-    config = _safe_path(config_path)
-    cfg, _ = _load_cfg(config)
+    _, cfg = _load_cfg(str(config_path))
     root = cfg.root
 
     if cross_year:
@@ -323,7 +322,7 @@ def list_runs(
 
     limit = limit if limit is not None else 20
 
-    records = list_runs(
+    records = _list_runs_records(
         run_dir,
         since=since_dt,
         until=until_dt,
@@ -333,7 +332,7 @@ def list_runs(
 
     return {
         "dataset": cfg.dataset,
-        "config_path": str(config),
+        "config_path": str(config_path),
         "requested_year": year,
         "cross_year": cross_year,
         "filters": {
@@ -452,7 +451,7 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
 
     return {
         "dataset": paths.get("dataset"),
-        "config_path": str(config),
+        "config_path": str(config_path),
         "year": paths.get("year"),
         "layers": {
             "raw": {
@@ -615,7 +614,7 @@ def blocker_hints(config_path: str, year: int | None = None) -> dict[str, Any]:
 
     return {
         "dataset": s.get("dataset"),
-        "config_path": str(config),
+        "config_path": str(config_path),
         "year": s.get("year"),
         "hint_count": len(hints),
         "hints": hints,
@@ -761,7 +760,7 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
 
     return {
         "dataset": s.get("dataset"),
-        "config_path": str(config),
+        "config_path": str(config_path),
         "year": s.get("year"),
         "readiness": readiness,
         "check_count": len(checks),

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -348,6 +348,76 @@ def list_runs(
     }
 
 
+def run_summary(config_path: str, year: int | None = None) -> dict[str, Any]:
+    """Aggregated run statistics for a dataset/year.
+
+    Returns: total_runs, success_count, failed_count, run_rate,
+    avg_duration_seconds, last_30d_runs, status_breakdown.
+    """
+    config = _safe_path(config_path)
+    cfg, _ = _load_cfg(config)
+    root = cfg.root
+
+    from datetime import datetime, timezone, timedelta
+    from toolkit.core.run_records import get_run_dir, list_runs
+
+    if year is None:
+        year = cfg.years[0] if cfg.years else 0
+    run_dir = get_run_dir(Path(root), cfg.dataset, year)
+
+    all_records = list_runs(run_dir, limit=None)
+
+    if not all_records:
+        return {
+            "dataset": cfg.dataset,
+            "year": year,
+            "run_dir": str(run_dir),
+            "total_runs": 0,
+            "success_count": 0,
+            "failed_count": 0,
+            "run_rate": None,
+            "avg_duration_seconds": None,
+            "last_30d_runs": 0,
+            "status_breakdown": {},
+        }
+
+    total = len(all_records)
+    success = sum(1 for r in all_records if r.get("status") == "SUCCESS")
+    failed = sum(1 for r in all_records if r.get("status") == "FAILED")
+    durations = [r.get("duration_seconds") for r in all_records if r.get("duration_seconds") is not None]
+    avg_duration = round(sum(durations) / len(durations), 1) if durations else None
+
+    thirty_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
+    last_30d = 0
+    for r in all_records:
+        started = r.get("started_at", "")
+        if started:
+            try:
+                dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+                if dt >= thirty_days_ago:
+                    last_30d += 1
+            except ValueError:
+                pass
+
+    status_breakdown: dict[str, int] = {}
+    for r in all_records:
+        s = r.get("status", "UNKNOWN")
+        status_breakdown[s] = status_breakdown.get(s, 0) + 1
+
+    return {
+        "dataset": cfg.dataset,
+        "year": year,
+        "run_dir": str(run_dir),
+        "total_runs": total,
+        "success_count": success,
+        "failed_count": failed,
+        "run_rate": round(success / total * 100, 1) if total > 0 else None,
+        "avg_duration_seconds": avg_duration,
+        "last_30d_runs": last_30d,
+        "status_breakdown": status_breakdown,
+    }
+
+
 def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
     config = _safe_path(config_path)
     paths = inspect_paths(str(config), year)

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -170,7 +170,7 @@ def show_schema(config_path: str, layer: str = "clean", year: int | None = None)
             "dataset": paths.get("dataset"),
             "year": paths.get("year"),
             "layer": safe_layer,
-"config_path": str(config_path),
+            "config_path": str(config_path),
         }
     )
     return payload
@@ -306,7 +306,7 @@ def list_runs(
         limit: max records to return (default 20, None for all)
         cross_year: if True, list runs across all years for this dataset
     """
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     _, cfg = _load_cfg(str(config_path))
     root = cfg.root

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -12,6 +12,7 @@ from .toolkit_client import (
     raw_profile as raw_profile_impl,
     review_readiness as review_readiness_impl,
     run_state as run_state_impl,
+    run_summary as run_summary_impl,
     summary as summary_impl,
     show_schema as show_schema_impl,
 )
@@ -57,6 +58,14 @@ def toolkit_raw_profile(config_path: str, year: int = 0) -> dict[str, Any]:
 )
 def toolkit_run_state(config_path: str, year: int = 0) -> dict[str, Any]:
     return _guard(run_state_impl, config_path, year or None)
+
+
+@mcp.tool(
+    description="Statistiche aggregate dei run: totali, successi, fallimenti, durata media.",
+    structured_output=True,
+)
+def toolkit_run_summary(config_path: str, year: int = 0) -> dict[str, Any]:
+    return _guard(run_summary_impl, config_path, year or None)
 
 
 @mcp.tool(

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -11,7 +11,6 @@ from .toolkit_client import (
     list_runs as list_runs_impl,
     raw_profile as raw_profile_impl,
     review_readiness as review_readiness_impl,
-    run_state as run_state_impl,
     run_summary as run_summary_impl,
     summary as summary_impl,
     show_schema as show_schema_impl,
@@ -51,13 +50,6 @@ def toolkit_show_schema(config_path: str, layer: str = "clean", year: int = 0) -
 )
 def toolkit_raw_profile(config_path: str, year: int = 0) -> dict[str, Any]:
     return _guard(raw_profile_impl, config_path, year or None)
-
-
-@mcp.tool(
-    description="Mostra lo stato minimo dei run per un dataset config.", structured_output=True
-)
-def toolkit_run_state(config_path: str, year: int = 0) -> dict[str, Any]:
-    return _guard(run_state_impl, config_path, year or None)
 
 
 @mcp.tool(

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -8,6 +8,7 @@ from .toolkit_client import (
     ToolkitClientError,
     blocker_hints as blocker_hints_impl,
     inspect_paths as inspect_paths_impl,
+    list_runs as list_runs_impl,
     raw_profile as raw_profile_impl,
     review_readiness as review_readiness_impl,
     run_state as run_state_impl,
@@ -80,6 +81,23 @@ def toolkit_blocker_hints(config_path: str, year: int = 0) -> dict[str, Any]:
 )
 def toolkit_review_readiness(config_path: str, year: int = 0) -> dict[str, Any]:
     return _guard(review_readiness_impl, config_path, year or None)
+
+
+@mcp.tool(
+    description="Lista run records con filtri opzionali. Ritorna record completi (non solo metadata).",
+    structured_output=True,
+)
+def toolkit_list_runs(
+    config_path: str,
+    year: int = 0,
+    *,
+    since: str | None = None,
+    until: str | None = None,
+    status: str | None = None,
+    limit: int | None = None,
+    cross_year: bool = False,
+) -> dict[str, Any]:
+    return _guard(list_runs_impl, config_path, year or None, since=since, until=until, status=status, limit=limit, cross_year=cross_year)
 
 
 if __name__ == "__main__":

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -56,8 +56,14 @@ def toolkit_raw_profile(config_path: str, year: int = 0) -> dict[str, Any]:
     description="Statistiche aggregate dei run: totali, successi, fallimenti, durata media.",
     structured_output=True,
 )
-def toolkit_run_summary(config_path: str, year: int = 0) -> dict[str, Any]:
-    return _guard(run_summary_impl, config_path, year or None)
+def toolkit_run_summary(
+    config_path: str,
+    year: int = 0,
+    *,
+    since: str | None = None,
+    until: str | None = None,
+) -> dict[str, Any]:
+    return _guard(run_summary_impl, config_path, year or None, since=since, until=until)
 
 
 @mcp.tool(

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -6,6 +6,9 @@ This module is a thin facade. The actual implementation lives in dedicated sub-m
 - path_safety: _safe_path, _load_cfg
 - cli_adapter: _toolkit_json, inspect_paths
 - schema_ops: list_runs, show_schema, raw_profile, run_state, summary, blocker_hints, review_readiness
+
+Note: run_state is kept here for internal use (tests) but is no longer a registered MCP tool.
+Use inspect_paths (with run_file_count, years_seen) or summary (with latest_run_record) instead.
 """
 
 from __future__ import annotations

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -5,7 +5,7 @@ This module is a thin facade. The actual implementation lives in dedicated sub-m
 - errors: ToolkitClientError
 - path_safety: _safe_path, _load_cfg
 - cli_adapter: _toolkit_json, inspect_paths
-- schema_ops: show_schema, raw_profile, run_state, summary, blocker_hints, review_readiness
+- schema_ops: list_runs, show_schema, raw_profile, run_state, summary, blocker_hints, review_readiness
 """
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.cli_adapter import inspect_paths
 from toolkit.mcp.schema_ops import (
     blocker_hints,
+    list_runs,
     raw_profile,
     review_readiness,
     run_state,

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -19,6 +19,7 @@ from toolkit.mcp.schema_ops import (
     raw_profile,
     review_readiness,
     run_state,
+    run_summary,
     show_schema,
     summary,
 )


### PR DESCRIPTION
## Summary

- **8 MCP tool** invece di 9 — rimosso `toolkit_run_state` (funzionalità ora in `inspect_paths` e `summary`)
- **Arricchimento validation**: `row_count`/`col_count` estratti da `summary.stats` (clean/mart)
- **Nuovo `toolkit_run_summary`**: statistiche aggregate run (success rate, avg duration, last_30d)
- **Filtri `list_runs`**: `since`/`until`/`status`/`limit` — query custom su run records
- **Parallel tests**: `pytest-xdist -n auto` — 543 test in 21s (era 44s)
- **Bugfix multipli**: `_safe_path` globale mancante, `str(config)` → `str(config_path)`, name collision `list_runs`

## Changed files

- `toolkit/mcp/schema_ops.py` — consolidamento tool run, fix validation
- `toolkit/mcp/server.py` — rimuove `toolkit_run_state`, aggiunge filter params a `list_runs`
- `toolkit/mcp/toolkit_client.py` — re-export aggiornato
- `toolkit/mcp/README.md` — aggiornato a 8 tool
- `toolkit/cli/cmd_inspect.py` — `run_file_count` + `years_seen` in payload
- `toolkit/core/run_records.py` — `list_runs` riscritto con filtri
- `toolkit/core/metadata.py` — single-write manifest
- `pyproject.toml` — `pytest-xdist` aggiunto
- `tests/test_mcp_server.py` — aggiornato assertion a 8 tool

## Test

- 543 test passano ✅
- 21s con `-n auto` (era 44s)