### PR TITLE
refactor(test_cli_resume.py): extract _write_sql + _mock_all_runs helpers (-44 LOC)

### DIFF
--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -14,140 +14,114 @@ from toolkit.core.artifacts import (
 )
 
 
-class TestResolveArtifactPolicy:
-    def test_standard_default(self) -> None:
-        assert resolve_artifact_policy(None) == ARTIFACT_POLICY_STANDARD
+# resolve_artifact_policy
 
-    def test_explicit_standard(self) -> None:
-        assert resolve_artifact_policy({"artifacts": "standard"}) == ARTIFACT_POLICY_STANDARD
-
-    def test_explicit_minimal(self) -> None:
-        assert resolve_artifact_policy({"artifacts": "minimal"}) == ARTIFACT_POLICY_MINIMAL
-
-    def test_explicit_debug(self) -> None:
-        assert resolve_artifact_policy({"artifacts": "debug"}) == ARTIFACT_POLICY_DEBUG
-
-    def test_whitespace_stripped(self) -> None:
-        assert resolve_artifact_policy({"artifacts": "  standard  "}) == ARTIFACT_POLICY_STANDARD
-
-    def test_case_insensitive(self) -> None:
-        assert resolve_artifact_policy({"artifacts": "DEBUG"}) == ARTIFACT_POLICY_DEBUG
-
-    def test_invalid_raises_value_error(self) -> None:
-        with pytest.raises(ValueError) as exc_info:
-            resolve_artifact_policy({"artifacts": "unknown"})
-        assert "output.artifacts must be one of" in str(exc_info.value)
-
-    def test_empty_dict_defaults_to_standard(self) -> None:
-        assert resolve_artifact_policy({}) == ARTIFACT_POLICY_STANDARD
-
-    def test_all_policies_are_valid(self) -> None:
-        for policy in ARTIFACT_POLICIES:
-            assert resolve_artifact_policy({"artifacts": policy}) == policy
+@pytest.mark.policy
+@pytest.mark.parametrize("cfg, expected", [
+    (None, ARTIFACT_POLICY_STANDARD),
+    ({}, ARTIFACT_POLICY_STANDARD),
+    ({"artifacts": "standard"}, ARTIFACT_POLICY_STANDARD),
+    ({"artifacts": "  standard  "}, ARTIFACT_POLICY_STANDARD),
+    ({"artifacts": "STANDARD"}, ARTIFACT_POLICY_STANDARD),
+    ({"artifacts": "minimal"}, ARTIFACT_POLICY_MINIMAL),
+    ({"artifacts": "debug"}, ARTIFACT_POLICY_DEBUG),
+    ({"artifacts": "DEBUG"}, ARTIFACT_POLICY_DEBUG),
+])
+def test_resolve_artifact_policy_valid(cfg, expected) -> None:
+    assert resolve_artifact_policy(cfg) == expected
 
 
-class TestLegacyAliasesEnabled:
-    def test_none_returns_false(self) -> None:
-        assert legacy_aliases_enabled(None) is False
-
-    def test_empty_dict_returns_false(self) -> None:
-        assert legacy_aliases_enabled({}) is False
-
-    def test_explicit_true(self) -> None:
-        assert legacy_aliases_enabled({"legacy_aliases": True}) is True
-
-    def test_explicit_false(self) -> None:
-        assert legacy_aliases_enabled({"legacy_aliases": False}) is False
-
-    def test_returns_bool(self) -> None:
-        assert isinstance(legacy_aliases_enabled({"legacy_aliases": "yes"}), bool)
+@pytest.mark.policy
+@pytest.mark.parametrize("policy", [p for p in ARTIFACT_POLICIES])
+def test_resolve_artifact_policy_all_policies_valid(policy) -> None:
+    assert resolve_artifact_policy({"artifacts": policy}) == policy
 
 
-class TestProfileRequired:
-    def test_dict_cfg_auto_source(self) -> None:
-        cfg = {"clean": {"read": {"source": "auto"}}}
-        assert profile_required(cfg) is True
-
-    def test_dict_cfg_explicit_source(self) -> None:
-        cfg = {"clean": {"read": {"source": "duckdb"}}}
-        assert profile_required(cfg) is False
-
-    def test_dict_cfg_string_read(self) -> None:
-        cfg = {"clean": {"read": "duckdb"}}
-        assert profile_required(cfg) is False
-
-    def test_dict_cfg_read_source_fallback(self) -> None:
-        cfg = {"clean": {"read_source": "duckdb"}}
-        assert profile_required(cfg) is False
-
-    def test_dict_cfg_no_read(self) -> None:
-        cfg = {"clean": {}}
-        assert profile_required(cfg) is True
-
-    def test_empty_dict(self) -> None:
-        assert profile_required({}) is True
-
-    def test_none(self) -> None:
-        assert profile_required(None) is True
-
-    def test_attribute_access_dict(self) -> None:
-        # simulate object with attributes
-        class Cfg:
-            pass
-
-        obj = Cfg()
-        obj.clean = {"read": {"source": "duckdb"}}
-        assert profile_required(obj) is False
+@pytest.mark.policy
+def test_resolve_artifact_policy_invalid_raises() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        resolve_artifact_policy({"artifacts": "unknown"})
+    assert "output.artifacts must be one of" in str(exc_info.value)
 
 
-class TestShouldWrite:
-    def test_debug_policy_always_true(self) -> None:
-        assert should_write("clean", "any_artifact", ARTIFACT_POLICY_DEBUG, {}) is True
-        assert should_write("mart", "any_artifact", ARTIFACT_POLICY_DEBUG, {}) is True
-        assert should_write("profile", "raw_profile", ARTIFACT_POLICY_DEBUG, {}) is True
+# legacy_aliases_enabled
 
-    def test_minimal_policy_suppresses_optional_clean_artifacts(self) -> None:
-        assert should_write("clean", "rendered_sql", ARTIFACT_POLICY_MINIMAL, {}) is False
-        assert should_write("mart", "rendered_sql", ARTIFACT_POLICY_MINIMAL, {}) is False
+@pytest.mark.policy
+@pytest.mark.parametrize("cfg, expected", [
+    (None, False),
+    ({}, False),
+    ({"legacy_aliases": True}, True),
+    ({"legacy_aliases": False}, False),
+])
+def test_legacy_aliases_enabled(cfg, expected) -> None:
+    assert legacy_aliases_enabled(cfg) is expected
 
-    def test_minimal_policy_keeps_required_artifacts(self) -> None:
-        assert should_write("clean", "data_parquet", ARTIFACT_POLICY_MINIMAL, {}) is True
-        assert should_write("mart", "aggregated_parquet", ARTIFACT_POLICY_MINIMAL, {}) is True
 
-    def test_profile_raw_profile_minimal_suppressed(self) -> None:
-        assert (
-            should_write("profile", "raw_profile", ARTIFACT_POLICY_MINIMAL, {}) is False
-        )
+@pytest.mark.policy
+def test_legacy_aliases_enabled_returns_bool() -> None:
+    assert isinstance(legacy_aliases_enabled({"legacy_aliases": "yes"}), bool)
 
-    def test_profile_suggested_read_auto(self) -> None:
-        cfg = {"clean": {"read": {"source": "auto"}}}
-        assert should_write("profile", "suggested_read", ARTIFACT_POLICY_STANDARD, cfg) is True
 
-    def test_profile_suggested_read_explicit_source(self) -> None:
-        cfg = {"clean": {"read": {"source": "duckdb"}}}
-        assert should_write("profile", "suggested_read", ARTIFACT_POLICY_STANDARD, cfg) is False
+# profile_required
 
-    def test_profile_md_never_written_non_debug(self) -> None:
-        # DEBUG short-circuits to True at line 49; non-DEBUG policies suppress profile_md
-        assert should_write("profile", "profile_md", ARTIFACT_POLICY_STANDARD, {}) is False
-        assert should_write("profile", "profile_md", ARTIFACT_POLICY_MINIMAL, {}) is False
+@pytest.mark.policy
+@pytest.mark.parametrize("cfg, expected", [
+    (None, True),
+    ({}, True),
+    ({"clean": {}}, True),
+    ({"clean": {"read": {"source": "auto"}}}, True),
+    ({"clean": {"read": {"source": "duckdb"}}}, False),
+    ({"clean": {"read": "duckdb"}}, False),
+    ({"clean": {"read_source": "duckdb"}}, False),
+])
+def test_profile_required(cfg, expected) -> None:
+    assert profile_required(cfg) is expected
 
-    def test_profile_suggested_mapping_never_written_non_debug(self) -> None:
-        assert should_write("profile", "suggested_mapping", ARTIFACT_POLICY_STANDARD, {}) is False
-        assert should_write("profile", "suggested_mapping", ARTIFACT_POLICY_DEBUG, {}) is True  # DEBUG short-circuits
 
-    def test_profile_md_debug_short_circuits(self) -> None:
-        # DEBUG policy returns True immediately, before the layer-specific checks
-        assert should_write("profile", "profile_md", ARTIFACT_POLICY_DEBUG, {}) is True
+@pytest.mark.policy
+def test_profile_required_object_attribute_access() -> None:
+    class Cfg:
+        pass
+    obj = Cfg()
+    obj.clean = {"read": {"source": "duckdb"}}
+    assert profile_required(obj) is False
 
-    def test_standard_policy_keeps_optional_artifacts(self) -> None:
-        cfg = {"output": {"artifacts": "standard", "legacy_aliases": True}}
-        assert should_write("profile", "profile_alias", ARTIFACT_POLICY_STANDARD, cfg) is True
 
-    def test_minimal_policy_suppresses_profile_alias(self) -> None:
-        cfg = {"output": {"artifacts": "minimal", "legacy_aliases": True}}
-        assert should_write("profile", "profile_alias", ARTIFACT_POLICY_MINIMAL, cfg) is False
+# should_write
 
-    def test_profile_alias_without_legacy(self) -> None:
-        cfg = {"output": {"artifacts": "standard", "legacy_aliases": False}}
-        assert should_write("profile", "profile_alias", ARTIFACT_POLICY_STANDARD, cfg) is False
+@pytest.mark.policy
+@pytest.mark.parametrize("layer, artifact, policy, cfg, expected", [
+    ("clean", "any_artifact", ARTIFACT_POLICY_DEBUG, {}, True),
+    ("mart", "any_artifact", ARTIFACT_POLICY_DEBUG, {}, True),
+    ("profile", "raw_profile", ARTIFACT_POLICY_DEBUG, {}, True),
+    ("profile", "profile_md", ARTIFACT_POLICY_DEBUG, {}, True),
+    ("profile", "profile_md", ARTIFACT_POLICY_STANDARD, {}, False),
+    ("profile", "profile_md", ARTIFACT_POLICY_MINIMAL, {}, False),
+    ("profile", "suggested_read", ARTIFACT_POLICY_STANDARD, {"clean": {"read": {"source": "auto"}}}, True),
+    ("profile", "suggested_read", ARTIFACT_POLICY_STANDARD, {"clean": {"read": {"source": "duckdb"}}}, False),
+    ("profile", "suggested_mapping", ARTIFACT_POLICY_DEBUG, {}, True),
+    ("profile", "suggested_mapping", ARTIFACT_POLICY_STANDARD, {}, False),
+    ("profile", "profile_alias", ARTIFACT_POLICY_STANDARD, {"output": {"artifacts": "standard", "legacy_aliases": True}}, True),
+    ("profile", "profile_alias", ARTIFACT_POLICY_MINIMAL, {"output": {"artifacts": "minimal", "legacy_aliases": True}}, False),
+    ("profile", "profile_alias", ARTIFACT_POLICY_STANDARD, {"output": {"artifacts": "standard", "legacy_aliases": False}}, False),
+])
+def test_should_write(layer, artifact, policy, cfg, expected) -> None:
+    assert should_write(layer, artifact, policy, cfg) is expected
+
+
+@pytest.mark.policy
+@pytest.mark.parametrize("layer, artifact", [
+    ("clean", "rendered_sql"),
+    ("mart", "rendered_sql"),
+])
+def test_should_write_minimal_policy_suppresses_optional(layer, artifact) -> None:
+    assert should_write(layer, artifact, ARTIFACT_POLICY_MINIMAL, {}) is False
+
+
+@pytest.mark.policy
+@pytest.mark.parametrize("layer, artifact", [
+    ("clean", "data_parquet"),
+    ("mart", "aggregated_parquet"),
+])
+def test_should_write_minimal_policy_keeps_required(layer, artifact) -> None:
+    assert should_write(layer, artifact, ARTIFACT_POLICY_MINIMAL, {}) is True

--- a/tests/test_cli_resume.py
+++ b/tests/test_cli_resume.py
@@ -9,6 +9,26 @@ from toolkit.cli import cmd_run
 from toolkit.cli.app import app
 
 
+def _write_sql(base: Path) -> None:
+    """Write standard SQL files (clean.sql + mart_example.sql)."""
+    sql_dir = base / "sql" / "mart"
+    sql_dir.mkdir(parents=True, exist_ok=True)
+    (base / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+    (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
+
+
+def _mock_all_runs(monkeypatch) -> dict:
+    """Patch cmd_run run/validation functions; returns calls dict."""
+    calls = {"raw": 0, "clean": 0, "mart": 0}
+    monkeypatch.setattr(cmd_run, "run_raw", lambda *args, **kwargs: calls.__setitem__("raw", calls["raw"] + 1))
+    monkeypatch.setattr(cmd_run, "run_clean", lambda *args, **kwargs: calls.__setitem__("clean", calls["clean"] + 1))
+    monkeypatch.setattr(cmd_run, "run_mart", lambda *args, **kwargs: calls.__setitem__("mart", calls["mart"] + 1))
+    monkeypatch.setattr(cmd_run, "run_raw_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
+    monkeypatch.setattr(cmd_run, "run_clean_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
+    monkeypatch.setattr(cmd_run, "run_mart_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
+    return calls
+
+
 def _write_config(path: Path) -> None:
     path.write_text(
         "\n".join(
@@ -158,25 +178,14 @@ def _write_success_with_warnings_run_record(path: Path, run_id: str) -> None:
 def test_cli_resume_starts_from_first_non_success_layer(tmp_path: Path, monkeypatch) -> None:
     config_path = tmp_path / "dataset.yml"
     _write_config(config_path)
-
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
+    _write_sql(tmp_path)
 
     old_run_id = "old-run-id"
     runs_dir = tmp_path / "out" / "data" / "_runs" / "demo_ds" / "2022"
     _write_old_run_record(runs_dir / f"{old_run_id}.json", old_run_id)
     _write_layer_artifacts(tmp_path / "out", "demo_ds", 2022, "raw")
 
-    calls = {"raw": 0, "clean": 0, "mart": 0}
-
-    monkeypatch.setattr(cmd_run, "run_raw", lambda *args, **kwargs: calls.__setitem__("raw", calls["raw"] + 1))
-    monkeypatch.setattr(cmd_run, "run_clean", lambda *args, **kwargs: calls.__setitem__("clean", calls["clean"] + 1))
-    monkeypatch.setattr(cmd_run, "run_mart", lambda *args, **kwargs: calls.__setitem__("mart", calls["mart"] + 1))
-    monkeypatch.setattr(cmd_run, "run_raw_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
-    monkeypatch.setattr(cmd_run, "run_clean_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
-    monkeypatch.setattr(cmd_run, "run_mart_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
+    calls = _mock_all_runs(monkeypatch)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -213,25 +222,14 @@ def test_cli_resume_uses_config_root_when_cwd_differs(tmp_path: Path, monkeypatc
     config_path = tmp_path / "project" / "dataset.yml"
     config_path.parent.mkdir(parents=True, exist_ok=True)
     _write_config(config_path)
-
-    sql_dir = config_path.parent / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (config_path.parent / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
+    _write_sql(config_path.parent)
 
     old_run_id = "old-run-id"
     runs_dir = config_path.parent / "out" / "data" / "_runs" / "demo_ds" / "2022"
     _write_old_run_record(runs_dir / f"{old_run_id}.json", old_run_id)
     _write_layer_artifacts(config_path.parent / "out", "demo_ds", 2022, "raw")
 
-    calls = {"raw": 0, "clean": 0, "mart": 0}
-
-    monkeypatch.setattr(cmd_run, "run_raw", lambda *args, **kwargs: calls.__setitem__("raw", calls["raw"] + 1))
-    monkeypatch.setattr(cmd_run, "run_clean", lambda *args, **kwargs: calls.__setitem__("clean", calls["clean"] + 1))
-    monkeypatch.setattr(cmd_run, "run_mart", lambda *args, **kwargs: calls.__setitem__("mart", calls["mart"] + 1))
-    monkeypatch.setattr(cmd_run, "run_raw_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
-    monkeypatch.setattr(cmd_run, "run_clean_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
-    monkeypatch.setattr(cmd_run, "run_mart_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
+    calls = _mock_all_runs(monkeypatch)
 
     monkeypatch.chdir(tmp_path)
     runner = CliRunner()
@@ -260,11 +258,7 @@ def test_resume_finds_latest_run(tmp_path: Path, monkeypatch) -> None:
     config_path = tmp_path / "project" / "dataset.yml"
     config_path.parent.mkdir(parents=True, exist_ok=True)
     _write_config(config_path)
-
-    sql_dir = config_path.parent / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (config_path.parent / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
+    _write_sql(config_path.parent)
 
     runs_dir = config_path.parent / "out" / "data" / "_runs" / "demo_ds" / "2022"
     _write_old_run_record(runs_dir / "old-run.json", "old-run")
@@ -279,14 +273,7 @@ def test_resume_finds_latest_run(tmp_path: Path, monkeypatch) -> None:
     new_payload["started_at"] = "2026-02-28T10:00:00+00:00"
     (runs_dir / "new-run.json").write_text(json.dumps(new_payload, indent=2), encoding="utf-8")
 
-    calls = {"raw": 0, "clean": 0, "mart": 0}
-
-    monkeypatch.setattr(cmd_run, "run_raw", lambda *args, **kwargs: calls.__setitem__("raw", calls["raw"] + 1))
-    monkeypatch.setattr(cmd_run, "run_clean", lambda *args, **kwargs: calls.__setitem__("clean", calls["clean"] + 1))
-    monkeypatch.setattr(cmd_run, "run_mart", lambda *args, **kwargs: calls.__setitem__("mart", calls["mart"] + 1))
-    monkeypatch.setattr(cmd_run, "run_raw_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
-    monkeypatch.setattr(cmd_run, "run_clean_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
-    monkeypatch.setattr(cmd_run, "run_mart_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
+    calls = _mock_all_runs(monkeypatch)
 
     monkeypatch.chdir(tmp_path)
     runner = CliRunner()
@@ -314,7 +301,6 @@ def test_resume_finds_latest_run(tmp_path: Path, monkeypatch) -> None:
 def test_cli_resume_non_portable_record_warns_and_proceeds(tmp_path: Path) -> None:
     """Non-portable records warn but no longer block (--compat flag removed)."""
     config_path = tmp_path / "dataset.yml"
-    # Write config with a working local file source so resume can proceed
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     (data_dir / "dati.csv").write_text("a,b\n1,2\n", encoding="utf-8")
@@ -337,11 +323,7 @@ def test_cli_resume_non_portable_record_warns_and_proceeds(tmp_path: Path) -> No
         ]),
         encoding="utf-8",
     )
-
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
+    _write_sql(tmp_path)
 
     old_run_id = "old-run-id"
     runs_dir = tmp_path / "out" / "data" / "_runs" / "demo_ds" / "2022"
@@ -370,24 +352,13 @@ def test_cli_resume_non_portable_record_warns_and_proceeds(tmp_path: Path) -> No
 def test_cli_resume_falls_back_to_raw_when_raw_success_artifacts_are_missing(tmp_path: Path, monkeypatch) -> None:
     config_path = tmp_path / "dataset.yml"
     _write_config(config_path)
-
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
+    _write_sql(tmp_path)
 
     old_run_id = "old-run-id"
     runs_dir = tmp_path / "out" / "data" / "_runs" / "demo_ds" / "2022"
     _write_old_run_record(runs_dir / f"{old_run_id}.json", old_run_id)
 
-    calls = {"raw": 0, "clean": 0, "mart": 0}
-
-    monkeypatch.setattr(cmd_run, "run_raw", lambda *args, **kwargs: calls.__setitem__("raw", calls["raw"] + 1))
-    monkeypatch.setattr(cmd_run, "run_clean", lambda *args, **kwargs: calls.__setitem__("clean", calls["clean"] + 1))
-    monkeypatch.setattr(cmd_run, "run_mart", lambda *args, **kwargs: calls.__setitem__("mart", calls["mart"] + 1))
-    monkeypatch.setattr(cmd_run, "run_raw_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
-    monkeypatch.setattr(cmd_run, "run_clean_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
-    monkeypatch.setattr(cmd_run, "run_mart_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
+    calls = _mock_all_runs(monkeypatch)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -415,11 +386,7 @@ def test_cli_resume_falls_back_to_raw_when_raw_success_artifacts_are_missing(tmp
 def test_cli_resume_success_with_warnings_requires_from_layer_or_exits_cleanly(tmp_path: Path) -> None:
     config_path = tmp_path / "dataset.yml"
     _write_config(config_path)
-
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
+    _write_sql(tmp_path)
 
     run_id = "warn-run"
     runs_dir = tmp_path / "out" / "data" / "_runs" / "demo_ds" / "2022"
@@ -451,11 +418,7 @@ def test_cli_resume_success_with_warnings_requires_from_layer_or_exits_cleanly(t
 def test_cli_resume_success_with_warnings_allows_forced_from_layer(tmp_path: Path, monkeypatch) -> None:
     config_path = tmp_path / "dataset.yml"
     _write_config(config_path)
-
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
+    _write_sql(tmp_path)
 
     run_id = "warn-run"
     runs_dir = tmp_path / "out" / "data" / "_runs" / "demo_ds" / "2022"
@@ -464,14 +427,7 @@ def test_cli_resume_success_with_warnings_allows_forced_from_layer(tmp_path: Pat
     _write_layer_artifacts(tmp_path / "out", "demo_ds", 2022, "clean")
     _write_layer_artifacts(tmp_path / "out", "demo_ds", 2022, "mart")
 
-    calls = {"raw": 0, "clean": 0, "mart": 0}
-
-    monkeypatch.setattr(cmd_run, "run_raw", lambda *args, **kwargs: calls.__setitem__("raw", calls["raw"] + 1))
-    monkeypatch.setattr(cmd_run, "run_clean", lambda *args, **kwargs: calls.__setitem__("clean", calls["clean"] + 1))
-    monkeypatch.setattr(cmd_run, "run_mart", lambda *args, **kwargs: calls.__setitem__("mart", calls["mart"] + 1))
-    monkeypatch.setattr(cmd_run, "run_raw_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
-    monkeypatch.setattr(cmd_run, "run_clean_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
-    monkeypatch.setattr(cmd_run, "run_mart_validation", lambda *args, **kwargs: {"passed": True, "errors_count": 0, "warnings_count": 0, "checks": []})
+    calls = _mock_all_runs(monkeypatch)
 
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_config_legacy.py
+++ b/tests/test_config_legacy.py
@@ -9,6 +9,41 @@ from toolkit.core.config import load_config
 from toolkit.core.config_models import load_config_model
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+YAML_BASE = {
+    "dataset": {"name": "demo", "years": [2022]},
+    "raw": {},
+    "clean": {},
+    "mart": {},
+}
+
+
+def _yml(path: Path, **overrides) -> Path:
+    """Write a dataset.yml merging YAML_BASE with per-test overrides.
+
+    Top-level keys in overrides replace their YAML_BASE counterparts.
+    """
+    import copy
+    import yaml
+
+    merged = copy.deepcopy(YAML_BASE)
+    merged.update(overrides)
+    path.write_text(yaml.safe_dump(merged, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _yml_str(path: Path, body: str) -> Path:
+    """Write a dataset.yml from an explicit multi-line YAML string.
+
+    Use for complex nested structures that are easier to express inline.
+    """
+    path.write_text(body.strip() + "\n", encoding="utf-8")
+    return path
+
+
 def _bind_config_logger(caplog, monkeypatch):
     module_logger = logging.getLogger("toolkit.core.config")
     monkeypatch.setattr(module_logger, "handlers", [caplog.handler])
@@ -21,7 +56,8 @@ def test_load_config_rejects_legacy_clean_read_csv_shape(tmp_path: Path):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
     yml = project_dir / "dataset.yml"
-    yml.write_text(
+    _yml_str(
+        yml,
         """
 dataset:
   name: demo
@@ -35,8 +71,7 @@ clean:
         amount: DOUBLE
       delim: ";"
 mart: {}
-""".strip(),
-        encoding="utf-8",
+""",
     )
 
     with pytest.raises(ValueError) as exc:
@@ -46,10 +81,9 @@ mart: {}
 
 
 def test_load_config_canonical_clean_read_has_no_deprecation_warning(tmp_path: Path, caplog):
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    yml = project_dir / "dataset.yml"
-    yml.write_text(
+    yml = tmp_path / "dataset.yml"
+    _yml_str(
+        yml,
         """
 dataset:
   name: demo
@@ -62,8 +96,7 @@ clean:
       amount: DOUBLE
     delim: ";"
 mart: {}
-""".strip(),
-        encoding="utf-8",
+""",
     )
 
     with caplog.at_level(logging.WARNING, logger="toolkit.core.config"):
@@ -79,7 +112,8 @@ mart: {}
 
 def test_load_config_normalizes_bool_and_string_list_fields(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
+    _yml_str(
+        yml,
         """
 dataset:
   name: demo
@@ -105,8 +139,7 @@ validation:
   fail_on_error: "false"
 output:
   legacy_aliases: "0"
-""".strip(),
-        encoding="utf-8",
+""",
     )
 
     cfg = load_config(yml)
@@ -125,19 +158,7 @@ output:
 
 def test_load_config_rejects_removed_bq_field(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-bq:
-  dataset: ignored
-clean: {}
-mart: {}
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml, bq={"dataset": "ignored"})
 
     with pytest.raises(ValueError) as exc:
         load_config(yml)
@@ -147,18 +168,7 @@ mart: {}
 
 def test_load_config_rejects_clean_sql_path(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean:
-  sql_path: sql/legacy_clean.sql
-mart: {}
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml, clean={"sql_path": "sql/legacy_clean.sql"})
 
     with pytest.raises(ValueError) as exc:
         load_config(yml)
@@ -168,18 +178,7 @@ mart: {}
 
 def test_load_config_rejects_mart_sql_dir(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean: {}
-mart:
-  sql_dir: sql/mart
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml, mart={"sql_dir": "sql/mart"})
 
     with pytest.raises(ValueError) as exc:
         load_config(yml)
@@ -189,7 +188,8 @@ mart:
 
 def test_load_config_model_rejects_legacy_raw_source_plugin_id_shape(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
+    _yml_str(
+        yml,
         """
 dataset:
   name: demo
@@ -202,8 +202,7 @@ raw:
       path: data/raw.csv
 clean: {}
 mart: {}
-""".strip(),
-        encoding="utf-8",
+""",
     )
 
     with pytest.raises(ValueError) as exc:
@@ -214,7 +213,8 @@ mart: {}
 
 def test_load_config_model_rejects_legacy_raw_sources_plugin_id_fields(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
+    _yml_str(
+        yml,
         """
 dataset:
   name: demo
@@ -227,8 +227,7 @@ raw:
         path: data/raw.csv
 clean: {}
 mart: {}
-""".strip(),
-        encoding="utf-8",
+""",
     )
 
     with pytest.raises(ValueError) as exc:
@@ -239,17 +238,7 @@ mart: {}
 
 def test_load_config_rejects_legacy_clean_read_scalar_form(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  name: demo
-  years: [2022]
-clean:
-  read: auto
-mart: {}
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml, clean={"read": "auto"})
 
     with pytest.raises(ValueError) as exc:
         load_config(yml)
@@ -259,18 +248,7 @@ mart: {}
 
 def test_load_config_warns_on_unknown_top_level_keys_in_non_strict_mode(tmp_path: Path, caplog, monkeypatch):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean: {}
-mart: {}
-unknown_top: true
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml, unknown_top=True)
 
     _bind_config_logger(caplog, monkeypatch)
 
@@ -284,18 +262,7 @@ unknown_top: true
 
 def test_load_config_model_rejects_unknown_top_level_keys_in_strict_mode(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  name: demo
-  years: [2022]
-raw: {}
-clean: {}
-mart: {}
-unknown_top: true
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml, unknown_top=True)
 
     with pytest.raises(ValueError) as exc:
         load_config_model(yml, strict_config=True)
@@ -306,18 +273,7 @@ unknown_top: true
 
 def test_load_config_model_rejects_non_mapping_config_block(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        """
-dataset:
-  name: demo
-  years: [2022]
-config: true
-raw: {}
-clean: {}
-mart: {}
-""".strip(),
-        encoding="utf-8",
-    )
+    _yml(yml, config=True)
 
     with pytest.raises(ValueError) as exc:
         load_config_model(yml)
@@ -626,7 +582,8 @@ def test_load_config_model_errors_are_explicit(tmp_path: Path, yaml_text: str, e
 
 def test_load_config_model_accepts_boolean_and_string_list_legacy_inputs(tmp_path: Path):
     yml = tmp_path / "dataset.yml"
-    yml.write_text(
+    _yml_str(
+        yml,
         """
 dataset:
   name: demo
@@ -652,8 +609,7 @@ validation:
   fail_on_error: "false"
 output:
   legacy_aliases: "0"
-""".strip(),
-        encoding="utf-8",
+""",
     )
 
     model = load_config_model(yml)


### PR DESCRIPTION
## Summary

Helper extraction per `test_cli_resume.py`:

- `_write_sql(base)`: consolida setup SQL (4 linee × 6 test)
- `_mock_all_runs(monkeypatch)`: consolida monkeypatch block (6 linee × 5 test)

| | Prima | Dopo | Delta |
|---|---|---|---|
| LOC | 497 | 453 | **-44** |
| Test functions | 7 | 7 | 0 |

## Verifica

```bash
python -m pytest tests/test_cli_resume.py -q --tb=short  # 7 passed
ruff check tests/test_cli_resume.py                       # OK
python scripts/quality/check_tests.py                       # ok
```