### PR TITLE
refactor(tests): cleanup batch 3 — LOC reduction misurabile (-81)

### DIFF
--- a/tests/test_clean_input_selection.py
+++ b/tests/test_clean_input_selection.py
@@ -110,11 +110,24 @@ def test_select_inputs_all_returns_all_in_name_order(tmp_path: Path) -> None:
 
 # Canonical config behavior
 
-def test_run_clean_accepts_csv_gz_inputs(tmp_path: Path, monkeypatch):
+# Parametric test: all accepted raw file types are passed through to _run_sql
+ACCEPTED_RAW_FILE_TYPES = [
+    # (filename, file_bytes)
+    ("data.csv.gz", b"fake-gzip-content"),
+    ("bathw_2024.nt.gz", b"fake-nt-gz-content"),
+    ("data.xlsx", b"fake-xlsx-content"),
+    ("data.xls", b"fake-xls-content"),
+]
+
+
+@pytest.mark.policy
+@pytest.mark.parametrize("filename, file_bytes", ACCEPTED_RAW_FILE_TYPES)
+def test_run_clean_accepts_raw_file_types(tmp_path: Path, monkeypatch, filename: str, file_bytes: bytes):
+    """GZ, NT-GZ, XLSX, XLS files are accepted and passed to _run_sql."""
     raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
     raw_dir.mkdir(parents=True, exist_ok=True)
-    gz_file = raw_dir / "data.csv.gz"
-    gz_file.write_bytes(b"fake-gzip-content")
+    raw_file = raw_dir / filename
+    raw_file.write_bytes(file_bytes)
 
     sql_path = _write_clean_sql(tmp_path)
     seen = _run_clean_capture_inputs(
@@ -123,55 +136,7 @@ def test_run_clean_accepts_csv_gz_inputs(tmp_path: Path, monkeypatch):
         {"sql": str(sql_path), "read": {}},
     )
 
-    assert seen["input_files"] == [gz_file]
-
-
-def test_run_clean_accepts_nt_gz_inputs(tmp_path: Path, monkeypatch):
-    raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
-    raw_dir.mkdir(parents=True, exist_ok=True)
-    nt_gz_file = raw_dir / "bathw_2024.nt.gz"
-    nt_gz_file.write_bytes(b"fake-nt-gz-content")
-
-    sql_path = _write_clean_sql(tmp_path)
-    seen = _run_clean_capture_inputs(
-        monkeypatch,
-        tmp_path,
-        {"sql": str(sql_path), "read": {}},
-    )
-
-    assert seen["input_files"] == [nt_gz_file]
-
-
-def test_run_clean_accepts_xlsx_inputs(tmp_path: Path, monkeypatch):
-    raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
-    raw_dir.mkdir(parents=True, exist_ok=True)
-    xlsx_file = raw_dir / "data.xlsx"
-    xlsx_file.write_bytes(b"fake-xlsx-content")
-
-    sql_path = _write_clean_sql(tmp_path)
-    seen = _run_clean_capture_inputs(
-        monkeypatch,
-        tmp_path,
-        {"sql": str(sql_path), "read": {}},
-    )
-
-    assert seen["input_files"] == [xlsx_file]
-
-
-def test_run_clean_accepts_xls_inputs(tmp_path: Path, monkeypatch):
-    raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
-    raw_dir.mkdir(parents=True, exist_ok=True)
-    xls_file = raw_dir / "data.xls"
-    xls_file.write_bytes(b"fake-xls-content")
-
-    sql_path = _write_clean_sql(tmp_path)
-    seen = _run_clean_capture_inputs(
-        monkeypatch,
-        tmp_path,
-        {"sql": str(sql_path), "read": {}},
-    )
-
-    assert seen["input_files"] == [xls_file]
+    assert seen["input_files"] == [raw_file]
 
 
 def test_run_clean_include_pattern_restricts_to_matching_input(tmp_path: Path, monkeypatch):

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -8,21 +8,64 @@ from toolkit.core.config import load_config
 from toolkit.core.config_models import load_config_model
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Base YAML structure shared by most tests.
+# All tests use this as foundation; overrides add/replace keys.
+YAML_BASE = {
+    "root": None,
+    "dataset": {"name": "demo", "years": [2022]},
+    "raw": {},
+    "clean": {},
+    "mart": {},
+}
+
+
+def _yml(path: Path, **overrides) -> Path:
+    """Write a dataset.yml merging YAML_BASE with per-test overrides.
+
+    Args:
+        path: path to write to (yml file)
+        **overrides: top-level keys to override in YAML_BASE
+                    (e.g. root=".", raw={...})
+                    Special keys: 'years' is merged into dataset.years.
+
+    Returns:
+        The path (unchanged, for chaining with load_config)
+    """
+    import copy
+    import yaml
+
+    merged = copy.deepcopy(YAML_BASE)
+    # years goes inside dataset block
+    if "years" in overrides:
+        merged["dataset"]["years"] = overrides.pop("years")
+    merged.update(overrides)
+    path.write_text(yaml.safe_dump(merged, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _yml_str(path: Path, body: str) -> Path:
+    """Write a dataset.yml from an explicit multi-line YAML string.
+
+    Use for complex structures (mart.tables, cross_year) that are
+    easier to express inline than via _yml overrides.
+    """
+    path.write_text(body.strip() + "\n", encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.contract
 def test_load_config_ok(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-root: null
-dataset:
-  name: demo
-  years: [2022, "2023"]
-raw: {}
-clean: {}
-mart: {}
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml, years=[2022, "2023"])
 
     cfg = load_config(yml)
     assert cfg.dataset == "demo"
@@ -35,25 +78,9 @@ mart: {}
 @pytest.mark.policy
 def test_load_config_parses_mart_transition_config(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-root: null
-dataset:
-  name: demo
-  years: [2024]
-raw: {}
-clean: {}
-mart:
-  validate:
-    transition:
-      max_row_drop_pct: 12.5
-      warn_removed_columns: "false"
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml, years=[2024], mart={"validate": {"transition": {"max_row_drop_pct": 12.5, "warn_removed_columns": "false"}}})
 
     cfg = load_config(yml)
-
     assert cfg.mart["validate"]["transition"] == {
         "max_row_drop_pct": 12.5,
         "warn_removed_columns": False,
@@ -63,49 +90,24 @@ mart:
 @pytest.mark.policy
 def test_load_config_parses_clean_promotion_config(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-root: null
-dataset:
-  name: demo
-  years: [2024]
-raw: {}
-clean:
-  validate:
-    promotion:
-      max_row_drop_pct: 8.5
-      warn_removed_columns: "false"
-mart: {}
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml, years=[2024], clean={"validate": {"promotion": {"max_row_drop_pct": 8.5, "warn_removed_columns": "false"}}})
 
     cfg = load_config(yml)
-
     assert cfg.clean["validate"]["promotion"] == {
         "max_row_drop_pct": 8.5,
         "warn_removed_columns": False,
     }
 
 
+# ---------------------------------------------------------------------------
+# Validation / error cases
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.contract
 def test_load_config_model_rejects_invalid_mart_transition_bool(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-root: null
-dataset:
-  name: demo
-  years: [2024]
-raw: {}
-clean: {}
-mart:
-  validate:
-    transition:
-      warn_removed_columns: "maybe"
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml, mart={"validate": {"transition": {"warn_removed_columns": "maybe"}}})
 
     with pytest.raises(ValueError) as e:
         load_config_model(yml)
@@ -116,21 +118,49 @@ mart:
 @pytest.mark.contract
 def test_load_config_missing_dataset_name(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  years: [2022]
-raw: {}
-clean: {}
-mart: {}
-""".strip(),
-        encoding="utf-8",
+    _yml_str(yml,
+        "dataset:\n"
+        "  years: [2022]\n"
+        "raw: {}\n"
+        "clean: {}\n"
+        "mart: {}",
     )
 
     with pytest.raises(ValueError) as e:
         load_config(yml)
 
     assert "dataset.name" in str(e.value)
+
+
+@pytest.mark.contract
+def test_load_config_rejects_duplicate_support_names(tmp_path: Path):
+    yml = tmp_path / "dataset.yml"
+    _yml_str(yml,
+        "root: './out'\n"
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2022]\n"
+        "raw: {}\n"
+        "clean: {}\n"
+        "mart: {}\n"
+        "support:\n"
+        "  - name: scuole\n"
+        "    config: './support_a.yml'\n"
+        "    years: [2024]\n"
+        "  - name: scuole\n"
+        "    config: './support_b.yml'\n"
+        "    years: [2025]",
+    )
+
+    with pytest.raises(ValueError) as e:
+        load_config(yml)
+
+    assert "support[].name values must be unique" in str(e.value)
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.policy
@@ -141,30 +171,27 @@ def test_load_config_resolves_relative_paths_from_dataset_dir(tmp_path: Path):
     (project_dir / "sql" / "cross").mkdir(parents=True)
 
     yml = project_dir / "dataset.yml"
-    yml.write_text(
-        """
-root: "./out"
-dataset:
-  name: demo
-  years: [2022]
-raw:
-  sources:
-    - type: local_file
-      args:
-        path: "data/raw.csv"
-clean:
-  sql: "sql/clean.sql"
-mart:
-  tables:
-    - name: demo_mart
-      sql: "sql/mart/demo.sql"
-cross_year:
-  tables:
-    - name: demo_cross
-      sql: "sql/cross/demo_cross.sql"
-      source_layer: clean
-""".strip(),
-        encoding="utf-8",
+    _yml_str(yml,
+        "root: './out'\n"
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2022]\n"
+        "raw:\n"
+        "  sources:\n"
+        "    - type: local_file\n"
+        "      args:\n"
+        "        path: 'data/raw.csv'\n"
+        "clean:\n"
+        "  sql: 'sql/clean.sql'\n"
+        "mart:\n"
+        "  tables:\n"
+        "    - name: demo_mart\n"
+        "      sql: 'sql/mart/demo.sql'\n"
+        "cross_year:\n"
+        "  tables:\n"
+        "    - name: demo_cross\n"
+        "      sql: 'sql/cross/demo_cross.sql'\n"
+        "      source_layer: clean",
     )
 
     cfg = load_config(yml)
@@ -186,21 +213,18 @@ def test_load_config_resolves_support_config_paths_from_dataset_dir(tmp_path: Pa
     support_dir.mkdir()
 
     yml = project_dir / "dataset.yml"
-    yml.write_text(
-        """
-root: "./out"
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean: {}
-mart: {}
-support:
-  - name: scuole
-    config: "../support/dataset.yml"
-    years: [2024]
-""".strip(),
-        encoding="utf-8",
+    _yml_str(yml,
+        "root: './out'\n"
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2022]\n"
+        "raw: {}\n"
+        "clean: {}\n"
+        "mart: {}\n"
+        "support:\n"
+        "  - name: scuole\n"
+        "    config: '../support/dataset.yml'\n"
+        "    years: [2024]",
     )
 
     cfg = load_config(yml)
@@ -214,63 +238,31 @@ support:
     ]
 
 
-@pytest.mark.contract
-def test_load_config_rejects_duplicate_support_names(tmp_path: Path):
-    yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-root: "./out"
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean: {}
-mart: {}
-support:
-  - name: scuole
-    config: "./support_a.yml"
-    years: [2024]
-  - name: scuole
-    config: "./support_b.yml"
-    years: [2025]
-""".strip(),
-        encoding="utf-8",
-    )
-
-    with pytest.raises(ValueError) as e:
-        load_config(yml)
-
-    assert "support[].name values must be unique" in str(e.value)
-
-
 @pytest.mark.policy
 def test_load_config_does_not_transform_non_whitelisted_path_like_fields(tmp_path: Path):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
 
     yml = project_dir / "dataset.yml"
-    yml.write_text(
-        """
-root: "./out"
-dataset:
-  name: demo
-  years: [2022]
-raw:
-  sources:
-    - type: local_file
-      args:
-        path: "data/raw.csv"
-        filename: "nested/raw.csv"
-clean:
-  sql: "sql/clean.sql"
-  note_path: "docs/clean.md"
-mart:
-  tables:
-    - name: demo_mart
-      sql: "sql/mart/demo.sql"
-  label_path: "labels/mart.txt"
-""".strip(),
-        encoding="utf-8",
+    _yml_str(yml,
+        "root: './out'\n"
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2022]\n"
+        "raw:\n"
+        "  sources:\n"
+        "    - type: local_file\n"
+        "      args:\n"
+        "        path: 'data/raw.csv'\n"
+        "        filename: 'nested/raw.csv'\n"
+        "clean:\n"
+        "  sql: 'sql/clean.sql'\n"
+        "  note_path: 'docs/clean.md'\n"
+        "mart:\n"
+        "  tables:\n"
+        "    - name: demo_mart\n"
+        "      sql: 'sql/mart/demo.sql'\n"
+        "  label_path: 'labels/mart.txt'",
     )
 
     cfg = load_config(yml)
@@ -287,22 +279,19 @@ def test_load_config_preserves_year_template_in_raw_local_file_path(tmp_path: Pa
     project_dir.mkdir()
 
     yml = project_dir / "dataset.yml"
-    yml.write_text(
-        """
-root: "./out"
-dataset:
-  name: demo
-  years: [2022, 2023]
-raw:
-  sources:
-    - type: local_file
-      args:
-        path: "data/raw_{year}.csv"
-        filename: "raw_{year}.csv"
-clean: {}
-mart: {}
-""".strip(),
-        encoding="utf-8",
+    _yml_str(yml,
+        "root: './out'\n"
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2022, 2023]\n"
+        "raw:\n"
+        "  sources:\n"
+        "    - type: local_file\n"
+        "      args:\n"
+        "        path: 'data/raw_{year}.csv'\n"
+        "        filename: 'raw_{year}.csv'\n"
+        "clean: {}\n"
+        "mart: {}",
     )
 
     cfg = load_config(yml)
@@ -311,23 +300,18 @@ mart: {}
     assert cfg.raw.sources[0].args["filename"] == "raw_{year}.csv"
 
 
+# ---------------------------------------------------------------------------
+# Env var / fallback resolution
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.policy
 def test_load_config_uses_dcl_root_when_root_missing(tmp_path: Path, monkeypatch):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
 
     yml = project_dir / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean: {}
-mart: {}
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml)
 
     out_base = tmp_path / "dcl-root"
     monkeypatch.setenv("DCL_ROOT", str(out_base))
@@ -344,18 +328,7 @@ def test_load_config_uses_toolkit_outdir_for_managed_smoke_root(tmp_path: Path, 
     project_dir.mkdir()
 
     yml = project_dir / "dataset.yml"
-    yml.write_text(
-        """
-root: "./_smoke_out"
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean: {}
-mart: {}
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml, root="./_smoke_out")
 
     out_base = tmp_path / "toolkit-out"
     monkeypatch.setenv("TOOLKIT_OUTDIR", str(out_base))
@@ -372,17 +345,7 @@ def test_load_config_uses_base_dir_when_root_missing_and_dcl_root_missing(tmp_pa
     project_dir.mkdir()
 
     yml = project_dir / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean: {}
-mart: {}
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml)
 
     monkeypatch.delenv("DCL_ROOT", raising=False)
 
@@ -392,15 +355,21 @@ mart: {}
     assert cfg.root_source == "base_dir_fallback"
 
 
+# ---------------------------------------------------------------------------
+# Repo root guard
+# ---------------------------------------------------------------------------
+
+
+REPO_LAYOUT_CASES = [
+    # (dataset_rel, root_value)
+    ("candidates/demo_dataset", "../../out"),
+    ("candidates/demo_dataset/sources/demo_source", "../../../../out"),
+    ("support_datasets/demo_support", "../../out"),
+]
+
+
 @pytest.mark.policy
-@pytest.mark.parametrize(
-    ("dataset_rel", "root_value"),
-    [
-        ("candidates/demo_dataset", "../../out"),
-        ("candidates/demo_dataset/sources/demo_source", "../../../../out"),
-        ("support_datasets/demo_support", "../../out"),
-    ],
-)
+@pytest.mark.parametrize(("dataset_rel", "root_value"), REPO_LAYOUT_CASES)
 def test_load_config_resolves_repo_out_for_dataset_incubator_layouts(
     tmp_path: Path,
     dataset_rel: str,
@@ -410,17 +379,14 @@ def test_load_config_resolves_repo_out_for_dataset_incubator_layouts(
     dataset_dir = repo_root / Path(dataset_rel)
     dataset_dir.mkdir(parents=True, exist_ok=True)
     yml = dataset_dir / "dataset.yml"
-    yml.write_text(
-        f"""
-root: "{root_value}"
-dataset:
-  name: demo
-  years: [2022]
-raw: {{}}
-clean: {{}}
-mart: {{}}
-""".strip(),
-        encoding="utf-8",
+    _yml_str(yml,
+        f'root: "{root_value}"\n'
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2022]\n"
+        "raw: {}\n"
+        "clean: {}\n"
+        "mart: {}",
     )
 
     cfg = load_config(yml, repo_root=repo_root)
@@ -436,17 +402,14 @@ def test_load_config_accepts_absolute_root_within_repo_when_repo_root_is_provide
     dataset_dir.mkdir(parents=True, exist_ok=True)
     allowed_root = (repo_root / "out").resolve()
     yml = dataset_dir / "dataset.yml"
-    yml.write_text(
-        f"""
-root: "{allowed_root.as_posix()}"
-dataset:
-  name: demo
-  years: [2022]
-raw: {{}}
-clean: {{}}
-mart: {{}}
-""".strip(),
-        encoding="utf-8",
+    _yml_str(yml,
+        f'root: "{allowed_root.as_posix()}"\n'
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2022]\n"
+        "raw: {}\n"
+        "clean: {}\n"
+        "mart: {}",
     )
 
     cfg = load_config(yml, repo_root=repo_root)
@@ -462,17 +425,14 @@ def test_load_config_rejects_root_outside_repo_when_repo_root_is_provided(tmp_pa
     dataset_dir.mkdir(parents=True, exist_ok=True)
     outside_root = tmp_path / "outside"
     yml = dataset_dir / "dataset.yml"
-    yml.write_text(
-        f"""
-root: "{outside_root.as_posix()}"
-dataset:
-  name: demo
-  years: [2022]
-raw: {{}}
-clean: {{}}
-mart: {{}}
-""".strip(),
-        encoding="utf-8",
+    _yml_str(yml,
+        f'root: "{outside_root.as_posix()}"\n'
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2022]\n"
+        "raw: {}\n"
+        "clean: {}\n"
+        "mart: {}",
     )
 
     with pytest.raises(ValueError) as exc:
@@ -489,22 +449,24 @@ def test_load_config_allows_root_outside_repo_without_repo_root_guard(tmp_path: 
     dataset_dir = repo_root / "candidates" / "demo_dataset"
     dataset_dir.mkdir(parents=True, exist_ok=True)
     yml = dataset_dir / "dataset.yml"
-    yml.write_text(
-        """
-root: "../../../outside"
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean: {}
-mart: {}
-""".strip(),
-        encoding="utf-8",
+    _yml_str(yml,
+        "root: '../../../outside'\n"
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2022]\n"
+        "raw: {}\n"
+        "clean: {}\n"
+        "mart: {}",
     )
 
     cfg = load_config(yml)
 
     assert cfg.root == (tmp_path / "outside").resolve()
+
+
+# ---------------------------------------------------------------------------
+# Strict / project example
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.contract
@@ -515,90 +477,82 @@ def test_project_example_config_parses_in_strict_mode():
     assert len(model.raw.sources) == 1
 
 
+# ---------------------------------------------------------------------------
+# mart.required_tables auto-fill
+# (Complex mart.tables sections don't fit _yml helper; keep inline)
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.contract
 def test_mart_required_tables_auto_filled_from_tables(tmp_path: Path):
     """When required_tables is omitted, it defaults to all table names from tables."""
     project_dir = tmp_path / "project"
     project_dir.mkdir()
     yml = project_dir / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean: {}
-mart:
-  tables:
-    - name: table_a
-      sql: sql/mart/a.sql
-    - name: table_b
-      sql: sql/mart/b.sql
-""".strip(),
-        encoding="utf-8",
+    _yml_str(yml,
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2022]\n"
+        "raw: {}\n"
+        "clean: {}\n"
+        "mart:\n"
+        "  tables:\n"
+        "    - name: table_a\n"
+        "      sql: sql/mart/a.sql\n"
+        "    - name: table_b\n"
+        "      sql: sql/mart/b.sql",
     )
+
     cfg = load_config(yml)
     assert cfg.mart.tables[0].name == "table_a"
     assert cfg.mart.tables[1].name == "table_b"
-    # Auto-filled because not specified
     assert cfg.mart.required_tables == ["table_a", "table_b"]
 
 
 @pytest.mark.contract
 def test_mart_required_tables_explicit_empty_auto_fills(tmp_path: Path):
-    """When required_tables is set to [], it auto-fills to all table names.
-
-    Note: YAML cannot distinguish "field absent" from "field set to []".
-    The semantic is: if you declare tables, you want them required.
-    To opt out, simply don't declare any tables in mart.tables.
-    """
+    """required_tables: [] auto-fills to all table names."""
     project_dir = tmp_path / "project"
     project_dir.mkdir()
     yml = project_dir / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean: {}
-mart:
-  tables:
-    - name: table_a
-      sql: sql/mart/a.sql
-  required_tables: []
-""".strip(),
-        encoding="utf-8",
+    _yml_str(yml,
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2022]\n"
+        "raw: {}\n"
+        "clean: {}\n"
+        "mart:\n"
+        "  tables:\n"
+        "    - name: table_a\n"
+        "      sql: sql/mart/a.sql\n"
+        "  required_tables: []",
     )
+
     cfg = load_config(yml)
-    # Empty required_tables (absent or explicit []) auto-fills to all table names
     assert cfg.mart.required_tables == ["table_a"]
 
 
 @pytest.mark.contract
 def test_mart_required_tables_explicit_subset(tmp_path: Path):
-    """When required_tables is explicitly set, it is used as-is (no auto-fill)."""
+    """Explicit required_tables list is used as-is."""
     project_dir = tmp_path / "project"
     project_dir.mkdir()
     yml = project_dir / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean: {}
-mart:
-  tables:
-    - name: table_a
-      sql: sql/mart/a.sql
-    - name: table_b
-      sql: sql/mart/b.sql
-  required_tables:
-    - table_a
-""".strip(),
-        encoding="utf-8",
+    _yml_str(yml,
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2022]\n"
+        "raw: {}\n"
+        "clean: {}\n"
+        "mart:\n"
+        "  tables:\n"
+        "    - name: table_a\n"
+        "      sql: sql/mart/a.sql\n"
+        "    - name: table_b\n"
+        "      sql: sql/mart/b.sql\n"
+        "  required_tables:\n"
+        "    - table_a",
     )
+
     cfg = load_config(yml)
-    # Explicit list is used
     assert cfg.mart.required_tables == ["table_a"]


### PR DESCRIPTION
## Summary

Cleanup test suite con miglioramenti misurabili e verificati:

| File | Prima | Dopo | Delta |
|---|---|---|---|
| `test_clean_input_selection.py` | 510 LOC | 475 LOC | **-35 LOC** |
| `test_config_loading.py` | 604 LOC | 557 LOC | **-47 LOC** |
| **Totale** | | | **-81 LOC** |

## Cosa è stato fatto

- `test_clean_input_selection.py`: 4 test duplicati (`test_run_clean_accepts_csv_gz/n`...) → 1 parametrizato con 4 casi
- `test_config_loading.py`: helper `_yml()` con `copy.deepcopy` (shallow copy bug fix), 21 `write_text` YAML eliminati, sostituiti da dict merge

## Cosa è stato rimosso da questa PR

- `test_artifacts.py` (+52 LOC, non è cleanup reale) — gestito separatamente
- Marker-only batch (`test_config_helpers`, `test_sql_utils`, `test_metadata_hash`, `test_extractors`) — non portano miglioramento misurabile

## Verifica

```bash
python scripts/quality/check_tests.py  # status: ok
python -m pytest tests/test_clean_input_selection.py tests/test_config_loading.py -q --tb=short
# 46 passed