### PR TITLE
fix(validate): instrument raw_probe_source and warn on legacy autodetect

### DIFF
--- a/tests/test_validate_layers.py
+++ b/tests/test_validate_layers.py
@@ -341,6 +341,114 @@ def test_run_clean_validation_uses_columns_raw_from_raw_profile(tmp_path: Path):
     assert summary["stats"]["raw_cols"] == len(real_columns)
     assert summary["stats"]["col_drop_count"] == len(real_columns) - 2
 
+    # raw_probe_source must be "raw_profile" when profile exists
+    assert summary["stats"].get("raw_probe_source") == "raw_profile"
+
+
+def test_run_clean_validation_raw_probe_source_legacy_autodetect(tmp_path: Path):
+    """When no profile exists and a CSV raw file is present, validation falls back
+    to read_csv(auto_detect=true) and sets raw_probe_source = 'legacy_autodetect'."""
+    root = tmp_path / "root"
+    dataset = "demo"
+    year = 2024
+
+    raw_dir = root / "data" / "raw" / dataset / str(year)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    # No profile created — simulating a candidate that hasn't run init
+    (raw_dir / "data.csv").write_text("col1,col2,col3\nval1,val2,val3\n", encoding="utf-8")
+
+    clean_dir = root / "data" / "clean" / dataset / str(year)
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    _write_parquet(clean_dir / f"{dataset}_{year}_clean.parquet", "CREATE TABLE t AS SELECT 1 AS col1, 2 AS col2")
+
+    (clean_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "input_files": ["data.csv"],
+                "read_params_used": {},
+                "output_profile": {
+                    "columns": [
+                        {"name": "col1", "type": "INTEGER"},
+                        {"name": "col2", "type": "INTEGER"},
+                    ],
+                    "row_count": 1,
+                },
+                "outputs": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = SimpleNamespace(
+        root=root,
+        dataset=dataset,
+        clean={},
+    )
+    logger = SimpleNamespace(info=lambda *args, **kwargs: None)
+
+    result = run_clean_validation(cfg, year, logger=logger)
+
+    # With no profile, the probe must fall back to legacy autodetect
+    assert result["stats"].get("raw_probe_source") == "legacy_autodetect"
+    # Warning must mention the fallback reason
+    # build_validation_summary only includes the raw stats, not the full result.warnings
+    # So we check the warning was emitted by inspecting via the ValidationResult if accessible,
+    # or by verifying that the fallback path was taken (raw_probe_source = legacy_autodetect)
+    warning_texts = " ".join(_read_warnings_from_validation_report(clean_dir))
+    assert "falling back to read_csv(auto_detect=true)" in warning_texts
+
+
+def test_run_clean_validation_raw_probe_source_unavailable_when_no_raw_file(
+    tmp_path: Path,
+):
+    """When neither profile nor raw file exist, raw_probe_source = 'unavailable'."""
+    root = tmp_path / "root"
+    dataset = "demo"
+    year = 2024
+
+    raw_dir = root / "data" / "raw" / dataset / str(year)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    # No profile, no raw file
+
+    clean_dir = root / "data" / "clean" / dataset / str(year)
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    _write_parquet(clean_dir / f"{dataset}_{year}_clean.parquet", "CREATE TABLE t AS SELECT 1 AS col1")
+
+    (clean_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "input_files": ["data.csv"],
+                "read_params_used": {},
+                "output_profile": {
+                    "columns": [{"name": "col1", "type": "INTEGER"}],
+                    "row_count": 1,
+                },
+                "outputs": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = SimpleNamespace(
+        root=root,
+        dataset=dataset,
+        clean={},
+    )
+    logger = SimpleNamespace(info=lambda *args, **kwargs: None)
+
+    result = run_clean_validation(cfg, year, logger=logger)
+
+    assert result["stats"].get("raw_probe_source") == "unavailable"
+
+
+def _read_warnings_from_validation_report(clean_dir: Path) -> list[str]:
+    """Read warnings from the written validation JSON."""
+    report_path = clean_dir / "_validate" / "clean_validation.json"
+    if report_path.exists():
+        data = json.loads(report_path.read_text(encoding="utf-8"))
+        return data.get("warnings", [])
+    return []
+
 
 def test_ensure_dict_preserves_validate_alias() -> None:
     """Verify ensure_dict converts validate_config -> validate (by_alias=True)."""

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -303,6 +303,7 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
     profile_path = _profile_dir / "raw_profile.json"
     if not profile_path.exists():
         profile_path = _profile_dir / "profile.json"
+    profile_parse_error: bool = False
     trusted_raw_cols: list[str] = []
     if profile_path.exists():
         try:
@@ -322,10 +323,23 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
                     f"(drop senza -- DROP: <motivo>?): {unmapped}"
                 )
         except Exception:
+            profile_parse_error = True
             pass
 
     actual_raw_col_count: int | None = len(trusted_raw_cols) if trusted_raw_cols else None
     raw_missing_columns: list[str] = []
+    raw_probe_source: str | None = None
+    raw_probe_reason: str | None = None
+
+    if trusted_raw_cols:
+        raw_probe_source = "raw_profile"
+    elif profile_parse_error:
+        raw_probe_reason = "profile_parse_failed"
+    elif not profile_path.exists():
+        raw_probe_reason = "no_profile_found"
+    else:
+        # profile exists and parsed OK but columns_raw is missing/empty
+        raw_probe_reason = "profile_missing_columns_raw"
 
     if not trusted_raw_cols:
         # Find raw file(s) to probe actual column count — parquet preferred, CSV fallback
@@ -346,9 +360,16 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
                         _query = (
                             f"DESCRIBE SELECT * FROM read_csv(\"{_csv_path}\", auto_detect=true)"
                         )
+                        raw_probe_source = "legacy_autodetect"
+                        if raw_probe_reason:
+                            merged_warnings.append(
+                                f"[scaffold] falling back to read_csv(auto_detect=true) — "
+                                f"reason: {raw_probe_reason}. Run 'toolkit run init' to generate a profile."
+                            )
                     _col_rows = _con.execute(_query).fetchall()
                     _actual_raw_col_names = [str(r[0]) for r in _col_rows]
                     actual_raw_col_count = len(_actual_raw_col_names)
+                    raw_probe_source = raw_probe_source or "runtime_profile"
 
                     # Infer expected columns from config
                     _read_cfg = clean_cfg.get("read") or {}
@@ -370,6 +391,13 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
                     _con.close()
             except Exception:
                 pass
+
+    if actual_raw_col_count is None:
+        raw_probe_source = "unavailable"
+        merged_warnings.append(
+            "[scaffold] Profilo raw non disponibile — impossibile verificare coverage colonne raw. "
+            "Considera eseguire 'toolkit run init' per generare il profilo."
+        )
 
     row_drop_pct = (
         round((raw_row_count - clean_row_count) / raw_row_count * 100, 2)
@@ -399,6 +427,7 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
             "col_drop_count": col_drop_count,
             **({"actual_raw_cols": actual_raw_col_count} if actual_raw_col_count is not None else {}),
             **({"raw_missing_columns": raw_missing_columns} if raw_missing_columns else {}),
+            **({"raw_probe_source": raw_probe_source} if raw_probe_source else {}),
         },
         "columns": clean_cols,
         **({"rules": rules} if rules else {}),


### PR DESCRIPTION
## Summary
Strumentato il campo diagnostico `raw_probe_source` in `run_clean_validation` per tracciare come viene risolto il conteggio delle colonne raw durante la validazione.

## Comportamento

| `raw_probe_source` | Significato | Warning |
|---|---|---|
| `raw_profile` | columns_raw preso dal profile salvato | no |
| `legacy_autodetect` | Fallback `read_csv(auto_detect=true)` dopo fallimento profile | sì, con motivo |
| `runtime_profile` | Profilo parquet senza profile file (rara) | no |
| `unavailable` | Nessun raw file trovato | sì, "Profilo raw non disponibile" |

Il warning emesso contiene il motivo del fallback (`no_profile_found` o `profile_parse_failed`) e suggerisce `toolkit run init`.

## Changes
- `toolkit/clean/validate.py`: aggiunto `raw_probe_source` e `raw_probe_reason` con warning espliciti
- `tests/test_validate_layers.py`: 3 nuovi test per i path principali

## Test
```
610 passed in 59.61s
```
- `test_run_clean_validation_raw_probe_source_legacy_autodetect`
- `test_run_clean_validation_raw_probe_source_unavailable_when_no_raw_file`
- `test_run_clean_validation_uses_columns_raw_from_raw_profile` (esteso)

## Priorità 2 — completata
Strumentazione fatta. Nessuna rimozione immediata del fallback — ora abbiamo visibilità su quanto viene usato. Se dopo analisi risulta raro o innocuo, si depreca in follow-up.