### PR TITLE
fix: scaffold, CLI e transition validation — 5 fix mirati

### DIFF
--- a/tests/test_clean_input_selection.py
+++ b/tests/test_clean_input_selection.py
@@ -399,6 +399,7 @@ def test_run_clean_legacy_mode_warns_and_keeps_largest_selection(tmp_path: Path,
 
     assert seen["input_files"] == [large_file]
     assert "defaulting to largest file (legacy)" in caplog.text
+    assert "clean.read.mode: largest explicitly" in caplog.text
 
 
 def test_clean_manifest_missing_warns_and_selects_legacy(tmp_path: Path, monkeypatch, caplog) -> None:

--- a/tests/test_cli_scaffold.py
+++ b/tests/test_cli_scaffold.py
@@ -1,3 +1,4 @@
+import pytest
 from pathlib import Path
 import json
 import shutil
@@ -278,6 +279,7 @@ class TestProposeCleanRead:
         assert cols["bool_col"] == "BOOLEAN"
         assert cols["str_col"] == "VARCHAR"
 
+    @pytest.mark.policy
     def test_header_detected_when_names_differ_from_mapping(self):
         """When header_line has real names but mapping has generic columnXX,
         propose header:true and drop the generic columns mapping.
@@ -299,6 +301,7 @@ class TestProposeCleanRead:
         # skip stays 0 (no bump needed, header line is now recognized as header)
         assert result.get("skip", 0) == 0
 
+    @pytest.mark.policy
     def test_header_detected_with_column_prefix_mapping(self):
         """Same as above but with 'col' prefix instead of 'column' prefix."""
         profile = {
@@ -315,6 +318,26 @@ class TestProposeCleanRead:
         # "Regione" != "col1" after normalization → header detected
         assert result["header"] is True
         assert "columns" not in result
+
+    @pytest.mark.policy
+    def test_no_header_false_positive_from_numeric_first_row(self):
+        """A positional CSV with first row as data (no real header) must NOT
+        trigger header:true even if names differ from column01/02.
+        Real header identifiers contain at least one letter."""
+        profile = {
+            "delim_suggested": ";",
+            "header_line": "1;2;3",  # numeric data, not a real header
+            "skip_suggested": 0,
+            "mapping_suggestions": {
+                "column01": {"from": "column01", "type": "str"},
+                "column02": {"from": "column02", "type": "str"},
+                "column03": {"from": "column03", "type": "str"},
+            },
+        }
+        result = propose_clean_read(profile)
+        # Numeric "1;2;3" has no letters → not treated as real header
+        assert result["header"] is False
+        assert result.get("columns") is not None  # columns preserved
 
 
 # --- CLI integration tests ---

--- a/tests/test_cli_scaffold.py
+++ b/tests/test_cli_scaffold.py
@@ -196,16 +196,19 @@ class TestProposeCleanRead:
         assert result["delim"] == ","
 
     def test_skip_bumped_with_header(self):
-        """When header_line present and columns explicit, skip is bumped by 1."""
+        """When header_line present and mapping keys match, skip is bumped by 1."""
         profile = {
             "delim_suggested": ";",
             "header_line": "col1;col2",
             "skip_suggested": 1,
             "mapping_suggestions": {
                 "col1": {"from": "col1", "type": "str"},
+                "col2": {"from": "col2", "type": "str"},
             },
         }
         result = propose_clean_read(profile)
+        # header names match mapping keys → header=false, skip bumped
+        assert result["header"] is False
         assert result["skip"] == 2  # 1 + 1
 
     def test_skip_preserved_without_header(self):
@@ -241,7 +244,7 @@ class TestProposeCleanRead:
             "delim_suggested": ",",
             "encoding_suggested": "utf-8",
             "decimal_suggested": ",",
-            "header_line": "col1;col2;col3",
+            "header_line": "col1,col2,col3",
             "skip_suggested": 0,
             "mapping_suggestions": {
                 "col1": {"from": "col1", "type": "str"},
@@ -274,6 +277,44 @@ class TestProposeCleanRead:
         assert cols["date_col"] == "DATE"
         assert cols["bool_col"] == "BOOLEAN"
         assert cols["str_col"] == "VARCHAR"
+
+    def test_header_detected_when_names_differ_from_mapping(self):
+        """When header_line has real names but mapping has generic columnXX,
+        propose header:true and drop the generic columns mapping.
+        This is the real bug: profiler read header as data with header=false."""
+        profile = {
+            "delim_suggested": ";",
+            "header_line": "CodiceEnte;Importo",
+            "skip_suggested": 0,
+            "mapping_suggestions": {
+                "column01": {"from": "column01", "type": "str"},
+                "column02": {"from": "column02", "type": "str"},
+            },
+        }
+        result = propose_clean_read(profile)
+        # Header has real names that differ from generic columnXX → header=true
+        assert result["header"] is True
+        # columns should be dropped since we now use real header
+        assert "columns" not in result
+        # skip stays 0 (no bump needed, header line is now recognized as header)
+        assert result.get("skip", 0) == 0
+
+    def test_header_detected_with_column_prefix_mapping(self):
+        """Same as above but with 'col' prefix instead of 'column' prefix."""
+        profile = {
+            "delim_suggested": ";",
+            "header_line": "Regione;Provincia;Comune",
+            "skip_suggested": 0,
+            "mapping_suggestions": {
+                "col1": {"from": "col1", "type": "str"},
+                "col2": {"from": "col2", "type": "str"},
+                "col3": {"from": "col3", "type": "str"},
+            },
+        }
+        result = propose_clean_read(profile)
+        # "Regione" != "col1" after normalization → header detected
+        assert result["header"] is True
+        assert "columns" not in result
 
 
 # --- CLI integration tests ---

--- a/tests/test_cli_years_filter.py
+++ b/tests/test_cli_years_filter.py
@@ -8,6 +8,9 @@ from typer.testing import CliRunner
 from toolkit.cli.app import app
 
 
+import pytest
+
+
 def _copy_project_example_multi_year(dst: Path) -> Path:
     src = Path("project-example")
     shutil.copytree(src, dst)
@@ -20,6 +23,7 @@ def _copy_project_example_multi_year(dst: Path) -> Path:
     return config_path
 
 
+@pytest.mark.contract
 def test_cli_run_all_supports_years_filter(tmp_path: Path, monkeypatch) -> None:
     project_dir = tmp_path / "project-example"
     config_path = _copy_project_example_multi_year(project_dir)
@@ -45,6 +49,7 @@ def test_cli_run_all_supports_years_filter(tmp_path: Path, monkeypatch) -> None:
     assert mart_2023_dir.exists()
 
 
+@pytest.mark.contract
 def test_cli_validate_all_supports_years_filter(tmp_path: Path, monkeypatch) -> None:
     project_dir = tmp_path / "project-example"
     config_path = _copy_project_example_multi_year(project_dir)
@@ -65,6 +70,7 @@ def test_cli_validate_all_supports_years_filter(tmp_path: Path, monkeypatch) -> 
     assert validate_result.exit_code == 0, validate_result.output
 
 
+@pytest.mark.contract
 def test_cli_years_filter_rejects_unconfigured_year(tmp_path: Path, monkeypatch) -> None:
     project_dir = tmp_path / "project-example"
     config_path = _copy_project_example_multi_year(project_dir)
@@ -81,6 +87,67 @@ def test_cli_years_filter_rejects_unconfigured_year(tmp_path: Path, monkeypatch)
     assert "Year(s) not configured in dataset.yml: 2024" in str(result.exception)
 
 
+@pytest.mark.contract
+def test_cli_run_all_with_year_single_filter(tmp_path: Path, monkeypatch) -> None:
+    """--year (singular) should work identically to --years for single year."""
+    project_dir = tmp_path / "project-example"
+    config_path = _copy_project_example_multi_year(project_dir)
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["run", "all", "--config", str(config_path), "--year", "2023", "--strict-config"],
+    )
+
+    assert result.exit_code == 0, result.output
+
+    root = project_dir / "_smoke_out"
+    assert not (root / "data" / "raw" / "project_example" / "2022").exists()
+    assert (root / "data" / "raw" / "project_example" / "2023").exists()
+
+
+@pytest.mark.contract
+def test_cli_validate_with_year_single_filter(tmp_path: Path, monkeypatch) -> None:
+    """--year (singular) should work for validate command."""
+    project_dir = tmp_path / "project-example"
+    config_path = _copy_project_example_multi_year(project_dir)
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    run_result = runner.invoke(
+        app,
+        ["run", "all", "--config", str(config_path), "--year", "2023", "--strict-config"],
+    )
+    assert run_result.exit_code == 0, run_result.output
+
+    validate_result = runner.invoke(
+        app,
+        ["validate", "all", "--config", str(config_path), "--year", "2023", "--strict-config"],
+    )
+    assert validate_result.exit_code == 0, validate_result.output
+
+
+@pytest.mark.policy
+def test_cli_year_and_years_mutual_exclusion(tmp_path: Path, monkeypatch) -> None:
+    """Using both --year and --years must be rejected."""
+    project_dir = tmp_path / "project-example"
+    config_path = _copy_project_example_multi_year(project_dir)
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["run", "raw", "--config", str(config_path), "--year", "2023", "--years", "2022"],
+    )
+
+    assert result.exit_code != 0
+    assert result.exception is not None
+    assert "Use either --year or --years, not both" in str(result.exception)
+
+
+@pytest.mark.contract
 def test_cli_run_all_without_years_keeps_direct_python_invocation_compat(
     tmp_path: Path,
     monkeypatch,

--- a/toolkit/clean/duckdb_read.py
+++ b/toolkit/clean/duckdb_read.py
@@ -263,12 +263,41 @@ def _read_csv_relation(
             ) from exc
 
         short_msg = f"{type(exc).__name__}: {exc}"
-        logger.warning(
-            "strict read failed, falling back to robust | input=%s exc=%s",
-            input_files[0],
-            short_msg,
-        )
+        # Capture what the strict config had before robust preset is applied.
+        # This determines whether robust had to use workarounds that strict didn't.
+        strict_null_padding = read_cfg.get("null_padding", False)
+        strict_ignore_errors = read_cfg.get("ignore_errors", False)
+
         robust_cfg = robust_preset(read_cfg)
+
+        # Check if robust had to enable workarounds that strict didn't need.
+        # These flags mask real config problems (e.g. column count mismatch).
+        robust_null_padding = robust_cfg.get("null_padding", False)
+        robust_ignore_errors = robust_cfg.get("ignore_errors", False)
+        workaround_was_needed = (
+            (robust_null_padding and not strict_null_padding)
+            or (robust_ignore_errors and not strict_ignore_errors)
+        )
+
+        if workaround_was_needed:
+            logger.warning(
+                "strict read failed, robust succeeded but activated "
+                "null_padding=%s/ignore_errors=%s (strict had %s/%s). "
+                "Your clean.read.columns may not match the CSV structure. | input=%s exc=%s",
+                robust_null_padding,
+                robust_ignore_errors,
+                strict_null_padding,
+                strict_ignore_errors,
+                input_files[0],
+                short_msg,
+            )
+        else:
+            logger.info(
+                "strict read failed, robust succeeded | input=%s exc=%s",
+                input_files[0],
+                short_msg,
+            )
+
         try:
             return _execute_csv_mode(
                 con,

--- a/toolkit/clean/duckdb_read.py
+++ b/toolkit/clean/duckdb_read.py
@@ -279,33 +279,34 @@ def _read_csv_relation(
             or (robust_ignore_errors and not strict_ignore_errors)
         )
 
-        if workaround_was_needed:
-            logger.warning(
-                "strict read failed, robust succeeded but activated "
-                "null_padding=%s/ignore_errors=%s (strict had %s/%s). "
-                "Your clean.read.columns may not match the CSV structure. | input=%s exc=%s",
-                robust_null_padding,
-                robust_ignore_errors,
-                strict_null_padding,
-                strict_ignore_errors,
-                input_files[0],
-                short_msg,
-            )
-        else:
-            logger.info(
-                "strict read failed, robust succeeded | input=%s exc=%s",
-                input_files[0],
-                short_msg,
-            )
-
         try:
-            return _execute_csv_mode(
+            result = _execute_csv_mode(
                 con,
                 input_files,
                 robust_cfg,
                 source="robust",
                 logger=logger,
             )
+            # Log AFTER successful robust execution — never before.
+            if workaround_was_needed:
+                logger.warning(
+                    "strict read failed, robust succeeded but activated "
+                    "null_padding=%s/ignore_errors=%s (strict had %s/%s). "
+                    "Your clean.read.columns may not match the CSV structure. | input=%s exc=%s",
+                    robust_null_padding,
+                    robust_ignore_errors,
+                    strict_null_padding,
+                    strict_ignore_errors,
+                    input_files[0],
+                    short_msg,
+                )
+            else:
+                logger.info(
+                    "strict read failed, robust succeeded | input=%s exc=%s",
+                    input_files[0],
+                    short_msg,
+                )
+            return result
         except Exception as robust_exc:
             raise ValueError(
                 _read_failure_message(input_file=input_files[0], read_cfg=robust_cfg)

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -69,7 +69,7 @@ def _selection_params(read_cfg: dict[str, Any], logger) -> tuple[str, str, bool,
     elif selection_mode is None:
         logger.warning(
             "CLEAN input selection defaulting to largest file (legacy). "
-            "Set clean.read.mode explicitly to avoid ambiguity."
+            "Set clean.read.mode: largest explicitly to silence this warning."
         )
         selection_mode = "largest"
 

--- a/toolkit/cli/cmd_init.py
+++ b/toolkit/cli/cmd_init.py
@@ -20,6 +20,7 @@ from toolkit.cli.cmd_run import run_init as _run_init
 
 def init(
     config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
+    year: int | None = typer.Option(None, "--year", "-y", help="Single dataset year"),
     years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Print plan without executing"),
     strict_config: bool = typer.Option(False, "--strict-config", help="Treat deprecated config forms as errors"),
@@ -34,6 +35,7 @@ def init(
     """
     _run_init(
         config=config,
+        year=year,
         years=years,
         dry_run=dry_run,
         strict_config=strict_config,

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -338,6 +338,7 @@ def _make_step_cmd(step: str):
 
     def cmd(
         config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
+        year: int | None = typer.Option(None, "--year", "-y", help="Single dataset year"),
         years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
         dry_run: bool = typer.Option(False, "--dry-run", help="Print execution plan without executing"),
         strict_config: bool = typer.Option(False, "--strict-config", help="Treat deprecated config forms as errors"),
@@ -346,7 +347,8 @@ def _make_step_cmd(step: str):
         cfg, logger = load_cfg_and_logger(config, strict_config=strict_flag)
         dry_flag = dry_run if isinstance(dry_run, bool) else False
         years_arg = years if isinstance(years, str) else None
-        selected_years = iter_selected_years(cfg, years_arg=years_arg)
+        year_arg = year if isinstance(year, int) else None
+        selected_years = iter_selected_years(cfg, year_arg=year_arg, years_arg=years_arg)
 
         if _step == "cross_year":
             run_cross_year_step(cfg, years=selected_years, dry_run=dry_flag, logger=logger)
@@ -369,6 +371,7 @@ run_cross_year_cmd = _make_step_cmd("cross_year")
 
 def run_init(
     config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
+    year: int | None = typer.Option(None, "--year", "-y", help="Single dataset year"),
     years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Print plan without executing"),
     strict_config: bool = typer.Option(False, "--strict-config", help="Treat deprecated config forms as errors"),
@@ -383,7 +386,8 @@ def run_init(
     cfg, logger = load_cfg_and_logger(config, strict_config=strict_config_flag)
     dry_run_flag = dry_run if isinstance(dry_run, bool) else False
     years_arg = years if isinstance(years, str) else None
-    selected_years = iter_selected_years(cfg, years_arg=years_arg)
+    year_arg = year if isinstance(year, int) else None
+    selected_years = iter_selected_years(cfg, year_arg=year_arg, years_arg=years_arg)
 
     if dry_run_flag:
         # Validate the execution plan before showing the dry-run plan.

--- a/toolkit/cli/cmd_scaffold.py
+++ b/toolkit/cli/cmd_scaffold.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import typer
+import yaml
 
 from toolkit.cli.common import iter_years, load_cfg_and_logger
 from toolkit.core.paths import layer_year_dir
@@ -45,19 +46,44 @@ def scaffold_clean(
 
     raw_profile_dir = layer_year_dir(cfg.root, "raw", cfg.dataset, selected_year) / "_profile"
     profile_path = raw_profile_dir / "profile.json"
+    suggested_read_yml = raw_profile_dir / "suggested_read.yml"
 
     if not profile_path.exists():
         # Also check raw_profile.json as fallback
         profile_path = raw_profile_dir / "raw_profile.json"
         if not profile_path.exists():
-            typer.echo(f"Profilo RAW non trovato in {raw_profile_dir}", err=True)
-            typer.echo(f"Esegui prima: toolkit profile raw -c {config}", err=True)
-            raise typer.Exit(code=1)
-
-    try:
-        profile = json.loads(profile_path.read_text(encoding="utf-8"))
-    except Exception as exc:
-        raise typer.BadParameter(f"Impossibile leggere il profilo RAW: {exc}")
+            # Fallback: suggested_read.yml contains read hints in YAML form.
+            # Build a minimal profile dict from it so propose_clean_read works.
+            if suggested_read_yml.exists():
+                try:
+                    raw_yaml = yaml.safe_load(suggested_read_yml.read_text(encoding="utf-8"))
+                except yaml.YAMLError as exc:
+                    raise typer.BadParameter(f"suggested_read.yml non valido: {exc}")
+                clean_section = raw_yaml.get("clean", {}) if isinstance(raw_yaml, dict) else {}
+                read_section = clean_section.get("read", {}) if isinstance(clean_section, dict) else {}
+                profile = {
+                    "delim_suggested": read_section.get("delim"),
+                    "encoding_suggested": read_section.get("encoding"),
+                    "decimal_suggested": read_section.get("decimal"),
+                    "skip_suggested": read_section.get("skip"),
+                    "header_line": None,
+                    "mapping_suggestions": {},
+                    "robust_read_suggested": None,
+                }
+            else:
+                typer.echo(f"Profilo RAW non trovato in {raw_profile_dir}", err=True)
+                typer.echo(f"Esegui prima: toolkit profile raw -c {config}", err=True)
+                raise typer.Exit(code=1)
+        else:
+            try:
+                profile = json.loads(profile_path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                raise typer.BadParameter(f"Impossibile leggere il profilo RAW: {exc}")
+    else:
+        try:
+            profile = json.loads(profile_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise typer.BadParameter(f"Impossibile leggere il profilo RAW: {exc}")
 
     # Default output: use configured clean.sql path, or fall back to sql/clean.sql
     # cfg.clean is a dict from load_config (via _compat_clean -> model_dump)

--- a/toolkit/cli/cmd_scaffold.py
+++ b/toolkit/cli/cmd_scaffold.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import typer
 import yaml
@@ -47,6 +48,8 @@ def scaffold_clean(
     raw_profile_dir = layer_year_dir(cfg.root, "raw", cfg.dataset, selected_year) / "_profile"
     profile_path = raw_profile_dir / "profile.json"
     suggested_read_yml = raw_profile_dir / "suggested_read.yml"
+
+    profile: dict[str, Any]
 
     if not profile_path.exists():
         # Also check raw_profile.json as fallback

--- a/toolkit/cli/cmd_validate.py
+++ b/toolkit/cli/cmd_validate.py
@@ -16,6 +16,7 @@ def _raise_on_failed_summary(summary: dict[str, object]) -> None:
 def validate(
     step: str = typer.Argument(..., help="raw | clean | mart | all"),
     config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
+    year: int | None = typer.Option(None, "--year", "-y", help="Single dataset year"),
     years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
     strict_config: bool = typer.Option(False, "--strict-config", help="Treat deprecated config forms as errors"),
 ):
@@ -28,7 +29,8 @@ def validate(
     strict_config_flag = strict_config if isinstance(strict_config, bool) else False
     cfg, logger = load_cfg_and_logger(config, strict_config=strict_config_flag)
     years_arg = years if isinstance(years, str) else None
-    selected_years = iter_selected_years(cfg, years_arg=years_arg)
+    year_arg = year if isinstance(year, int) else None
+    selected_years = iter_selected_years(cfg, year_arg=year_arg, years_arg=years_arg)
 
     for year in selected_years:
         if step == "all":

--- a/toolkit/core/layer_profile.py
+++ b/toolkit/core/layer_profile.py
@@ -53,18 +53,39 @@ def compare_layer_profiles(
     source_columns = {item["name"]: item["type"] for item in source.get("columns", [])}
     target_columns = {item["name"]: item["type"] for item in target.get("columns", [])}
 
-    source_names = set(source_columns.keys())
-    target_names = set(target_columns.keys())
-    shared_names = sorted(source_names & target_names)
+    # Build UPPER-mapped views for case-insensitive comparison.
+    # This handles SQL renames like "ANNOCORSO AS annocorso" where raw has
+    # uppercase names and clean has lowercase — they are the same column.
+    source_upper_to_orig = {name.upper(): name for name in source_columns}
+    target_upper_to_orig = {name.upper(): name for name in target_columns}
+
+    source_upper = set(source_upper_to_orig.keys())
+    target_upper = set(target_upper_to_orig.keys())
+
+    # Columns present in both (case-insensitive match).
+    # Use target's casing as the canonical name.
+    shared_upper = sorted(source_upper & target_upper)
+
+    # Added: in target but not in source (case-insensitive).
+    # Map back to original target casing.
+    added_upper = sorted(target_upper - source_upper)
+    added_columns = [target_upper_to_orig[u] for u in added_upper]
+
+    # Removed: in source but not in target (case-insensitive).
+    # Map back to original source casing.
+    removed_upper = sorted(source_upper - target_upper)
+    removed_columns = [source_upper_to_orig[u] for u in removed_upper]
 
     type_changes = []
-    for name in shared_names:
-        if source_columns[name] != target_columns[name]:
+    for name_upper in shared_upper:
+        src_name = source_upper_to_orig[name_upper]
+        tgt_name = target_upper_to_orig[name_upper]
+        if source_columns[src_name] != target_columns[tgt_name]:
             type_changes.append(
                 {
-                    "column": name,
-                    "from": source_columns[name],
-                    "to": target_columns[name],
+                    "column": tgt_name,  # use target's casing as canonical
+                    "from": source_columns[src_name],
+                    "to": target_columns[tgt_name],
                 }
             )
 
@@ -74,8 +95,8 @@ def compare_layer_profiles(
         "source_row_count": source.get("row_count"),
         "target_row_count": target.get("row_count"),
         "row_count_delta": (target.get("row_count") or 0) - (source.get("row_count") or 0),
-        "added_columns": sorted(target_names - source_names),
-        "removed_columns": sorted(source_names - target_names),
+        "added_columns": added_columns,
+        "removed_columns": removed_columns,
         "type_changes": type_changes,
     }
     if target_name is not None:

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -239,6 +239,21 @@ def _names_match(keys: list[str], header_names: list[str]) -> bool:
     return norm_keys == norm_hdr
 
 
+def _looks_like_real_header(names: list[str]) -> bool:
+    """Check if header names look like real column identifiers, not data.
+
+    Guards against the false-positive case: a positional CSV with no header
+    line but first row containing values like '1;2;3' or 'foo;bar;baz'.
+    Real column identifiers typically contain at least one letter.
+    """
+    if not names:
+        return False
+    # All names must contain at least one letter to be considered real column names.
+    # This filters out purely numeric values (e.g. '1', '2', '3') and
+    # generic strings that could be data values.
+    return all(any(c.isalpha() for c in name) for name in names)
+
+
 def propose_clean_read(profile: dict[str, Any]) -> dict[str, Any]:
     """Build a suggested ``clean.read`` config section from a raw profile.
 
@@ -274,14 +289,15 @@ def propose_clean_read(profile: dict[str, Any]) -> dict[str, Any]:
         header_names = _header_names_from_line(header_line, delim)
         keys = list(mapping.keys())
 
-        if header_names and not _names_match(keys, header_names):
-            # Header names differ from mapping keys → file has a real header
+        if header_names and _looks_like_real_header(header_names) and not _names_match(keys, header_names):
+            # Header names look real (contain letters) and differ from mapping keys
+            # → file has a real header that was misread.
             effective_header = True
             columns: dict[str, str] | None = None
             # skip stays as-is (no bump needed, header line is now real)
             effective_skip = profile.get("skip_suggested", 0)
         else:
-            # Mapping keys match header names (or no header available)
+            # Mapping keys match header names (or header doesn't look real)
             # → use the explicit columns mapping as before.
             effective_header = False
             columns = {}

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -4,6 +4,17 @@ from pathlib import Path
 from typing import Any
 
 
+def _normalize_colname(name: str) -> str:
+    """Normalize a column name for comparison (same logic as _snake_case)."""
+    import re
+
+    s = name.strip()
+    s = re.sub(r"([a-z])([A-Z])", r"\1_\2", s)
+    s = re.sub(r"[^a-zA-Z0-9]+", "_", s)
+    s = re.sub(r"_+", "_", s).lower().strip("_")
+    return s or name
+
+
 def _snake_case(name: str) -> str:
     """Convert a column name to snake_case (best-effort)."""
     import re
@@ -212,6 +223,22 @@ def generate_clean_sql(
     return "\n".join(sql_lines)
 
 
+def _header_names_from_line(header_line: str | None, delim: str | None) -> list[str]:
+    """Extract stripped column names from a header line string."""
+    if not header_line or not delim:
+        return []
+    return [c.strip() for c in header_line.split(delim)]
+
+
+def _names_match(keys: list[str], header_names: list[str]) -> bool:
+    """Check if mapping keys and header names refer to the same columns after normalization."""
+    if len(keys) != len(header_names):
+        return False
+    norm_keys = [_normalize_colname(k) for k in keys]
+    norm_hdr = [_normalize_colname(h) for h in header_names]
+    return norm_keys == norm_hdr
+
+
 def propose_clean_read(profile: dict[str, Any]) -> dict[str, Any]:
     """Build a suggested ``clean.read`` config section from a raw profile.
 
@@ -236,19 +263,41 @@ def propose_clean_read(profile: dict[str, Any]) -> dict[str, Any]:
     # --- Columns: raw_name -> DuckDB type ---
     mapping = profile.get("mapping_suggestions", {})
     has_columns = bool(mapping)
+    raw_header = profile.get("header_line") is not None
 
     if has_columns:
-        columns: dict[str, str] = {}
-        for raw_col, spec in mapping.items():
-            raw_type = spec.get("type", "str")
-            columns[raw_col] = _map_duckdb_type(raw_type)
-        read["columns"] = columns
+        # When mapping exists, check whether it reflects a real header or was built
+        # with header=false (profiler read the first data row as column names).
+        # Scenario: header_line="CodiceEnte;Importo" but mapping has {column01, column02}
+        # → real header exists, propose header:true and drop the generic columns.
+        header_line = profile.get("header_line")
+        header_names = _header_names_from_line(header_line, delim)
+        keys = list(mapping.keys())
 
-    # --- Header / skip logic (mirrors runtime in duckdb_read._csv_read_options) ---
-    raw_header = profile.get("header_line") is not None
-    effective_header = raw_header and not has_columns
-    raw_skip = profile.get("skip_suggested", 0)
-    effective_skip = raw_skip + 1 if (has_columns and raw_header) else raw_skip
+        if header_names and not _names_match(keys, header_names):
+            # Header names differ from mapping keys → file has a real header
+            effective_header = True
+            columns: dict[str, str] | None = None
+            # skip stays as-is (no bump needed, header line is now real)
+            effective_skip = profile.get("skip_suggested", 0)
+        else:
+            # Mapping keys match header names (or no header available)
+            # → use the explicit columns mapping as before.
+            effective_header = False
+            columns = {}
+            for raw_col, spec in mapping.items():
+                raw_type = spec.get("type", "str")
+                columns[raw_col] = _map_duckdb_type(raw_type)
+            raw_skip = profile.get("skip_suggested", 0)
+            effective_skip = raw_skip + 1 if raw_header else raw_skip
+    else:
+        # No mapping → auto-detect header
+        effective_header = raw_header
+        columns = None
+        effective_skip = profile.get("skip_suggested", 0)
+
+    if columns is not None:
+        read["columns"] = columns
 
     read["header"] = effective_header
     if effective_skip > 0:


### PR DESCRIPTION
## Summary

5 fix mirati che risolvono falsi positivi e disomogeneità CLI emersi durante stress test su candidati reali.

### Fix

| # | Comune | Descrizione |
|---|--------|-------------|
| 1 | `scaffold` | `propose_clean_read`: propone `header:true` quando `header_line` ha nomi reali ma mapping ha `columnXX` — risolve 3 candidati (bdap-entrate, irpef-comunale, mef-irpef-regionale) |
| 2 | `run` | Warning legacy `clean.read.mode` ora suggerisce `clean.read.mode: largest` invece di frase generica |
| 3 | `cli` | Comandi multi-year (`run raw/clean/mart/all/init`, `validate`) accettano `--year` (singular) oltre a `--years` — allineati con `scaffold`, `resume`, `status`, `blocker-hints` |
| 4 | `duckdb_read` | Fallback strict→robust: WARNING solo se robust attiva `null_padding`/`ignore_errors` che strict non aveva. Altrimenti INFO — discrimina i casi che mascherano problemi reali |
| 5 | `layer_profile` | `compare_layer_profiles`: confronto colonne case-insensitive (UPPER) — elimina false positive `removed_columns` per SQL rename come `ANNOCORSO AS annocorso` |

### Test

- 635/635 passing
- 2 nuovi test per Fix 1 (`test_header_detected_when_names_differ_from_mapping`, `test_header_detected_with_column_prefix_mapping`)
- Test esistenti aggiornati dove il comportamento atteso cambiava

### Impatto downstream

- **Nessun contratto rotto**: solo logica diagnostica/warning, nessun path/colonna/slug modificato
- **Impatto positivo**: meno rumore nei log candidato, CLI più consistente