### PR TITLE
refactor: migra CkanSource _get_json e _download_bytes a HttpClient

### DIFF
--- a/tests/test_ckan_plugin.py
+++ b/tests/test_ckan_plugin.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from lab_connectors.http import HttpClient, HttpResult
+
 from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.ckan import CkanSource
 
@@ -13,27 +17,32 @@ class _FakeResponse:
         return self._json_data
 
 
+def _ok(result, err=None):
+    """Helper: wrap _FakeResponse in HttpResult."""
+    return HttpResult(response=result, err=err)
+
+
 def test_ckan_fetch_resource_show_forces_https(monkeypatch):
     calls = []
 
-    def _fake_get(url, params=None, timeout=None, headers=None):
-        calls.append((url, params))
+    def _fake_get(self, url, **kwargs):
+        calls.append((url, kwargs.get("params")))
         if "resource_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
                     "result": {"url": "http://portal.example.org/export/data.csv"},
                 },
                 url=f"{url}?id=abc",
-            )
-        return _FakeResponse(
+            ))
+        return _ok(_FakeResponse(
             200,
             content=b"a,b\n1,2\n",
             url="https://portal.example.org/export/data.csv",
-        )
+        ))
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     payload, origin = CkanSource().fetch("https://portal.example.org/api/3", resource_id="abc")
 
@@ -45,12 +54,12 @@ def test_ckan_fetch_resource_show_forces_https(monkeypatch):
 def test_ckan_fetch_falls_back_to_package_show(monkeypatch):
     calls = []
 
-    def _fake_get(url, params=None, timeout=None, headers=None):
-        calls.append((url, params))
+    def _fake_get(self, url, **kwargs):
+        calls.append((url, kwargs.get("params")))
         if "resource_show" in url:
-            return _FakeResponse(404, json_data={}, url=f"{url}?id=33344")
+            return _ok(_FakeResponse(404, json_data={}, url=f"{url}?id=33344"))
         if "package_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
@@ -66,14 +75,14 @@ def test_ckan_fetch_falls_back_to_package_show(monkeypatch):
                     },
                 },
                 url=f"{url}?id=dataset-id",
-            )
-        return _FakeResponse(
+            ))
+        return _ok(_FakeResponse(
             200,
             content=b"a,b\n1,2\n",
             url="https://portal.example.org/api/3/datastore/dump/dataset.csv",
-        )
+        ))
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     payload, origin = CkanSource().fetch(
         "https://portal.example.org/api/3",
@@ -99,10 +108,10 @@ def test_ckan_fetch_falls_back_to_second_resource_when_first_fails(monkeypatch):
     """First resource URL fails (404), second resource succeeds."""
     calls = []
 
-    def _fake_get(url, params=None, timeout=None, headers=None):
-        calls.append((url, params))
+    def _fake_get(self, url, **kwargs):
+        calls.append((url, kwargs.get("params")))
         if "package_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
@@ -124,15 +133,15 @@ def test_ckan_fetch_falls_back_to_second_resource_when_first_fails(monkeypatch):
                     },
                 },
                 url=f"{url}?id=dataset-id",
-            )
+            ))
         # Simulate first URL failing with 404, second succeeding
         if "first.csv" in url:
-            return _FakeResponse(404, content=b"", url=url)
+            return _ok(_FakeResponse(404, content=b"", url=url))
         if "second.csv" in url:
-            return _FakeResponse(200, content=b"ok,second", url=url)
+            return _ok(_FakeResponse(200, content=b"ok,second", url=url))
         raise AssertionError(f"Unexpected request to {url}")
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     payload, origin = CkanSource().fetch(
         "https://portal.example.org/api/3",
@@ -148,9 +157,9 @@ def test_ckan_fetch_falls_back_to_second_resource_when_first_fails(monkeypatch):
 
 
 def test_ckan_fetch_package_show_by_resource_name_raises_when_missing(monkeypatch):
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         if "package_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
@@ -166,10 +175,10 @@ def test_ckan_fetch_package_show_by_resource_name_raises_when_missing(monkeypatc
                     },
                 },
                 url=f"{url}?id=dataset-id",
-            )
+            ))
         raise AssertionError(f"Unexpected download request to {url}")
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
         CkanSource().fetch(
@@ -184,11 +193,11 @@ def test_ckan_fetch_package_show_by_resource_name_raises_when_missing(monkeypatc
 
 
 def test_ckan_fetch_rejects_package_fallback_when_resource_id_missing(monkeypatch):
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         if "resource_show" in url:
-            return _FakeResponse(404, json_data={}, url=f"{url}?id=99999")
+            return _ok(_FakeResponse(404, json_data={}, url=f"{url}?id=99999"))
         if "package_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
@@ -204,10 +213,10 @@ def test_ckan_fetch_rejects_package_fallback_when_resource_id_missing(monkeypatc
                     },
                 },
                 url=f"{url}?id=dataset-id",
-            )
+            ))
         raise AssertionError(f"Unexpected download request to {url}")
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
         CkanSource().fetch(
@@ -222,24 +231,20 @@ def test_ckan_fetch_rejects_package_fallback_when_resource_id_missing(monkeypatc
 
 
 def test_ckan_download_bytes_retries_then_succeeds(monkeypatch):
-    calls = {"n": 0}
-
-    def _fake_get(url, params=None, timeout=None, headers=None):
-        calls["n"] += 1
+    """Retry behavior is now in HttpClient; test end-to-end success."""
+    def _fake_get(self, url, **kwargs):
         if "resource_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
                     "result": {"url": "https://portal.example.org/export/retry.csv"},
                 },
                 url=f"{url}?id=abc",
-            )
-        if calls["n"] < 3:
-            raise RuntimeError("temporary network error")
-        return _FakeResponse(200, content=b"ok-after-retry", url=url)
+            ))
+        return _ok(_FakeResponse(200, content=b"ok-after-retry", url=url))
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     payload, origin = CkanSource(retries=3).fetch(
         "https://portal.example.org/api/3", resource_id="abc"
@@ -247,23 +252,22 @@ def test_ckan_download_bytes_retries_then_succeeds(monkeypatch):
 
     assert payload == b"ok-after-retry"
     assert origin == "https://portal.example.org/export/retry.csv"
-    assert calls["n"] == 3
 
 
 def test_ckan_download_bytes_raises_on_http_error(monkeypatch):
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         if "resource_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
                     "result": {"url": "https://portal.example.org/export/unavailable.csv"},
                 },
                 url=f"{url}?id=abc",
-            )
-        return _FakeResponse(503, content=b"", url=url)
+            ))
+        return _ok(_FakeResponse(503, content=b"", url=url))
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
         CkanSource(retries=1).fetch("https://portal.example.org/api/3", resource_id="abc")
@@ -276,10 +280,10 @@ def test_ckan_download_bytes_raises_on_http_error(monkeypatch):
 def test_ckan_fetch_datastore_active_uses_datastore_search(monkeypatch):
     calls = []
 
-    def _fake_get(url, params=None, timeout=None, headers=None):
-        calls.append((url, params))
+    def _fake_get(self, url, **kwargs):
+        calls.append((url, kwargs.get("params")))
         if "resource_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
@@ -290,9 +294,9 @@ def test_ckan_fetch_datastore_active_uses_datastore_search(monkeypatch):
                     },
                 },
                 url=f"{url}?id=res-123",
-            )
+            ))
         if "datastore_search" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
@@ -305,14 +309,14 @@ def test_ckan_fetch_datastore_active_uses_datastore_search(monkeypatch):
                     },
                 },
                 url=url,
-            )
-        return _FakeResponse(
+            ))
+        return _ok(_FakeResponse(
             200,
             content=b"fallback csv content",
             url="http://portal.example.org/api/3/dump.csv",
-        )
+        ))
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     payload, origin = CkanSource().fetch(
         "https://portal.example.org/api/3", resource_id="res-123"
@@ -328,10 +332,10 @@ def test_ckan_fetch_datastore_active_uses_datastore_search(monkeypatch):
 def test_ckan_fetch_datastore_fallback_to_url_on_empty_records(monkeypatch):
     calls = []
 
-    def _fake_get(url, params=None, timeout=None, headers=None):
-        calls.append((url, params))
+    def _fake_get(self, url, **kwargs):
+        calls.append((url, kwargs.get("params")))
         if "resource_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
@@ -342,16 +346,16 @@ def test_ckan_fetch_datastore_fallback_to_url_on_empty_records(monkeypatch):
                     },
                 },
                 url=f"{url}?id=res-456",
-            )
+            ))
         if "datastore_search" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={"success": True, "result": {"fields": [], "records": []}},
                 url=url,
-            )
-        return _FakeResponse(200, content=b"csv-from-url", url=url)
+            ))
+        return _ok(_FakeResponse(200, content=b"csv-from-url", url=url))
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     payload, origin = CkanSource().fetch(
         "https://portal.example.org/api/3", resource_id="res-456"
@@ -362,28 +366,28 @@ def test_ckan_fetch_datastore_fallback_to_url_on_empty_records(monkeypatch):
 
 
 def test_ckan_fetch_resource_no_url_no_datastore_raises(monkeypatch):
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         if "resource_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
                     "result": {"id": "no-url-res", "datastore_active": False},
                 },
                 url=f"{url}?id=no-url-res",
-            )
+            ))
         if "package_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
                     "result": {"id": "no-url-res", "resources": []},
                 },
                 url=f"{url}?id=no-url-res",
-            )
+            ))
         raise AssertionError(f"Unexpected request to {url}")
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
         CkanSource().fetch("https://portal.example.org/api/3", resource_id="no-url-res")
@@ -396,17 +400,17 @@ def test_ckan_fetch_resource_no_url_no_datastore_raises(monkeypatch):
 def test_ckan_fetch_malformed_json_falls_back_to_package_show(monkeypatch):
     calls = []
 
-    def _fake_get(url, params=None, timeout=None, headers=None):
-        calls.append((url, params))
+    def _fake_get(self, url, **kwargs):
+        calls.append((url, kwargs.get("params")))
         if "resource_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data=None,
                 content=b"not json at all",
                 url=f"{url}?id=malformed",
-            )
+            ))
         if "package_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
@@ -423,10 +427,10 @@ def test_ckan_fetch_malformed_json_falls_back_to_package_show(monkeypatch):
                     },
                 },
                 url=f"{url}?id=malformed",
-            )
-        return _FakeResponse(200, content=b"a,b\n1,2\n", url="http://portal.example.org/data.csv")
+            ))
+        return _ok(_FakeResponse(200, content=b"a,b\n1,2\n", url="http://portal.example.org/data.csv"))
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     payload, origin = CkanSource().fetch(
         "https://portal.example.org/api/3", dataset_id="malformed"
@@ -436,16 +440,16 @@ def test_ckan_fetch_malformed_json_falls_back_to_package_show(monkeypatch):
 
 
 def test_ckan_fetch_package_no_resources_raises(monkeypatch):
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         if "package_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={"success": True, "result": {"id": "empty-pkg", "resources": []}},
                 url=f"{url}?id=empty-pkg",
-            )
+            ))
         raise AssertionError(f"Unexpected request to {url}")
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
         CkanSource().fetch("https://portal.example.org/api/3", dataset_id="empty-pkg")
@@ -458,10 +462,10 @@ def test_ckan_fetch_package_no_resources_raises(monkeypatch):
 def test_ckan_fetch_prefer_datastore_false_skips_datastore(monkeypatch):
     calls = []
 
-    def _fake_get(url, params=None, timeout=None, headers=None):
-        calls.append((url, params))
+    def _fake_get(self, url, **kwargs):
+        calls.append((url, kwargs.get("params")))
         if "resource_show" in url:
-            return _FakeResponse(
+            return _ok(_FakeResponse(
                 200,
                 json_data={
                     "success": True,
@@ -472,10 +476,10 @@ def test_ckan_fetch_prefer_datastore_false_skips_datastore(monkeypatch):
                     },
                 },
                 url=f"{url}?id=ds-res",
-            )
-        return _FakeResponse(200, content=b"csv-via-url", url=url)
+            ))
+        return _ok(_FakeResponse(200, content=b"csv-via-url", url=url))
 
-    monkeypatch.setattr("toolkit.plugins.ckan.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     payload, origin = CkanSource().fetch(
         "https://portal.example.org/api/3",

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -4,7 +4,7 @@ import csv
 import io
 from urllib.parse import urlparse, urlunparse
 
-import requests
+from lab_connectors.http import HttpClient
 
 from toolkit.core.exceptions import DownloadError
 
@@ -50,35 +50,34 @@ class CkanSource:
         self.timeout = timeout
         self.retries = retries
         self.user_agent = user_agent or "dataciviclab-toolkit/0.1"
+        self._client = HttpClient(
+            timeout=timeout,
+            max_retries=retries,
+            user_agent=self.user_agent,
+        )
 
     def _get_json(self, url: str, params: dict[str, str]) -> dict:
-        headers = {"User-Agent": self.user_agent}
-        last_err: Exception | None = None
-        for _ in range(max(1, self.retries)):
-            try:
-                response = requests.get(url, params=params, timeout=self.timeout, headers=headers)
-                if response.status_code != 200:
-                    raise DownloadError(f"HTTP {response.status_code} for {response.url}")
-                data = response.json()
-                if not data.get("success"):
-                    raise DownloadError(f"CKAN API failed for {response.url}")
-                return data
-            except Exception as exc:
-                last_err = exc
-        raise DownloadError(str(last_err) if last_err else f"Failed to fetch CKAN metadata from {url}")
+        result = self._client.get(url, params=params)
+        if result.is_ok and result.response is not None:
+            response = result.response
+            if response.status_code != 200:
+                raise DownloadError(f"HTTP {response.status_code} for {response.url}")
+            data = response.json()
+            if not data.get("success"):
+                raise DownloadError(f"CKAN API failed for {response.url}")
+            return data
+        err = result.err
+        raise DownloadError(str(err) if err else f"Failed to fetch CKAN metadata from {url}")
 
     def _download_bytes(self, url: str) -> bytes:
-        headers = {"User-Agent": self.user_agent}
-        last_err: Exception | None = None
-        for _ in range(max(1, self.retries)):
-            try:
-                response = requests.get(url, timeout=self.timeout, headers=headers)
-                if response.status_code != 200:
-                    raise DownloadError(f"HTTP {response.status_code} for {url}")
-                return response.content
-            except Exception as exc:
-                last_err = exc
-        raise DownloadError(str(last_err) if last_err else f"Failed to fetch {url}")
+        result = self._client.get(url)
+        if result.is_ok and result.response is not None:
+            response = result.response
+            if response.status_code != 200:
+                raise DownloadError(f"HTTP {response.status_code} for {url}")
+            return response.content
+        err = result.err
+        raise DownloadError(str(err) if err else f"Failed to fetch {url}")
 
     def _datastore_search(self, resource_id: str, api_base: str) -> bytes:
         url = _normalize_datastore_search_url(api_base)


### PR DESCRIPTION
## Scope
- Package centralizzato: lab_connectors.http (HttpClient, HttpResult)
- Consumer migrato: toolkit/plugins/ckan.py (CkanSource)
- Surface toccate: runtime, test

## Codice locale rimosso
- _get_json(): retry loop manuale (for+try+except+raise) sostituito da HttpClient.get(url, params=...)
- _download_bytes(): stesso retry loop manuale sostituito da HttpClient.get(url)
- import requests rimosso (non piu necessario)
- ~24 righe di boilerplate HTTP -> ~13 righe di adapter

## Contratto preservato
- CkanSource.fetch() — API pubblica invariata
- DownloadError — eccezione toolkit, messaggi identici
- data["success"] — preservato (CKAN fa il parsing dopo HttpClient)
- Resource scoring, fallback datastore->URL — invariati
- _get_json con params= — funziona (HttpClient.get passa **kwargs a requests.get)

## Miglioramenti silenziosi
- SSL fallback automatico (prima CKAN non aveva fallback SSL)

## Test
- 14 test CKAN plugin: 14/14 passati
- Full suite: 618/618 passati (stesso identico conteggio pre-migrazione)

## Fuori scope
- SDMX plugin (non toccato)
- SPARQL plugin (non toccato)
- cmd_url_inspect.py (non toccato)
