### PR TITLE
feat: TypedDict contracts per blocker-hints, review-readiness, schema-diff

### DIFF
--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -467,3 +467,86 @@ def test_inspect_paths_multi_year_requires_year(tmp_path: Path, monkeypatch) -> 
 
     with pytest.raises(ToolkitClientError, match="year è obbligatorio"):
         inspect_paths(str(yml))
+
+
+@pytest.mark.policy
+def test_blocker_hints_cli_contract_alignment(tmp_path: Path, monkeypatch) -> None:
+    """toolkit blocker-hints --json output matches BlockerHintsResult TypedDict."""
+    from typer.testing import CliRunner
+
+    from toolkit.cli.app import app
+    from toolkit.mcp.contracts import BlockerHintsResult, Hint
+
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["blocker-hints", "--config", str(config_path), "--year", "2022", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    for key in BlockerHintsResult.__required_keys__:
+        assert key in payload, f"BlockerHintsResult: chiave '{key}' mancante"
+    for hint in payload.get("hints", []):
+        for key in Hint.__required_keys__:
+            assert key in hint, f"Hint: chiave '{key}' mancante in {hint.get('code')}"
+
+
+@pytest.mark.policy
+def test_schema_diff_cli_contract_alignment(tmp_path: Path, monkeypatch) -> None:
+    """toolkit inspect schema-diff --json output matches SchemaDiffResult TypedDict."""
+    from typer.testing import CliRunner
+
+    from toolkit.cli.app import app
+    from toolkit.mcp.contracts import (
+        RawSchemaEntry,
+        SchemaComparison,
+        SchemaDiffResult,
+    )
+
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["inspect", "schema-diff", "--config", str(config_path), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    for key in SchemaDiffResult.__required_keys__:
+        assert key in payload, f"SchemaDiffResult: chiave '{key}' mancante"
+    for entry in payload.get("entries", []):
+        for key in RawSchemaEntry.__required_keys__:
+            assert key in entry, f"RawSchemaEntry: chiave '{key}' mancante in anno {entry.get('year')}"
+    for comp in payload.get("comparisons", []):
+        for key in SchemaComparison.__required_keys__:
+            assert key in comp, f"SchemaComparison: chiave '{key}' mancante"
+
+
+@pytest.mark.policy
+def test_review_readiness_mcp_contract_shape(tmp_path: Path, monkeypatch) -> None:
+    """review_readiness() output matches ReviewReadinessResult TypedDict."""
+    from toolkit.mcp.contracts import ReadinessCheck, ReviewReadinessResult
+    from toolkit.mcp.toolkit_client import review_readiness
+
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst)
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.chdir(tmp_path)
+
+    payload = review_readiness(str(config_path), 2022)
+
+    for key in ReviewReadinessResult.__required_keys__:
+        assert key in payload, f"ReviewReadinessResult: chiave '{key}' mancante"
+    for check in payload.get("checks", []):
+        for ck in ReadinessCheck.__required_keys__:
+            assert ck in check, f"ReadinessCheck: chiave '{ck}' mancante in {check.get('check')}"

--- a/toolkit/mcp/contracts.py
+++ b/toolkit/mcp/contracts.py
@@ -80,10 +80,10 @@ class Hint(TypedDict):
     message: str
 
 
-class BlockerHintsResult(TypedDict, total=False):
+class BlockerHintsResult(TypedDict):
     dataset: str | None
     config_path: str
-    year: str | None
+    year: int | None
     hint_count: int
     hints: list[Hint]
     blocker_count: int
@@ -105,10 +105,10 @@ class ReadinessCheck(TypedDict):
     detail: str | list[MartOutputCheck]
 
 
-class ReviewReadinessResult(TypedDict, total=False):
+class ReviewReadinessResult(TypedDict):
     dataset: str | None
     config_path: str
-    year: str | None
+    year: int | None
     readiness: str  # "ready" | "needs-review" | "incomplete"
     check_count: int
     ok_count: int
@@ -118,7 +118,7 @@ class ReviewReadinessResult(TypedDict, total=False):
 
 # --- schema-diff ---
 
-class RawSchemaEntry(TypedDict, total=False):
+class RawSchemaEntry(TypedDict):
     year: int
     raw_dir: str
     raw_exists: bool
@@ -136,7 +136,7 @@ class RawSchemaEntry(TypedDict, total=False):
     warnings: list[str]
 
 
-class SchemaComparison(TypedDict, total=False):
+class SchemaComparison(TypedDict):
     from_year: int
     to_year: int
     from_columns_count: int
@@ -146,7 +146,7 @@ class SchemaComparison(TypedDict, total=False):
     changed: bool
 
 
-class SchemaDiffResult(TypedDict, total=False):
+class SchemaDiffResult(TypedDict):
     dataset: str
     config_path: str
     years: list[int]

--- a/toolkit/mcp/contracts.py
+++ b/toolkit/mcp/contracts.py
@@ -70,3 +70,85 @@ class InspectPathsResult(TypedDict):
     raw_hints: RawHints
     layer_profiles: dict[str, Any]
     latest_run: LatestRun | None
+
+
+# --- blocker-hints ---
+
+class Hint(TypedDict):
+    code: str
+    severity: str  # "blocker" | "warning"
+    message: str
+
+
+class BlockerHintsResult(TypedDict, total=False):
+    dataset: str | None
+    config_path: str
+    year: str | None
+    hint_count: int
+    hints: list[Hint]
+    blocker_count: int
+    warning_count: int
+
+
+# --- review-readiness (MCP only, no CLI) ---
+
+class MartOutputCheck(TypedDict):
+    name: str
+    exists: bool
+    readable: bool | None
+    rows: int | None
+
+
+class ReadinessCheck(TypedDict):
+    check: str
+    ok: bool
+    detail: str | list[MartOutputCheck]
+
+
+class ReviewReadinessResult(TypedDict, total=False):
+    dataset: str | None
+    config_path: str
+    year: str | None
+    readiness: str  # "ready" | "needs-review" | "incomplete"
+    check_count: int
+    ok_count: int
+    fail_count: int
+    checks: list[ReadinessCheck]
+
+
+# --- schema-diff ---
+
+class RawSchemaEntry(TypedDict, total=False):
+    year: int
+    raw_dir: str
+    raw_exists: bool
+    primary_output_file: str | None
+    file_used: str | None
+    profile_source: str | None
+    is_binary_file: bool | None
+    encoding: str | None
+    delim: str | None
+    decimal: str | None
+    skip: int | None
+    header_line: str | None
+    columns_count: int
+    columns_preview: list[str]
+    warnings: list[str]
+
+
+class SchemaComparison(TypedDict, total=False):
+    from_year: int
+    to_year: int
+    from_columns_count: int
+    to_columns_count: int
+    added_columns: list[str]
+    removed_columns: list[str]
+    changed: bool
+
+
+class SchemaDiffResult(TypedDict, total=False):
+    dataset: str
+    config_path: str
+    years: list[int]
+    entries: list[RawSchemaEntry]
+    comparisons: list[SchemaComparison]


### PR DESCRIPTION
## Cosa

Aggiunge contratti TypedDict per 3 output MCP, stesso pattern di PR #228:

### Contratti aggiunti

| Contratto | Comando | Ha CLI? | Test |
|---|---|---|---|
| `BlockerHintsResult` + `Hint` | `blocker-hints` | ✅ | ✅ |
| `SchemaDiffResult` + `RawSchemaEntry` + `SchemaComparison` | `inspect schema-diff` | ✅ | ✅ |
| `ReviewReadinessResult` + `ReadinessCheck` + `MartOutputCheck` | solo MCP | ❌ | ✅ (output diretto) |

### Test di allineamento

- `test_blocker_hints_cli_contract_alignment` — invoca `toolkit blocker-hints --json` via CLI runner e verifica ogni chiave contro `BlockerHintsResult`
- `test_schema_diff_cli_contract_alignment` — invoca `toolkit inspect schema-diff --json` e verifica contro `SchemaDiffResult`
- `test_review_readiness_mcp_contract_shape` — verifica output di `review_readiness()` contro `ReviewReadinessResult`

### Stat

619 test passanti, ruff pulito, 165 righe aggiunte.