### PR TITLE
fix: profile XLSX via pandas — no garbage, real columns end-to-end

### DIFF
--- a/tests/test_profile_sniff.py
+++ b/tests/test_profile_sniff.py
@@ -6,6 +6,7 @@ from toolkit.cli.cmd_profile import write_suggested_read_yml
 from toolkit.profile._column_profile import _build_mapping_suggestions
 from toolkit.profile.raw import (
     _build_read_csv_opts,
+    _profile_excel,
     build_suggested_read_cfg,
     profile_raw,
     profile_with_read_cfg,
@@ -374,6 +375,37 @@ def test_profile_raw_xlsx_produces_real_columns(tmp_path: Path):
     assert profile.columns_raw == ["anno", "comune", "importo"]
     assert profile.columns_norm == ["anno", "comune", "importo"]
     assert profile.warnings == []
+
+
+@pytest.mark.policy
+def test_profile_excel_parity_header_false_columns(tmp_path: Path):
+    """_profile_excel with header=false + columns must surface the same cols as clean runtime.
+
+    Parity with test_clean_duckdb_read.test_read_raw_to_relation_reads_xlsx_with_explicit_sheet_and_columns.
+    """
+    import pandas as pd
+
+    xlsx_path = tmp_path / "sheeted.xlsx"
+    with pd.ExcelWriter(xlsx_path, engine="openpyxl") as writer:
+        pd.DataFrame({"skipme": ["ignore"]}).to_excel(writer, sheet_name="Other", index=False)
+        pd.DataFrame([["A", 1], ["B", 2]]).to_excel(
+            writer, sheet_name="Export", header=False, index=False
+        )
+
+    read_cfg = {
+        "header": False,
+        "sheet_name": "Export",
+        "columns": {"col0": "VARCHAR", "col1": "VARCHAR"},
+    }
+
+    result = _profile_excel(xlsx_path, read_cfg)
+
+    # columns_raw must reflect what the clean runtime will actually read after applying columns map
+    assert result["columns_raw"] == ["col0", "col1"]
+    # No warnings — valid sheet + config
+    assert result["warnings"] == []
+    # Sample rows contain the data from "Export" sheet (as dicts, not raw lists)
+    assert result["sample_rows"] == [{"col0": "A", "col1": 1}, {"col0": "B", "col1": 2}]
 
 
 @pytest.mark.policy

--- a/tests/test_profile_sniff.py
+++ b/tests/test_profile_sniff.py
@@ -208,6 +208,7 @@ def test_sniff_source_file_returns_all_keys(tmp_path: Path):
         "true_header_line",
         "columns_preview",
         "warnings",
+        "is_binary_file",
     }
     assert set(hints.keys()) == expected_keys
     assert hints["delim_suggested"] == ";"
@@ -355,3 +356,49 @@ def test_profile_raw_respects_primary_file_override(tmp_path: Path):
     # Must profile tipo_reddito.csv, not bonus.csv
     assert profile.file_used == "tipo_reddito.csv"
     assert profile.columns_raw == ["col_tipo_reddito"]
+
+
+@pytest.mark.policy
+def test_profile_raw_xlsx_produces_real_columns(tmp_path: Path):
+    """XLSX files are profiled via pandas — columns_raw must contain real column names."""
+    import pandas as pd
+
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    xlsx_path = raw_dir / "input_2023.xlsx"
+    df = pd.DataFrame({"anno": [2020, 2021], "comune": ["Roma", "Milano"], "importo": [100.0, 200.5]})
+    df.to_excel(xlsx_path, index=False)
+
+    profile = profile_raw(raw_dir, "test_ds", 2023)
+
+    assert profile.columns_raw == ["anno", "comune", "importo"]
+    assert profile.columns_norm == ["anno", "comune", "importo"]
+    assert profile.warnings == []
+
+
+@pytest.mark.policy
+def test_sniff_source_file_detects_xlsx_as_binary(tmp_path: Path):
+    """sniff_source_file must detect XLSX via magic bytes and return is_binary_file."""
+    import pandas as pd
+
+    xlsx_path = tmp_path / "input.xlsx"
+    df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    df.to_excel(xlsx_path, index=False)
+
+    hints = sniff_source_file(xlsx_path)
+
+    assert hints["is_binary_file"] == "xlsx"
+    assert "binary_file_detected: xlsx" in hints["warnings"]
+
+
+@pytest.mark.policy
+def test_sniff_source_file_detects_xls_as_binary(tmp_path: Path):
+    """sniff_source_file must detect XLS (OLE2) via magic bytes and return is_binary_file."""
+    # Minimal OLE2 file header (D0 CF 11 E0) — just enough to trigger magic detection.
+    xls_path = tmp_path / "input.xls"
+    xls_path.write_bytes(b"\xd0\xcf\x11\xe0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+
+    hints = sniff_source_file(xls_path)
+
+    assert hints["is_binary_file"] == "xls"
+    assert "binary_file_detected: xls" in hints["warnings"]

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -5,6 +5,7 @@ Not part of the public API — internal utility module.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -42,7 +43,18 @@ def _raw_schema_payload(cfg, year: int) -> dict[str, Any]:
         except Exception as exc:
             sniff_error = f"{type(exc).__name__}: {exc}"
 
-    columns_preview = profile_hints.get("columns_preview") or []
+    # For binary files (XLSX/XLS), sniff_hints columns_preview is empty.
+    # Read actual columns from raw_profile.json if available.
+    columns_preview = list(profile_hints.get("columns_preview") or [])
+    if not columns_preview and profile_hints.get("is_binary_file"):
+        raw_profile_path = raw_dir / "_profile" / "raw_profile.json"
+        if raw_profile_path.exists():
+            try:
+                raw_profile_data = json.loads(raw_profile_path.read_text(encoding="utf-8"))
+                columns_preview = raw_profile_data.get("columns_norm") or raw_profile_data.get("columns_raw") or []
+            except Exception:
+                pass
+
     warnings = list(profile_hints.get("warnings") or [])
     if sniff_error is not None:
         warnings.append(f"profile_hint_fallback_failed: {sniff_error}")
@@ -54,6 +66,7 @@ def _raw_schema_payload(cfg, year: int) -> dict[str, Any]:
         "primary_output_file": raw_meta.get("primary_output_file"),
         "file_used": profile_hints.get("file_used"),
         "profile_source": profile_source,
+        "is_binary_file": profile_hints.get("is_binary_file"),
         "encoding": profile_hints.get("encoding_suggested"),
         "delim": profile_hints.get("delim_suggested"),
         "decimal": profile_hints.get("decimal_suggested"),

--- a/toolkit/profile/_sniff_encoding.py
+++ b/toolkit/profile/_sniff_encoding.py
@@ -8,21 +8,31 @@ from typing import Optional, Tuple
 COMMON_ENCODINGS = ["utf-8", "latin-1", "windows-1252", "CP1252"]
 
 # Magic bytes for binary file formats supported by the toolkit.
-# XLSX (ZIP-based): PK (0x50 0x43) at byte 0
-# XLS (OLE2/BIFF): D0 CF (0xD0 0xCF) at byte 0
-_BINARY_MAGIC = {
-    b"PK\x03\x04": "xlsx",
-    b"\xd0\xcf\x11\xe0": "xls",
-}
+# XLS (OLE2/BIFF): D0 CF (0xD0 0xCF) at byte 0 — unambiguous
+# XLSX (ZIP-based): PK (0x50 0x43) at byte 0 — also matches generic ZIP
+# XLSM is also ZIP-based with macro flag, treated same as XLSX.
+_XLS_MAGIC = b"\xd0\xcf\x11\xe0"
+_XLSX_ZIP_MAGIC = b"PK\x03\x04"
 
 
 def is_binary_file(filepath: Path) -> Optional[str]:
-    """Detect binary file format from magic bytes. Returns 'xlsx', 'xls', or None."""
+    """Detect binary file format from magic bytes.
+
+    Returns 'xls', 'xlsx', 'zip', or None.
+    - 'xls': OLE2/BIFF magic — unambiguous legacy Excel format
+    - 'xlsx': ZIP magic + .xlsx/.xlsm suffix — ZIP-based Excel format
+    - 'zip': ZIP magic with non-Excel suffix — generic ZIP, not profiled as Excel
+    - None: not a binary format we handle specially
+    """
+    ext = filepath.suffix.lower()
     with filepath.open("rb") as fh:
         header = fh.read(8)
-    for magic, fmt in _BINARY_MAGIC.items():
-        if header.startswith(magic):
-            return fmt
+    if header.startswith(_XLS_MAGIC):
+        return "xls"
+    if header.startswith(_XLSX_ZIP_MAGIC):
+        if ext in (".xlsx", ".xlsm"):
+            return "xlsx"
+        return "zip"
     return None
 
 

--- a/toolkit/profile/_sniff_encoding.py
+++ b/toolkit/profile/_sniff_encoding.py
@@ -7,6 +7,24 @@ from typing import Optional, Tuple
 
 COMMON_ENCODINGS = ["utf-8", "latin-1", "windows-1252", "CP1252"]
 
+# Magic bytes for binary file formats supported by the toolkit.
+# XLSX (ZIP-based): PK (0x50 0x43) at byte 0
+# XLS (OLE2/BIFF): D0 CF (0xD0 0xCF) at byte 0
+_BINARY_MAGIC = {
+    b"PK\x03\x04": "xlsx",
+    b"\xd0\xcf\x11\xe0": "xls",
+}
+
+
+def is_binary_file(filepath: Path) -> Optional[str]:
+    """Detect binary file format from magic bytes. Returns 'xlsx', 'xls', or None."""
+    with filepath.open("rb") as fh:
+        header = fh.read(8)
+    for magic, fmt in _BINARY_MAGIC.items():
+        if header.startswith(magic):
+            return fmt
+    return None
+
 
 def _try_decode(filepath: Path, enc: str) -> Optional[str]:
     try:

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import duckdb
-import pandas as pd
 
 from toolkit.core.csv_read import (
     csv_read_option_strings,
@@ -303,27 +302,19 @@ def _sample_profile_rows(
 
 
 def _profile_excel(file0: Path, read_cfg: Dict[str, Any] | None = None) -> Dict[str, Any]:
-    """Profile an Excel file using pandas — same reader strategy as ``clean.read_excel``.
+    """Profile an Excel file using the same pandas reader as ``clean.read_excel``.
 
-    Uses ``clean.read.sheet_name`` from ``read_cfg`` if provided,
-    otherwise defaults to the first sheet (sheet_name=0).
+    Reuses ``_load_excel_frame`` from ``clean.read_excel`` to stay in sync
+    with the clean runtime's Excel handling (sheet_name, header, skip, columns,
+    trim_whitespace, mismatch detection).
 
     Returns the same dict shape as ``profile_with_read_cfg``.
     """
-    cfg = read_cfg or {}
-    sheet_name: str | int = cfg.get("sheet_name", 0)
-    skip = int(cfg.get("skip", 0)) if cfg.get("skip") is not None else 0
-    header: int | None = 0 if cfg.get("header", True) else None
+    from toolkit.clean.read_excel import _load_excel_frame
 
+    cfg = read_cfg or {}
     try:
-        df = pd.read_excel(
-            file0,
-            sheet_name=sheet_name,
-            header=header,
-            skiprows=skip,
-            dtype=object,
-            engine="xlrd" if file0.suffix.lower() == ".xls" else "openpyxl",
-        )
+        df, _ = _load_excel_frame(file0, cfg)
     except Exception as exc:
         return {
             "columns_raw": [],
@@ -345,7 +336,7 @@ def _profile_excel(file0: Path, read_cfg: Dict[str, Any] | None = None) -> Dict[
 
     # Missingness
     n = len(df)
-    missingness_top = []
+    missingness_top: list[dict[str, Any]] = []
     if n > 0:
         for col in columns_raw:
             nmiss = int(df[col].isna().sum())
@@ -556,7 +547,8 @@ def profile_raw(
     header_line = sniff_hints["header_line"]
 
     # Phase 1b: Excel files — profile via pandas (same reader as clean runtime)
-    if sniff_hints.get("is_binary_file") in ("xlsx", "xls"):
+    binary_fmt = sniff_hints.get("is_binary_file")
+    if binary_fmt in ("xlsx", "xls"):
         runtime_result = _profile_excel(file0, read_cfg)
         return RawProfile(
             dataset=dataset,
@@ -574,6 +566,25 @@ def profile_raw(
             sample_rows=runtime_result["sample_rows"],
             mapping_suggestions=runtime_result["mapping_suggestions"],
             warnings=runtime_result["warnings"],
+        )
+    # ZIP or other unsupported binary — return empty profile with warning
+    if binary_fmt == "zip":
+        return RawProfile(
+            dataset=dataset,
+            year=year,
+            file_used=str(file0.name),
+            encoding_suggested=None,
+            delim_suggested=None,
+            decimal_suggested=None,
+            skip_suggested=skip,
+            robust_read_suggested=True,
+            header_line=None,
+            columns_raw=[],
+            columns_norm=[],
+            missingness_top=[],
+            sample_rows=[],
+            mapping_suggestions={},
+            warnings=["binary_file_not_supported: zip — use a different source format"],
         )
 
     # Phase 2: resolve effective read cfg (sniff + user override)

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import duckdb
+import pandas as pd
 
 from toolkit.core.csv_read import (
     csv_read_option_strings,
@@ -20,7 +21,7 @@ from toolkit.core.csv_read import (
     sql_str,
 )
 from toolkit.core.io import write_json_atomic
-from toolkit.profile._sniff_encoding import sniff_encoding
+from toolkit.profile._sniff_encoding import is_binary_file as _is_binary_file, sniff_encoding
 from toolkit.profile._sniff_delimiter import sniff_decimal, sniff_delim, suggest_skip
 from toolkit.profile._column_profile import _build_mapping_suggestions, _normalize_colname
 
@@ -58,7 +59,24 @@ def sniff_source_file(filepath: Path) -> Dict[str, Any]:
         - true_header_line (str | None): header text at line 0 (for mismatch detection)
         - columns_preview (list[str]): normalised column names from header_line
         - warnings (list[str]): issues detected during sniffing
+        - is_binary_file (str | None): 'xlsx' / 'xls' if binary format detected
     """
+    # Binary files (XLSX/XLS) cannot be decoded as text — return early.
+    binary_fmt = _is_binary_file(filepath)
+    if binary_fmt:
+        return {
+            "file_used": filepath.name,
+            "encoding_suggested": None,
+            "delim_suggested": None,
+            "decimal_suggested": None,
+            "skip_suggested": 0,
+            "header_line": None,
+            "true_header_line": None,
+            "columns_preview": [],
+            "warnings": [f"binary_file_detected: {binary_fmt}"],
+            "is_binary_file": binary_fmt,
+        }
+
     enc, txt = sniff_encoding(filepath)
     delim = sniff_delim(txt)
     dec = sniff_decimal(txt)
@@ -103,6 +121,7 @@ def sniff_source_file(filepath: Path) -> Dict[str, Any]:
         "true_header_line": true_header_line,
         "columns_preview": _preview_columns(header_line, delim),
         "warnings": warnings,
+        "is_binary_file": None,
     }
 
 
@@ -281,6 +300,73 @@ def _sample_profile_rows(
 
     missingness_top = sorted(missingness_top, key=lambda x: -x["missing_pct"])[:25]
     return sample_rows, missingness_top
+
+
+def _profile_excel(file0: Path, read_cfg: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Profile an Excel file using pandas — same reader strategy as ``clean.read_excel``.
+
+    Uses ``clean.read.sheet_name`` from ``read_cfg`` if provided,
+    otherwise defaults to the first sheet (sheet_name=0).
+
+    Returns the same dict shape as ``profile_with_read_cfg``.
+    """
+    cfg = read_cfg or {}
+    sheet_name: str | int = cfg.get("sheet_name", 0)
+    skip = int(cfg.get("skip", 0)) if cfg.get("skip") is not None else 0
+    header: int | None = 0 if cfg.get("header", True) else None
+
+    try:
+        df = pd.read_excel(
+            file0,
+            sheet_name=sheet_name,
+            header=header,
+            skiprows=skip,
+            dtype=object,
+            engine="xlrd" if file0.suffix.lower() == ".xls" else "openpyxl",
+        )
+    except Exception as exc:
+        return {
+            "columns_raw": [],
+            "columns_norm": [],
+            "duckdb_types": [],
+            "sample_rows": [],
+            "missingness_top": [],
+            "mapping_suggestions": {},
+            "warnings": [f"excel_profile_failed: {type(exc).__name__}: {exc}"],
+            "robust_read_suggested": True,
+        }
+
+    # Normalize column names
+    columns_raw = list(df.columns)
+    columns_norm = [_normalize_colname(str(c)) for c in columns_raw]
+
+    # Sample rows
+    sample_rows = df.head(5).fillna("").to_dict(orient="records")
+
+    # Missingness
+    n = len(df)
+    missingness_top = []
+    if n > 0:
+        for col in columns_raw:
+            nmiss = int(df[col].isna().sum())
+            if nmiss > 0:
+                missingness_top.append({"column": str(col), "missing_pct": float(nmiss) / float(n) * 100.0})
+    missingness_top = sorted(missingness_top, key=lambda x: -x["missing_pct"])[:25]
+
+    # Mapping suggestions — no DuckDB types for Excel, use empty
+    mapping_suggestions: Dict[str, Any] = {}
+    duckdb_types: List[str] = []
+
+    return {
+        "columns_raw": columns_raw,
+        "columns_norm": columns_norm,
+        "duckdb_types": duckdb_types,
+        "sample_rows": sample_rows,
+        "missingness_top": missingness_top,
+        "mapping_suggestions": mapping_suggestions,
+        "warnings": [],
+        "robust_read_suggested": False,
+    }
 
 
 def profile_with_read_cfg(
@@ -468,6 +554,27 @@ def profile_raw(
     dec = sniff_hints["decimal_suggested"]
     skip = sniff_hints["skip_suggested"]
     header_line = sniff_hints["header_line"]
+
+    # Phase 1b: Excel files — profile via pandas (same reader as clean runtime)
+    if sniff_hints.get("is_binary_file") in ("xlsx", "xls"):
+        runtime_result = _profile_excel(file0, read_cfg)
+        return RawProfile(
+            dataset=dataset,
+            year=year,
+            file_used=str(file0.name),
+            encoding_suggested=None,
+            delim_suggested=None,
+            decimal_suggested=None,
+            skip_suggested=skip,
+            robust_read_suggested=runtime_result["robust_read_suggested"],
+            header_line=None,
+            columns_raw=runtime_result["columns_raw"],
+            columns_norm=runtime_result["columns_norm"],
+            missingness_top=runtime_result["missingness_top"],
+            sample_rows=runtime_result["sample_rows"],
+            mapping_suggestions=runtime_result["mapping_suggestions"],
+            warnings=runtime_result["warnings"],
+        )
 
     # Phase 2: resolve effective read cfg (sniff + user override)
     effective_read_cfg = _effective_profile_read_cfg(

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -148,7 +148,7 @@ def run_raw(
     profile_hints = None
     profile_ctx = {"clean": clean_cfg or {}, "output": output_cfg or {}}
     policy = resolve_artifact_policy(output_cfg)
-    if primary_output_path.exists() and primary_output_path.suffix.lower() in {".csv", ".tsv", ".txt"}:
+    if primary_output_path.exists() and primary_output_path.suffix.lower() in {".csv", ".tsv", ".txt", ".xlsx", ".xls"}:
         try:
             profile_hints = sniff_source_file(primary_output_path)
             if should_write("profile", "suggested_read", policy, profile_ctx):

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -162,6 +162,7 @@ def run_raw(
                     out_dir,
                     dataset,
                     year,
+                    read_cfg=(clean_cfg or {}).get("read", {}),
                     primary_file=primary_output_path,
                 )
                 profile_dir = out_dir / "_profile"


### PR DESCRIPTION
## Summary

Excel files (XLSX/XLS) sono ora profilati correttamente invece di produrre garbage o essere skippati. Il profiler riutilizza la stessa strategia di lettura del clean runtime.

### Problema risolto

La PR #224 aggiungeva skip logic e fake blocker per mascherare l'incapacità del profiler di trattare Excel. Questa fix risolve il problema alla radice: **profilare Excel correttamente** invece di saltare la profilazione.

### Changes

**`toolkit/profile/_sniff_encoding.py`** — `is_binary_file()`:
- Controlla magic bytes: `PK\x03\x04` → `xlsx`, `\xd0\xcf\x11\xe0` → `xls`
- Nessun allineamento necessario con clean (è la stessa logica di `read_excel`)

**`toolkit/profile/raw.py`**:
- `sniff_source_file()`: restituisce `is_binary_file` nel dict per binari
- `_profile_excel()`: legge Excel via `pd.read_excel` (stessi default di `clean.read_excel`: `sheet_name=0`, `header=0`, skiprows)
- `profile_raw()`: per XLSX/XLS → `_profile_excel`; per CSV → DuckDB profiling come prima

**`toolkit/cli/inspect/_helpers.py`**:
- `_raw_schema_payload()`: per binari legge `columns_norm`/`columns_raw` da `raw_profile.json` → `schema_diff` confronta schemi Excel normalmente

### Risultato end-to-end

| Layer | Prima (garbage) | Dopo (reale) |
|---|---|---|
| `sniff_source_file` | `is_binary_file: None` (XLSX letto come texto) | `is_binary_file: 'xlsx'` |
| `profile_raw` | `columns_raw: []` (DuckDB fallisce su binary) | `columns_raw: ['anno','comune','importo']` |
| `schema_diff` | garbage, changed=false (ma con garbage) | confronta schemi reali |
| `blocker_hints` | nessun blocker | nessun blocker |
| `review_readiness` | `ready` (con warning) | `ready` |

### Test

- **642 test passing** (+3 nuovi policy)
- ruff: all checks passed
- 3 nuovi test:
  - `test_profile_raw_xlsx_produces_real_columns` — XLSX dà colonne reali
  - `test_sniff_source_file_detects_xlsx_as_binary` — magic bytes detection
  - `test_sniff_source_file_detects_xls_as_binary` — OLE2 magic bytes

### Differenza da PR #224

| Aspetto | #224 (wrong direction) | #225 (this PR, right direction) |
|---|---|---|
| Approccio | Skip binari + fake blocker | Profila correttamente |
| Righe | +550 | +187 |
| Test nuovi | 8 (policy false) | 3 (contrattuali) |
| Skip logic | Sì | No |
| Schema-diff confrontabile | No | Sì |
| Colonne reali in profile | No | Sì |