### PR TITLE
feat(cli): aggiunge comando pubblico blocker-hints

### DIFF
--- a/tests/test_cli_blocker_hints.py
+++ b/tests/test_cli_blocker_hints.py
@@ -254,8 +254,8 @@ mart:
     )
 
     assert result.exit_code == 0
-    # Should flag this as a blocker
-    assert "clean_dir_missing" in result.output or "blocker" in result.output
+    # Should flag this as a blocker — check specific code, not just word "blocker"
+    assert "clean_dir_missing" in result.output
 
 
 def test_blocker_hints_exit_code_0_even_with_blockers(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_cli_blocker_hints.py
+++ b/tests/test_cli_blocker_hints.py
@@ -12,12 +12,16 @@ from toolkit.cli.app import app
 
 def test_blocker_hints_help() -> None:
     """--help works without config."""
+    import re
     runner = CliRunner()
     result = runner.invoke(app, ["blocker-hints", "--help"])
     assert result.exit_code == 0
-    assert "--config" in result.output
-    assert "--year" in result.output
-    assert "--json" in result.output
+    # Strip ANSI codes and check for key option names
+    raw = result.output
+    clean = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', raw)
+    assert "--config" in clean
+    assert "--year" in clean
+    assert "--json" in clean
 
 
 def test_blocker_hints_missing_config() -> None:

--- a/tests/test_cli_blocker_hints.py
+++ b/tests/test_cli_blocker_hints.py
@@ -1,0 +1,319 @@
+"""Tests for toolkit blocker-hints CLI command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from toolkit.cli.app import app
+
+
+def test_blocker_hints_help() -> None:
+    """--help works without config."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["blocker-hints", "--help"])
+    assert result.exit_code == 0
+    assert "--config" in result.output
+    assert "--year" in result.output
+    assert "--json" in result.output
+
+
+def test_blocker_hints_missing_config() -> None:
+    """Missing config file exits with code 1 and error message."""
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["blocker-hints", "--config", "nonexistent.yml", "--year", "2023"],
+    )
+    assert result.exit_code == 1
+    assert "non trovata" in result.output.lower() or "not found" in result.output.lower()
+
+
+def test_blocker_hints_returns_json_when_flag_set(tmp_path: Path, monkeypatch) -> None:
+    """--json returns structured dict instead of human-readable output."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    config_path = project_dir / "dataset.yml"
+
+    config_path.write_text(
+        """
+root: "./out"
+dataset:
+  name: test_ds
+  years: [2023]
+raw: {}
+clean:
+  sql: "sql/clean.sql"
+mart:
+  tables:
+    - name: test_table
+      sql: "sql/mart/test_table.sql"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    sql_dir = project_dir / "sql" / "mart"
+    sql_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+    (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "blocker-hints",
+            "--config",
+            str(config_path),
+            "--year",
+            "2023",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert "dataset" in payload
+    assert "config_path" in payload
+    assert "year" in payload
+    assert "blocker_count" in payload
+    assert "warning_count" in payload
+    assert "hints" in payload
+    assert "hint_count" in payload
+
+
+def test_blocker_hints_no_blockers_when_all_present(tmp_path: Path, monkeypatch) -> None:
+    """No blockers when config and outputs are consistent."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    config_path = project_dir / "dataset.yml"
+
+    config_path.write_text(
+        """
+root: "./out"
+dataset:
+  name: test_ds
+  years: [2023]
+raw: {}
+clean:
+  sql: "sql/clean.sql"
+mart:
+  tables:
+    - name: test_table
+      sql: "sql/mart/test_table.sql"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    sql_dir = project_dir / "sql" / "mart"
+    sql_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+    (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
+
+    # Create all output directories and files so nothing is missing
+    raw_dir = project_dir / "out" / "data" / "raw" / "test_ds" / "2023"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "raw_data.csv").write_text("id,value\n1,100\n", encoding="utf-8")
+    (raw_dir / "manifest.json").write_text(
+        json.dumps({"primary_output_file": "raw_data.csv"}, indent=2),
+        encoding="utf-8",
+    )
+
+    clean_dir = project_dir / "out" / "data" / "clean" / "test_ds" / "2023"
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    (clean_dir / "test_ds_2023_clean.parquet").write_text("dummy parquet", encoding="utf-8")
+    (clean_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "outputs": [{"file": "test_ds_2023_clean.parquet"}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
+    mart_dir.mkdir(parents=True, exist_ok=True)
+    (mart_dir / "test_table.parquet").write_text("dummy parquet", encoding="utf-8")
+    (mart_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "outputs": [{"file": "test_table.parquet"}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    # Create run record so latest_run exists
+    run_dir = project_dir / "out" / "data" / "_runs" / "test_ds" / "2023"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    run_record_path = run_dir / "run-abc.json"
+    run_record_path.write_text(
+        json.dumps(
+            {
+                "dataset": "test_ds",
+                "year": 2023,
+                "run_id": "run-abc",
+                "status": "SUCCESS",
+                "layers": {
+                    "raw": {"status": "SUCCESS"},
+                    "clean": {"status": "SUCCESS"},
+                    "mart": {"status": "SUCCESS"},
+                },
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "blocker-hints",
+            "--config",
+            str(config_path),
+            "--year",
+            "2023",
+        ],
+    )
+
+    assert result.exit_code == 0
+    # With all outputs present, blocker_count should be 0
+    assert "blockers: 0" in result.output
+
+
+def test_blocker_hints_detects_clean_dir_missing_when_mart_exists(tmp_path: Path, monkeypatch) -> None:
+    """Detects when mart dir exists but clean dir is missing (run order inconsistency)."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    config_path = project_dir / "dataset.yml"
+
+    config_path.write_text(
+        """
+root: "./out"
+dataset:
+  name: test_ds
+  years: [2023]
+raw: {}
+clean:
+  sql: "sql/clean.sql"
+mart:
+  tables:
+    - name: test_table
+      sql: "sql/mart/test_table.sql"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    sql_dir = project_dir / "sql" / "mart"
+    sql_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+    (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
+
+    # Only mart dir exists, not clean dir
+    mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
+    mart_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write manifest so mart is detected as existing
+    (mart_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "outputs": [{"file": "test_table.parquet"}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "blocker-hints",
+            "--config",
+            str(config_path),
+            "--year",
+            "2023",
+        ],
+    )
+
+    assert result.exit_code == 0
+    # Should flag this as a blocker
+    assert "clean_dir_missing" in result.output or "blocker" in result.output
+
+
+def test_blocker_hints_exit_code_0_even_with_blockers(tmp_path: Path, monkeypatch) -> None:
+    """Command exits 0 when hint generation succeeds, even with blockers present.
+
+    Exit code 1 means config not found or unexpected error.
+    Exit code 0 means blocker_hints ran successfully — blockers are in output.
+    """
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    config_path = project_dir / "dataset.yml"
+
+    config_path.write_text(
+        """
+root: "./out"
+dataset:
+  name: test_ds
+  years: [2023]
+raw: {}
+clean:
+  sql: "sql/clean.sql"
+mart:
+  tables:
+    - name: test_table
+      sql: "sql/mart/test_table.sql"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    sql_dir = project_dir / "sql" / "mart"
+    sql_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+    (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
+
+    # Only mart dir exists (clean missing) — this creates a blocker
+    mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
+    mart_dir.mkdir(parents=True, exist_ok=True)
+    (mart_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "outputs": [{"file": "test_table.parquet"}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "blocker-hints",
+            "--config",
+            str(config_path),
+            "--year",
+            "2023",
+        ],
+    )
+
+    # Should exit 0 even though there's a blocker
+    assert result.exit_code == 0
+    assert "blocker" in result.output.lower()

--- a/toolkit/cli/app.py
+++ b/toolkit/cli/app.py
@@ -10,6 +10,7 @@ from toolkit.cli.cmd_validate import register as register_validate
 from toolkit.cli.cmd_inspect import register as register_inspect
 from toolkit.cli.cmd_scaffold import register as register_scaffold
 from toolkit.cli.cmd_batch import register as register_batch
+from toolkit.cli.cmd_blocker_hints import register as register_blocker_hints
 
 app = typer.Typer(no_args_is_help=True, add_completion=False)
 
@@ -22,6 +23,7 @@ register_validate(app)
 register_inspect(app)
 register_scaffold(app)
 register_batch(app)
+register_blocker_hints(app)
 
 
 def main():

--- a/toolkit/cli/cmd_blocker_hints.py
+++ b/toolkit/cli/cmd_blocker_hints.py
@@ -1,0 +1,89 @@
+"""CLI command: toolkit blocker-hints
+
+Esporta blocker_hints come interfaccia CLI pubblica, invece di chiamare
+il modulo interno toolkit.mcp.toolkit_client.
+
+Usage:
+    toolkit blocker-hints --config candidates/terna-electricity-by-source/dataset.yml --year 2023
+    toolkit blocker-hints --config candidates/terna-electricity-by-source/dataset.yml --year 2023 --json
+"""
+
+from __future__ import annotations
+
+from toolkit.mcp.schema_ops import blocker_hints as _blocker_hints
+
+import typer
+
+
+def blocker_hints(
+    config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
+    year: int | None = typer.Option(None, "--year", "-y", help="Dataset year (default: last declared year)"),
+    as_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+    strict_config: bool = typer.Option(
+        False, "--strict-config", help="Treat deprecated config forms as errors"
+    ),
+) -> None:
+    """
+    Mostra hint diagnostici per mismatch comuni tra config dichiarato e output实际.
+
+    I blocker sono errori che impediscono al candidate di funzionare.
+    I warning sono segnali di possibili problemi che non bloccano l'esecuzione.
+
+    Exit code:
+        0 — hint generati (anche se ci sono blocker, il comando funziona)
+        1 — config non trovato o errore nell'analisi
+    """
+    strict_flag = strict_config if isinstance(strict_config, bool) else False
+
+    try:
+        result = _blocker_hints(config, year)
+    except FileNotFoundError:
+        typer.echo(f"error: config file not found: {config}", err=True)
+        raise typer.Exit(code=1)
+    except Exception as exc:
+        typer.echo(f"error: {type(exc).__name__}: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    if as_json:
+        import json
+        typer.echo(json.dumps(result, indent=2, ensure_ascii=False))
+        return
+
+    # Human-readable output
+    dataset = result.get("dataset", "?")
+    config_path = result.get("config_path", "?")
+    year_val = result.get("year", "?")
+    blocker_count = result.get("blocker_count", 0)
+    warning_count = result.get("warning_count", 0)
+    hint_count = result.get("hint_count", 0)
+
+    typer.echo(f"dataset: {dataset}")
+    typer.echo(f"config: {config_path}")
+    typer.echo(f"year: {year_val}")
+    typer.echo(f"blockers: {blocker_count}")
+    typer.echo(f"warnings: {warning_count}")
+    typer.echo("")
+
+    hints = result.get("hints", [])
+    if not hints:
+        typer.echo("nessun hint — config e output sono coerenti")
+        return
+
+    typer.echo("hints:")
+    for hint in hints:
+        severity = hint.get("severity", "?")
+        code = hint.get("code", "?")
+        message = hint.get("message", "")
+        icon = "🔴" if severity == "blocker" else "⚠️"
+        typer.echo(f"  {icon} [{severity}] {code}")
+        typer.echo(f"      {message}")
+
+    typer.echo("")
+    if blocker_count > 0:
+        typer.echo(f"🔴 {blocker_count} blocker(s) trovati — fix obbligatori prima del merge")
+    else:
+        typer.echo("✅ nessun blocker — config看起来 ok")
+
+
+def register(app: typer.Typer) -> None:
+    app.command("blocker-hints")(blocker_hints)

--- a/toolkit/cli/cmd_blocker_hints.py
+++ b/toolkit/cli/cmd_blocker_hints.py
@@ -19,12 +19,9 @@ def blocker_hints(
     config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
     year: int | None = typer.Option(None, "--year", "-y", help="Dataset year (default: last declared year)"),
     as_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
-    strict_config: bool = typer.Option(
-        False, "--strict-config", help="Treat deprecated config forms as errors"
-    ),
 ) -> None:
     """
-    Mostra hint diagnostici per mismatch comuni tra config dichiarato e output实际.
+    Mostra hint diagnostici per mismatch comuni tra config dichiarato e output.
 
     I blocker sono errori che impediscono al candidate di funzionare.
     I warning sono segnali di possibili problemi che non bloccano l'esecuzione.
@@ -79,7 +76,7 @@ def blocker_hints(
     if blocker_count > 0:
         typer.echo(f"🔴 {blocker_count} blocker(s) trovati — fix obbligatori prima del merge")
     else:
-        typer.echo("✅ nessun blocker — config看起来 ok")
+        typer.echo("✅ nessun blocker — config e output sono coerenti")
 
 
 def register(app: typer.Typer) -> None:

--- a/toolkit/cli/cmd_blocker_hints.py
+++ b/toolkit/cli/cmd_blocker_hints.py
@@ -33,8 +33,6 @@ def blocker_hints(
         0 — hint generati (anche se ci sono blocker, il comando funziona)
         1 — config non trovato o errore nell'analisi
     """
-    strict_flag = strict_config if isinstance(strict_config, bool) else False
-
     try:
         result = _blocker_hints(config, year)
     except FileNotFoundError:
@@ -55,7 +53,6 @@ def blocker_hints(
     year_val = result.get("year", "?")
     blocker_count = result.get("blocker_count", 0)
     warning_count = result.get("warning_count", 0)
-    hint_count = result.get("hint_count", 0)
 
     typer.echo(f"dataset: {dataset}")
     typer.echo(f"config: {config_path}")


### PR DESCRIPTION
## Summary
- Aggiunge `toolkit blocker-hints --config <path> --year <N> [--json]`
- Esporta `blocker_hints` come CLI pubblica invece di modulo interno `toolkit.mcp.toolkit_client`
- Consente a DI di consumare l'interfaccia via shell senza coupling a strutture Python interne

## Test
- 6 test nuovi in `tests/test_cli_blocker_hints.py`
- 551 test passano (invariati)

## Usage
```bash
toolkit blocker-hints --config candidates/terna/dataset.yml --year 2023
toolkit blocker-hints --config candidates/terna/dataset.yml --year 2023 --json
```