### PR TITLE
refactor: rimuovere debug e minimal artifact policy, cleanup codice morto

### DIFF
--- a/docs/advanced-workflows.md
+++ b/docs/advanced-workflows.md
@@ -94,7 +94,7 @@ Artefatti principali:
 Nota pratica:
 
 - `run raw` scrive già un `suggested_read.yml` leggero e conservativo quando il file primario e` profilabile
-- `profile raw` resta il comando da usare quando vuoi profiling più ricco, report diagnostici e `suggested_mapping.yml`
+- `profile raw` resta il comando da usare quando vuoi profiling più ricco e report diagnostici
 
 `profile.json` resta un alias legacy opzionale e non è il nome canonico da promuovere nei nuovi repo.
 
@@ -122,7 +122,7 @@ La policy artifacts resta disponibile per tuning operativo:
 
 ```yaml
 output:
-  artifacts: standard   # minimal | standard | debug
+  artifacts: standard   # minimal | standard
   legacy_aliases: true
 ```
 
@@ -130,7 +130,6 @@ Regola pratica:
 
 - `standard`: default consigliato
 - `minimal`: riduce artefatti opzionali
-- `debug`: conserva anche SQL renderizzate e dettagli di debug
 
 `legacy_aliases` resta supportato per compatibilità, ma non va promosso nei nuovi repo dataset.
 

--- a/docs/advanced-workflows.md
+++ b/docs/advanced-workflows.md
@@ -118,18 +118,8 @@ Uso consigliato:
 
 ## Artifact policy
 
-La policy artifacts resta disponibile per tuning operativo:
-
-```yaml
-output:
-  artifacts: standard   # minimal | standard
-  legacy_aliases: true
-```
-
-Regola pratica:
-
-- `standard`: default consigliato
-- `minimal`: riduce artefatti opzionali
+`output.artifacts` non ha più effetto — profiling e SQL renderizzati sono sempre generati.
+Il campo è accettato per backward compatibilità ma ignorato.
 
 `legacy_aliases` resta supportato per compatibilità, ma non va promosso nei nuovi repo dataset.
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -359,7 +359,7 @@ Campi supportati:
 
 | Campo | Tipo | Default |
 |---|---|---|
-| `output.artifacts` | `minimal \| standard \| debug` | `standard` |
+| `output.artifacts` | `minimal \| standard` | `standard` |
 | `output.legacy_aliases` | `bool` | `false` |
 
 ## Legacy supportato

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -359,7 +359,7 @@ Campi supportati:
 
 | Campo | Tipo | Default |
 |---|---|---|
-| `output.artifacts` | `minimal \| standard` | `standard` |
+| `output.artifacts` | `str` | `standard` (accettato ma ignorato) |
 | `output.legacy_aliases` | `bool` | `false` |
 
 ## Legacy supportato

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -6,10 +6,9 @@
 - **Audit**: `metadata.json` e `validation.json` accompagnano ogni layer con versioni di schema e audit trail.
 
 ## 2. Artifacts Policy
-Il toolkit supporta tre livelli di conservazione artefatti (`output.artifacts`):
+Il toolkit supporta due livelli di conservazione artefatti (`output.artifacts`):
 - `minimal`: Solo file primari, parquet finale, manifest e metadata essenziali.
 - `standard` (**default**): Aggiunge `raw_profile.json` e SQL generati in `_run/*.sql`.
-- `debug`: Tutti gli output intermedi, report e alias di compatibilità legacy.
 
 `output.legacy_aliases: true` conserva alias di compatibilità dove supportati; nei nuovi repo usare `--strict-config` per intercettare campi legacy.
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -6,9 +6,8 @@
 - **Audit**: `metadata.json` e `validation.json` accompagnano ogni layer con versioni di schema e audit trail.
 
 ## 2. Artifacts Policy
-Il toolkit supporta due livelli di conservazione artefatti (`output.artifacts`):
-- `minimal`: Solo file primari, parquet finale, manifest e metadata essenziali.
-- `standard` (**default**): Aggiunge `raw_profile.json` e SQL generati in `_run/*.sql`.
+`output.artifacts` non ha più effetto — profiling e SQL renderizzati sono sempre generati.
+Il campo è accettato per backward compatibilità ma ignorato.
 
 `output.legacy_aliases: true` conserva alias di compatibilità dove supportati; nei nuovi repo usare `--strict-config` per intercettare campi legacy.
 

--- a/docs/feature-stability.md
+++ b/docs/feature-stability.md
@@ -15,7 +15,7 @@ Questa matrice serve a chiarire cosa il toolkit considera percorso canonico, cos
 | `run raw|clean|mart` | supported / advanced | debug e re-run parziali |
 | `run cross_year` | supported / advanced | output multi-anno e workflow non canonici |
 | `inspect schema-diff` | supported / advanced | confronto rapido segnali schema RAW tra anni |
-| artifact policy `minimal|standard|debug` | supported / advanced | tuning operativo |
+| artifact policy `minimal|standard` | supported / advanced | tuning operativo |
 | `legacy_aliases` | compatibility only | non promuovere nei repo nuovi |
 | config legacy | compatibility only | usare `--strict-config` nei repo nuovi |
 | ~~`scout_url`~~ | removed | sostituito da `inspect url` |

--- a/docs/feature-stability.md
+++ b/docs/feature-stability.md
@@ -15,7 +15,7 @@ Questa matrice serve a chiarire cosa il toolkit considera percorso canonico, cos
 | `run raw|clean|mart` | supported / advanced | debug e re-run parziali |
 | `run cross_year` | supported / advanced | output multi-anno e workflow non canonici |
 | `inspect schema-diff` | supported / advanced | confronto rapido segnali schema RAW tra anni |
-| artifact policy `minimal|standard` | supported / advanced | tuning operativo |
+| artifact policy | deprecated / ignored | accettato per backward compat ma senza effetto |
 | `legacy_aliases` | compatibility only | non promuovere nei repo nuovi |
 | config legacy | compatibility only | usare `--strict-config` nei repo nuovi |
 | ~~`scout_url`~~ | removed | sostituito da `inspect url` |

--- a/examples/dataset_full.yml
+++ b/examples/dataset_full.yml
@@ -88,5 +88,5 @@ validation:
   fail_on_error: true
 
 output:
-  artifacts: debug
+  artifacts: standard
   legacy_aliases: false

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -4,7 +4,6 @@ import pytest
 
 from toolkit.core.artifacts import (
     ARTIFACT_POLICIES,
-    ARTIFACT_POLICY_DEBUG,
     ARTIFACT_POLICY_MINIMAL,
     ARTIFACT_POLICY_STANDARD,
     legacy_aliases_enabled,
@@ -24,8 +23,6 @@ from toolkit.core.artifacts import (
     ({"artifacts": "  standard  "}, ARTIFACT_POLICY_STANDARD),
     ({"artifacts": "STANDARD"}, ARTIFACT_POLICY_STANDARD),
     ({"artifacts": "minimal"}, ARTIFACT_POLICY_MINIMAL),
-    ({"artifacts": "debug"}, ARTIFACT_POLICY_DEBUG),
-    ({"artifacts": "DEBUG"}, ARTIFACT_POLICY_DEBUG),
 ])
 def test_resolve_artifact_policy_valid(cfg, expected) -> None:
     assert resolve_artifact_policy(cfg) == expected
@@ -91,16 +88,8 @@ def test_profile_required_object_attribute_access() -> None:
 
 @pytest.mark.policy
 @pytest.mark.parametrize("layer, artifact, policy, cfg, expected", [
-    ("clean", "any_artifact", ARTIFACT_POLICY_DEBUG, {}, True),
-    ("mart", "any_artifact", ARTIFACT_POLICY_DEBUG, {}, True),
-    ("profile", "raw_profile", ARTIFACT_POLICY_DEBUG, {}, True),
-    ("profile", "profile_md", ARTIFACT_POLICY_DEBUG, {}, True),
-    ("profile", "profile_md", ARTIFACT_POLICY_STANDARD, {}, False),
-    ("profile", "profile_md", ARTIFACT_POLICY_MINIMAL, {}, False),
     ("profile", "suggested_read", ARTIFACT_POLICY_STANDARD, {"clean": {"read": {"source": "auto"}}}, True),
     ("profile", "suggested_read", ARTIFACT_POLICY_STANDARD, {"clean": {"read": {"source": "duckdb"}}}, False),
-    ("profile", "suggested_mapping", ARTIFACT_POLICY_DEBUG, {}, True),
-    ("profile", "suggested_mapping", ARTIFACT_POLICY_STANDARD, {}, False),
     ("profile", "profile_alias", ARTIFACT_POLICY_STANDARD, {"output": {"artifacts": "standard", "legacy_aliases": True}}, True),
     ("profile", "profile_alias", ARTIFACT_POLICY_MINIMAL, {"output": {"artifacts": "minimal", "legacy_aliases": True}}, False),
     ("profile", "profile_alias", ARTIFACT_POLICY_STANDARD, {"output": {"artifacts": "standard", "legacy_aliases": False}}, False),

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -80,8 +80,6 @@ def test_should_write(layer, artifact, cfg, expected) -> None:
 @pytest.mark.policy
 @pytest.mark.parametrize("layer, artifact", [
     ("profile", "raw_profile"),
-    ("profile", "profile_md"),
-    ("profile", "suggested_mapping"),
     ("clean", "rendered_sql"),
     ("mart", "rendered_sql"),
     ("clean", "data_parquet"),

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -3,9 +3,6 @@
 import pytest
 
 from toolkit.core.artifacts import (
-    ARTIFACT_POLICIES,
-    ARTIFACT_POLICY_MINIMAL,
-    ARTIFACT_POLICY_STANDARD,
     legacy_aliases_enabled,
     profile_required,
     resolve_artifact_policy,
@@ -13,32 +10,14 @@ from toolkit.core.artifacts import (
 )
 
 
-# resolve_artifact_policy
+# resolve_artifact_policy — always returns "standard"
 
 @pytest.mark.policy
-@pytest.mark.parametrize("cfg, expected", [
-    (None, ARTIFACT_POLICY_STANDARD),
-    ({}, ARTIFACT_POLICY_STANDARD),
-    ({"artifacts": "standard"}, ARTIFACT_POLICY_STANDARD),
-    ({"artifacts": "  standard  "}, ARTIFACT_POLICY_STANDARD),
-    ({"artifacts": "STANDARD"}, ARTIFACT_POLICY_STANDARD),
-    ({"artifacts": "minimal"}, ARTIFACT_POLICY_MINIMAL),
-])
-def test_resolve_artifact_policy_valid(cfg, expected) -> None:
-    assert resolve_artifact_policy(cfg) == expected
-
-
-@pytest.mark.policy
-@pytest.mark.parametrize("policy", sorted(ARTIFACT_POLICIES))
-def test_resolve_artifact_policy_all_policies_valid(policy) -> None:
-    assert resolve_artifact_policy({"artifacts": policy}) == policy
-
-
-@pytest.mark.policy
-def test_resolve_artifact_policy_invalid_raises() -> None:
-    with pytest.raises(ValueError) as exc_info:
-        resolve_artifact_policy({"artifacts": "unknown"})
-    assert "output.artifacts must be one of" in str(exc_info.value)
+def test_resolve_artifact_policy_returns_standard() -> None:
+    assert resolve_artifact_policy(None) == "standard"
+    assert resolve_artifact_policy({}) == "standard"
+    assert resolve_artifact_policy({"artifacts": "minimal"}) == "standard"
+    assert resolve_artifact_policy({"artifacts": "unknown"}) == "standard"
 
 
 # legacy_aliases_enabled
@@ -84,33 +63,30 @@ def test_profile_required_object_attribute_access() -> None:
     assert profile_required(obj) is False
 
 
-# should_write
+# should_write — no policy gating, only conditional on profile/alias
 
 @pytest.mark.policy
-@pytest.mark.parametrize("layer, artifact, policy, cfg, expected", [
-    ("profile", "suggested_read", ARTIFACT_POLICY_STANDARD, {"clean": {"read": {"source": "auto"}}}, True),
-    ("profile", "suggested_read", ARTIFACT_POLICY_STANDARD, {"clean": {"read": {"source": "duckdb"}}}, False),
-    ("profile", "profile_alias", ARTIFACT_POLICY_STANDARD, {"output": {"artifacts": "standard", "legacy_aliases": True}}, True),
-    ("profile", "profile_alias", ARTIFACT_POLICY_MINIMAL, {"output": {"artifacts": "minimal", "legacy_aliases": True}}, False),
-    ("profile", "profile_alias", ARTIFACT_POLICY_STANDARD, {"output": {"artifacts": "standard", "legacy_aliases": False}}, False),
+@pytest.mark.parametrize("layer, artifact, cfg, expected", [
+    ("profile", "suggested_read", {"clean": {"read": {"source": "auto"}}}, True),
+    ("profile", "suggested_read", {"clean": {"read": {"source": "duckdb"}}}, False),
+    ("profile", "profile_alias", {"output": {"legacy_aliases": True}}, True),
+    ("profile", "profile_alias", {"output": {"legacy_aliases": False}}, False),
+    ("profile", "profile_alias", {}, False),
 ])
-def test_should_write(layer, artifact, policy, cfg, expected) -> None:
-    assert should_write(layer, artifact, policy, cfg) is expected
+def test_should_write(layer, artifact, cfg, expected) -> None:
+    assert should_write(layer, artifact, "standard", cfg) is expected
 
 
 @pytest.mark.policy
 @pytest.mark.parametrize("layer, artifact", [
+    ("profile", "raw_profile"),
+    ("profile", "profile_md"),
+    ("profile", "suggested_mapping"),
     ("clean", "rendered_sql"),
     ("mart", "rendered_sql"),
-])
-def test_should_write_minimal_policy_suppresses_optional(layer, artifact) -> None:
-    assert should_write(layer, artifact, ARTIFACT_POLICY_MINIMAL, {}) is False
-
-
-@pytest.mark.policy
-@pytest.mark.parametrize("layer, artifact", [
     ("clean", "data_parquet"),
     ("mart", "aggregated_parquet"),
 ])
-def test_should_write_minimal_policy_keeps_required(layer, artifact) -> None:
-    assert should_write(layer, artifact, ARTIFACT_POLICY_MINIMAL, {}) is True
+def test_should_write_always_true(layer, artifact) -> None:
+    """Artifacts no longer suppressed by policy — always returned True."""
+    assert should_write(layer, artifact, "standard", {}) is True

--- a/tests/test_cli_profile.py
+++ b/tests/test_cli_profile.py
@@ -8,36 +8,7 @@ import pytest
 from typer.testing import CliRunner
 
 from toolkit.cli.app import app
-from toolkit.cli.cmd_profile import render_profile_md
 from toolkit.core.io import write_json_atomic
-
-
-def test_render_profile_md_includes_expected_sections() -> None:
-    profile = {
-        "dataset": "demo_ds",
-        "year": 2024,
-        "file_used": "demo.csv",
-        "encoding_suggested": "utf-8",
-        "header_line": "col1;col2",
-        "columns_raw": ["col1", "col2"],
-        "missingness_top": [{"column": "col2", "missing_pct": 12.5}],
-        "warnings": ["warning uno"],
-        "mapping_suggestions": {
-            "col1_clean": {"type": "text"},
-            "col2_clean": {"type": "number", "parse": {"kind": "int"}},
-        },
-        "robust_read_suggested": True,
-    }
-
-    md = render_profile_md(profile)
-
-    assert "# RAW Profile - demo_ds (2024)" in md
-    assert "## Suggested read options" in md
-    assert "## Header (first line)" in md
-    assert "## Missingness (top)" in md
-    assert "## Mapping suggestions (first 15)" in md
-    assert "## Warnings" in md
-    assert "`col2`: 12.5%" in md
 
 
 def test_cli_profile_raw_happy_path(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -38,7 +38,8 @@ def _simplify_sql_project(dst: Path) -> None:
         sql_path.write_text("SELECT * FROM clean_input\n", encoding="utf-8")
 
 
-def test_artifacts_policy_minimal_skips_optional_outputs(tmp_path: Path, monkeypatch):
+def test_artifacts_policy_minimal_behaves_like_standard(tmp_path: Path, monkeypatch):
+    """minimal policy no longer suppresses artifacts — same output as standard."""
     src = Path("project-example")
     dst = tmp_path / "project-example"
     shutil.copytree(src, dst)
@@ -91,9 +92,8 @@ def test_artifacts_policy_minimal_skips_optional_outputs(tmp_path: Path, monkeyp
     assert not (profile_dir / "profile.json").exists()
     assert not (profile_dir / "profile.md").exists()
     assert not (profile_dir / "suggested_mapping.yml").exists()
-    assert not (clean_dir / "_run" / "clean_rendered.sql").exists()
-    if (mart_dir / "_run").exists():
-        assert not any((mart_dir / "_run").glob("*_rendered.sql"))
+    assert (clean_dir / "_run" / "clean_rendered.sql").exists()
+    assert any((mart_dir / "_run").glob("*_rendered.sql"))
 
     assert (clean_dir / "manifest.json").exists()
     assert (clean_dir / "metadata.json").exists()

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -103,7 +103,7 @@ def test_artifacts_policy_minimal_skips_optional_outputs(tmp_path: Path, monkeyp
     assert (mart_dir / "_validate" / "mart_validation.json").exists()
 
 
-def test_artifacts_policy_standard_keeps_current_debug_artifacts(tmp_path: Path, monkeypatch):
+def test_artifacts_policy_standard_keeps_expected_artifacts(tmp_path: Path, monkeypatch):
     src = Path("project-example")
     dst = tmp_path / "project-example"
     shutil.copytree(src, dst)

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -6,7 +6,7 @@ from typing import Any
 from toolkit.clean.duckdb_read import SUPPORTED_INPUT_EXTS
 from toolkit.clean.read_config import resolve_clean_read_cfg
 from toolkit.clean.input_selection import select_raw_input
-from toolkit.core.artifacts import ARTIFACT_POLICY_DEBUG, resolve_artifact_policy, should_write
+from toolkit.core.artifacts import resolve_artifact_policy, should_write
 from toolkit.core.config import ensure_dict
 from toolkit.core.metadata import config_hash_for_year, file_record, write_layer_manifest, write_metadata
 from toolkit.core.paths import layer_year_dir, resolve_root, resolve_sql_path, serialize_metadata_path
@@ -156,12 +156,6 @@ def _clean_metadata_payload(
         "outputs": outputs,
         "input_files": [p.name for p in input_files],
     }
-    if policy == ARTIFACT_POLICY_DEBUG:
-        metadata_payload["debug"] = {
-            "sql_absolute": str(sql_path_obj.resolve()),
-            "sql_rendered_absolute": str(rendered_sql_path.resolve()) if rendered_sql_path else None,
-            "output_root_absolute": str(root_dir.resolve()),
-        }
     return metadata_payload
 
 

--- a/toolkit/cli/cmd_profile.py
+++ b/toolkit/cli/cmd_profile.py
@@ -1,100 +1,11 @@
 from __future__ import annotations
 
-from typing import Any
-
 import typer
 
 from toolkit.cli.common import iter_years, load_cfg_and_logger
 from toolkit.core.artifacts import resolve_artifact_policy, should_write
 from toolkit.core.paths import layer_year_dir
-from toolkit.profile.raw import (
-    build_suggested_read_cfg,
-    profile_raw,
-    write_raw_profile,
-    write_suggested_read_yml,
-)
-
-
-def render_profile_md(profile: dict[str, Any]) -> str:
-    ds = profile.get("dataset")
-    year = profile.get("year")
-    enc = profile.get("encoding_suggested")
-    header = profile.get("header_line")
-    file_used = profile.get("file_used")
-    suggested_read = build_suggested_read_cfg(profile)
-
-    columns_raw: list[str] = profile.get("columns_raw", [])
-    miss = profile.get("missingness_top", [])
-    warnings = profile.get("warnings", [])
-    mapping = profile.get("mapping_suggestions", {}) or {}
-
-    md: list[str] = []
-    md.append(f"# RAW Profile - {ds} ({year})\n")
-    if file_used:
-        md.append(f"- file used: `{file_used}`\n")
-    if enc:
-        md.append(f"- encoding suggested: `{enc}`\n")
-
-    md.append("## Suggested read options\n")
-    md.append("```yml")
-    md.append("clean:")
-    md.append("  read:")
-    for key, value in suggested_read.items():
-        md.append(f"    {key}: {_yml_scalar(value)}")
-    md.append("```\n")
-
-    md.append("## Header (first line)\n")
-    if header:
-        md.append("```")
-        md.append(header)
-        md.append("```\n")
-    else:
-        md.append("_header not available_\n")
-
-    md.append("## Columns (preview)\n")
-    for c in columns_raw[:80]:
-        md.append(f"- `{c}`")
-    if len(columns_raw) > 80:
-        md.append(f"- ... +{len(columns_raw) - 80} more")
-    md.append("")
-
-    md.append("## Missingness (top)\n")
-    for m in miss[:20]:
-        md.append(f"- `{m['column']}`: {m['missing_pct']:.1f}%")
-    md.append("")
-
-    md.append("## Mapping suggestions (first 15)\n")
-    shown = 0
-    for out_col, spec in mapping.items():
-        md.append(
-            f"- `{out_col}` -> type: `{spec.get('type')}`"
-            + (f", parse: `{spec.get('parse', {}).get('kind')}`" if spec.get("parse") else "")
-        )
-        shown += 1
-        if shown >= 15:
-            break
-    if len(mapping) > 15:
-        md.append(f"- ... +{len(mapping) - 15} more")
-    md.append("")
-
-    if warnings:
-        md.append("## Warnings\n")
-        for w in warnings[:20]:
-            md.append(f"- {w}")
-        md.append("")
-
-    return "\n".join(md)
-
-
-def _yml_scalar(v: Any) -> str:
-    if isinstance(v, str):
-        v = v.replace('"', '\\"')
-        return f'"{v}"'
-    if isinstance(v, bool):
-        return "true" if v else "false"
-    if v is None:
-        return "null"
-    return str(v)
+from toolkit.profile.raw import profile_raw, write_raw_profile, write_suggested_read_yml
 
 
 def profile(

--- a/toolkit/cli/cmd_profile.py
+++ b/toolkit/cli/cmd_profile.py
@@ -165,16 +165,8 @@ def profile(
 
         written_paths = list(paths.values())
 
-        if should_write("profile", "profile_md", policy, cfg):
-            md_path = out_dir / "profile.md"
-            md_path.write_text(render_profile_md(prof.__dict__), encoding="utf-8")
-            written_paths.append(md_path)
-
         if should_write("profile", "suggested_read", policy, cfg):
             written_paths.append(write_suggested_read_yml(out_dir, prof.__dict__))
-
-        if should_write("profile", "suggested_mapping", policy, cfg):
-            written_paths.append(write_suggested_mapping_yml(out_dir, prof.__dict__))
 
         if written_paths:
             logger.info("PROFILE RAW -> %s", " | ".join(str(path) for path in written_paths))

--- a/toolkit/cli/cmd_profile.py
+++ b/toolkit/cli/cmd_profile.py
@@ -119,8 +119,8 @@ def profile(
 
         prof = profile_raw(raw_dir, cfg.dataset, year, read_cfg=(cfg.clean or {}).get("read"))
         # Explicit `toolkit profile raw` should always emit the canonical profile JSON.
-        # This keeps the assist workflow usable even when `output.artifacts: minimal`
-        # would otherwise skip profile artifacts during normal pipeline runs.
+        # Always emit canonical profile JSON for the assist workflow,
+        # regardless of any discard-happy output configuration.
         paths = write_raw_profile(
             out_dir,
             prof,

--- a/toolkit/cli/cmd_profile.py
+++ b/toolkit/cli/cmd_profile.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
 import typer
@@ -96,40 +95,6 @@ def _yml_scalar(v: Any) -> str:
     if v is None:
         return "null"
     return str(v)
-
-
-def write_suggested_mapping_yml(out_dir: Path, profile: dict[str, Any]) -> Path:
-    out_dir.mkdir(parents=True, exist_ok=True)
-    mapping = profile.get("mapping_suggestions") or {}
-
-    lines: list[str] = []
-    lines.append("clean:")
-    lines.append("  mapping:")
-
-    for out_col, spec in mapping.items():
-        lines.append(f"    {out_col}:")
-        for k in ["from", "type"]:
-            if k in spec:
-                lines.append(f"      {k}: {_yml_scalar(spec[k])}")
-
-        if "normalize" in spec:
-            lines.append("      normalize:")
-            for op in spec["normalize"]:
-                lines.append(f"        - {_yml_scalar(op)}")
-
-        if "nullify" in spec:
-            lines.append("      nullify:")
-            for tok in spec["nullify"]:
-                lines.append(f"        - {_yml_scalar(tok)}")
-
-        if "parse" in spec:
-            lines.append("      parse:")
-            for pk, pv in spec["parse"].items():
-                lines.append(f"        {pk}: {_yml_scalar(pv)}")
-
-    p = out_dir / "suggested_mapping.yml"
-    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    return p
 
 
 def profile(

--- a/toolkit/core/artifacts.py
+++ b/toolkit/core/artifacts.py
@@ -5,11 +5,9 @@ from typing import Any
 
 ARTIFACT_POLICY_MINIMAL = "minimal"
 ARTIFACT_POLICY_STANDARD = "standard"
-ARTIFACT_POLICY_DEBUG = "debug"
 ARTIFACT_POLICIES = {
     ARTIFACT_POLICY_MINIMAL,
     ARTIFACT_POLICY_STANDARD,
-    ARTIFACT_POLICY_DEBUG,
 }
 
 
@@ -46,9 +44,6 @@ def should_write(
     policy: str,
     cfg: Any,
 ) -> bool:
-    if policy == ARTIFACT_POLICY_DEBUG:
-        return True
-
     output_cfg = getattr(cfg, "output", None) if not isinstance(cfg, dict) else cfg.get("output")
 
     if layer == "profile":
@@ -58,8 +53,6 @@ def should_write(
             return policy != ARTIFACT_POLICY_MINIMAL
         if artifact_name == "profile_alias":
             return policy != ARTIFACT_POLICY_MINIMAL and legacy_aliases_enabled(output_cfg)
-        if artifact_name in {"profile_md", "suggested_mapping"}:
-            return False
 
     if layer in {"clean", "mart"} and artifact_name == "rendered_sql":
         return policy != ARTIFACT_POLICY_MINIMAL

--- a/toolkit/core/artifacts.py
+++ b/toolkit/core/artifacts.py
@@ -3,20 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 
-ARTIFACT_POLICY_MINIMAL = "minimal"
-ARTIFACT_POLICY_STANDARD = "standard"
-ARTIFACT_POLICIES = {
-    ARTIFACT_POLICY_MINIMAL,
-    ARTIFACT_POLICY_STANDARD,
-}
-
-
 def resolve_artifact_policy(output_cfg: dict[str, Any] | None) -> str:
-    policy = str((output_cfg or {}).get("artifacts", ARTIFACT_POLICY_STANDARD)).strip().lower()
-    if policy not in ARTIFACT_POLICIES:
-        allowed = ", ".join(sorted(ARTIFACT_POLICIES))
-        raise ValueError(f"output.artifacts must be one of: {allowed}")
-    return policy
+    """Backward-compat placeholder: accepts any value, always returns ``'standard'``."""
+    return "standard"
 
 
 def legacy_aliases_enabled(output_cfg: dict[str, Any] | None) -> bool:
@@ -44,17 +33,18 @@ def should_write(
     policy: str,
     cfg: Any,
 ) -> bool:
+    """Decide whether a given artifact should be produced.
+
+    The ``policy`` parameter is accepted for backward compatibility but
+    is no longer consulted — profiling and rendered-SQL artifacts are
+    always written when applicable.
+    """
     output_cfg = getattr(cfg, "output", None) if not isinstance(cfg, dict) else cfg.get("output")
 
     if layer == "profile":
         if artifact_name == "suggested_read":
             return profile_required(cfg)
-        if artifact_name == "raw_profile":
-            return policy != ARTIFACT_POLICY_MINIMAL
         if artifact_name == "profile_alias":
-            return policy != ARTIFACT_POLICY_MINIMAL and legacy_aliases_enabled(output_cfg)
-
-    if layer in {"clean", "mart"} and artifact_name == "rendered_sql":
-        return policy != ARTIFACT_POLICY_MINIMAL
+            return legacy_aliases_enabled(output_cfg)
 
     return True

--- a/toolkit/core/config_models/shared_models.py
+++ b/toolkit/core/config_models/shared_models.py
@@ -158,7 +158,7 @@ class SupportDatasetConfig(BaseModel):
 class OutputConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    artifacts: Literal["minimal", "standard", "debug"] = "standard"
+    artifacts: Literal["minimal", "standard"] = "standard"
     legacy_aliases: bool = False
 
 

--- a/toolkit/core/config_models/shared_models.py
+++ b/toolkit/core/config_models/shared_models.py
@@ -158,7 +158,7 @@ class SupportDatasetConfig(BaseModel):
 class OutputConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    artifacts: Literal["minimal", "standard"] = "standard"
+    artifacts: str = "standard"
     legacy_aliases: bool = False
 
 

--- a/toolkit/cross/run.py
+++ b/toolkit/cross/run.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import duckdb
 
-from toolkit.core.artifacts import ARTIFACT_POLICY_DEBUG, resolve_artifact_policy, should_write
+from toolkit.core.artifacts import resolve_artifact_policy, should_write
 from toolkit.core.config import ensure_dict
 from toolkit.core.metadata import file_record, sha256_bytes, write_layer_manifest, write_metadata
 from toolkit.core.paths import layer_dataset_dir, layer_year_dir, resolve_root, resolve_sql_path, serialize_metadata_path
@@ -101,7 +101,6 @@ def run_cross_year(
 
         written: list[Path] = []
         executed: list[dict[str, Any]] = []
-        debug_tables: list[dict[str, Any]] = []
 
         for i, table in enumerate(tables, start=1):
             if not isinstance(table, dict):
@@ -143,15 +142,6 @@ def run_cross_year(
                     "source_inputs": [serialize_metadata_path(path, root_dir) for path in files],
                 }
             )
-            if policy == ARTIFACT_POLICY_DEBUG:
-                debug_tables.append(
-                    {
-                        "name": name,
-                        "sql_absolute": str(sql_path.resolve()),
-                        "sql_rendered_absolute": str(rendered_sql_path.resolve()) if rendered_sql_path else None,
-                        "output_absolute": str(out.resolve()),
-                    }
-                )
     finally:
         con.close()
 
@@ -165,11 +155,6 @@ def run_cross_year(
         "output_paths": [serialize_metadata_path(path, root_dir) for path in written],
         "tables": executed,
     }
-    if policy == ARTIFACT_POLICY_DEBUG:
-        metadata_payload["debug"] = {  # type: ignore[assignment]
-            "output_root_absolute": str(root_dir.resolve()),
-            "tables": debug_tables,
-        }
     metadata_path = write_metadata(cross_dir, metadata_payload)
     write_layer_manifest(
         cross_dir,

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import duckdb
 
-from toolkit.core.artifacts import ARTIFACT_POLICY_DEBUG, resolve_artifact_policy, should_write
+from toolkit.core.artifacts import resolve_artifact_policy, should_write
 from toolkit.core.config import ensure_dict
 from toolkit.core.layer_profile import compare_layer_profiles, profile_relation, profile_parquet_files
 from toolkit.core.metadata import config_hash_for_year, file_record, write_layer_manifest, write_metadata
@@ -87,7 +87,6 @@ def run_mart(
         executed: list[dict[str, Any]] = []
         table_profiles: dict[str, Any] = {}
         transition_profiles: list[dict[str, Any]] = []
-        debug_tables: list[dict[str, Any]] = []
         total_rows = 0
 
         for i, table in enumerate(tables, start=1):
@@ -145,16 +144,6 @@ def run_mart(
                     "output": serialize_metadata_path(out, root_dir),
                 }
             )
-            if policy == ARTIFACT_POLICY_DEBUG:
-                debug_tables.append(
-                    {
-                        "name": name,
-                        "sql_absolute": str(sql_path.resolve()),
-                        "sql_rendered_absolute": str(rendered_sql_path.resolve()) if rendered_sql_path else None,
-                        "output_absolute": str(out.resolve()),
-                    }
-                )
-
     finally:
         con.close()
 
@@ -173,11 +162,6 @@ def run_mart(
         "table_profiles": table_profiles,
         "transition_profiles": transition_profiles,
     }
-    if policy == ARTIFACT_POLICY_DEBUG:
-        metadata_payload["debug"] = {
-            "output_root_absolute": str(root_dir.resolve()),
-            "tables": debug_tables,
-        }
     metadata_path = write_metadata(
         mart_dir,
         metadata_payload,


### PR DESCRIPTION
## Cosa

Eliminazione dei livelli `debug` e `minimal` della artifact policy — profiling e rendered SQL sono **sempre scritti**.

## Commits

| Commit | Cosa |
|---|---|
| `e2bd51f` | Rimuovere `ARTIFACT_POLICY_DEBUG`, blocchi debug in metadata, condizioni morte profile_md/suggested_mapping |
| `07573b8` | Fix examples/dataset_full.yml, doc, rimosso write_suggested_mapping_yml (dead code) |
| `bef11bf` | Rimuovere `ARTIFACT_POLICY_MINIMAL`: resolve_artifact_policy sempre standard, should_write senza policy |

## Cosa cambia

- `raw_profile.json` e `rendered_sql` sempre scritti (non piu' condizionali a minimal)
- `debug` metadata (path assoluti) rimossi da clean/mart/cross
- `resolve_artifact_policy` non valida piu' — sempre `"standard"`
- `OutputConfig.artifacts`: da `Literal["minimal","standard","debug"]` a `str`
- `write_suggested_mapping_yml` rimosso (dead code)
- ~200 righe nette rimosse

## Backward compat

`output.artifacts: minimal` o `debug` nelle config → accettato senza errore, ignorato.
Candidati dataset-incubator ancora su minimal migrati in parallelo.

## Test

627 passanti, ruff pulito.