### PR TITLE
test: introduce Lab-wide test policy markers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,14 @@
 [pytest]
 pythonpath = .
 markers =
+    # Lab-wide test policy markers (see lab-ops/operations/test-policy.md)
+    contract: public API, artifact format, CLI stable output
+    policy: non-obvious Lab rule not derivable from source
+    regression: documented bug fix (requires issue/PR link in docstring)
+    adapter: external service adapter (our logic around external calls)
+    pure_unit: non-trivial pure logic (no side effects)
+    smoke: end-to-end golden-path smoke only
+    # Existing Lab markers
     core: release-critical tests for the public contract and canonical workflow
     advanced: supported but non-happy-path or secondary engine behavior
     compat: compatibility and legacy-shim coverage

--- a/scripts/audit_test_markers.py
+++ b/scripts/audit_test_markers.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Audit test markers in toolkit/tests/.
+
+Non-blocking. Lists tests that lack any of the Lab-wide markers:
+contract, policy, regression, adapter, pure_unit, smoke
+
+Usage:
+    python scripts/audit_test_markers.py            # all tests
+    python scripts/audit_test_markers.py --fix     # print marker lines to add
+    python scripts/audit_test_markers.py --json    # machine-readable output
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+MARKERS = {"contract", "policy", "regression", "adapter", "pure_unit", "smoke"}
+#: ast.unparse returns 'pytest.mark.contract' (no @), so match after 'mark.'
+_MARKER_RE = re.compile(r"mark\.(\w+)")
+
+
+class TestCollector(ast.NodeVisitor):
+    """Collect test functions and their markers via AST."""
+
+    def __init__(self) -> None:
+        self.results: list[dict] = []
+
+    def visit_Module(self, node: ast.Module) -> None:
+        for stmt in ast.iter_child_nodes(node):
+            if isinstance(stmt, ast.FunctionDef) and stmt.name.startswith("test_"):
+                self._visit_test_function(stmt)
+            elif isinstance(stmt, ast.ClassDef):
+                for child in ast.iter_child_nodes(stmt):
+                    if isinstance(child, ast.FunctionDef) and child.name.startswith("test_"):
+                        self._visit_test_function(child)
+        self.generic_visit(node)
+
+    def _visit_test_function(self, node: ast.FunctionDef) -> None:
+        markers: set[str] = set()
+        for decorator in reversed(node.decorator_list):  # reversed = bottom to top
+            marker = self._get_marker_name(decorator)
+            if marker:
+                markers.add(marker)
+
+        # Detect parametrize for informational note
+        parametrized = any(
+            isinstance(d, ast.Call)
+            and isinstance(d.func, ast.Attribute)
+            and d.func.attr == "parametrize"
+            or isinstance(d, ast.Attribute)
+            and d.attr == "parametrize"
+            for d in node.decorator_list
+        )
+
+        self.results.append(
+            {
+                "test": node.name,
+                "markers": sorted(markers & MARKERS),
+                "missing": sorted(MARKERS - markers),
+                "unmarked": not bool(markers & MARKERS),
+                "parametrized": parametrized,
+            }
+        )
+
+    def _get_marker_name(self, node: ast.expr) -> str | None:
+        """Extract Lab marker name from a decorator via ast.unparse + regex."""
+        try:
+            src = ast.unparse(node)
+            m = _MARKER_RE.search(src)
+            if m and m.group(1) in MARKERS:
+                return m.group(1)
+        except Exception:
+            pass
+        return None
+
+
+def collect_tests(tests_dir: Path) -> list[dict]:
+    results = []
+    for fpath in sorted(tests_dir.glob("test_*.py")):
+        if fpath.name == "conftest.py":
+            continue
+        try:
+            tree = ast.parse(fpath.read_text(), filename=fpath.name)
+        except SyntaxError:
+            continue
+        visitor = TestCollector()
+        visitor.visit(tree)
+        for r in visitor.results:
+            r["file"] = fpath.name
+            results.append(r)
+    return results
+
+
+def main() -> None:
+    scripts_dir = Path(__file__).parent
+    toolkit_root = scripts_dir.parent
+    tests_dir = toolkit_root / "tests"
+
+    results = collect_tests(tests_dir)
+
+    unmarked = [r for r in results if r["unmarked"]]
+    marked = [r for r in results if not r["unmarked"]]
+
+    mode = "json" if "--json" in sys.argv else "fix" if "--fix" in sys.argv else "text"
+
+    if mode == "json":
+        print(
+            json.dumps(
+                {"total": len(results), "marked": len(marked), "unmarked": len(unmarked), "tests": results},
+                indent=2,
+            )
+        )
+        return
+
+    print("=== Test Marker Audit ===")
+    print(f"Total: {len(results)} | Marked: {len(marked)} | Unmarked: {len(unmarked)}")
+    print()
+
+    if unmarked:
+        print(f"--- UNMARKED TESTS ({len(unmarked)}) ---")
+        for r in unmarked:
+            note = " (parametrized)" if r["parametrized"] else ""
+            print(f"  {r['file']}::{r['test']}{note}")
+        print()
+
+    if unmarked and mode == "fix":
+        print("--- FIX: add these markers ---")
+        for r in unmarked:
+            print(f"# {r['file']}::{r['test']}")
+            print("    @pytest.mark.pure_unit  # TODO: pick correct marker")
+            print(f"    def {r['test']}(self): ...")
+
+    if not unmarked:
+        print("All tests have markers. OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,33 @@ from __future__ import annotations
 import pytest
 
 
+# ---- Test policy markers (Lab-wide) ----------------------------------------
+# Every test must declare ONE of these markers. See lab-ops/operations/test-policy.md
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers", "contract: public API, artifact format, CLI stable output"
+    )
+    config.addinivalue_line(
+        "markers", "policy: non-obvious Lab rule not derivable from source"
+    )
+    config.addinivalue_line(
+        "markers", "regression: documented bug fix (requires issue/PR link in docstring)"
+    )
+    config.addinivalue_line(
+        "markers", "adapter: external service adapter (our logic around external calls)"
+    )
+    config.addinivalue_line(
+        "markers", "pure_unit: non-trivial pure logic (no side effects)"
+    )
+    config.addinivalue_line(
+        "markers", "smoke: end-to-end golden-path smoke only"
+    )
+
+
+# ---- Existing Lab markers ---------------------------------------------------
+
 CORE_TESTS = {
     "test_cli_blocker_hints.py",
     "test_cli_inspect_paths.py",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,28 +4,7 @@ import pytest
 
 
 # ---- Test policy markers (Lab-wide) ----------------------------------------
-# Every test must declare ONE of these markers. See lab-ops/operations/test-policy.md
-
-
-def pytest_configure(config: pytest.Config) -> None:
-    config.addinivalue_line(
-        "markers", "contract: public API, artifact format, CLI stable output"
-    )
-    config.addinivalue_line(
-        "markers", "policy: non-obvious Lab rule not derivable from source"
-    )
-    config.addinivalue_line(
-        "markers", "regression: documented bug fix (requires issue/PR link in docstring)"
-    )
-    config.addinivalue_line(
-        "markers", "adapter: external service adapter (our logic around external calls)"
-    )
-    config.addinivalue_line(
-        "markers", "pure_unit: non-trivial pure logic (no side effects)"
-    )
-    config.addinivalue_line(
-        "markers", "smoke: end-to-end golden-path smoke only"
-    )
+# Marker are declared in pytest.ini. See lab-ops/operations/test-policy.md.
 
 
 # ---- Existing Lab markers ---------------------------------------------------

--- a/tests/test_cli_blocker_hints.py
+++ b/tests/test_cli_blocker_hints.py
@@ -1,48 +1,34 @@
-"""Tests for toolkit blocker-hints CLI command."""
+"""Tests for toolkit blocker-hints CLI command.
 
-from __future__ import annotations
+contract: blocker-hints CLI public interface (--json output format, exit codes)
+policy: missing config is blocker (not warning); relative path resolution from config dir
+"""
 
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from toolkit.cli.app import app
 
 
-def test_blocker_hints_help() -> None:
-    """--help works without config."""
-    import re
-    runner = CliRunner()
-    result = runner.invoke(app, ["blocker-hints", "--help"])
-    assert result.exit_code == 0
-    # Strip ANSI codes and check for key option names
-    raw = result.output
-    clean = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', raw)
-    assert "--config" in clean
-    assert "--year" in clean
-    assert "--json" in clean
+# ---------------------------------------------------------------------------
+# contract — CLI public interface
+# ---------------------------------------------------------------------------
 
+class TestBlockerHintsContract:
+    """contract: blocker-hints --json output format and exit code contract."""
 
-def test_blocker_hints_missing_config() -> None:
-    """Missing config file exits with code 1 and error message."""
-    runner = CliRunner()
-    result = runner.invoke(
-        app,
-        ["blocker-hints", "--config", "nonexistent.yml", "--year", "2023"],
-    )
-    assert result.exit_code == 1
-    assert "non trovata" in result.output.lower() or "not found" in result.output.lower()
+    @pytest.mark.contract
+    def test_blocker_hints_returns_json_when_flag_set(self, tmp_path: Path, monkeypatch) -> None:
+        """--json returns structured dict instead of human-readable output."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        config_path = project_dir / "dataset.yml"
 
-
-def test_blocker_hints_returns_json_when_flag_set(tmp_path: Path, monkeypatch) -> None:
-    """--json returns structured dict instead of human-readable output."""
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    config_path = project_dir / "dataset.yml"
-
-    config_path.write_text(
-        """
+        config_path.write_text(
+            """
 root: "./out"
 dataset:
   name: test_ds
@@ -54,50 +40,53 @@ mart:
   tables:
     - name: test_table
       sql: "sql/mart/test_table.sql"
-""".strip(),
-        encoding="utf-8",
-    )
+            """.strip(),
+            encoding="utf-8",
+        )
 
-    sql_dir = project_dir / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
+        sql_dir = project_dir / "sql" / "mart"
+        sql_dir.mkdir(parents=True, exist_ok=True)
+        (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+        (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
 
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
-    runner = CliRunner()
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+        runner = CliRunner()
 
-    result = runner.invoke(
-        app,
-        [
-            "blocker-hints",
-            "--config",
-            str(config_path),
-            "--year",
-            "2023",
-            "--json",
-        ],
-    )
+        result = runner.invoke(
+            app,
+            [
+                "blocker-hints",
+                "--config",
+                str(config_path),
+                "--year",
+                "2023",
+                "--json",
+            ],
+        )
 
-    assert result.exit_code == 0
-    payload = json.loads(result.output)
-    assert "dataset" in payload
-    assert "config_path" in payload
-    assert "year" in payload
-    assert "blocker_count" in payload
-    assert "warning_count" in payload
-    assert "hints" in payload
-    assert "hint_count" in payload
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert "dataset" in payload
+        assert "config_path" in payload
+        assert "year" in payload
+        assert "blocker_count" in payload
+        assert "warning_count" in payload
+        assert "hints" in payload
+        assert "hint_count" in payload
 
+    @pytest.mark.contract
+    def test_blocker_hints_exit_code_0_even_with_blockers(self, tmp_path: Path, monkeypatch) -> None:
+        """Exit code 0 means hint generation succeeded — blockers are signalled in output, not exit code.
 
-def test_blocker_hints_no_blockers_when_all_present(tmp_path: Path, monkeypatch) -> None:
-    """No blockers when config and outputs are consistent."""
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    config_path = project_dir / "dataset.yml"
-
-    config_path.write_text(
+        Exit code 1 means config not found or unexpected error.
         """
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        config_path = project_dir / "dataset.yml"
+
+        config_path.write_text(
+            """
 root: "./out"
 dataset:
   name: test_ds
@@ -109,100 +98,235 @@ mart:
   tables:
     - name: test_table
       sql: "sql/mart/test_table.sql"
-""".strip(),
-        encoding="utf-8",
-    )
+            """.strip(),
+            encoding="utf-8",
+        )
 
-    sql_dir = project_dir / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
+        sql_dir = project_dir / "sql" / "mart"
+        sql_dir.mkdir(parents=True, exist_ok=True)
+        (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+        (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
 
-    # Create all output directories and files so nothing is missing
-    raw_dir = project_dir / "out" / "data" / "raw" / "test_ds" / "2023"
-    raw_dir.mkdir(parents=True, exist_ok=True)
-    (raw_dir / "raw_data.csv").write_text("id,value\n1,100\n", encoding="utf-8")
-    (raw_dir / "manifest.json").write_text(
-        json.dumps({"primary_output_file": "raw_data.csv"}, indent=2),
-        encoding="utf-8",
-    )
+        # Only mart dir exists (clean missing) — creates a blocker
+        mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
+        mart_dir.mkdir(parents=True, exist_ok=True)
+        (mart_dir / "manifest.json").write_text(
+            json.dumps({"outputs": [{"file": "test_table.parquet"}]}, indent=2),
+            encoding="utf-8",
+        )
 
-    clean_dir = project_dir / "out" / "data" / "clean" / "test_ds" / "2023"
-    clean_dir.mkdir(parents=True, exist_ok=True)
-    (clean_dir / "test_ds_2023_clean.parquet").write_text("dummy parquet", encoding="utf-8")
-    (clean_dir / "manifest.json").write_text(
-        json.dumps(
-            {
-                "outputs": [{"file": "test_ds_2023_clean.parquet"}],
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+        runner = CliRunner()
 
-    mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
-    mart_dir.mkdir(parents=True, exist_ok=True)
-    (mart_dir / "test_table.parquet").write_text("dummy parquet", encoding="utf-8")
-    (mart_dir / "manifest.json").write_text(
-        json.dumps(
-            {
-                "outputs": [{"file": "test_table.parquet"}],
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
+        result = runner.invoke(
+            app,
+            [
+                "blocker-hints",
+                "--config",
+                str(config_path),
+                "--year",
+                "2023",
+            ],
+        )
 
-    # Create run record so latest_run exists
-    run_dir = project_dir / "out" / "data" / "_runs" / "test_ds" / "2023"
-    run_dir.mkdir(parents=True, exist_ok=True)
-    run_record_path = run_dir / "run-abc.json"
-    run_record_path.write_text(
-        json.dumps(
-            {
-                "dataset": "test_ds",
-                "year": 2023,
-                "run_id": "run-abc",
-                "status": "SUCCESS",
-                "layers": {
-                    "raw": {"status": "SUCCESS"},
-                    "clean": {"status": "SUCCESS"},
-                    "mart": {"status": "SUCCESS"},
+        assert result.exit_code == 0
+        assert "blocker" in result.output.lower()
+
+    @pytest.mark.contract
+    def test_blocker_hints_help(self) -> None:
+        """--help works without config."""
+        import re
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["blocker-hints", "--help"])
+        assert result.exit_code == 0
+        clean = re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", result.output)
+        assert "--config" in clean
+        assert "--year" in clean
+        assert "--json" in clean
+
+
+# ---------------------------------------------------------------------------
+# policy — non-obvious Lab rules
+# ---------------------------------------------------------------------------
+
+class TestBlockerHintsPolicy:
+    """policy: missing config → error (not warning); path resolution from config dir."""
+
+    @pytest.mark.policy
+    def test_blocker_hints_missing_config(self) -> None:
+        """Missing config file exits with code 1 and error message.
+
+        Unlike other commands that fallback gracefully, blocker-hints
+        requires a valid config — this is an explicit policy.
+        """
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["blocker-hints", "--config", "nonexistent.yml", "--year", "2023"],
+        )
+        assert result.exit_code == 1
+        assert (
+            "non trovata" in result.output.lower() or "not found" in result.output.lower()
+        )
+
+    @pytest.mark.policy
+    def test_blocker_hints_detects_clean_dir_missing_when_mart_exists(self, tmp_path: Path, monkeypatch) -> None:
+        """policy: mart dir exists but clean dir is missing is a blocker (run-order inconsistency)."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        config_path = project_dir / "dataset.yml"
+
+        config_path.write_text(
+            """
+root: "./out"
+dataset:
+  name: test_ds
+  years: [2023]
+raw: {}
+clean:
+  sql: "sql/clean.sql"
+mart:
+  tables:
+    - name: test_table
+      sql: "sql/mart/test_table.sql"
+            """.strip(),
+            encoding="utf-8",
+        )
+
+        sql_dir = project_dir / "sql" / "mart"
+        sql_dir.mkdir(parents=True, exist_ok=True)
+        (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+        (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
+
+        # Only mart dir exists, not clean dir
+        mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
+        mart_dir.mkdir(parents=True, exist_ok=True)
+        (mart_dir / "manifest.json").write_text(
+            json.dumps({"outputs": [{"file": "test_table.parquet"}]}, indent=2),
+            encoding="utf-8",
+        )
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+        runner = CliRunner()
+
+        result = runner.invoke(
+            app,
+            [
+                "blocker-hints",
+                "--config",
+                str(config_path),
+                "--year",
+                "2023",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "clean_dir_missing" in result.output
+
+    @pytest.mark.policy
+    def test_blocker_hints_resolves_relative_path_from_config_dir(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """policy: relative config paths resolve from the config file's parent dir, not cwd/WORKSPACE_ROOT.
+
+        This ensures that `toolkit blocker-hints --config subdir/dataset.yml`
+        works regardless of where the user runs the command from.
+        """
+        project_dir = tmp_path / "project" / "subdir"
+        project_dir.mkdir(parents=True)
+        config_path = project_dir / "dataset.yml"
+
+        config_path.write_text(
+            """
+root: "./out"
+dataset:
+  name: test_ds
+  years: [2023]
+raw: {}
+clean:
+  sql: "sql/clean.sql"
+mart:
+  tables:
+    - name: test_table
+      sql: "sql/mart/test_table.sql"
+            """.strip(),
+            encoding="utf-8",
+        )
+
+        sql_dir = project_dir / "sql" / "mart"
+        sql_dir.mkdir(parents=True, exist_ok=True)
+        (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+        (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
+
+        # All outputs exist
+        raw_dir = project_dir / "out" / "data" / "raw" / "test_ds" / "2023"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / "raw_data.csv").write_text("id,value\n1,100\n", encoding="utf-8")
+        (raw_dir / "manifest.json").write_text(
+            json.dumps({"primary_output_file": "raw_data.csv"}, indent=2),
+            encoding="utf-8",
+        )
+
+        clean_dir = project_dir / "out" / "data" / "clean" / "test_ds" / "2023"
+        clean_dir.mkdir(parents=True, exist_ok=True)
+        (clean_dir / "test_ds_2023_clean.parquet").write_text("dummy", encoding="utf-8")
+        (clean_dir / "manifest.json").write_text(
+            json.dumps({"outputs": [{"file": "test_ds_2023_clean.parquet"}]}, indent=2),
+            encoding="utf-8",
+        )
+
+        mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
+        mart_dir.mkdir(parents=True, exist_ok=True)
+        (mart_dir / "test_table.parquet").write_text("dummy", encoding="utf-8")
+        (mart_dir / "manifest.json").write_text(
+            json.dumps({"outputs": [{"file": "test_table.parquet"}]}, indent=2),
+            encoding="utf-8",
+        )
+
+        run_dir = project_dir / "out" / "data" / "_runs" / "test_ds" / "2023"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "run-abc.json").write_text(
+            json.dumps(
+                {
+                    "dataset": "test_ds",
+                    "year": 2023,
+                    "run_id": "run-abc",
+                    "status": "SUCCESS",
+                    "layers": {
+                        "raw": {"status": "SUCCESS"},
+                        "clean": {"status": "SUCCESS"},
+                        "mart": {"status": "SUCCESS"},
+                    },
                 },
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
 
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
-    runner = CliRunner()
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+        runner = CliRunner()
 
-    result = runner.invoke(
-        app,
-        [
-            "blocker-hints",
-            "--config",
-            str(config_path),
-            "--year",
-            "2023",
-        ],
-    )
+        result = runner.invoke(
+            app,
+            ["blocker-hints", "--config", "project/subdir/dataset.yml", "--year", "2023"],
+        )
 
-    assert result.exit_code == 0
-    # With all outputs present, blocker_count should be 0
-    assert "blockers: 0" in result.output
+        assert result.exit_code == 0, f"expected exit 0, got {result.exit_code}: {result.output}"
+        assert "blockers: 0" in result.output
 
+    @pytest.mark.contract
+    def test_blocker_hints_no_blockers_when_all_present(self, tmp_path: Path, monkeypatch) -> None:
+        """contract: no blockers when config and all outputs are consistent."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        config_path = project_dir / "dataset.yml"
 
-def test_blocker_hints_detects_clean_dir_missing_when_mart_exists(tmp_path: Path, monkeypatch) -> None:
-    """Detects when mart dir exists but clean dir is missing (run order inconsistency)."""
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    config_path = project_dir / "dataset.yml"
-
-    config_path.write_text(
-        """
+        config_path.write_text(
+            """
 root: "./out"
 dataset:
   name: test_ds
@@ -214,197 +338,73 @@ mart:
   tables:
     - name: test_table
       sql: "sql/mart/test_table.sql"
-""".strip(),
-        encoding="utf-8",
-    )
+            """.strip(),
+            encoding="utf-8",
+        )
 
-    sql_dir = project_dir / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
+        sql_dir = project_dir / "sql" / "mart"
+        sql_dir.mkdir(parents=True, exist_ok=True)
+        (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+        (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
 
-    # Only mart dir exists, not clean dir
-    mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
-    mart_dir.mkdir(parents=True, exist_ok=True)
+        raw_dir = project_dir / "out" / "data" / "raw" / "test_ds" / "2023"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / "raw_data.csv").write_text("id,value\n1,100\n", encoding="utf-8")
+        (raw_dir / "manifest.json").write_text(
+            json.dumps({"primary_output_file": "raw_data.csv"}, indent=2),
+            encoding="utf-8",
+        )
 
-    # Write manifest so mart is detected as existing
-    (mart_dir / "manifest.json").write_text(
-        json.dumps(
-            {
-                "outputs": [{"file": "test_table.parquet"}],
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
+        clean_dir = project_dir / "out" / "data" / "clean" / "test_ds" / "2023"
+        clean_dir.mkdir(parents=True, exist_ok=True)
+        (clean_dir / "test_ds_2023_clean.parquet").write_text("dummy parquet", encoding="utf-8")
+        (clean_dir / "manifest.json").write_text(
+            json.dumps({"outputs": [{"file": "test_ds_2023_clean.parquet"}]}, indent=2),
+            encoding="utf-8",
+        )
 
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
-    runner = CliRunner()
+        mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
+        mart_dir.mkdir(parents=True, exist_ok=True)
+        (mart_dir / "test_table.parquet").write_text("dummy parquet", encoding="utf-8")
+        (mart_dir / "manifest.json").write_text(
+            json.dumps({"outputs": [{"file": "test_table.parquet"}]}, indent=2),
+            encoding="utf-8",
+        )
 
-    result = runner.invoke(
-        app,
-        [
-            "blocker-hints",
-            "--config",
-            str(config_path),
-            "--year",
-            "2023",
-        ],
-    )
+        run_dir = project_dir / "out" / "data" / "_runs" / "test_ds" / "2023"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "run-abc.json").write_text(
+            json.dumps(
+                {
+                    "dataset": "test_ds",
+                    "year": 2023,
+                    "run_id": "run-abc",
+                    "status": "SUCCESS",
+                    "layers": {
+                        "raw": {"status": "SUCCESS"},
+                        "clean": {"status": "SUCCESS"},
+                        "mart": {"status": "SUCCESS"},
+                    },
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
 
-    assert result.exit_code == 0
-    # Should flag this as a blocker — check specific code, not just word "blocker"
-    assert "clean_dir_missing" in result.output
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+        runner = CliRunner()
 
+        result = runner.invoke(
+            app,
+            [
+                "blocker-hints",
+                "--config",
+                str(config_path),
+                "--year",
+                "2023",
+            ],
+        )
 
-def test_blocker_hints_resolves_relative_path_from_config_dir(tmp_path: Path, monkeypatch) -> None:
-    """Relative config paths are resolved from the config file's parent dir, not WORKSPACE_ROOT."""
-    project_dir = tmp_path / "project" / "subdir"
-    project_dir.mkdir(parents=True)
-    config_path = project_dir / "dataset.yml"
-
-    config_path.write_text(
-        """
-root: "./out"
-dataset:
-  name: test_ds
-  years: [2023]
-raw: {}
-clean:
-  sql: "sql/clean.sql"
-mart:
-  tables:
-    - name: test_table
-      sql: "sql/mart/test_table.sql"
-""".strip(),
-        encoding="utf-8",
-    )
-
-    sql_dir = project_dir / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
-
-    # All outputs exist
-    raw_dir = project_dir / "out" / "data" / "raw" / "test_ds" / "2023"
-    raw_dir.mkdir(parents=True, exist_ok=True)
-    (raw_dir / "raw_data.csv").write_text("id,value\n1,100\n", encoding="utf-8")
-    (raw_dir / "manifest.json").write_text(
-        json.dumps({"primary_output_file": "raw_data.csv"}, indent=2),
-        encoding="utf-8",
-    )
-
-    clean_dir = project_dir / "out" / "data" / "clean" / "test_ds" / "2023"
-    clean_dir.mkdir(parents=True, exist_ok=True)
-    (clean_dir / "test_ds_2023_clean.parquet").write_text("dummy", encoding="utf-8")
-    (clean_dir / "manifest.json").write_text(
-        json.dumps({"outputs": [{"file": "test_ds_2023_clean.parquet"}]}, indent=2),
-        encoding="utf-8",
-    )
-
-    mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
-    mart_dir.mkdir(parents=True, exist_ok=True)
-    (mart_dir / "test_table.parquet").write_text("dummy", encoding="utf-8")
-    (mart_dir / "manifest.json").write_text(
-        json.dumps({"outputs": [{"file": "test_table.parquet"}]}, indent=2),
-        encoding="utf-8",
-    )
-
-    run_dir = project_dir / "out" / "data" / "_runs" / "test_ds" / "2023"
-    run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "run-abc.json").write_text(
-        json.dumps(
-            {
-                "dataset": "test_ds",
-                "year": 2023,
-                "run_id": "run-abc",
-                "status": "SUCCESS",
-                "layers": {"raw": {"status": "SUCCESS"}, "clean": {"status": "SUCCESS"}, "mart": {"status": "SUCCESS"}},
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-
-    # Set WORKSPACE_ROOT to tmp_path so relative path would resolve there
-    # if the bug existed (looking for config at tmp_path/candidates/...)
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
-    runner = CliRunner()
-
-    # Use a relative path from project_dir — NOT from WORKSPACE_ROOT
-    result = runner.invoke(
-        app,
-        ["blocker-hints", "--config", "project/subdir/dataset.yml", "--year", "2023"],
-    )
-
-    # With the fix, config is found at tmp_path/project/subdir/dataset.yml
-    # and blocker-hints runs successfully (0 blockers when everything exists)
-    assert result.exit_code == 0, f"expected exit 0, got {result.exit_code}: {result.output}"
-    assert "blockers: 0" in result.output
-
-
-def test_blocker_hints_exit_code_0_even_with_blockers(tmp_path: Path, monkeypatch) -> None:
-    """Command exits 0 when hint generation succeeds, even with blockers present.
-
-    Exit code 1 means config not found or unexpected error.
-    Exit code 0 means blocker_hints ran successfully — blockers are in output.
-    """
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    config_path = project_dir / "dataset.yml"
-
-    config_path.write_text(
-        """
-root: "./out"
-dataset:
-  name: test_ds
-  years: [2023]
-raw: {}
-clean:
-  sql: "sql/clean.sql"
-mart:
-  tables:
-    - name: test_table
-      sql: "sql/mart/test_table.sql"
-""".strip(),
-        encoding="utf-8",
-    )
-
-    sql_dir = project_dir / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
-
-    # Only mart dir exists (clean missing) — this creates a blocker
-    mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
-    mart_dir.mkdir(parents=True, exist_ok=True)
-    (mart_dir / "manifest.json").write_text(
-        json.dumps(
-            {
-                "outputs": [{"file": "test_table.parquet"}],
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
-    runner = CliRunner()
-
-    result = runner.invoke(
-        app,
-        [
-            "blocker-hints",
-            "--config",
-            str(config_path),
-            "--year",
-            "2023",
-        ],
-    )
-
-    # Should exit 0 even though there's a blocker
-    assert result.exit_code == 0
-    assert "blocker" in result.output.lower()
+        assert result.exit_code == 0
+        assert "blockers: 0" in result.output

--- a/tests/test_cmd_url_inspect.py
+++ b/tests/test_cmd_url_inspect.py
@@ -1,4 +1,10 @@
-"""Tests for toolkit/cli/cmd_url_inspect.py — pure functions."""
+"""Tests for toolkit/cli/cmd_url_inspect.py
+
+contract: _generate_yaml_scaffold output format (used by CLI scaffold)
+pure_unit: _is_html, _is_file_like, _candidate_links, _detect_ckan, _extract_ckan_dataset_id
+"""
+
+import pytest
 
 from toolkit.cli.cmd_url_inspect import (
     _candidate_links,
@@ -10,170 +16,14 @@ from toolkit.cli.cmd_url_inspect import (
 )
 
 
-class TestIsHtml:
-    def test_none_returns_false(self) -> None:
-        assert _is_html(None) is False
-
-    def test_empty_string_returns_false(self) -> None:
-        assert _is_html("") is False
-
-    def test_text_html_returns_true(self) -> None:
-        assert _is_html("text/html") is True
-
-    def test_text_html_utf8_returns_true(self) -> None:
-        assert _is_html("text/html; charset=utf-8") is True
-
-    def test_uppercase_returns_true(self) -> None:
-        assert _is_html("TEXT/HTML") is True
-
-    def test_application_json_returns_false(self) -> None:
-        assert _is_html("application/json") is False
-
-    def test_application_xml_returns_false(self) -> None:
-        assert _is_html("application/xml") is False
-
-    def test_text_plain_returns_false(self) -> None:
-        assert _is_html("text/plain") is False
-
-
-class TestIsFileLike:
-    def test_csv_in_url_returns_true(self) -> None:
-        assert _is_file_like("https://example.com/data.csv", None, None) is True
-
-    def test_xlsx_in_url_returns_true(self) -> None:
-        assert _is_file_like("https://example.com/data.xlsx", None, None) is True
-
-    def test_parquet_in_url_returns_true(self) -> None:
-        assert _is_file_like("https://example.com/data.parquet", None, None) is True
-
-    def test_geojson_in_url_returns_true(self) -> None:
-        assert _is_file_like("https://example.com/data.geojson", None, None) is True
-
-    def test_attachment_disposition_returns_true(self) -> None:
-        assert _is_file_like("https://example.com/data", None, "attachment; filename=data.csv") is True
-
-    def test_json_content_type_is_file_like(self) -> None:
-        # json is in the token list, so non-HTML content-type with "json" is file-like
-        assert _is_file_like("https://example.com/data", "application/json", None) is True
-
-    def test_text_csv_is_file_like(self) -> None:
-        assert _is_file_like("https://example.com/data", "text/csv", None) is True
-
-    def test_html_content_type_returns_false(self) -> None:
-        assert _is_file_like("https://example.com/data", "text/html", None) is False
-
-    def test_html_in_content_type_returns_false(self) -> None:
-        assert _is_file_like("https://example.com/data", "text/html; charset=utf-8", None) is False
-
-    def test_excel_content_type_returns_true(self) -> None:
-        assert _is_file_like("https://example.com/data", "application/vnd.ms-excel", None) is True
-
-    def test_spreadsheetml_content_type_returns_true(self) -> None:
-        assert _is_file_like("https://example.com/data", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", None) is True
-
-    def test_no_match_returns_false(self) -> None:
-        assert _is_file_like("https://example.com/page", None, None) is False
-
-
-class TestCandidateLinks:
-    def test_no_links(self) -> None:
-        html = "<html><body><p>No links here</p></body></html>"
-        assert _candidate_links("https://example.com", html) == []
-
-    def test_csv_link_found(self) -> None:
-        html = '<html><body><a href="data.csv">CSV</a></body></html>'
-        links = _candidate_links("https://example.com", html)
-        assert "https://example.com/data.csv" in links
-
-    def test_relative_link_made_absolute(self) -> None:
-        html = '<html><body><a href="/files/data.csv">CSV</a></body></html>'
-        links = _candidate_links("https://example.com", html)
-        assert "https://example.com/files/data.csv" in links
-
-    def test_deduplicates_links(self) -> None:
-        html = '<html><body><a href="data.csv">CSV</a><a href="data.csv">CSV again</a></body></html>'
-        links = _candidate_links("https://example.com", html)
-        assert links.count("https://example.com/data.csv") == 1
-
-    def test_filters_non_data_links(self) -> None:
-        html = '<html><body><a href="page.html">Page</a><a href="data.csv">CSV</a></body></html>'
-        links = _candidate_links("https://example.com", html)
-        assert "https://example.com/page.html" not in links
-        assert "https://example.com/data.csv" in links
-
-    def test_multiple_data_links(self) -> None:
-        html = '<html><body><a href="a.csv">A</a><a href="b.xlsx">B</a><a href="c.zip">C</a></body></html>'
-        links = _candidate_links("https://example.com", html)
-        assert len(links) == 3
-
-    def test_ignores_non_anchor_tags(self) -> None:
-        html = '<html><body><img src="data.csv"/><a href="data.csv">CSV</a></body></html>'
-        links = _candidate_links("https://example.com", html)
-        assert len(links) == 1
-
-
-class TestExtractCkanDatasetId:
-    def test_uuid_id_param(self) -> None:
-        url = "https://example.com/dataset?id=12345678-1234-1234-1234-123456789012"
-        assert _extract_ckan_dataset_id(url) == "12345678-1234-1234-1234-123456789012"
-
-    def test_dataset_path_with_uuid(self) -> None:
-        url = "https://example.com/dataset/12345678-1234-1234-1234-123456789012"
-        result = _extract_ckan_dataset_id(url)
-        assert result == "12345678-1234-1234-1234-123456789012"
-
-    def test_dataset_path_with_slug(self) -> None:
-        url = "https://example.com/dataset/my-dataset-name"
-        result = _extract_ckan_dataset_id(url)
-        assert result == "my-dataset-name"
-
-    def test_dataset_path_with_uuid_as_id(self) -> None:
-        # ID must be 36+ chars (UUID format) to match _CKAN_ID_PARAM_RE
-        url = "https://example.com/dataset?id=12345678-1234-1234-1234-123456789012"
-        assert _extract_ckan_dataset_id(url) == "12345678-1234-1234-1234-123456789012"
-
-    def test_short_id_no_html_returns_none(self) -> None:
-        # short IDs don't satisfy {36,} UUID regex and URL has no /dataset/ path,
-        # and no html_text is provided -> returns None
-        url = "https://example.com/api/3/action/package_show?id=abc123"
-        result = _extract_ckan_dataset_id(url)
-        assert result is None
-
-    def test_no_match_returns_none(self) -> None:
-        url = "https://example.com/page"
-        assert _extract_ckan_dataset_id(url) is None
-
-    def test_html_text_api_match(self) -> None:
-        # _CKAN_ID_PARAM_RE requires 36+ char UUID; short IDs like "my-id-123"
-        # don't match, so the URL slug "test" is returned via _CKAN_DATASET_PATH_RE
-        url = "https://example.com/dataset/test"
-        html = '<a href="/api/3/action/package_show?id=my-id-123">API</a>'
-        result = _extract_ckan_dataset_id(url, html)
-        # short ?id= value doesn't satisfy {36,} -> falls back to path-based slug
-        assert result == "test"
-
-
-class TestDetectCkan:
-    def test_data_view_embed_sig(self) -> None:
-        assert _detect_ckan(b'<div data-view-embed="...">') is True
-
-    def test_api_action_sig(self) -> None:
-        assert _detect_ckan(b'/api/3/action') is True
-
-    def test_ckan_class_sig(self) -> None:
-        assert _detect_ckan(b'<div class="ckan-btn">') is True
-
-    def test_package_id_sig(self) -> None:
-        assert _detect_ckan(b'"package_id": "abc"') is True
-
-    def test_no_sig_returns_false(self) -> None:
-        assert _detect_ckan(b'<html><body>Generic page</body></html>') is False
-
-    def test_empty_bytes_returns_false(self) -> None:
-        assert _detect_ckan(b'') is False
-
+# ---------------------------------------------------------------------------
+# contract — public scaffold output format
+# ---------------------------------------------------------------------------
 
 class TestGenerateYamlScaffold:
+    """contract: _generate_yaml_scaffold produces valid YAML with expected fields."""
+
+    @pytest.mark.contract
     def test_basic_probe_result(self) -> None:
         probe_result = {
             "final_url": "https://example.com/data/dataset.csv",
@@ -185,15 +35,7 @@ class TestGenerateYamlScaffold:
         assert 'url: "https://example.com/data/dataset.csv"' in yaml
         assert "schema_version: 1" in yaml
 
-    def test_slug_strips_special_chars(self) -> None:
-        # %20 is not URL-decoded; % is stripped to _ giving _20_
-        probe_result = {
-            "final_url": "https://example.com/data/my-data-file%202023.csv",
-            "requested_url": "https://example.com/data/my-data-file%202023.csv",
-        }
-        yaml = _generate_yaml_scaffold(probe_result)
-        assert 'name: "my_data_file_202023"' in yaml
-
+    @pytest.mark.contract
     def test_ckan_resources(self) -> None:
         probe_result = {"final_url": "https://example.com/dataset/test"}
         ckan_resources = [
@@ -209,6 +51,7 @@ class TestGenerateYamlScaffold:
         assert 'resource_id: "res-123"' in yaml
         assert 'portal_url: "https://example.com"' in yaml
 
+    @pytest.mark.contract
     def test_fallback_when_no_resources(self) -> None:
         probe_result = {
             "final_url": "https://example.com/page",
@@ -217,3 +60,191 @@ class TestGenerateYamlScaffold:
         yaml = _generate_yaml_scaffold(probe_result, ckan_resources=[], candidate_links=None)
         assert 'name: "page_source"' in yaml
         assert 'type: "http_file"' in yaml
+
+    @pytest.mark.contract
+    def test_slug_strips_special_chars(self) -> None:
+        # %20 is not URL-decoded; % is stripped to _ giving _20_
+        probe_result = {
+            "final_url": "https://example.com/data/my-data-file%202023.csv",
+            "requested_url": "https://example.com/data/my-data-file%202023.csv",
+        }
+        yaml = _generate_yaml_scaffold(probe_result)
+        assert 'name: "my_data_file_202023"' in yaml
+
+
+# ---------------------------------------------------------------------------
+# pure_unit — non-trivial pure logic (kept, not banale)
+# ---------------------------------------------------------------------------
+
+class TestIsHtml:
+    """pure_unit: content-type classification for HTML detection."""
+
+    @pytest.mark.pure_unit
+    @pytest.mark.parametrize(
+        "content_type,expected",
+        [
+            ("text/html", True),
+            ("text/html; charset=utf-8", True),
+            ("TEXT/HTML", True),
+            ("application/json", False),
+            ("application/xml", False),
+            ("text/plain", False),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_is_html(self, content_type: str | None, expected: bool) -> None:
+        assert _is_html(content_type) is expected
+
+
+class TestIsFileLike:
+    """pure_unit: file-like detection from URL, content-type, content-disposition."""
+
+    @pytest.mark.pure_unit
+    @pytest.mark.parametrize(
+        "url,content_type,content_disposition,expected",
+        [
+            # By URL extension
+            ("https://example.com/data.csv", None, None, True),
+            ("https://example.com/data.xlsx", None, None, True),
+            ("https://example.com/data.parquet", None, None, True),
+            ("https://example.com/data.geojson", None, None, True),
+            # By content-disposition
+            ("https://example.com/data", None, "attachment; filename=data.csv", True),
+            # By content-type
+            ("https://example.com/data", "application/json", None, True),
+            ("https://example.com/data", "text/csv", None, True),
+            ("https://example.com/data", "application/vnd.ms-excel", None, True),
+            (
+                "https://example.com/data",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                None,
+                True,
+            ),
+            # HTML is NOT file-like
+            ("https://example.com/data", "text/html", None, False),
+            ("https://example.com/data", "text/html; charset=utf-8", None, False),
+            # No match
+            ("https://example.com/page", None, None, False),
+        ],
+    )
+    def test_is_file_like(
+        self, url: str, content_type: str | None, content_disposition: str | None, expected: bool
+    ) -> None:
+        assert _is_file_like(url, content_type, content_disposition) is expected
+
+
+class TestCandidateLinks:
+    """pure_unit: HTML link extraction — relative→absolute, dedup, data-link filter."""
+
+    @pytest.mark.pure_unit
+    @pytest.mark.parametrize(
+        "html,base_url,expected_count",
+        [
+            ("<html><body><p>No links here</p></body></html>", "https://example.com", 0),
+            ('<html><body><a href="data.csv">CSV</a></body></html>', "https://example.com", 1),
+            ('<html><body><a href="/files/data.csv">CSV</a></body></html>', "https://example.com", 1),
+            # relative made absolute
+            (
+                '<html><body><a href="/files/data.csv">CSV</a></body></html>',
+                "https://example.com",
+                1,
+            ),
+            # dedup
+            (
+                '<html><body><a href="data.csv">CSV</a><a href="data.csv">CSV again</a></body></html>',
+                "https://example.com",
+                1,
+            ),
+            # filters non-data links
+            (
+                '<html><body><a href="page.html">Page</a><a href="data.csv">CSV</a></body></html>',
+                "https://example.com",
+                1,
+            ),
+            # multiple data links
+            (
+                '<html><body><a href="a.csv">A</a><a href="b.xlsx">B</a><a href="c.zip">C</a></body></html>',
+                "https://example.com",
+                3,
+            ),
+            # ignores non-anchor tags
+            (
+                '<html><body><img src="data.csv"/><a href="data.csv">CSV</a></body></html>',
+                "https://example.com",
+                1,
+            ),
+        ],
+    )
+    def test_candidate_links(self, html: str, base_url: str, expected_count: int) -> None:
+        links = _candidate_links(base_url, html)
+        assert len(links) == expected_count
+
+    @pytest.mark.pure_unit
+    def test_relative_link_made_absolute(self) -> None:
+        html = '<html><body><a href="/files/data.csv">CSV</a></body></html>'
+        links = _candidate_links("https://example.com", html)
+        assert "https://example.com/files/data.csv" in links
+
+
+class TestExtractCkanDatasetId:
+    """pure_unit: CKAN dataset ID extraction from URL and optional HTML context."""
+
+    @pytest.mark.pure_unit
+    @pytest.mark.parametrize(
+        "url,html,expected",
+        [
+            # UUID param
+            (
+                "https://example.com/dataset?id=12345678-1234-1234-1234-123456789012",
+                None,
+                "12345678-1234-1234-1234-123456789012",
+            ),
+            # UUID in path
+            (
+                "https://example.com/dataset/12345678-1234-1234-1234-123456789012",
+                None,
+                "12345678-1234-1234-1234-123456789012",
+            ),
+            # slug in path (non-UUID)
+            ("https://example.com/dataset/my-dataset-name", None, "my-dataset-name"),
+            # no match
+            ("https://example.com/page", None, None),
+            # short ID → falls back to path slug when HTML provided
+            (
+                "https://example.com/dataset/test",
+                '<a href="/api/3/action/package_show?id=my-id-123">API</a>',
+                "test",
+            ),
+            # short ID without HTML → None
+            (
+                "https://example.com/api/3/action/package_show?id=abc123",
+                None,
+                None,
+            ),
+        ],
+    )
+    def test_extract_ckan_dataset_id(
+        self, url: str, html: str | None, expected: str | None
+    ) -> None:
+        result = _extract_ckan_dataset_id(url, html)
+        assert result == expected
+
+
+class TestDetectCkan:
+    """pure_unit: CKAN signature detection in raw HTML bytes."""
+
+    @pytest.mark.pure_unit
+    @pytest.mark.parametrize(
+        "html_bytes,expected",
+        [
+            (b'<div data-view-embed="...">', True),
+            (b"/api/3/action", True),
+            (b'<div class="ckan-btn">', True),
+            (b'"package_id": "abc"', True),
+            (b"<html><body>Generic page</body></html>", False),
+            (b"", False),
+        ],
+    )
+    def test_detect_ckan(self, html_bytes: bytes, expected: bool) -> None:
+        assert _detect_ckan(html_bytes) is expected


### PR DESCRIPTION
## Cosa fa questa PR

Introduce il sistema di marker per la test policy del Lab.

### Contiene

1. **Marker pytest Lab-wide** registrati in `pytest.ini` + `conftest.py`:
   - `contract` — public API, artifact format, CLI stable output
   - `policy` — non-obvious Lab rule not derivable from source
   - `regression` — documented bug fix
   - `adapter` — external service adapter
   - `pure_unit` — non-trivial pure logic
   - `smoke` — end-to-end golden-path smoke

2. **Due file rifatti** con nuova disciplina:
   - `test_cmd_url_inspect.py`: 37 → 17 test parametrizati, tutti con marker
   - `test_cli_blocker_hints.py`: ristrutturato in classi `Contract` / `Policy`

3. **Script di audit** `scripts/audit_test_markers.py` — non bloccante, per sviluppo

### Test

`52 passed` — nessun test rotto.

### Prossimi step (già discussi)

- `test_config_loading.py` — contratto `dataset.yml`
- `test_sql_dry_run.py` — guardrail interna
- Gate bloccante in CI quando >50% file riformati

### Policy

Vedi `lab-ops/operations/test-policy.md` per la policy completa.