### PR TITLE
feat(scaffold): year injection + DuckDB types in profiling

### DIFF
--- a/tests/test_clean_csv_columns.py
+++ b/tests/test_clean_csv_columns.py
@@ -189,3 +189,91 @@ def test_run_clean_positional_csv_empty_rows(tmp_path: Path):
     # Le righe vuote producono righe con colonne vuote
     assert len(df) == 4
     assert df.iloc[2].tolist() == ["", ""]  # riga con solo ';'
+
+
+def test_run_clean_compact_columns_format_renames_and_types(tmp_path: Path):
+    """Compact format 'clean_name:DUCKDB_TYPE' in columns: renames + passes only type to DuckDB.
+
+    The DuckDB columns={} option must receive only the raw name and DuckDB type.
+    The projection (csv_trim_projection) handles the rename separately.
+    """
+    raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = raw_dir / "data.csv"
+    csv_path.write_text(
+        "a;b\n  val_a ; val_b \n", encoding="utf-8"
+    )
+
+    sql_path = tmp_path / "clean.sql"
+    sql_path.write_text("SELECT a_renamed, b_renamed FROM raw_input", encoding="utf-8")
+
+    run_clean(
+        "demo",
+        2024,
+        str(tmp_path),
+        {
+            "sql": str(sql_path),
+            "read": {
+                "mode": "latest",
+                "delim": ";",
+                "header": True,
+                "trim_whitespace": True,
+                "columns": {
+                    "a": "a_renamed:VARCHAR",  # compact: raw=a, clean=a_renamed, type=VARCHAR
+                    "b": "b_renamed:VARCHAR",
+                },
+            },
+        },
+        _NoopLogger(),
+    )
+
+    out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
+    assert out.exists()
+
+    con = duckdb.connect(":memory:")
+    rows = con.execute(
+        f"SELECT a_renamed, b_renamed FROM read_parquet('{out.as_posix()}')"
+    ).fetchall()
+    con.close()
+    # Spaces trimmed by TRIM in projection
+    assert rows == [("val_a", "val_b")]
+
+
+def test_run_clean_compact_columns_format_with_int_type(tmp_path: Path):
+    """Compact format with non-VARCHAR type (e.g. BIGINT) passes type to DuckDB columns={}."""
+    raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = raw_dir / "data.csv"
+    csv_path.write_text("anno;valore\n2024;42\n", encoding="utf-8")
+
+    sql_path = tmp_path / "clean.sql"
+    sql_path.write_text("SELECT anno_clean, valore_clean FROM raw_input", encoding="utf-8")
+
+    run_clean(
+        "demo",
+        2024,
+        str(tmp_path),
+        {
+            "sql": str(sql_path),
+            "read": {
+                "mode": "latest",
+                "delim": ";",
+                "header": True,
+                "columns": {
+                    "anno": "anno_clean:BIGINT",
+                    "valore": "valore_clean:BIGINT",
+                },
+            },
+        },
+        _NoopLogger(),
+    )
+
+    out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
+    assert out.exists()
+
+    con = duckdb.connect(":memory:")
+    rows = con.execute(
+        f"SELECT anno_clean, valore_clean FROM read_parquet('{out.as_posix()}')"
+    ).fetchall()
+    con.close()
+    assert rows == [(2024, 42)]

--- a/tests/test_clean_csv_columns.py
+++ b/tests/test_clean_csv_columns.py
@@ -277,3 +277,49 @@ def test_run_clean_compact_columns_format_with_int_type(tmp_path: Path):
     ).fetchall()
     con.close()
     assert rows == [(2024, 42)]
+
+
+def test_run_clean_compact_columns_format_no_trim_whitespace(tmp_path: Path):
+    """Compact format rename is applied even when trim_whitespace=False.
+
+    When trim_whitespace=False the code must still produce the clean-name
+    projection (raw_name AS clean_name), not just raw_name columns.
+    Regression: projection fell back to raw names only.
+    """
+    raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = raw_dir / "data.csv"
+    csv_path.write_text("anno;valore\n2024;42\n", encoding="utf-8")
+
+    sql_path = tmp_path / "clean.sql"
+    sql_path.write_text("SELECT anno_clean, valore_clean FROM raw_input", encoding="utf-8")
+
+    run_clean(
+        "demo",
+        2024,
+        str(tmp_path),
+        {
+            "sql": str(sql_path),
+            "read": {
+                "mode": "latest",
+                "delim": ";",
+                "header": True,
+                "trim_whitespace": False,  # key: no TRIM, but rename must work
+                "columns": {
+                    "anno": "anno_clean:BIGINT",
+                    "valore": "valore_clean:BIGINT",
+                },
+            },
+        },
+        _NoopLogger(),
+    )
+
+    out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
+    assert out.exists()
+
+    con = duckdb.connect(":memory:")
+    rows = con.execute(
+        f"SELECT anno_clean, valore_clean FROM read_parquet('{out.as_posix()}')"
+    ).fetchall()
+    con.close()
+    assert rows == [(2024, 42)]

--- a/tests/test_cli_scaffold.py
+++ b/tests/test_cli_scaffold.py
@@ -122,7 +122,12 @@ class TestGenerateCleanSql:
         assert "skip=2" in sql
 
     def test_no_columns_keeps_header_true(self, tmp_path: Path):
-        """When truly no columns available, header stays true."""
+        """When truly no columns available, header stays true.
+
+        Note: the scaffold injects {year}::INTEGER AS anno_di_imposta as first
+        column when no 'anno' column is detected in the raw file — so the SELECT
+        is no longer bare '*'.
+        """
         profile = {
             "file_used": "test.csv",
             "delim_suggested": ",",
@@ -134,8 +139,29 @@ class TestGenerateCleanSql:
         }
         sql = generate_clean_sql(profile, "test", 2024)
         assert "header=true" in sql
-        # With no columns, SELECT * is used
-        assert "SELECT\n    *" in sql
+        # Scaffold injects "{year}::INTEGER AS anno" — runtime resolves {year}
+        assert "anno" in sql
+        assert "{year}::INTEGER" in sql
+
+    def test_anno_not_injected_when_present_in_raw(self, tmp_path: Path):
+        """When the raw CSV already has a column that normalizes to 'anno', scaffold does NOT inject a duplicate."""
+        profile = {
+            "file_used": "test.csv",
+            "delim_suggested": ",",
+            "header_line": "anno,regione",
+            "skip_suggested": 0,
+            "columns_raw": ["anno", "regione"],
+            "mapping_suggestions": {
+                "anno": {"from": "anno", "type": "int"},
+                "regione": {"from": "regione", "type": "str"},
+            },
+            "warnings": [],
+        }
+        sql = generate_clean_sql(profile, "test", 2024)
+        # Scaffold must NOT inject 2024::INTEGER when raw CSV already has 'anno'
+        assert "2024::INTEGER" not in sql
+        # The mapping provides 'anno' normally; no duplicate injection
+        assert "anno" in sql  # from TRY_CAST
 
     def test_columns_sql_is_single_line(self, tmp_path: Path):
         """Verify columns param is on same line as other params (no missing comma)."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -21,6 +21,7 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_review_readiness",
         "toolkit_list_runs",
         "toolkit_schema_diff",
+        "toolkit_csv_preview",
     }
 
 

--- a/tests/test_profile_sniff.py
+++ b/tests/test_profile_sniff.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import toolkit.profile.raw as profile_raw_module
 from toolkit.cli.cmd_profile import write_suggested_read_yml
+from toolkit.profile._column_profile import _build_mapping_suggestions
 from toolkit.profile.raw import (
     _build_read_csv_opts,
     build_suggested_read_cfg,
@@ -115,3 +116,63 @@ def test_build_read_csv_opts_keeps_header_and_skip_for_profiler():
     assert "max_line_size=4096" in opts
     assert "header=false" in opts
     assert "skip=2" in opts
+
+
+def test_build_mapping_suggestions_varchar_falls_back_to_heuristics():
+    """When DuckDB reports VARCHAR (generic), regex heuristics must surface.
+
+    Italian decimal format 1.234,56 should produce type=float + parse=number_it,
+    not plain str — DuckDB sees VARCHAR but the heuristic detects number_it.
+    Regression test for the DuckDB-override fix.
+    """
+    sample = [
+        {"Importo": "1.234,56"},
+        {"Importo": "2.345,67"},
+    ]
+    duckdb_types = {"Importo": "VARCHAR"}
+
+    result = _build_mapping_suggestions(["Importo"], sample, duckdb_types=duckdb_types)
+    spec = result["Importo"]
+
+    # Must NOT be plain str — heuristic should detect Italian number
+    assert spec["type"] == "float", f"Expected float, got {spec['type']}"
+    assert spec.get("parse", {}).get("kind") == "number_it", (
+        f"Expected parse={{kind: number_it}}, got {spec.get('parse')}"
+    )
+
+
+def test_profile_raw_mismatch_header_data_cols_triggers_null_padding(tmp_path: Path):
+    """When DESCRIBE columns != true header token count, retry with null_padding.
+
+    IRPEF comunale real file: header has 50 cols, data rows have 52 cols.
+    suggest_skip returns 0 because 49 < 51 but 49 > 1 (first_count <= 1 fails).
+
+    In this test: header has 2 tokens, data rows have 4 tokens.
+    suggest_skip returns 1 (first_count=1 <= 1 and second_count=3 >= 3).
+    The profiler must detect that the true header (line 0) has fewer tokens
+    than the data columns returned by DESCRIBE, and emit a mismatch warning.
+
+    Note: the test file structure mirrors the IRPEF column-count pattern,
+    not the exact delimiter counts (skip logic differs).
+    """
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+
+    # Header: 2 tokens (1 comma), Data rows: 4 tokens (3 commas)
+    # first_count=1 <= 1 and second_count=3 >= 3 → suggest_skip=1
+    # But the mismatch is between true header (line 0 = 2 tokens) and data cols
+    (raw_dir / "test.csv").write_text(
+        "Codice,Descrizione\n"  # 1 comma = 2 tokens at line 0
+        "A001,B001,C001,D001\n"  # 3 commas = 4 tokens at line 1+
+        "A002,B002,C002,D002\n",
+        encoding="utf-8",
+    )
+
+    profile = profile_raw(raw_dir, "demo", 2024)
+
+    # Mismatch detected: true_header=2 tokens, data=4 cols
+    mismatch_warnings = [w for w in profile.warnings if "mismatch" in w]
+    assert mismatch_warnings, f"Expected mismatch warning, got {profile.warnings}"
+
+    # columns_raw reflects 4 data columns from DESCRIBE
+    assert len(profile.columns_raw) == 4

--- a/toolkit/clean/duckdb_read.py
+++ b/toolkit/clean/duckdb_read.py
@@ -7,14 +7,14 @@ from typing import Any
 
 import duckdb
 from toolkit.clean.read_csv_normalized import _execute_normalized_csv_read
+from toolkit.clean.read_excel import _execute_excel_read
 from toolkit.clean.read_sql_utils import (
+    _parse_column_value,
     csv_trim_projection,
     q_ident,
     quote_list,
     sql_path,
 )
-
-from toolkit.clean.read_excel import _execute_excel_read
 from toolkit.core.csv_read import (
     csv_read_option_strings,
     normalize_read_cfg,
@@ -59,7 +59,19 @@ def _csv_read_options(
     skip = read_cfg.get("skip")
     columns = read_cfg.get("columns")
 
-    source_columns = dict(columns) if columns else None
+    # Parse compact column values ("clean_name:DUCKDB_TYPE") and separate
+    # raw names from types.  DuckDB's columns={} option needs raw names + types;
+    # the projection (csv_trim_projection) handles the rename using the original
+    # columns values which may contain "clean_name:DUCKDB_TYPE".
+    source_columns: dict[str, str] | None = None
+    if columns:
+        columns_csv: dict[str, str] = {}  # raw_name -> dtype for DuckDB columns={}
+        for raw_name, value in columns.items():
+            _, dtype = _parse_column_value(raw_name, value)
+            columns_csv[raw_name] = dtype
+        source_columns = columns_csv
+        # Mutate read_cfg["columns"] so csv_read_option_strings sees clean types
+        read_cfg["columns"] = columns_csv
 
     # Runtime override: when explicit columns are set, force header=false
     # and bump skip by 1 so the header row is consumed as data.
@@ -120,6 +132,11 @@ def _execute_csv_read(
     trim_whitespace = read_cfg.get("trim_whitespace", True)
     sample_size = read_cfg.get("sample_size")
 
+    # Capture original columns (may contain "clean_name:DUCKDB_TYPE") before
+    # _csv_read_options mutates read_cfg["columns"] to have only types.
+    # This is needed for csv_trim_projection to perform the rename.
+    original_columns = read_cfg.get("columns")
+
     opts, params_used, source_columns = _csv_read_options(read_cfg)
     if sample_size is not None:
         opts.append(f"sample_size={int(sample_size)}")
@@ -132,7 +149,9 @@ def _execute_csv_read(
             f"SELECT * FROM read_csv([{paths}], {opt_sql});"
         )
         if trim_whitespace:
-            projection = csv_trim_projection(source_columns)
+            # original_columns has compact values for rename; source_columns
+            # has only types (set by _csv_read_options mutation)
+            projection = csv_trim_projection(original_columns)
         else:
             projection = ", ".join(q_ident(name) for name in source_columns)
         con.execute(

--- a/toolkit/clean/duckdb_read.py
+++ b/toolkit/clean/duckdb_read.py
@@ -153,7 +153,21 @@ def _execute_csv_read(
             # use source_columns (the already-parsed dict with types only).
             projection = csv_trim_projection(original_columns or source_columns)
         else:
-            projection = ", ".join(q_ident(name) for name in source_columns)
+            # Even without trim, we must apply the clean-name rename from
+            # compact format (original_columns). Build "raw_name AS clean_name"
+            # for each column that has a rename.
+            parts = []
+            for raw_name in source_columns:
+                value = original_columns.get(raw_name) if original_columns else None
+                if value is not None:
+                    clean_name, _ = _parse_column_value(raw_name, value)
+                else:
+                    clean_name = raw_name
+                if clean_name != raw_name:
+                    parts.append(f"{q_ident(raw_name)} AS {q_ident(clean_name)}")
+                else:
+                    parts.append(q_ident(raw_name))
+            projection = ", ".join(parts)
         con.execute(
             f"CREATE OR REPLACE VIEW raw_input AS SELECT {projection} FROM raw_input_source;"
         )

--- a/toolkit/clean/duckdb_read.py
+++ b/toolkit/clean/duckdb_read.py
@@ -149,9 +149,9 @@ def _execute_csv_read(
             f"SELECT * FROM read_csv([{paths}], {opt_sql});"
         )
         if trim_whitespace:
-            # original_columns has compact values for rename; source_columns
-            # has only types (set by _csv_read_options mutation)
-            projection = csv_trim_projection(original_columns)
+            # original_columns may be None if no columns key; in that case
+            # use source_columns (the already-parsed dict with types only).
+            projection = csv_trim_projection(original_columns or source_columns)
         else:
             projection = ", ".join(q_ident(name) for name in source_columns)
         con.execute(

--- a/toolkit/clean/read_csv_normalized.py
+++ b/toolkit/clean/read_csv_normalized.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pandas as pd
 
+from toolkit.clean.read_sql_utils import _parse_column_value
 from toolkit.core.csv_read import normalize_encoding
 
 
@@ -31,7 +32,14 @@ def _load_normalized_csv_frame(
     trim_whitespace = bool(read_cfg.get("trim_whitespace", True))
     header = bool(read_cfg.get("header", True))
     skip = int(read_cfg.get("skip") or 0)
-    expected_names = list(columns.keys())
+    # Build list of raw column names from columns dict, parsing compact format
+    # ("clean_name:DUCKDB_TYPE") to extract only the raw name for CSV reading.
+    # The projection/copy step applies the rename separately.
+    raw_names: list[str] = []
+    for raw_name, value in columns.items():
+        actual_raw, _ = _parse_column_value(raw_name, value)
+        raw_names.append(actual_raw)
+    expected_names = raw_names
     expected_len = len(expected_names)
     skip_rows = skip + (1 if header else 0)
 

--- a/toolkit/clean/read_sql_utils.py
+++ b/toolkit/clean/read_sql_utils.py
@@ -19,14 +19,40 @@ def quote_list(paths: list[Path]) -> str:
     return ", ".join([f"'{sql_path(p)}'" for p in paths])
 
 
+def _parse_column_value(raw_name: str, value: str) -> tuple[str, str]:
+    """Parse a columns dict value, supporting compact 'clean_name:DUCKDB_TYPE' format.
+
+    Examples:
+        "VARCHAR"                          -> ("column_name", "VARCHAR")
+        "anno_di_imposta:VARCHAR"         -> ("anno_di_imposta", "VARCHAR")
+        "numero_contribuenti:DOUBLE"      -> ("numero_contribuenti", "DOUBLE")
+    """
+    if ":" in value:
+        clean_name, dtype = value.rsplit(":", 1)
+        return clean_name.strip(), dtype.strip()
+    return raw_name, value.strip()
+
+
 def csv_trim_projection(columns: dict[str, str]) -> str:
-    """Build a SQL projection that trims CHAR/TEXT/STRING columns."""
+    """Build a SQL projection that renames and optionally trims CHAR/TEXT columns.
+
+    Supports compact format in columns dict values: "clean_name:DUCKDB_TYPE".
+    When the clean name differs from the raw name, produces "raw_name AS clean_name".
+    Text-type columns are trimmed of surrounding whitespace.
+
+    Examples:
+        {"column00": "VARCHAR"}                          -> '"column00" AS "column00"'
+        {"column00": "anno_di_imposta:VARCHAR"}          -> 'TRIM("column00", \' \t\\r\\n\') AS "anno_di_imposta"'
+        {"column00": "numero:DOUBLE"}                    -> '"column00" AS "numero"'
+    """
     exprs: list[str] = []
-    for name, dtype in columns.items():
-        qname = q_ident(name)
+    for raw_name, value in columns.items():
+        clean_name, dtype = _parse_column_value(raw_name, value)
+        qraw = q_ident(raw_name)
+        qclean = q_ident(clean_name)
         dtype_upper = dtype.upper()
         if "CHAR" in dtype_upper or "TEXT" in dtype_upper or "STRING" in dtype_upper:
-            exprs.append(f"TRIM({qname}, ' \t\r\n') AS {qname}")
+            exprs.append(f"TRIM({qraw}, ' \t\\r\\n') AS {qclean}")
         else:
-            exprs.append(qname)
+            exprs.append(f"{qraw} AS {qclean}")
     return ", ".join(exprs)

--- a/toolkit/clean/read_sql_utils.py
+++ b/toolkit/clean/read_sql_utils.py
@@ -52,7 +52,7 @@ def csv_trim_projection(columns: dict[str, str]) -> str:
         qclean = q_ident(clean_name)
         dtype_upper = dtype.upper()
         if "CHAR" in dtype_upper or "TEXT" in dtype_upper or "STRING" in dtype_upper:
-            exprs.append(f"TRIM({qraw}, ' \t\\r\\n') AS {qclean}")
+            exprs.append(f"TRIM({qraw}, ' \t\r\n') AS {qclean}")
         else:
             exprs.append(f"{qraw} AS {qclean}")
     return ", ".join(exprs)

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -12,6 +12,7 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_review_readiness(config_path, year=0)`
 - `toolkit_list_runs(config_path, year=0, since=None, until=None, status=None, limit=20, cross_year=False)`
 - `toolkit_schema_diff(config_path)` — confronto segnali schema raw cross-year (encoding, colonne, ecc.)
+- `toolkit_csv_preview(csv_path, limit=20)` — schema + preview CSV via DuckDB auto-detect (senza runnare pipeline); utile per validare CSV prima di scrivere clean.sql
 
 ## Boundary
 
@@ -51,6 +52,7 @@ Sostituire il path del `command` con il Python reale del clone locale che usera'
   - `raw`: usa `toolkit inspect schema-diff --json`
   - `clean` / `mart`: legge schema reale dei parquet risolti via `inspect paths`
 - `toolkit_schema_diff` confronta segnali schema raw (encoding, delim, colonne) tra tutti gli anni configurati per il dataset; riutilizza la stessa logica di `toolkit inspect schema-diff` ma esposto come tool MCP
+- `toolkit_csv_preview` legge un CSV con DuckDB auto-detect (delimiter, encoding, header, tipos automatici) e restituisce schema + prime N righe — utile per ispezionare file raw senza runnare la pipeline
 - `toolkit_run_summary` aggrega tutti i run record per dataset/year
 - `toolkit_summary` include `run.latest_run_record` (payload completo dell'ultimo run)
 - `toolkit_blocker_hints` evidenzia mismatch pratici tra output risolti e stato run

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -8,6 +8,7 @@ Provides read-only diagnostics on config, layers, and run records:
 - blocker_hints: common mismatches between config and outputs
 - review_readiness: readiness check for candidate review
 - schema_diff: compare RAW schema signals across configured years
+- csv_preview: schema + preview of a CSV file via DuckDB auto-detect
 """
 
 from __future__ import annotations
@@ -756,3 +757,67 @@ def schema_diff(config_path: str) -> dict[str, Any]:
         "entries": entries,
         "comparisons": comparisons,
     }
+
+
+def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
+    """Read a CSV file with DuckDB auto-detect and return schema + data preview.
+
+    Useful for quick inspection of raw files without running the full pipeline.
+    DuckDB auto-detects delimiter, encoding, header, and column types.
+
+    Args:
+        csv_path: path to the CSV file (absolute or relative to workspace root)
+        limit: max rows to return in preview (default 20)
+
+    Returns:
+        dict with keys: path, encoding_hint, delimiter_hint, header, column_count,
+        row_count_estimate, columns (name + inferred_type), preview (list of rows)
+    """
+    import duckdb
+
+    from toolkit.mcp.path_safety import _safe_path
+
+    path = _safe_path(csv_path)
+    if not path.exists():
+        raise ToolkitClientError(f"CSV non trovato: {path}")
+
+    def _sql_literal(value: str) -> str:
+        return value.replace("'", "''")
+
+    try:
+        with duckdb.connect(database=":memory:") as conn:
+            conn.execute("PRAGMA disable_progress_bar")
+            # Auto-detect all options; sample to infer types properly
+            conn.execute(
+                f"CREATE VIEW csv_preview AS SELECT * FROM read_csv("
+                f"'{_sql_literal(str(path))}', "
+                f"auto_detect=true, header=true)"
+            )
+            describe_rows = conn.execute("DESCRIBE csv_preview").fetchall()
+            columns = [{"name": row[0], "inferred_type": row[1]} for row in describe_rows]
+
+            # Row count estimate without loading full file
+            count_result = conn.execute(
+                f"SELECT COUNT(*) FROM read_csv("
+                f"'{_sql_literal(str(path))}', "
+                f"auto_detect=true, header=true)"
+            ).fetchone()
+            row_count_estimate = int(count_result[0]) if count_result else None
+
+            # Fetch preview rows
+            preview_rows = conn.execute(
+                f"SELECT * FROM csv_preview LIMIT {int(limit)}"
+            ).fetchall()
+            col_names = [row[0] for row in describe_rows]
+            preview = [dict(zip(col_names, row)) for row in preview_rows]
+
+            return {
+                "path": str(path),
+                "column_count": len(columns),
+                "columns": columns,
+                "row_count_estimate": row_count_estimate,
+                "preview": preview,
+                "note": "type inference via DuckDB auto_detect on full file",
+            }
+    except Exception as exc:
+        raise ToolkitClientError(f"Lettura CSV fallita per {path}: {exc}") from exc

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -770,12 +770,14 @@ def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
         limit: max rows to return in preview (default 20)
 
     Returns:
-        dict with keys: path, encoding_hint, delimiter_hint, header, column_count,
-        row_count_estimate, columns (name + inferred_type), preview (list of rows)
+        dict with keys: path, column_count, columns (name + inferred_type),
+        row_count_estimate, preview (list of rows), mapping_suggestions
+        (same format as RawProfile.mapping_suggestions — compatible with clean.sql config)
     """
     import duckdb
 
     from toolkit.mcp.path_safety import _safe_path
+    from toolkit.profile._column_profile import _build_mapping_suggestions
 
     path = _safe_path(csv_path)
     if not path.exists():
@@ -787,16 +789,36 @@ def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
     try:
         with duckdb.connect(database=":memory:") as conn:
             conn.execute("PRAGMA disable_progress_bar")
-            # Auto-detect all options; sample to infer types properly
+            # Auto-detect all options; DuckDB infers types from full file
             conn.execute(
                 f"CREATE VIEW csv_preview AS SELECT * FROM read_csv("
                 f"'{_sql_literal(str(path))}', "
                 f"auto_detect=true, header=true)"
             )
             describe_rows = conn.execute("DESCRIBE csv_preview").fetchall()
-            columns = [{"name": row[0], "inferred_type": row[1]} for row in describe_rows]
 
-            # Row count estimate without loading full file
+            # Build DuckDB type map (raw_name -> type)
+            duckdb_type_map: dict[str, str] = {}
+            columns_raw: list[str] = []
+            columns_info: list[dict[str, str]] = []
+            for row in describe_rows:
+                raw_name = str(row[0])
+                dtype = str(row[1])
+                columns_raw.append(raw_name)
+                duckdb_type_map[raw_name] = dtype
+                columns_info.append({"name": raw_name, "inferred_type": dtype})
+
+            # Fetch sample rows for nullify/normalize suggestions
+            sample_rows = conn.execute(
+                "SELECT * FROM csv_preview LIMIT 50"
+            ).fetchdf().to_dict(orient="records")
+
+            # Build mapping_suggestions using DuckDB-inferred types
+            mapping_suggestions = _build_mapping_suggestions(
+                columns_raw, sample_rows, duckdb_types=duckdb_type_map
+            )
+
+            # Row count estimate
             count_result = conn.execute(
                 f"SELECT COUNT(*) FROM read_csv("
                 f"'{_sql_literal(str(path))}', "
@@ -813,11 +835,12 @@ def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
 
             return {
                 "path": str(path),
-                "column_count": len(columns),
-                "columns": columns,
+                "column_count": len(columns_info),
+                "columns": columns_info,
                 "row_count_estimate": row_count_estimate,
                 "preview": preview,
-                "note": "type inference via DuckDB auto_detect on full file",
+                "mapping_suggestions": mapping_suggestions,
+                "note": "type inference via DuckDB auto_detect on full file; mapping_suggestions use DuckDB types",
             }
     except Exception as exc:
         raise ToolkitClientError(f"Lettura CSV fallita per {path}: {exc}") from exc

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -7,6 +7,7 @@ from mcp.server.fastmcp import FastMCP
 from .toolkit_client import (
     ToolkitClientError,
     blocker_hints as blocker_hints_impl,
+    csv_preview as csv_preview_impl,
     inspect_paths as inspect_paths_impl,
     list_runs as list_runs_impl,
     raw_profile as raw_profile_impl,
@@ -114,6 +115,16 @@ def toolkit_list_runs(
     cross_year: bool = False,
 ) -> dict[str, Any]:
     return _guard(list_runs_impl, config_path, year or None, since=since, until=until, status=status, limit=limit, cross_year=cross_year)
+
+
+@mcp.tool(
+    description="Legge un CSV con DuckDB auto-detect e restituisce schema e preview. "
+    "Utile per ispezionare rapidamente il contenuto di un file raw senza runnare la pipeline. "
+    "Inferisce tipi, delimitatore, encoding e header in automatico.",
+    structured_output=True,
+)
+def toolkit_csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
+    return _guard(csv_preview_impl, csv_path, limit)
 
 
 if __name__ == "__main__":

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -18,6 +18,7 @@ from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.cli_adapter import inspect_paths
 from toolkit.mcp.schema_ops import (
     blocker_hints,
+    csv_preview,
     list_runs,
     raw_profile,
     review_readiness,

--- a/toolkit/profile/_column_profile.py
+++ b/toolkit/profile/_column_profile.py
@@ -147,9 +147,9 @@ def _duckdb_type_to_mapping_type(duckdb_type: str) -> str:
     t = duckdb_type.upper()
     if t in ("VARCHAR", "CHAR", "TEXT", "STRING", "UUID"):
         return "str"
-    if t in ("INTEGER", "BIGINT", "SMALLINT", "TINYINT", "UBIGINT", "UINTEGER", "USMALLINT", "UTINYINT"):
+    if t in ("INTEGER", "BIGINT", "SMALLINT", "TINYINT", "UBIGINT", "UINTEGER", "USMALLINT", "UTINYINT", "HUGEINT", "UHUGEINT"):
         return "int"
-    if t in ("DOUBLE", "FLOAT", "REAL", "DECIMAL", "NUMERIC", "HUGEINT", "UHUGGINT"):
+    if t in ("DOUBLE", "FLOAT", "REAL", "DECIMAL", "NUMERIC", "UHUGGINT"):
         return "float"
     if t in ("DATE", "TIMESTAMP", "TIMESTAMP_NS", "TIMESTAMP_S", "TIMESTAMP_MS", "TIMESTAMP_US"):
         return "date"

--- a/toolkit/profile/_column_profile.py
+++ b/toolkit/profile/_column_profile.py
@@ -89,17 +89,43 @@ def _suggest_normalize(colname: str, detected_type: str) -> Optional[List[str]]:
 
 
 def _build_mapping_suggestions(
-    columns: List[str], sample_rows: List[Dict[str, Any]]
-) -> Dict[str, Any]:
-    out: Dict[str, Any] = {}
+    columns: list[str],
+    sample_rows: list[dict[str, Any]],
+    duckdb_types: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build mapping suggestions for each column.
+
+    When duckdb_types is provided (raw_name -> DuckDB type string), those types
+    are used instead of regex-based type inference. This produces more accurate
+    type suggestions since DuckDB has already inferred types from the full file.
+
+    Each entry: {"from": col, "type": duckdb_type_or_inferred, ...}
+    """
+    out: dict[str, Any] = {}
     for col in columns:
         vals = _sample_values(sample_rows, col, limit=30)
         parse_kind = _detect_parse_kind(vals)
-        dtype = _detect_type(vals, parse_kind)
+
+        # Use DuckDB-inferred type when available and specific.
+        # DuckDB VARCHAR is too generic — only use it as definitive when DuckDB
+        # found a specific type (int/float/date/bool).  For VARCHAR fall back to
+        # regex-based _detect_type so that heuristics like number_it/percent_it
+        # can surface (DuckDB doesn't detect Italian decimal/comma formats).
+        if duckdb_types and col in duckdb_types:
+            duckdb_t = duckdb_types[col].upper()
+            is_varchar = duckdb_t in ("VARCHAR", "CHAR", "TEXT", "STRING", "UUID")
+            if not is_varchar:
+                # DuckDB found a specific type — use it
+                dtype = _duckdb_type_to_mapping_type(duckdb_types[col])
+            else:
+                # DuckDB says VARCHAR — fall back to regex inference for more detail
+                dtype = _detect_type(vals, parse_kind)
+        else:
+            dtype = _detect_type(vals, parse_kind)
+
         nullify = _suggest_nullify(vals)
         normalize = _suggest_normalize(col, dtype)
-
-        spec: Dict[str, Any] = {"from": col, "type": dtype}
+        spec: dict[str, Any] = {"from": col, "type": dtype}
 
         if nullify:
             spec["nullify"] = nullify
@@ -110,3 +136,23 @@ def _build_mapping_suggestions(
 
         out[col] = spec
     return out
+
+
+def _duckdb_type_to_mapping_type(duckdb_type: str) -> str:
+    """Map DuckDB DESCRIBE type to mapping suggestion type.
+
+    DuckDB types: VARCHAR, BIGINT, DOUBLE, DATE, TIMESTAMP, BOOLEAN, etc.
+    Mapping types: str, int, float, date, bool.
+    """
+    t = duckdb_type.upper()
+    if t in ("VARCHAR", "CHAR", "TEXT", "STRING", "UUID"):
+        return "str"
+    if t in ("INTEGER", "BIGINT", "SMALLINT", "TINYINT", "UBIGINT", "UINTEGER", "USMALLINT", "UTINYINT"):
+        return "int"
+    if t in ("DOUBLE", "FLOAT", "REAL", "DECIMAL", "NUMERIC", "HUGEINT", "UHUGGINT"):
+        return "float"
+    if t in ("DATE", "TIMESTAMP", "TIMESTAMP_NS", "TIMESTAMP_S", "TIMESTAMP_MS", "TIMESTAMP_US"):
+        return "date"
+    if t in ("BOOLEAN", "BOOL"):
+        return "bool"
+    return "str"

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -211,11 +211,12 @@ def _profile_view(
     )
 
 
-def _describe_columns(con: duckdb.DuckDBPyConnection) -> tuple[list[str], list[str]]:
+def _describe_columns(con: duckdb.DuckDBPyConnection) -> tuple[list[str], list[str], list[str]]:
     cols = con.execute("DESCRIBE v").fetchall()
     columns_raw = [r[0] for r in cols]
     columns_norm = [_normalize_colname(c) for c in columns_raw]
-    return columns_raw, columns_norm
+    duckdb_types = [r[1] for r in cols]  # DuckDB-inferred types
+    return columns_raw, columns_norm, duckdb_types
 
 
 def _sample_profile_rows(
@@ -302,6 +303,8 @@ def profile_raw(
             "header_preamble_detected: first non-empty line looks like a title row, consider skip: 1"
         )
 
+    # Read header line at skip offset (where DuckDB starts reading data).
+    # This preserves backward-compatible header_line for suggested_read.
     skip_n = int(effective_read_cfg.get("skip") or 0)
     header_line = _read_header_line(
         file0,
@@ -310,6 +313,12 @@ def profile_raw(
     )
     if header_line is None:
         warnings.append("header_read_failed: could not read header line")
+
+    # Also read the true file header from line 0 (independent of skip).
+    # This is the ground-truth header row used for mismatch detection:
+    # if header at line 0 has fewer tokens than data columns returned by
+    # DESCRIBE, the file has extra cols in data rows (IRPEF comunale pattern).
+    true_header_line = _read_header_line(file0, encoding=enc, skip_n=0)
 
     con = duckdb.connect(":memory:")
     try:
@@ -330,9 +339,39 @@ def profile_raw(
                 effective_read_cfg=fallback_cfg,
             )
 
-        columns_raw, columns_norm = _describe_columns(con)
+        columns_raw, columns_norm, duckdb_types = _describe_columns(con)
+
+        # Detect column-count mismatch between header and data.
+        # When true_header_line has fewer tokens than what DESCRIBE returns, the file
+        # has more columns in data rows than in the header row (IRPEF comunale pattern:
+        # header=50 cols, data rows=52 cols).  Retry with null_padding=true so
+        # DuckDB accepts the wider rows without failing.
+        if true_header_line is not None:
+            true_header_tokens = true_header_line.count(effective_read_cfg.get("delim") or ";") + 1
+            if len(columns_raw) > true_header_tokens:
+                warnings.append(
+                    f"header_data_cols_mismatch: header has {true_header_tokens} tokens, "
+                    f"data has {len(columns_raw)} columns; retrying with null_padding=true"
+                )
+                robust_read_suggested = True
+                fallback_cfg = robust_preset(effective_read_cfg)
+                fallback_cfg.setdefault("auto_detect", False)
+                fallback_cfg.setdefault("null_padding", True)
+                _profile_view(
+                    con,
+                    file0,
+                    effective_read_cfg=fallback_cfg,
+                )
+                columns_raw, columns_norm, duckdb_types = _describe_columns(con)
+
+        # Build dict of raw_name -> duckdb_type for _build_mapping_suggestions
+        duckdb_type_map: dict[str, str] = {
+            raw: dtype for raw, dtype in zip(columns_raw, duckdb_types)
+        }
         sample_rows, missingness_top = _sample_profile_rows(con, columns_raw)
-        mapping_suggestions = _build_mapping_suggestions(columns_raw, sample_rows)
+        mapping_suggestions = _build_mapping_suggestions(
+            columns_raw, sample_rows, duckdb_types=duckdb_type_map
+        )
 
     except Exception as e:
         warnings.append(f"profile_failed: {type(e).__name__}: {e}")

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -95,7 +95,30 @@ def _read_csv_params(profile: dict[str, Any]) -> str:
     return ", ".join(params)
 
 
-def _columns_spec(profile: dict[str, Any]) -> tuple[list[str], dict[str, str]]:
+def _has_anno_column(profile: dict[str, Any]) -> bool:
+    """Check if any raw column name looks like a year column after normalization.
+
+    Checks both mapping_suggestions (explicit config) and columns_raw (raw file
+    header) so we don't inject a duplicate anno even when the raw CSV has the
+    column but the candidate hasn't mapped it yet.
+    """
+    # Collect candidate column names from both sources
+    mapping = profile.get("mapping_suggestions", {})
+    if mapping:
+        col_names = list(mapping.keys())
+    else:
+        col_names = profile.get("columns_raw", [])
+
+    for col in col_names:
+        normalized = _snake_case(col).lower()
+        if normalized in ("anno", "anno_di_imposta", "anno_imposta", "year", "tax_year"):
+            return True
+    return False
+
+
+def _columns_spec(
+    profile: dict[str, Any], year: int
+) -> tuple[list[str], dict[str, str]]:
     """Build SELECT expressions and read_csv columns spec from mapping_suggestions."""
     mapping = profile.get("mapping_suggestions", {})
     if not mapping:
@@ -164,8 +187,17 @@ def generate_clean_sql(
     file_used = profile.get("file_used", "")
 
     # Build SELECT expressions and columns spec
-    select_exprs, columns_spec = _columns_spec(profile)
+    select_exprs, columns_spec = _columns_spec(profile, year)
     has_columns = bool(columns_spec)
+
+    # If the CSV doesn't have a column named "anno" (after normalization),
+    # inject {year}::INTEGER AS anno so the clean layer has it without requiring
+    # a special mapping.  Using generic name "anno" —
+    # candidates that need domain-specific names (e.g. "anno_di_imposta" for
+    # fiscal data) can rename in clean.sql or config after scaffolding.
+    # The runtime will resolve {year} via render_template.
+    if not _has_anno_column(profile):
+        select_exprs.insert(0, "{year}::INTEGER AS anno")
 
     # Build read_csv parameters (unified list, includes columns when present)
     read_params = _read_csv_params_list(profile, has_columns=has_columns)


### PR DESCRIPTION
## Summary
- **Scaffold year injection**: `generate_clean_sql()` inietta `{year}::INTEGER AS anno` come prima colonna quando il CSV non ha una colonna "anno". Multi-year safe — il runtime risolve `{year}` via `render_template`.
- **DuckDB types con fallback euristica**: `_build_mapping_suggestions()` usa i tipi DuckDB quando specifici (int/float/date/bool), ma ricade nell euristica regex per VARCHAR — permettendo formati italiani come `1.234,56` di emergere come `float` + `parse: {kind: number_it}`.
- **Profiler mismatch retry**: quando `true_header_tokens < data_cols` (IRPEF comunale: 50 vs 52), il profiler riprova con `null_padding=true` e aggiunge un warning esplicito.
- **`csv_preview` arricchito**: il tool MCP ora restituisce anche `mapping_suggestions` già formattati per clean.sql.
- **Formato compatto columns**: `clean.sql` columns accetta `"clean_name:DUCKDB_TYPE"` per rename + tipo in un posto.

## Testing
- 580 test passano
- `ruff` passa su tutti i file del diff
- Verificato su IRPEF comunale 2020 reale: `header_line` corretta, `columns_raw` corrette, warning mismatch emesso

## Files changed
- `toolkit/profile/raw.py` — profiler mismatch retry
- `toolkit/profile/_column_profile.py` — DuckDB types fallback
- `toolkit/scaffold/clean.py` — year template injection
- `toolkit/mcp/schema_ops.py` — csv_preview arricchito
- `toolkit/clean/read_sql_utils.py` — formato compatto columns
- `tests/test_profile_sniff.py` — 2 nuovi test
- `tests/test_cli_scaffold.py` — test aggiornato

## Out of scope (design track separato)
- Refactor `FROM raw_input` in scaffold — tenuto fuori da questo branch