### PR TITLE
feat(mcp): aggiunge tool toolkit_schema_diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ tmp/
 
 # Generated artifacts
 generated/
+/sql/

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -20,6 +20,7 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_blocker_hints",
         "toolkit_review_readiness",
         "toolkit_list_runs",
+        "toolkit_schema_diff",
     }
 
 

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -11,6 +11,7 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_blocker_hints(config_path, year=0)`
 - `toolkit_review_readiness(config_path, year=0)`
 - `toolkit_list_runs(config_path, year=0, since=None, until=None, status=None, limit=20, cross_year=False)`
+- `toolkit_schema_diff(config_path)` — confronto segnali schema raw cross-year (encoding, colonne, ecc.)
 
 ## Boundary
 
@@ -49,6 +50,7 @@ Sostituire il path del `command` con il Python reale del clone locale che usera'
 - `toolkit_show_schema`
   - `raw`: usa `toolkit inspect schema-diff --json`
   - `clean` / `mart`: legge schema reale dei parquet risolti via `inspect paths`
+- `toolkit_schema_diff` confronta segnali schema raw (encoding, delim, colonne) tra tutti gli anni configurati per il dataset; riutilizza la stessa logica di `toolkit inspect schema-diff` ma esposto come tool MCP
 - `toolkit_run_summary` aggrega tutti i run record per dataset/year
 - `toolkit_summary` include `run.latest_run_record` (payload completo dell'ultimo run)
 - `toolkit_blocker_hints` evidenzia mismatch pratici tra output risolti e stato run

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -7,6 +7,7 @@ Provides read-only diagnostics on config, layers, and run records:
 - summary: layer-level overview with existence checks
 - blocker_hints: common mismatches between config and outputs
 - review_readiness: readiness check for candidate review
+- schema_diff: compare RAW schema signals across configured years
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from toolkit.cli.inspect._helpers import _compare_schema_entries, _raw_schema_payload
 from toolkit.mcp._schema_utils import (
     _exists,
     _read_parquet_row_count,
@@ -730,4 +732,27 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
         "ok_count": ok_count,
         "fail_count": fail_count,
         "checks": checks,
+    }
+
+
+def schema_diff(config_path: str) -> dict[str, Any]:
+    """Compare RAW schema signals across the years configured for a dataset.
+
+    Returns entries per year (encoding, delim, columns, etc.) and pairwise
+    comparisons showing added/removed columns between consecutive years.
+    """
+    config, cfg = _load_cfg(config_path)
+
+    from toolkit.cli.common import iter_years
+
+    years = iter_years(cfg, None)
+    entries = [_raw_schema_payload(cfg, selected_year) for selected_year in years]
+    comparisons = _compare_schema_entries(entries)
+
+    return {
+        "dataset": cfg.dataset,
+        "config_path": str(config_path),
+        "years": [entry["year"] for entry in entries],
+        "entries": entries,
+        "comparisons": comparisons,
     }

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -12,6 +12,7 @@ from .toolkit_client import (
     raw_profile as raw_profile_impl,
     review_readiness as review_readiness_impl,
     run_summary as run_summary_impl,
+    schema_diff as schema_diff_impl,
     summary as summary_impl,
     show_schema as show_schema_impl,
 )
@@ -88,6 +89,14 @@ def toolkit_blocker_hints(config_path: str, year: int = 0) -> dict[str, Any]:
 )
 def toolkit_review_readiness(config_path: str, year: int = 0) -> dict[str, Any]:
     return _guard(review_readiness_impl, config_path, year or None)
+
+
+@mcp.tool(
+    description="Confronta i segnali di schema raw (encoding, colonne, ecc.) tra gli anni configurati per un dataset.",
+    structured_output=True,
+)
+def toolkit_schema_diff(config_path: str) -> dict[str, Any]:
+    return _guard(schema_diff_impl, config_path)
 
 
 @mcp.tool(

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -23,6 +23,7 @@ from toolkit.mcp.schema_ops import (
     review_readiness,
     run_state,
     run_summary,
+    schema_diff,
     show_schema,
     summary,
 )


### PR DESCRIPTION
## Feature: nuovo tool MCP `toolkit_schema_diff`

### Cosa fa
Esporta `inspect schema-diff` (già esistente nella CLI) come tool MCP readonly.

**Tool**: `toolkit_schema_diff(config_path)` → `{dataset, years, entries[], comparisons[]}`

Ogni `entry` contiene encoding, delimitatore, colonne, header_line per un anno. Ogni `comparison` mostra colonne aggiunte/rimosse tra anni consecutivi.

### Implementazione
- `schema_ops.schema_diff()`: riutilizza `_raw_schema_payload` e `_compare_schema_entries` da `cli/inspect/_helpers.py` (gia esistenti, ora importati anche dal modulo MCP)
- Nessuna nuova logica — solo wrapper MCP attorno a funzioni già testate nella CLI

### Perché
Utile per agenti AI che vogliono capire come evolve lo schema raw di un dataset cross-year, senza dover parsare output CLI.

### Verifiche
- `python -c "from toolkit.mcp.server import mcp, toolkit_schema_diff; print('OK')"` ✅
- 8/8 test MCP passano ✅
- Nessuna regressione su 576 test totali ✅
- `sql/clean.sql` rimosso (era draft generato, aggiunto a .gitignore)

### Files
- `toolkit/mcp/schema_ops.py` — +25 righe (schema_diff())
- `toolkit/mcp/server.py` — +9 righe (tool declaration)
- `toolkit/mcp/toolkit_client.py` — +1 riga (export)
- `tests/test_mcp_server.py` — +1 riga (tool alla lista attesa)
- `.gitignore` — +1 riga (`/sql/`)