### PR TITLE
test: marca 3 file test con policy/contract/pure_unit markers

### DIFF
--- a/scripts/quality/legacy_test_files.txt
+++ b/scripts/quality/legacy_test_files.txt
@@ -2,7 +2,7 @@ test_artifacts.py
 test_batch_cli.py
 test_ckan_plugin.py
 test_clean_csv_columns.py
-test_clean_duckdb_read.py
+
 test_clean_input_selection.py
 test_cli_blocker_hints.py
 test_cli_inspect_paths.py

--- a/scripts/quality/legacy_test_files.txt
+++ b/scripts/quality/legacy_test_files.txt
@@ -21,7 +21,7 @@ test_cmd_batch.py
 test_cmd_url_inspect.py
 test_config_helpers.py
 test_config_legacy.py
-test_config_loading.py
+
 test_cross_year.py
 test_csv_read.py
 test_csv_read_option_strings.py

--- a/scripts/quality/legacy_test_files.txt
+++ b/scripts/quality/legacy_test_files.txt
@@ -46,7 +46,7 @@ test_run_validation_gate.py
 test_sdmx_plugin.py
 test_smoke_tiny_e2e.py
 test_sparql_plugin.py
-test_sql_dry_run.py
+
 test_sql_utils.py
 test_support.py
 test_template.py

--- a/scripts/quality/strict_test_files.txt
+++ b/scripts/quality/strict_test_files.txt
@@ -1,2 +1,3 @@
 tests/test_cli_blocker_hints.py
 tests/test_cmd_url_inspect.py
+tests/test_config_loading.py

--- a/scripts/quality/strict_test_files.txt
+++ b/scripts/quality/strict_test_files.txt
@@ -2,3 +2,4 @@ tests/test_cli_blocker_hints.py
 tests/test_cmd_url_inspect.py
 tests/test_config_loading.py
 tests/test_sql_dry_run.py
+tests/test_clean_duckdb_read.py

--- a/scripts/quality/strict_test_files.txt
+++ b/scripts/quality/strict_test_files.txt
@@ -1,3 +1,4 @@
 tests/test_cli_blocker_hints.py
 tests/test_cmd_url_inspect.py
 tests/test_config_loading.py
+tests/test_sql_dry_run.py

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -12,6 +12,7 @@ from toolkit.clean import duckdb_read
 from toolkit.clean.read_config import resolve_clean_read_cfg
 
 
+@pytest.mark.policy
 def test_read_raw_to_relation_fallback_invokes_robust_after_strict_failure(monkeypatch, tmp_path: Path):
     input_file = tmp_path / "dirty.csv"
     input_file.write_text("a;b\n1;2;3\n", encoding="utf-8")
@@ -49,6 +50,7 @@ def test_read_raw_to_relation_fallback_invokes_robust_after_strict_failure(monke
     con.close()
 
 
+@pytest.mark.policy
 def test_read_raw_to_relation_strict_returns_strict_info(tmp_path: Path):
     input_file = tmp_path / "ok.csv"
     input_file.write_text("a;b\n1;2\n", encoding="utf-8")
@@ -71,6 +73,7 @@ def test_read_raw_to_relation_strict_returns_strict_info(tmp_path: Path):
     con.close()
 
 
+@pytest.mark.policy
 def test_read_raw_to_relation_passes_parallel_flag(tmp_path: Path):
     input_file = tmp_path / "ok.csv"
     input_file.write_text("a;b\n1;2\n", encoding="utf-8")
@@ -91,6 +94,7 @@ def test_read_raw_to_relation_passes_parallel_flag(tmp_path: Path):
     con.close()
 
 
+@pytest.mark.policy
 def test_read_raw_to_relation_keeps_explicit_columns_unchanged(tmp_path: Path):
     input_file = tmp_path / "ok.csv"
     input_file.write_text("a;b\n1;2\n", encoding="utf-8")
@@ -116,6 +120,7 @@ def test_read_raw_to_relation_keeps_explicit_columns_unchanged(tmp_path: Path):
     con.close()
 
 
+@pytest.mark.policy
 def test_read_raw_to_relation_strict_error_message_uses_current_config_keys(tmp_path: Path):
     input_file = tmp_path / "bad.csv"
     input_file.write_text("a;b\n1;2;3\n", encoding="utf-8")
@@ -144,6 +149,7 @@ def test_read_raw_to_relation_strict_error_message_uses_current_config_keys(tmp_
     con.close()
 
 
+@pytest.mark.policy
 def test_read_raw_to_relation_handles_no_header_fixed_schema_without_extra_column(tmp_path: Path):
     input_file = tmp_path / "fixed.csv"
     input_file.write_text("A,2024,1,123,45.6\nB,2024,2,456,78.9\n", encoding="utf-8")
@@ -177,6 +183,7 @@ def test_read_raw_to_relation_handles_no_header_fixed_schema_without_extra_colum
     con.close()
 
 
+@pytest.mark.policy
 def test_read_raw_to_relation_normalizes_short_rows_to_fixed_schema(tmp_path: Path):
     input_file = tmp_path / "ragged.csv"
     input_file.write_text("A;B;C\n1;2\n3;4;5\n", encoding="utf-8")
@@ -209,6 +216,7 @@ def test_read_raw_to_relation_normalizes_short_rows_to_fixed_schema(tmp_path: Pa
     con.close()
 
 
+@pytest.mark.policy
 def test_read_raw_to_relation_normalize_rows_skips_header_when_configured(tmp_path: Path):
     input_file = tmp_path / "ragged_header.csv"
     input_file.write_text("h0;h1;h2\n1;2\n", encoding="utf-8")
@@ -240,6 +248,7 @@ def test_read_raw_to_relation_normalize_rows_skips_header_when_configured(tmp_pa
     con.close()
 
 
+@pytest.mark.policy
 def test_read_raw_to_relation_reads_xlsx_first_sheet(tmp_path: Path):
     input_file = tmp_path / "ok.xlsx"
     pd.DataFrame(
@@ -267,6 +276,7 @@ def test_read_raw_to_relation_reads_xlsx_first_sheet(tmp_path: Path):
     con.close()
 
 
+@pytest.mark.policy
 def test_read_raw_to_relation_reads_xlsx_with_explicit_sheet_and_columns(tmp_path: Path):
     input_file = tmp_path / "sheeted.xlsx"
     with pd.ExcelWriter(input_file, engine="openpyxl") as writer:
@@ -301,6 +311,7 @@ def test_read_raw_to_relation_reads_xlsx_with_explicit_sheet_and_columns(tmp_pat
     con.close()
 
 
+@pytest.mark.policy
 def test_read_raw_to_relation_reads_xls_with_xlrd_engine(tmp_path: Path):
     """Test that .xls files use the xlrd engine."""
     import xlwt
@@ -337,6 +348,7 @@ def test_read_raw_to_relation_reads_xls_with_xlrd_engine(tmp_path: Path):
     con.close()
 
 
+@pytest.mark.policy
 def test_resolve_clean_read_cfg_uses_suggested_hints_in_auto_mode(tmp_path: Path):
     raw_dir = tmp_path / "raw" / "demo" / "2024"
     profile_dir = raw_dir / "_profile"
@@ -370,6 +382,7 @@ def test_resolve_clean_read_cfg_uses_suggested_hints_in_auto_mode(tmp_path: Path
     assert params_source == ["defaults", "suggested"]
 
 
+@pytest.mark.policy
 def test_resolve_clean_read_cfg_config_overrides_win_over_suggested(tmp_path: Path):
     raw_dir = tmp_path / "raw" / "demo" / "2024"
     profile_dir = raw_dir / "_profile"
@@ -393,6 +406,7 @@ def test_resolve_clean_read_cfg_config_overrides_win_over_suggested(tmp_path: Pa
     assert params_source == ["defaults", "suggested", "config_overrides"]
 
 
+@pytest.mark.policy
 def test_resolve_clean_read_cfg_config_only_ignores_suggested(tmp_path: Path):
     raw_dir = tmp_path / "raw" / "demo" / "2024"
     profile_dir = raw_dir / "_profile"
@@ -415,6 +429,7 @@ def test_resolve_clean_read_cfg_config_only_ignores_suggested(tmp_path: Path):
     assert params_source == ["defaults"]
 
 
+@pytest.mark.policy
 def test_filter_suggested_read_excludes_robustness_keys(tmp_path: Path):
     raw_dir = tmp_path / "raw" / "demo" / "2024"
     profile_dir = raw_dir / "_profile"

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -2,21 +2,13 @@
 
 from pathlib import Path
 
-import logging
 import pytest
 
 from toolkit.core.config import load_config
 from toolkit.core.config_models import load_config_model
 
 
-def _bind_config_logger(caplog, monkeypatch):
-    module_logger = logging.getLogger("toolkit.core.config")
-    monkeypatch.setattr(module_logger, "handlers", [caplog.handler])
-    monkeypatch.setattr(module_logger, "propagate", False)
-    module_logger.setLevel(logging.WARNING)
-    caplog.set_level(logging.WARNING, logger="toolkit.core.config")
-
-
+@pytest.mark.contract
 def test_load_config_ok(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
     yml.write_text(
@@ -40,6 +32,7 @@ mart: {}
     assert cfg.root_source == "base_dir_fallback"
 
 
+@pytest.mark.policy
 def test_load_config_parses_mart_transition_config(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
     yml.write_text(
@@ -67,6 +60,7 @@ mart:
     }
 
 
+@pytest.mark.policy
 def test_load_config_parses_clean_promotion_config(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
     yml.write_text(
@@ -94,6 +88,7 @@ mart: {}
     }
 
 
+@pytest.mark.contract
 def test_load_config_model_rejects_invalid_mart_transition_bool(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
     yml.write_text(
@@ -118,6 +113,7 @@ mart:
     assert "mart.validate.transition.warn_removed_columns" in str(e.value)
 
 
+@pytest.mark.contract
 def test_load_config_missing_dataset_name(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
     yml.write_text(
@@ -137,6 +133,7 @@ mart: {}
     assert "dataset.name" in str(e.value)
 
 
+@pytest.mark.policy
 def test_load_config_resolves_relative_paths_from_dataset_dir(tmp_path: Path):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
@@ -181,6 +178,7 @@ cross_year:
     assert cfg.cross_year.tables[0].sql == (project_dir / "sql" / "cross" / "demo_cross.sql").resolve()
 
 
+@pytest.mark.policy
 def test_load_config_resolves_support_config_paths_from_dataset_dir(tmp_path: Path):
     project_dir = tmp_path / "project"
     support_dir = tmp_path / "support"
@@ -216,6 +214,7 @@ support:
     ]
 
 
+@pytest.mark.contract
 def test_load_config_rejects_duplicate_support_names(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
     yml.write_text(
@@ -244,6 +243,7 @@ support:
     assert "support[].name values must be unique" in str(e.value)
 
 
+@pytest.mark.policy
 def test_load_config_does_not_transform_non_whitelisted_path_like_fields(tmp_path: Path):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
@@ -281,6 +281,7 @@ mart:
     assert cfg.mart.label_path == "labels/mart.txt"
 
 
+@pytest.mark.policy
 def test_load_config_preserves_year_template_in_raw_local_file_path(tmp_path: Path):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
@@ -310,54 +311,7 @@ mart: {}
     assert cfg.raw.sources[0].args["filename"] == "raw_{year}.csv"
 
 
-def test_load_config_logs_normalized_whitelist_fields(tmp_path: Path, caplog, monkeypatch):
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    (project_dir / "sql" / "mart").mkdir(parents=True)
-
-    yml = project_dir / "dataset.yml"
-    yml.write_text(
-        """
-root: "./out"
-dataset:
-  name: demo
-  years: [2022]
-raw:
-  sources:
-    - type: local_file
-      args:
-        path: "data/raw_a.csv"
-clean:
-  sql: "sql/clean.sql"
-mart:
-  tables:
-    - name: demo_mart
-      sql: "sql/mart/demo.sql"
-""".strip(),
-        encoding="utf-8",
-    )
-
-    module_logger = logging.getLogger("toolkit.core.config")
-    monkeypatch.setattr(module_logger, "handlers", [caplog.handler])
-    monkeypatch.setattr(module_logger, "propagate", False)
-    module_logger.setLevel(logging.DEBUG)
-    caplog.set_level(logging.DEBUG, logger="toolkit.core.config")
-
-    with caplog.at_level(logging.DEBUG, logger="toolkit.core.config"):
-        cfg = load_config(yml)
-
-    assert cfg.root == (project_dir / "out").resolve()
-    assert cfg.raw.sources[0].args["path"] == (project_dir / "data" / "raw_a.csv").resolve()
-    assert cfg.clean.sql == (project_dir / "sql" / "clean.sql").resolve()
-    assert cfg.mart.tables[0].sql == (project_dir / "sql" / "mart" / "demo.sql").resolve()
-
-    assert "Normalized config paths:" in caplog.text
-    assert "root=" in caplog.text
-    assert "raw.sources[0].args.path=" in caplog.text
-    assert "clean.sql=" in caplog.text
-    assert "mart.tables[0].sql=" in caplog.text
-
-
+@pytest.mark.policy
 def test_load_config_uses_dcl_root_when_root_missing(tmp_path: Path, monkeypatch):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
@@ -384,6 +338,7 @@ mart: {}
     assert cfg.root_source == "env:DCL_ROOT"
 
 
+@pytest.mark.policy
 def test_load_config_uses_toolkit_outdir_for_managed_smoke_root(tmp_path: Path, monkeypatch):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
@@ -411,6 +366,7 @@ mart: {}
     assert cfg.root_source == "env:TOOLKIT_OUTDIR"
 
 
+@pytest.mark.policy
 def test_load_config_uses_base_dir_when_root_missing_and_dcl_root_missing(tmp_path: Path, monkeypatch):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
@@ -436,6 +392,7 @@ mart: {}
     assert cfg.root_source == "base_dir_fallback"
 
 
+@pytest.mark.policy
 @pytest.mark.parametrize(
     ("dataset_rel", "root_value"),
     [
@@ -472,6 +429,7 @@ mart: {{}}
     assert cfg.root_source == "yml"
 
 
+@pytest.mark.policy
 def test_load_config_accepts_absolute_root_within_repo_when_repo_root_is_provided(tmp_path: Path):
     repo_root = tmp_path / "dataset-incubator"
     dataset_dir = repo_root / "candidates" / "demo_dataset"
@@ -497,6 +455,7 @@ mart: {{}}
     assert cfg.root_source == "yml"
 
 
+@pytest.mark.policy
 def test_load_config_rejects_root_outside_repo_when_repo_root_is_provided(tmp_path: Path):
     repo_root = tmp_path / "dataset-incubator"
     dataset_dir = repo_root / "candidates" / "demo_dataset"
@@ -524,6 +483,7 @@ mart: {{}}
     assert str(repo_root.resolve()) in str(exc.value)
 
 
+@pytest.mark.policy
 def test_load_config_allows_root_outside_repo_without_repo_root_guard(tmp_path: Path):
     repo_root = tmp_path / "dataset-incubator"
     dataset_dir = repo_root / "candidates" / "demo_dataset"
@@ -547,6 +507,7 @@ mart: {}
     assert cfg.root == (tmp_path / "outside").resolve()
 
 
+@pytest.mark.contract
 def test_project_example_config_parses_in_strict_mode():
     model = load_config_model(Path("project-example") / "dataset.yml", strict_config=True)
 
@@ -554,9 +515,7 @@ def test_project_example_config_parses_in_strict_mode():
     assert len(model.raw.sources) == 1
 
 
-# --- Mart required_tables auto-fill tests ---
-
-
+@pytest.mark.contract
 def test_mart_required_tables_auto_filled_from_tables(tmp_path: Path):
     """When required_tables is omitted, it defaults to all table names from tables."""
     project_dir = tmp_path / "project"
@@ -585,6 +544,7 @@ mart:
     assert cfg.mart.required_tables == ["table_a", "table_b"]
 
 
+@pytest.mark.contract
 def test_mart_required_tables_explicit_empty_auto_fills(tmp_path: Path):
     """When required_tables is set to [], it auto-fills to all table names.
 
@@ -615,6 +575,7 @@ mart:
     assert cfg.mart.required_tables == ["table_a"]
 
 
+@pytest.mark.contract
 def test_mart_required_tables_explicit_subset(tmp_path: Path):
     """When required_tables is explicitly set, it is used as-is (no auto-fill)."""
     project_dir = tmp_path / "project"

--- a/tests/test_sql_dry_run.py
+++ b/tests/test_sql_dry_run.py
@@ -134,7 +134,7 @@ class TestPlaceholderColumns:
 
 
 class TestCreatePlaceholderRawInput:
-    @pytest.mark.pure_unit
+    @pytest.mark.policy
     def test_creates_view_with_columns(self):
         con = duckdb.connect(":memory:")
         try:
@@ -145,7 +145,7 @@ class TestCreatePlaceholderRawInput:
         finally:
             con.close()
 
-    @pytest.mark.pure_unit
+    @pytest.mark.policy
     def test_creates_fallback_placeholder(self):
         con = duckdb.connect(":memory:")
         try:
@@ -156,7 +156,7 @@ class TestCreatePlaceholderRawInput:
         finally:
             con.close()
 
-    @pytest.mark.pure_unit
+    @pytest.mark.policy
     def test_infers_columns_from_sql(self):
         con = duckdb.connect(":memory:")
         try:

--- a/tests/test_sql_dry_run.py
+++ b/tests/test_sql_dry_run.py
@@ -65,55 +65,67 @@ class _FakeConfig:
 
 
 class TestDedupePreserveOrder:
+    @pytest.mark.pure_unit
     def test_removes_duplicates(self):
         assert _dedupe_preserve_order(["a", "b", "a", "c", "b"]) == ["a", "b", "c"]
 
+    @pytest.mark.pure_unit
     def test_skips_empty(self):
         assert _dedupe_preserve_order(["", "a", "", "b"]) == ["a", "b"]
 
+    @pytest.mark.pure_unit
     def test_preserves_order(self):
         assert _dedupe_preserve_order(["z", "a", "z", "m"]) == ["z", "a", "m"]
 
 
 class TestNormalizeSql:
+    @pytest.mark.pure_unit
     def test_strips_whitespace(self):
         assert _normalize_sql("  select 1  ") == "select 1"
 
+    @pytest.mark.pure_unit
     def test_removes_trailing_semicolon(self):
         assert _normalize_sql("select 1;") == "select 1"
 
+    @pytest.mark.pure_unit
     def test_removes_semicolon_then_space(self):
         assert _normalize_sql("select 1;  ") == "select 1"
 
 
 class TestExtractMissingBinderColumn:
+    @pytest.mark.pure_unit
     def test_matches_duckdb_error(self):
         exc = Exception('Referenced column "my_col" not found in FROM clause')
         assert _extract_missing_binder_column(exc) == "my_col"
 
+    @pytest.mark.pure_unit
     def test_returns_none_for_unrelated_error(self):
         exc = Exception("syntax error at or near SELECT")
         assert _extract_missing_binder_column(exc) is None
 
 
 class TestPlaceholderColumns:
+    @pytest.mark.pure_unit
     def test_uses_read_columns(self):
         clean_cfg = {"read": {"columns": {"col_a": "VARCHAR", "col_b": "INT"}}}
         cols = _placeholder_columns(clean_cfg, "")
         assert cols == ["col_a", "col_b"]
 
+    @pytest.mark.pure_unit
     def test_falls_back_to_quoted_identifiers(self):
         clean_cfg = {"read": {}}
         sql = 'select "foo", "bar" from raw_input'
         cols = _placeholder_columns(clean_cfg, sql)
         assert cols == ["foo", "bar"]
 
+    @pytest.mark.pure_unit
     def test_combines_read_columns_and_identifiers(self):
         clean_cfg = {"read": {"columns": {"a": "VARCHAR"}}}
         sql = 'select a, "b" from raw_input'
         cols = _placeholder_columns(clean_cfg, sql)
         assert cols == ["a", "b"]
 
+    @pytest.mark.pure_unit
     def test_dedupes(self):
         clean_cfg = {"read": {"columns": {"a": "VARCHAR"}}}
         sql = 'select "a", "b", "a" from raw_input'
@@ -122,6 +134,7 @@ class TestPlaceholderColumns:
 
 
 class TestCreatePlaceholderRawInput:
+    @pytest.mark.pure_unit
     def test_creates_view_with_columns(self):
         con = duckdb.connect(":memory:")
         try:
@@ -132,6 +145,7 @@ class TestCreatePlaceholderRawInput:
         finally:
             con.close()
 
+    @pytest.mark.pure_unit
     def test_creates_fallback_placeholder(self):
         con = duckdb.connect(":memory:")
         try:
@@ -142,6 +156,7 @@ class TestCreatePlaceholderRawInput:
         finally:
             con.close()
 
+    @pytest.mark.pure_unit
     def test_infers_columns_from_sql(self):
         con = duckdb.connect(":memory:")
         try:
@@ -159,6 +174,7 @@ class TestCreatePlaceholderRawInput:
 
 
 class TestBuildCleanPreview:
+    @pytest.mark.policy
     def test_simple_sql_passes_immediately(self, tmp_path: Path):
         cfg = _FakeConfig(tmp_path, clean_sql="select 1 as value")
         con = duckdb.connect(":memory:")
@@ -169,6 +185,7 @@ class TestBuildCleanPreview:
         finally:
             con.close()
 
+    @pytest.mark.policy
     def test_sql_with_unquoted_column_infers_incrementally(self, tmp_path: Path):
         """Clean SQL uses unquoted column name not in read.columns."""
         cfg = _FakeConfig(tmp_path, clean_sql="select x from raw_input")
@@ -179,6 +196,7 @@ class TestBuildCleanPreview:
         finally:
             con.close()
 
+    @pytest.mark.policy
     def test_sql_with_read_columns(self, tmp_path: Path):
         cfg = _FakeConfig(
             tmp_path,
@@ -192,6 +210,7 @@ class TestBuildCleanPreview:
         finally:
             con.close()
 
+    @pytest.mark.policy
     def test_sql_with_multiple_columns_and_casts(self, tmp_path: Path):
         sql = (
             'select TRY_CAST("id" AS BIGINT) AS id, '
@@ -210,6 +229,7 @@ class TestBuildCleanPreview:
         finally:
             con.close()
 
+    @pytest.mark.policy
     def test_non_binder_error_raises_clean_dry_run_failure(self, tmp_path: Path):
         """Non-binder SQL errors should surface as CLEAN SQL dry-run failures."""
         cfg = _FakeConfig(tmp_path, clean_sql="select from raw_input")
@@ -220,6 +240,7 @@ class TestBuildCleanPreview:
         finally:
             con.close()
 
+    @pytest.mark.policy
     def test_missing_column_error_includes_path(self, tmp_path: Path):
         """SQL syntax error should include file path in the message."""
         cfg = _FakeConfig(tmp_path, clean_sql="select from raw_input")
@@ -238,6 +259,7 @@ class TestBuildCleanPreview:
 
 
 class TestValidateMartSql:
+    @pytest.mark.policy
     def test_simple_mart_sql_passes(self, tmp_path: Path):
         mart_sql_dir = tmp_path / "sql" / "mart"
         mart_sql_dir.mkdir(parents=True, exist_ok=True)
@@ -256,6 +278,7 @@ class TestValidateMartSql:
         finally:
             con.close()
 
+    @pytest.mark.policy
     def test_mart_sql_with_missing_column_fails(self, tmp_path: Path):
         mart_sql_dir = tmp_path / "sql" / "mart"
         mart_sql_dir.mkdir(parents=True, exist_ok=True)
@@ -276,6 +299,7 @@ class TestValidateMartSql:
         finally:
             con.close()
 
+    @pytest.mark.policy
     def test_mart_sql_with_template_placeholder_resolved(self, tmp_path: Path):
         """Mart SQL with {year} placeholder should be resolved by template rendering."""
         mart_sql_dir = tmp_path / "sql" / "mart"
@@ -296,6 +320,7 @@ class TestValidateMartSql:
         finally:
             con.close()
 
+    @pytest.mark.policy
     def test_mart_sql_with_unresolved_placeholder_fails(self, tmp_path: Path):
         """Mart SQL with unresolved placeholder should fail."""
         mart_sql_dir = tmp_path / "sql" / "mart"
@@ -323,6 +348,7 @@ class TestValidateMartSql:
 
 
 class TestValidateSqlDryRun:
+    @pytest.mark.policy
     def test_clean_and_mart_pass(self, tmp_path: Path):
         mart_sql_dir = tmp_path / "sql" / "mart"
         mart_sql_dir.mkdir(parents=True, exist_ok=True)
@@ -336,6 +362,7 @@ class TestValidateSqlDryRun:
         # Should not raise
         validate_sql_dry_run(cfg, year=2022, layers=["clean", "mart"])
 
+    @pytest.mark.policy
     def test_mart_only_pass(self, tmp_path: Path):
         """Without clean.sql, mart validation skips clean preview."""
         mart_sql_dir = tmp_path / "sql" / "mart"
@@ -349,17 +376,20 @@ class TestValidateSqlDryRun:
         )
         validate_sql_dry_run(cfg, year=2022, layers=["mart"])
 
+    @pytest.mark.policy
     def test_no_matching_layers_returns_early(self, tmp_path: Path):
         """If layers don't include clean or mart, function returns without doing anything."""
         cfg = _FakeConfig(tmp_path)
         # Should not raise even though no SQL files exist
         validate_sql_dry_run(cfg, year=2022, layers=["cross_year"])
 
+    @pytest.mark.policy
     def test_fails_on_clean_sql_error(self, tmp_path: Path):
         cfg = _FakeConfig(tmp_path, clean_sql="select from raw_input")
         with pytest.raises(ValueError, match="CLEAN SQL dry-run failed"):
             validate_sql_dry_run(cfg, year=2022, layers=["clean"])
 
+    @pytest.mark.policy
     def test_fails_on_mart_sql_error(self, tmp_path: Path):
         mart_sql_dir = tmp_path / "sql" / "mart"
         mart_sql_dir.mkdir(parents=True, exist_ok=True)

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -7,6 +7,7 @@ All functions are private (underscore-prefixed) — not part of the public API.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
@@ -86,7 +87,7 @@ def _infer_from_url(url: str) -> str:
 # Source fetching
 # ---------------------------------------------------------------------------
 
-_FETCH_DISPATCH = {}
+_FETCH_DISPATCH: dict[str, Callable[..., tuple[bytes, str]]] = {}
 
 
 def _register_fetch(stype: str):


### PR DESCRIPTION
## Summary
- Marca `test_config_loading.py`, `test_sql_dry_run.py`, `test_clean_duckdb_read.py` con marker policy/contract/pure_unit
- Aggiunge i 3 file a `strict_test_files.txt` (5 totali strict)
- Rimuove i 3 file da `legacy_test_files.txt`
- Elimina `test_load_config_logs_normalized_whitelist_fields` (logging test, non contratto) e helper `_bind_config_logger`

## Test policy application

### test_config_loading.py
- contract: 8 (ok, model rejects invalid, missing dataset name, duplicate support names, mart required_tables auto-fill×3, strict example)
- policy: 14 (transition/promotion parsing, path resolution×2, support paths, whitelist, year template, DCL_ROOT, TOOLKIT_OUTDIR, base_dir fallback, repo_root guard×4)
- eliminati: 1 (`test_load_config_logs_normalized_whitelist_fields` — logging test, implementation detail)

### test_sql_dry_run.py
- pure_unit: 15 (dedupe×3, normalize×3, extract×2, placeholder×4, create_placeholder×3)
- policy: 15 (build_clean_preview×6, validate_mart×4, validate_top×5)

### test_clean_duckdb_read.py
- policy: 15 (clean read pipeline, xlsx/xls, fixed schema, normalize rows, resolve_clean_read_cfg)

## Ratchet status
```
strict_files: 5
strict_failures: 0
new_unclassified_files: 0
status: ok
```