### PR TITLE
fix(profile): rispetta primary_file nei dataset multi-fonte

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ esegue le trasformazioni SQL su DuckDB e produce output in `root/data/`.
 ## MCP Server
 
 Il toolkit espone un server **MCP (Model Context Protocol)** per integrazione con agenti AI e IDE.
-Espone 7 tool read-only per ispezione rapida:
+Espone 9 tool read-only per ispezione rapida:
 
 | Tool | Cosa fa |
 |---|---|
@@ -177,6 +177,8 @@ Espone 7 tool read-only per ispezione rapida:
 | `toolkit_blocker_hints` | Mismatch tra config e output |
 | `toolkit_review_readiness` | Check di prontezza per review |
 | `toolkit_list_runs` | Run records con filtri |
+| `toolkit_schema_diff` | Confronto schema raw cross-year |
+| `toolkit_csv_preview` | Schema + preview CSV via profiler pipeline |
 
 Config esempio per IDE (`.mcp.json`):
 

--- a/tests/test_profile_sniff.py
+++ b/tests/test_profile_sniff.py
@@ -310,3 +310,32 @@ def test_profile_with_read_cfg_retry_sets_robust_read_suggested(tmp_path: Path, 
         "robust_read_suggested must be True after retry-success"
     )
     assert "profile_read_retry" in result["warnings"][-1]
+
+
+def test_profile_raw_respects_primary_file_override(tmp_path: Path):
+    """When primary_file is passed, profile_raw uses it instead of glob alphabetical.
+
+    Regression test: before the fix, multi-source datasets with different
+    source files per year would get the wrong file profiled because
+    _pick_data_file just returns the first alphabetical match.
+    """
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+
+    # Two source files: alphabetically bonus.csv comes first
+    bonus = raw_dir / "bonus.csv"
+    bonus.write_text("col_bonus\nval_bonus\n", encoding="utf-8")
+    tipo_reddito = raw_dir / "tipo_reddito.csv"
+    tipo_reddito.write_text("col_tipo_reddito\nval_tr\n", encoding="utf-8")
+
+    # Profile with primary_file pointing to tipo_reddito
+    profile = profile_raw(
+        raw_dir,
+        "demo",
+        2024,
+        primary_file=tipo_reddito,
+    )
+
+    # Must profile tipo_reddito.csv, not bonus.csv
+    assert profile.file_used == "tipo_reddito.csv"
+    assert profile.columns_raw == ["col_tipo_reddito"]

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -12,7 +12,7 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_review_readiness(config_path, year=0)`
 - `toolkit_list_runs(config_path, year=0, since=None, until=None, status=None, limit=20, cross_year=False)`
 - `toolkit_schema_diff(config_path)` — confronto segnali schema raw cross-year (encoding, colonne, ecc.)
-- `toolkit_csv_preview(csv_path, limit=20)` — schema + preview CSV via DuckDB auto-detect (senza runnare pipeline); utile per validare CSV prima di scrivere clean.sql
+- `toolkit_csv_preview(csv_path, limit=20)` — schema + preview CSV via profiler pipeline (`sniff_source_file` + `profile_with_read_cfg`); output allineato con `RawProfile` (delim, encoding, decimal, skip, robust_read_suggested)
 
 ## Boundary
 
@@ -52,7 +52,7 @@ Sostituire il path del `command` con il Python reale del clone locale che usera'
   - `raw`: usa `toolkit inspect schema-diff --json`
   - `clean` / `mart`: legge schema reale dei parquet risolti via `inspect paths`
 - `toolkit_schema_diff` confronta segnali schema raw (encoding, delim, colonne) tra tutti gli anni configurati per il dataset; riutilizza la stessa logica di `toolkit inspect schema-diff` ma esposto come tool MCP
-- `toolkit_csv_preview` legge un CSV con DuckDB auto-detect (delimiter, encoding, header, tipos automatici) e restituisce schema + prime N righe — utile per ispezionare file raw senza runnare la pipeline
+- `toolkit_csv_preview` legge un CSV usando la stessa pipeline di `profile_raw` (`sniff_source_file` + `profile_with_read_cfg`); restituisce schema + prime N righe + mapping_suggestions — utile per ispezionare file raw senza runnare la pipeline
 - `toolkit_run_summary` aggrega tutti i run record per dataset/year
 - `toolkit_summary` include `run.latest_run_record` (payload completo dell'ultimo run)
 - `toolkit_blocker_hints` evidenzia mismatch pratici tra output risolti e stato run

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -118,9 +118,9 @@ def toolkit_list_runs(
 
 
 @mcp.tool(
-    description="Legge un CSV con DuckDB auto-detect e restituisce schema e preview. "
-    "Utile per ispezionare rapidamente il contenuto di un file raw senza runnare la pipeline. "
-    "Inferisce tipi, delimitatore, encoding e header in automatico.",
+    description="Legge un CSV usando la stessa pipeline di profile_raw (sniff_source_file + profile_with_read_cfg). "
+    "Restituisce schema, preview, mapping_suggestions e parametri sniff (delim, encoding, decimal, skip). "
+    "Utile per ispezionare rapidamente il contenuto di un file raw senza runnare la pipeline.",
     structured_output=True,
 )
 def toolkit_csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -420,7 +420,12 @@ class RawProfile:
 
 
 def profile_raw(
-    raw_dir: Path, dataset: str, year: int, read_cfg: Optional[Dict[str, Any]] = None
+    raw_dir: Path,
+    dataset: str,
+    year: int,
+    read_cfg: Optional[Dict[str, Any]] = None,
+    *,
+    primary_file: Path | None = None,
 ) -> RawProfile:
     """Profile a RAW directory.
 
@@ -439,6 +444,11 @@ def profile_raw(
     read_cfg:
         Optional explicit read configuration. Values here override the
         sniffed suggestions.
+    primary_file:
+        Optional explicit path to the primary source file. When provided,
+        takes precedence over the alphabetical glob fallback. Should match
+        the ``primary_output_file`` from the RAW manifest (via
+        ``_choose_primary_output``).
 
     Returns
     -------
@@ -448,7 +458,7 @@ def profile_raw(
     if not files:
         raise FileNotFoundError(f"No RAW files found in {raw_dir}")
 
-    file0 = _pick_data_file(files)
+    file0 = primary_file if primary_file is not None else _pick_data_file(files)
 
     # Phase 1: pure source sniffing
     sniff_hints = sniff_source_file(file0)

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -158,7 +158,12 @@ def run_raw(
                 logger.info("RAW suggested_read -> %s", suggested_path)
 
             if should_write("profile", "raw_profile", policy, profile_ctx):
-                raw_profile = profile_raw(out_dir, dataset, year)
+                raw_profile = profile_raw(
+                    out_dir,
+                    dataset,
+                    year,
+                    primary_file=primary_output_path,
+                )
                 profile_dir = out_dir / "_profile"
                 write_raw_profile(
                     profile_dir,


### PR DESCRIPTION
## Summary

`profile_raw` ora accetta un parametro `primary_file: Path | None` che,
quando fornito, viene usato al posto del fallback alfabetico di `_pick_data_file`.

`raw/run.py` passa `primary_file=primary_output_path` — il file già
selezionato da `_choose_primary_output` tramite il manifest con `primary: true`.

**Prima**: multi-source (es. `mef-irpef-regionale` con 3 fonti) → profiling
basato su primo file alfabetico invece che quello marcato `primary: true`.

**Dopo**: `scaffold clean --print-read-config` genera `clean.read` basato
sul file corretto.

## Tests
- `pytest` — 607 passed
- `ruff check` — all checks passed
- `mypy` — no issues found