### PR TITLE
fix: SSL fallback per expired/invalid cert in HttpFileSource

### DIFF
--- a/tests/test_http_file_plugin.py
+++ b/tests/test_http_file_plugin.py
@@ -71,3 +71,71 @@ def test_http_file_fetch_http_status_error(monkeypatch: pytest.MonkeyPatch) -> N
     source = HttpFileSource(retries=1)
     with pytest.raises(DownloadError, match="HTTP 503"):
         source.fetch("https://example.test/unavailable")
+
+
+@pytest.mark.policy
+def test_http_file_ssl_fallback_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SSLError triggers verify=False fallback that succeeds."""
+    first_get = True
+
+    def fake_get(url: str, timeout: int, headers: dict[str, str]):
+        nonlocal first_get
+        if first_get:
+            first_get = False
+            raise requests.exceptions.SSLError("cert expired")
+        return _FakeResponse(200, b"ssl-fallback-payload")
+
+    monkeypatch.setattr("toolkit.plugins.http_file.requests.get", fake_get)
+
+    session_get_calls: list[dict[str, object]] = []
+
+    class FakeSession:
+        def get(self, url, timeout=60, headers=None, verify=True):
+            session_get_calls.append({"verify": verify})
+            return _FakeResponse(200, b"ssl-fallback-payload")
+
+        def close(self):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    monkeypatch.setattr("toolkit.plugins.http_file.requests.Session", lambda: FakeSession())
+
+    source = HttpFileSource(retries=2)
+    payload = source.fetch("https://example.test/ssl-expired")
+
+    assert payload == b"ssl-fallback-payload"
+    assert len(session_get_calls) == 1
+    assert session_get_calls[0]["verify"] is False
+
+
+@pytest.mark.policy
+def test_http_file_ssl_fallback_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SSLError → SSL fallback also fails → DownloadError."""
+    def fake_get(url: str, timeout: int, headers: dict[str, str]):
+        raise requests.exceptions.SSLError("cert expired")
+
+    monkeypatch.setattr("toolkit.plugins.http_file.requests.get", fake_get)
+
+    class FakeSession:
+        def get(self, url, timeout=60, headers=None, verify=True):
+            raise requests.exceptions.ConnectionError("fallback also failed")
+
+        def close(self):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    monkeypatch.setattr("toolkit.plugins.http_file.requests.Session", lambda: FakeSession())
+
+    source = HttpFileSource(retries=1)
+    with pytest.raises(DownloadError, match="fallback also failed"):
+        source.fetch("https://example.test/ssl-fail")

--- a/toolkit/plugins/http_file.py
+++ b/toolkit/plugins/http_file.py
@@ -1,8 +1,12 @@
+import logging
+
 import requests
 import urllib3
 from urllib3.exceptions import InsecureRequestWarning
 
 from toolkit.core.exceptions import DownloadError
+
+logger = logging.getLogger("toolkit.plugins.http_file")
 
 
 class HttpFileSource:
@@ -24,11 +28,11 @@ class HttpFileSource:
                 return r.content
             except requests.exceptions.SSLError:
                 # SSL fallback: make a fresh request with verify=False
+                logger.warning("SSL error per %s — retry con verify=False", url)
                 urllib3.disable_warnings(InsecureRequestWarning)
                 try:
-                    # Create fresh session to avoid urllib3 retry state carry-over
-                    session = requests.Session()
-                    r = session.get(url, timeout=self.timeout, headers=headers, verify=False)
+                    with requests.Session() as session:
+                        r = session.get(url, timeout=self.timeout, headers=headers, verify=False)
                     if r.status_code != 200:
                         raise DownloadError(f"HTTP {r.status_code} for {url}")
                     return r.content

--- a/toolkit/plugins/http_file.py
+++ b/toolkit/plugins/http_file.py
@@ -1,10 +1,12 @@
 import requests
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
 
 from toolkit.core.exceptions import DownloadError
 
 
 class HttpFileSource:
-    """Download a file via HTTP(S)."""
+    """Download a file via HTTP(S) with SSL fallback for expired/invalid certs."""
 
     def __init__(self, timeout: int = 60, retries: int = 2, user_agent: str | None = None):
         self.timeout = timeout
@@ -20,7 +22,21 @@ class HttpFileSource:
                 if r.status_code != 200:
                     raise DownloadError(f"HTTP {r.status_code} for {url}")
                 return r.content
+            except requests.exceptions.SSLError:
+                # SSL fallback: make a fresh request with verify=False
+                urllib3.disable_warnings(InsecureRequestWarning)
+                try:
+                    # Create fresh session to avoid urllib3 retry state carry-over
+                    session = requests.Session()
+                    r = session.get(url, timeout=self.timeout, headers=headers, verify=False)
+                    if r.status_code != 200:
+                        raise DownloadError(f"HTTP {r.status_code} for {url}")
+                    return r.content
+                except Exception as e:
+                    last_err = e
+                    continue  # try again in next outer iteration
             except Exception as e:
                 last_err = e
+                continue  # try again in next outer iteration
 
         raise DownloadError(str(last_err) if last_err else f"Failed to fetch {url}")


### PR DESCRIPTION
## Cosa

`HttpFileSource.fetch()` catturava `requests.exceptions.SSLError` nel generico `except Exception` e ritentava senza risolvere il problema — esauriti i retry, errore finale.

**Fix**: cattura `SSLError` prima del generico `except`, prova fresh session con `verify=False`. Se il fallback fallisce, retry normale.

## Dettaglio

| Prima | Dopo |
|---|---|
| `SSLError` → `except Exception` → retry senza fallback → errore | `SSLError` → fresh session `verify=False` → OK |
| `import urllib3` dentro `except` (rischio eccezione mascherata) | Import a inizio file |
| `continue` mancante dopo `last_err = e` | `continue` esplicito in entrambi i branch |

## Test

- opencivitas-fsc-rso: `b_enti` e `a_fsc` → RAW + CLEAN + MART OK (prima: SSL error, mai runnati)
- 614 test passanti, ruff e mypy puliti (solo pre-existing stub errors)