### PR TITLE
fix: XLSX profiler — 4 fix per binary detection e schema diff skip

### DIFF
--- a/tests/test_cli_blocker_hints.py
+++ b/tests/test_cli_blocker_hints.py
@@ -408,3 +408,211 @@ mart:
 
         assert result.exit_code == 0
         assert "blockers: 0" in result.output
+
+    @pytest.mark.policy
+    def test_blocker_hints_detects_binary_file_not_comparable(self, tmp_path: Path, monkeypatch) -> None:
+        """policy: XLSX binary file in raw_profile.json emits raw_binary_file_not_comparable blocker."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        config_path = project_dir / "dataset.yml"
+
+        config_path.write_text(
+            """
+root: "./out"
+dataset:
+  name: test_ds
+  years: [2023]
+raw:
+  sources:
+    - name: src
+      type: local_file
+      args:
+        path: "input.xlsx"
+        filename: "input_{year}.xlsx"
+clean:
+  sql: "sql/clean.sql"
+mart:
+  tables:
+    - name: test_table
+      sql: "sql/mart/test_table.sql"
+            """.strip(),
+            encoding="utf-8",
+        )
+
+        sql_dir = project_dir / "sql" / "mart"
+        sql_dir.mkdir(parents=True, exist_ok=True)
+        (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+        (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
+
+        raw_dir = project_dir / "out" / "data" / "raw" / "test_ds" / "2023"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / "input_2023.xlsx").write_bytes(b"PK\x03\x04\x14\x00\x00")
+        (raw_dir / "manifest.json").write_text(
+            json.dumps({"primary_output_file": "input_2023.xlsx"}),
+            encoding="utf-8",
+        )
+        profile_dir = raw_dir / "_profile"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        (profile_dir / "raw_profile.json").write_text(
+            json.dumps(
+                {
+                    "dataset": "test_ds",
+                    "year": 2023,
+                    "file_used": "input_2023.xlsx",
+                    "is_binary_file": "xlsx",
+                    "columns_raw": [],
+                    "columns_norm": [],
+                    "warnings": ["binary_file_detected: xlsx — use sheet_name in dataset.yml"],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        clean_dir = project_dir / "out" / "data" / "clean" / "test_ds" / "2023"
+        clean_dir.mkdir(parents=True, exist_ok=True)
+        (clean_dir / "test_ds_2023_clean.parquet").write_text("dummy parquet", encoding="utf-8")
+        (clean_dir / "manifest.json").write_text(
+            json.dumps({"outputs": [{"file": "test_ds_2023_clean.parquet"}]}, indent=2),
+            encoding="utf-8",
+        )
+
+        mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
+        mart_dir.mkdir(parents=True, exist_ok=True)
+        (mart_dir / "test_table.parquet").write_text("dummy parquet", encoding="utf-8")
+        (mart_dir / "manifest.json").write_text(
+            json.dumps({"outputs": [{"file": "test_table.parquet"}]}, indent=2),
+            encoding="utf-8",
+        )
+
+        run_dir = project_dir / "out" / "data" / "_runs" / "test_ds" / "2023"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "run-abc.json").write_text(
+            json.dumps(
+                {
+                    "dataset": "test_ds",
+                    "year": 2023,
+                    "run_id": "run-abc",
+                    "status": "SUCCESS",
+                    "layers": {
+                        "raw": {"status": "SUCCESS"},
+                        "clean": {"status": "SUCCESS"},
+                        "mart": {"status": "SUCCESS"},
+                    },
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+        runner = CliRunner()
+
+        result = runner.invoke(
+            app,
+            [
+                "blocker-hints",
+                "--config",
+                str(config_path),
+                "--year",
+                "2023",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        blocker_codes = [h["code"] for h in payload["hints"] if h["severity"] == "blocker"]
+        assert "raw_binary_file_not_comparable" in blocker_codes
+
+    @pytest.mark.policy
+    def test_blocker_hints_detects_raw_probe_unavailable(self, tmp_path: Path, monkeypatch) -> None:
+        """policy: raw_probe_source=unavailable in run record emits raw_probe_unavailable blocker."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        config_path = project_dir / "dataset.yml"
+
+        config_path.write_text(
+            """
+root: "./out"
+dataset:
+  name: test_ds
+  years: [2023]
+raw: {}
+clean:
+  sql: "sql/clean.sql"
+mart:
+  tables:
+    - name: test_table
+      sql: "sql/mart/test_table.sql"
+            """.strip(),
+            encoding="utf-8",
+        )
+
+        sql_dir = project_dir / "sql" / "mart"
+        sql_dir.mkdir(parents=True, exist_ok=True)
+        (project_dir / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+        (sql_dir / "test_table.sql").write_text("select * from clean_input", encoding="utf-8")
+
+        raw_dir = project_dir / "out" / "data" / "raw" / "test_ds" / "2023"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+
+        clean_dir = project_dir / "out" / "data" / "clean" / "test_ds" / "2023"
+        clean_dir.mkdir(parents=True, exist_ok=True)
+        (clean_dir / "test_ds_2023_clean.parquet").write_text("dummy", encoding="utf-8")
+        (clean_dir / "manifest.json").write_text(
+            json.dumps({"outputs": [{"file": "test_ds_2023_clean.parquet"}]}, indent=2),
+            encoding="utf-8",
+        )
+
+        mart_dir = project_dir / "out" / "data" / "mart" / "test_ds" / "2023"
+        mart_dir.mkdir(parents=True, exist_ok=True)
+        (mart_dir / "test_table.parquet").write_text("dummy", encoding="utf-8")
+        (mart_dir / "manifest.json").write_text(
+            json.dumps({"outputs": [{"file": "test_table.parquet"}]}, indent=2),
+            encoding="utf-8",
+        )
+
+        run_dir = project_dir / "out" / "data" / "_runs" / "test_ds" / "2023"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "run-abc.json").write_text(
+            json.dumps(
+                {
+                    "dataset": "test_ds",
+                    "year": 2023,
+                    "run_id": "run-abc",
+                    "status": "SUCCESS",
+                    "layers": {
+                        "raw": {"status": "SUCCESS"},
+                        "clean": {"status": "SUCCESS"},
+                        "mart": {"status": "SUCCESS"},
+                    },
+                    "stats": {
+                        "raw_probe_source": "unavailable",
+                    },
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+        runner = CliRunner()
+
+        result = runner.invoke(
+            app,
+            [
+                "blocker-hints",
+                "--config",
+                str(config_path),
+                "--year",
+                "2023",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        blocker_codes = [h["code"] for h in payload["hints"] if h["severity"] == "blocker"]
+        assert "raw_probe_unavailable" in blocker_codes

--- a/tests/test_cli_inspect_schema_diff.py
+++ b/tests/test_cli_inspect_schema_diff.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from toolkit.cli.app import app
@@ -98,6 +99,7 @@ def test_inspect_schema_diff_reports_multi_year_changes(tmp_path: Path, monkeypa
     assert "contribuenti" in result.output
 
 
+@pytest.mark.policy
 def test_inspect_schema_diff_skips_binary_file(tmp_path: Path, monkeypatch) -> None:
     """XLSX files produce garbage header_line — schema diff must skip comparison."""
     config_path = _write_dataset_config(tmp_path)

--- a/tests/test_cli_inspect_schema_diff.py
+++ b/tests/test_cli_inspect_schema_diff.py
@@ -68,7 +68,7 @@ def _write_raw_year(
                     "decimal_suggested": ".",
                     "skip_suggested": 0,
                     "header_line": header_line,
-                    "columns_preview": header_line.split(delim),
+                    "columns_preview": header_line.split(delim) if header_line else [],
                     "warnings": [],
                 }
             }
@@ -96,6 +96,47 @@ def test_inspect_schema_diff_reports_multi_year_changes(tmp_path: Path, monkeypa
     assert "counts: 3 -> 4" in result.output
     assert "added_columns:" in result.output
     assert "contribuenti" in result.output
+
+
+def test_inspect_schema_diff_skips_binary_file(tmp_path: Path, monkeypatch) -> None:
+    """XLSX files produce garbage header_line — schema diff must skip comparison."""
+    config_path = _write_dataset_config(tmp_path)
+    root = tmp_path / "_out"
+    # 2022: CSV (normal)
+    _write_raw_year(root, 2022, "input_2022.csv", "anno,comune,imponibile")
+    # 2023: fake XLSX binary in metadata
+    raw_dir_2023 = root / "data" / "raw" / "schema_diff_example" / "2023"
+    raw_dir_2023.mkdir(parents=True, exist_ok=True)
+    (raw_dir_2023 / "input_2023.xlsx").write_bytes(b"PK\x03\x04\x14\x00\x00")
+    (raw_dir_2023 / "manifest.json").write_text(
+        json.dumps({"primary_output_file": "input_2023.xlsx"}),
+        encoding="utf-8",
+    )
+    (raw_dir_2023 / "metadata.json").write_text(
+        json.dumps(
+            {
+                "profile_hints": {
+                    "file_used": "input_2023.xlsx",
+                    "is_binary_file": "xlsx",
+                    "warnings": ["binary_file_detected: xlsx — use sheet_name in dataset.yml"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(
+        app, ["inspect", "schema-diff", "--config", str(config_path), "--json", "--strict-config"]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["entries"][0]["is_binary_file"] is None
+    assert payload["entries"][1]["is_binary_file"] == "xlsx"
+    assert payload["comparisons"][0]["skipped"] is True
+    assert payload["comparisons"][0]["reason"] == "binary_file_not_comparable"
 
 
 def test_inspect_schema_diff_json_degrades_when_raw_is_missing(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -245,6 +245,7 @@ def test_review_readiness_needs_review_with_single_failure(tmp_path: Path, monke
     assert payload["fail_count"] == 1
 
 
+@pytest.mark.policy
 def test_review_readiness_fails_when_raw_binary_file(tmp_path: Path, monkeypatch) -> None:
     """policy: binary file in raw_profile.json causes raw_profiling_available check to fail."""
     src = Path("project-example")

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -245,6 +245,62 @@ def test_review_readiness_needs_review_with_single_failure(tmp_path: Path, monke
     assert payload["fail_count"] == 1
 
 
+def test_review_readiness_fails_when_raw_binary_file(tmp_path: Path, monkeypatch) -> None:
+    """policy: binary file in raw_profile.json causes raw_profiling_available check to fail."""
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Raw dir with binary file and profile
+    raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "input_2022.xlsx").write_bytes(b"PK\x03\x04\x14\x00\x00")
+    profile_dir = raw_dir / "_profile"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "raw_profile.json").write_text(
+        json.dumps(
+            {
+                "dataset": "project_example",
+                "year": 2022,
+                "file_used": "input_2022.xlsx",
+                "is_binary_file": "xlsx",
+                "columns_raw": [],
+                "columns_norm": [],
+                "warnings": ["binary_file_detected: xlsx"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Clean present and readable
+    clean_dir = dst / "_smoke_out" / "data" / "clean" / "project_example" / "2022"
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    import duckdb
+
+    clean_parquet = clean_dir / "project_example_2022_clean.parquet"
+    with duckdb.connect(":memory:") as conn:
+        conn.execute("CREATE TABLE t AS SELECT 1 AS x")
+        conn.execute(f"COPY t TO '{clean_parquet}' (FORMAT PARQUET)")
+
+    # Mart present
+    mart_dir = dst / "_smoke_out" / "data" / "mart" / "project_example" / "2022"
+    mart_dir.mkdir(parents=True, exist_ok=True)
+    with duckdb.connect(":memory:") as conn:
+        conn.execute("CREATE TABLE t AS SELECT 1 AS x")
+        conn.execute(f"COPY t TO '{mart_dir / 'rd_by_regione.parquet'}' (FORMAT PARQUET)")
+
+    payload = review_readiness(str(config_path), 2022)
+    check_names = {c["check"] for c in payload["checks"]}
+    assert "raw_profiling_available" in check_names
+    profiling_check = next(c for c in payload["checks"] if c["check"] == "raw_profiling_available")
+    assert profiling_check["ok"] is False
+    # readiness is not "ready" because of the profiling failure
+    assert payload["readiness"] != "ready"
+
+
 def test_mcp_raw_profile_handles_suggested_read_yaml(tmp_path: Path, monkeypatch) -> None:
     """raw_profile deve cadere su suggested_read.yml quando raw_profile.json non esiste."""
     src = Path("project-example")

--- a/tests/test_profile_sniff.py
+++ b/tests/test_profile_sniff.py
@@ -208,6 +208,7 @@ def test_sniff_source_file_returns_all_keys(tmp_path: Path):
         "true_header_line",
         "columns_preview",
         "warnings",
+        "is_binary_file",
     }
     assert set(hints.keys()) == expected_keys
     assert hints["delim_suggested"] == ";"
@@ -355,3 +356,58 @@ def test_profile_raw_respects_primary_file_override(tmp_path: Path):
     # Must profile tipo_reddito.csv, not bonus.csv
     assert profile.file_used == "tipo_reddito.csv"
     assert profile.columns_raw == ["col_tipo_reddito"]
+
+
+@pytest.mark.policy
+def test_sniff_source_file_detects_xlsx_as_binary(tmp_path: Path):
+    """XLSX files are ZIP archives — sniff_source_file must detect and warn."""
+    from toolkit.profile.raw import sniff_source_file
+
+    xlsx_path = tmp_path / "data.xlsx"
+    # Minimal valid ZIP with XLSX magic bytes (PK\x03\x04).
+    xlsx_path.write_bytes(b"PK\x03\x04\x14\x00\x00\x00\x08\x00")
+    result = sniff_source_file(xlsx_path)
+    assert result["is_binary_file"] == "xlsx"
+    assert any("binary_file_detected: xlsx" in w for w in result["warnings"])
+
+
+@pytest.mark.policy
+def test_sniff_source_file_detects_xls_as_binary(tmp_path: Path):
+    """XLS files (OLE2 format) are detected as binary."""
+    from toolkit.profile.raw import sniff_source_file
+
+    xls_path = tmp_path / "data.xls"
+    # OLE2 magic bytes.
+    xls_path.write_bytes(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1\x00\x00")
+    result = sniff_source_file(xls_path)
+    assert result["is_binary_file"] == "xls"
+    assert any("binary_file_detected: xls" in w for w in result["warnings"])
+
+
+@pytest.mark.policy
+def test_sniff_source_file_regular_csv_unchanged(tmp_path: Path):
+    """Regular CSV files are not flagged as binary."""
+    from toolkit.profile.raw import sniff_source_file
+
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("col1,col2\n1,2\n3,4\n", encoding="utf-8")
+    result = sniff_source_file(csv_path)
+    assert result["is_binary_file"] is None
+    assert result["delim_suggested"] == ","
+    assert result["columns_preview"] == ["col1", "col2"]
+
+
+@pytest.mark.policy
+def test_profile_raw_returns_early_for_binary_file(tmp_path: Path):
+    """profile_raw returns a minimal profile without DuckDB CSV profiling for XLSX."""
+    from toolkit.profile.raw import profile_raw
+
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir(parents=True)
+    xlsx_path = raw_dir / "data.xlsx"
+    xlsx_path.write_bytes(b"PK\x03\x04\x14\x00\x00\x00\x08\x00")
+
+    profile = profile_raw(raw_dir, "demo", 2024)
+    assert profile.columns_raw == []
+    assert profile.columns_norm == []
+    assert any("binary_file_detected" in w for w in profile.warnings)

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -47,6 +47,10 @@ def _raw_schema_payload(cfg, year: int) -> dict[str, Any]:
     if sniff_error is not None:
         warnings.append(f"profile_hint_fallback_failed: {sniff_error}")
 
+    is_binary_file = profile_hints.get("is_binary_file")
+    if is_binary_file:
+        warnings.append(f"binary_file_detected: {is_binary_file} — schema not comparable")
+
     return {
         "year": year,
         "raw_dir": str(raw_dir),
@@ -54,6 +58,7 @@ def _raw_schema_payload(cfg, year: int) -> dict[str, Any]:
         "primary_output_file": raw_meta.get("primary_output_file"),
         "file_used": profile_hints.get("file_used"),
         "profile_source": profile_source,
+        "is_binary_file": is_binary_file,
         "encoding": profile_hints.get("encoding_suggested"),
         "delim": profile_hints.get("delim_suggested"),
         "decimal": profile_hints.get("decimal_suggested"),
@@ -68,6 +73,23 @@ def _raw_schema_payload(cfg, year: int) -> dict[str, Any]:
 def _compare_schema_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     comparisons: list[dict[str, Any]] = []
     for previous, current in zip(entries, entries[1:]):
+        # Binary files (XLSX/XLS) produce garbage columns_preview — skip comparison.
+        if previous.get("is_binary_file") or current.get("is_binary_file"):
+            comparisons.append(
+                {
+                    "from_year": previous["year"],
+                    "to_year": current["year"],
+                    "skipped": True,
+                    "reason": "binary_file_not_comparable",
+                    "from_columns_count": previous.get("columns_count") or 0,
+                    "to_columns_count": current.get("columns_count") or 0,
+                    "added_columns": [],
+                    "removed_columns": [],
+                    "changed": False,
+                }
+            )
+            continue
+
         previous_columns = set(previous.get("columns_preview") or [])
         current_columns = set(current.get("columns_preview") or [])
         comparisons.append(

--- a/toolkit/cli/inspect/schema_diff_ops.py
+++ b/toolkit/cli/inspect/schema_diff_ops.py
@@ -69,6 +69,10 @@ def schema_diff(
         typer.echo("comparisons:")
         for comparison in comparisons:
             typer.echo(f"  {comparison['from_year']} -> {comparison['to_year']}:")
+            if comparison.get("skipped"):
+                typer.echo("    skipped: true")
+                typer.echo(f"    reason: {comparison['reason']}")
+                continue
             typer.echo(
                 f"    counts: {comparison['from_columns_count']} -> {comparison['to_columns_count']}"
             )

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -154,6 +154,7 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
         "missingness_top": profile.get("missingness_top", []),
         "mapping_suggestions": profile.get("mapping_suggestions", {}),
         "warnings": profile.get("warnings", []),
+        "is_binary_file": profile.get("is_binary_file"),
         "profile_exists": True,
     }
 
@@ -575,9 +576,38 @@ def blocker_hints(config_path: str, year: int | None = None) -> dict[str, Any]:
                         {
                             "code": "run_says_mart_success_but_outputs_missing",
                             "severity": "blocker",
-                            "message": "run record dice mart SUCCESS ma nessun output file presente",
+                            "message": "run record dice mart SUCCESS ma nessun output presente",
                         }
                     )
+
+    # XLSX/XLS binary file detected during profiling — schema is not comparable
+    raw_profile_path = Path(raw.get("dir", "")) / "_profile" / "raw_profile.json"
+    if raw_profile_path.exists():
+        try:
+            raw_profile_data = json.loads(raw_profile_path.read_text(encoding="utf-8"))
+            is_binary = raw_profile_data.get("is_binary_file")
+            if is_binary:
+                hints.append(
+                    {
+                        "code": "raw_binary_file_not_comparable",
+                        "severity": "blocker",
+                        "message": f"file binario '{is_binary}' rilevato — profiling non disponibile, schema non comparabile",
+                    }
+                )
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # raw_probe_source unavailable in run stats
+    if run_record:
+        stats = run_record.get("stats") or {}
+        if stats.get("raw_probe_source") == "unavailable":
+            hints.append(
+                {
+                    "code": "raw_probe_unavailable",
+                    "severity": "blocker",
+                    "message": "raw profiling non disponibile (file mancante o illeggibile)",
+                }
+            )
 
     return {
         "dataset": s.get("dataset"),
@@ -712,6 +742,27 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
             "check": "run_record_coherent",
             "ok": run_coherent,
             "detail": run_detail,
+        }
+    )
+
+    # --- Binary file check ---
+    raw_profile_path = Path(raw.get("dir", "")) / "_profile" / "raw_profile.json"
+    binary_ok = True
+    binary_detail = "schema profiling ok"
+    if raw_profile_path.exists():
+        try:
+            raw_profile_data = json.loads(raw_profile_path.read_text(encoding="utf-8"))
+            is_binary = raw_profile_data.get("is_binary_file")
+            if is_binary:
+                binary_ok = False
+                binary_detail = f"file binario '{is_binary}' — profiling non disponibile per review"
+        except (json.JSONDecodeError, OSError):
+            pass
+    checks.append(
+        {
+            "check": "raw_profiling_available",
+            "ok": binary_ok,
+            "detail": binary_detail,
         }
     )
 

--- a/toolkit/profile/_sniff_encoding.py
+++ b/toolkit/profile/_sniff_encoding.py
@@ -7,6 +7,45 @@ from typing import Optional, Tuple
 
 COMMON_ENCODINGS = ["utf-8", "latin-1", "windows-1252", "CP1252"]
 
+# Recognised binary file magic bytes.
+# XLSX/XLSM/XLTX/XLTM are ZIP archives (PK prefix).
+KNOWN_BINARY_SIGNATURES = [
+    b"PK\x03\x04",  # ZIP / XLSX / DOCX / ODSX
+    b"\xd0\xcf\x11\xe0",  # OLE2 / XLS (pre-2007)
+]
+
+
+def _file_magic_bytes(filepath: Path, n: int = 4) -> bytes:
+    """Read the first n bytes of a file, or empty bytes on read error."""
+    try:
+        with filepath.open("rb") as f:
+            return f.read(n)
+    except Exception:
+        return b""
+
+
+def is_binary_file(filepath: Path) -> str | None:
+    """Check if a file is a known binary format by magic bytes.
+
+    Returns the detected format name (e.g. "xlsx", "xls") or None if the
+    file appears to be text.
+    """
+    magic = _file_magic_bytes(filepath)
+    for sig in KNOWN_BINARY_SIGNATURES:
+        if magic.startswith(sig):
+            # Distinguish xlsx from older xls by second signature byte.
+            if sig == b"PK\x03\x04":
+                ext = filepath.suffix.lower()
+                if ext in (".xlsx", ".xlsm", ".xltx", ".xltm"):
+                    return "xlsx"
+                elif ext in (".zip",):
+                    return "zip"
+                # PK without a known Excel extension — treat generically
+                return "zip"
+            if sig == b"\xd0\xcf\x11\xe0":
+                return "xls"
+    return None
+
 
 def _try_decode(filepath: Path, enc: str) -> Optional[str]:
     try:

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -20,7 +20,9 @@ from toolkit.core.csv_read import (
     sql_str,
 )
 from toolkit.core.io import write_json_atomic
-from toolkit.profile._sniff_encoding import sniff_encoding
+from toolkit.profile._sniff_encoding import sniff_encoding as _sniff_encoding
+from toolkit.profile._sniff_encoding import sniff_encoding as sniff_encoding  # re-export for backward compat
+from toolkit.profile._sniff_encoding import is_binary_file as _is_binary_file
 from toolkit.profile._sniff_delimiter import sniff_decimal, sniff_delim, suggest_skip
 from toolkit.profile._column_profile import _build_mapping_suggestions, _normalize_colname
 
@@ -58,8 +60,25 @@ def sniff_source_file(filepath: Path) -> Dict[str, Any]:
         - true_header_line (str | None): header text at line 0 (for mismatch detection)
         - columns_preview (list[str]): normalised column names from header_line
         - warnings (list[str]): issues detected during sniffing
+        - is_binary_file (str | None): set to "xlsx" / "xls" if binary format detected
     """
-    enc, txt = sniff_encoding(filepath)
+    # Detect binary files first — XLSX/XLS can't be profiled as CSV.
+    binary_fmt = _is_binary_file(filepath)
+    if binary_fmt:
+        return {
+            "file_used": filepath.name,
+            "encoding_suggested": None,
+            "delim_suggested": None,
+            "decimal_suggested": None,
+            "skip_suggested": 0,
+            "header_line": None,
+            "true_header_line": None,
+            "columns_preview": [],
+            "warnings": [f"binary_file_detected: {binary_fmt} — use sheet_name in dataset.yml"],
+            "is_binary_file": binary_fmt,
+        }
+
+    enc, txt = _sniff_encoding(filepath)
     delim = sniff_delim(txt)
     dec = sniff_decimal(txt)
     skip = suggest_skip(txt, delim)
@@ -72,6 +91,7 @@ def sniff_source_file(filepath: Path) -> Dict[str, Any]:
 
     header_line: str | None = None
     true_header_line: str | None = None
+    is_binary_file: str | None = None
 
     # Read header at skip offset (where DuckDB would start reading data).
     # This preserves backward-compatible header_line for suggested_read.
@@ -103,6 +123,7 @@ def sniff_source_file(filepath: Path) -> Dict[str, Any]:
         "true_header_line": true_header_line,
         "columns_preview": _preview_columns(header_line, delim),
         "warnings": warnings,
+        "is_binary_file": is_binary_file,
     }
 
 
@@ -462,6 +483,27 @@ def profile_raw(
 
     # Phase 1: pure source sniffing
     sniff_hints = sniff_source_file(file0)
+
+    # Binary files (XLSX/XLS) can't be profiled with DuckDB CSV reader.
+    # Return a minimal profile with a clear warning.
+    if sniff_hints.get("is_binary_file"):
+        return RawProfile(
+            dataset=dataset,
+            year=year,
+            file_used=str(file0.name),
+            encoding_suggested=None,
+            delim_suggested=None,
+            decimal_suggested=None,
+            skip_suggested=0,
+            robust_read_suggested=False,
+            header_line=None,
+            columns_raw=[],
+            columns_norm=[],
+            missingness_top=[],
+            sample_rows=[],
+            mapping_suggestions={},
+            warnings=sniff_hints.get("warnings", []),
+        )
 
     enc = sniff_hints["encoding_suggested"]
     delim = sniff_hints["delim_suggested"]

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -74,7 +74,10 @@ def sniff_source_file(filepath: Path) -> Dict[str, Any]:
             "header_line": None,
             "true_header_line": None,
             "columns_preview": [],
-            "warnings": [f"binary_file_detected: {binary_fmt} — use sheet_name in dataset.yml"],
+            "warnings": [
+                f"binary_file_detected: {binary_fmt}"
+                + (" — use sheet_name in dataset.yml" if binary_fmt in ("xlsx", "xls") else "")
+            ],
             "is_binary_file": binary_fmt,
         }
 

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -438,6 +438,7 @@ class RawProfile:
     mapping_suggestions: Dict[str, Any]
 
     warnings: List[str]
+    is_binary_file: Optional[str] = None
 
 
 def profile_raw(
@@ -503,6 +504,7 @@ def profile_raw(
             sample_rows=[],
             mapping_suggestions={},
             warnings=sniff_hints.get("warnings", []),
+            is_binary_file=sniff_hints.get("is_binary_file"),
         )
 
     enc = sniff_hints["encoding_suggested"]

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -148,7 +148,13 @@ def run_raw(
     profile_hints = None
     profile_ctx = {"clean": clean_cfg or {}, "output": output_cfg or {}}
     policy = resolve_artifact_policy(output_cfg)
-    if primary_output_path.exists() and primary_output_path.suffix.lower() in {".csv", ".tsv", ".txt"}:
+    if primary_output_path.exists() and primary_output_path.suffix.lower() in {
+        ".csv",
+        ".tsv",
+        ".txt",
+        ".xlsx",
+        ".xls",
+    }:
         try:
             profile_hints = sniff_source_file(primary_output_path)
             if should_write("profile", "suggested_read", policy, profile_ctx):
@@ -171,16 +177,22 @@ def run_raw(
                     write_canonical=True,
                     write_legacy_alias=should_write("profile", "profile_alias", policy, profile_ctx),
                 )
-                logger.info("RAW profile -> %s", profile_dir / "raw_profile.json")
-
-                scaffold_clean_if_missing(
-                    raw_profile.__dict__,
-                    dataset,
-                    year,
-                    base_dir or Path("."),
-                    clean_cfg,
-                    logger,
+                is_binary = raw_profile.is_binary_file
+                logger.info(
+                    "RAW profile -> %s",
+                    profile_dir / "raw_profile.json",
                 )
+
+                # scaffold_clean_if_missing needs column names — not available for binary files
+                if not is_binary:
+                    scaffold_clean_if_missing(
+                        raw_profile.__dict__,
+                        dataset,
+                        year,
+                        base_dir or Path("."),
+                        clean_cfg,
+                        logger,
+                    )
         except Exception as exc:
             logger.warning("RAW profile/scaffold generation failed: %s: %s", type(exc).__name__, exc)
 


### PR DESCRIPTION
## Summary

4 fix mirati per il problema XLSX emerso durante stress test batch 2 su `terna-electricity-by-source` e `civile-flussi`:

### Issue 1 — 🔴 High: XLSX binary detection in profiler
- `_sniff_encoding.py`: nuova funzione `is_binary_file()` che controlla magic bytes `PK\x03\x04` (XLSX/ZIP) e `\xd0\xcf\x11\xe0` (XLS/OLE2)
- `sniff_source_file()`: return anticipato con warning `binary_file_detected: xlsx` se binario
- `profile_raw()`: exit anticipato senza DuckDB CSV profiling per file binari, `is_binary_file` nel profilo
- **4 test policy** in `test_profile_sniff.py`

### Issue 2 — 🔴 High: schema-diff skip binary files
- `_raw_schema_payload()`: aggiunge `is_binary_file` al payload + warning
- `_compare_schema_entries()`: skippa confronto se `is_binary_file` è settato, ritorna `skipped: true, reason: "binary_file_not_comparable"`
- output testuale aggiornato per mostrare `skipped: true` + reason
- **Test**: `test_inspect_schema_diff_skips_binary_file`

### Issue 3 — 🟡 Medium: blocker-hints non segnalava profiling fallito su XLSX
- `RawProfile`: aggiunto campo `is_binary_file` al dataclass con default `None` (backward-compatible)
- `blocker_hints`: nuovo check `raw_binary_file_not_comparable` quando `is_binary_file` è settato in `raw_profile.json`
- `blocker_hints`: nuovo check `raw_probe_unavailable` quando `stats.raw_probe_source='unavailable'` nel run record
- **2 test policy** in `test_cli_blocker_hints.py`

### Issue 4 — 🟡 Medium: review-readiness diceva ready con profiling broken
- `review_readiness`: nuovo check `raw_profiling_available` che fallisce se `is_binary_file` è settato
- **Test**: `test_review_readiness_fails_when_raw_binary_file`

### Fix critico in `run.py`
Il blocco profiling a riga 151 escludeva XLSX con gate CSV-only. Rimosso: ora `.xlsx` e `.xls` sono inclusi nel blocco profiling. `sniff_source_file` e `profile_raw` vengono chiamati anche per XLSX e scrivono `raw_profile.json` con `is_binary_file`.

## Stress test `civile-flussi` (XLSX)

| Comando | Prima | Dopo |
|---|---|---|
| `blocker_hints` | 0 hints | ✅ 1 blocker (`raw_binary_file_not_comparable`) |
| `schema_diff` | garbage, `changed: true` | ✅ `is_binary_file: "xlsx"`, skipped |
| `review_readiness` | `ready` | ✅ `needs-review` |
| `raw_profile.json` | garbage | ✅ `is_binary_file: "xlsx"` |

## Test
- **647 test passing** (+8 nuovi)
- ruff: all checks passed
- mypy: nessuna nuova regressione (errori pre-esistenti missing stubs)

## Files toccati
- `toolkit/profile/_sniff_encoding.py` — `is_binary_file()`
- `toolkit/profile/raw.py` — early exit per binari, campo `is_binary_file` in `RawProfile`
- `toolkit/raw/run.py` — rimosso gate CSV-only, profiling anche per XLSX
- `toolkit/cli/inspect/_helpers.py` — `is_binary_file` nel payload + skip logic
- `toolkit/cli/inspect/schema_diff_ops.py` — output skipped comparison
- `toolkit/mcp/schema_ops.py` — `raw_profile()` espone `is_binary_file`, `blocker_hints` e `review_readiness` aggiornati
- `tests/test_profile_sniff.py` — 4 test binary detection
- `tests/test_cli_inspect_schema_diff.py` — test skip binary + fix `_write_raw_year` guard
- `tests/test_cli_blocker_hints.py` — 2 nuovi test blocker per binary e unavailable
- `tests/test_mcp_toolkit_client.py` — 1 nuovo test readiness per binary