### PR TITLE
refactor: migra SdmxSource _get_text a HttpClient + test integrazione reale

### DIFF
--- a/tests/test_http_file_plugin.py
+++ b/tests/test_http_file_plugin.py
@@ -75,6 +75,15 @@ def test_fetch_passes_params() -> None:
     assert source2._client.user_agent == "dataciviclab-toolkit/0.1"
 
 
+@pytest.mark.adapter
+def test_integration_fetch_real_url() -> None:
+    """Real HTTPS fetch against a stable public URL (no mocks)."""
+    source = HttpFileSource(timeout=30, retries=1)
+    data = source.fetch("https://raw.githubusercontent.com/dataciviclab/toolkit/main/README.md")
+    assert len(data) > 100
+    assert b"DataCivicLab Toolkit" in data
+
+
 @pytest.mark.policy
 def test_ssl_fallback_semantics_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
     """ssl_fallback_used=True in HttpResult is transparent to caller."""

--- a/tests/test_http_file_plugin.py
+++ b/tests/test_http_file_plugin.py
@@ -75,15 +75,6 @@ def test_fetch_passes_params() -> None:
     assert source2._client.user_agent == "dataciviclab-toolkit/0.1"
 
 
-@pytest.mark.adapter
-def test_integration_fetch_real_url() -> None:
-    """Real HTTPS fetch against a stable public URL (no mocks)."""
-    source = HttpFileSource(timeout=30, retries=1)
-    data = source.fetch("https://raw.githubusercontent.com/dataciviclab/toolkit/main/README.md")
-    assert len(data) > 100
-    assert b"DataCivicLab Toolkit" in data
-
-
 @pytest.mark.policy
 def test_ssl_fallback_semantics_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
     """ssl_fallback_used=True in HttpResult is transparent to caller."""

--- a/tests/test_sdmx_plugin.py
+++ b/tests/test_sdmx_plugin.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
+import requests
+
+from lab_connectors.http import HttpClient, HttpResult
+
 from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.sdmx import SdmxSource
-import requests
 
 
 class _FakeResponse:
@@ -84,23 +89,27 @@ PREVIEW_JSON_WITH_VALUES = """
 }
 """
 
-EMPTY_DATA_JSON = '{"dataSets":[{"series":{}}],"structure":{"dimensions":{"series":[{"id":"FREQ","values":[{"id":"A","name":"annual"}]}]}}}'
+
+def _ok(result, err=None):
+    return HttpResult(response=result, err=err)
 
 
 def test_sdmx_fetch_normalizes_csv(monkeypatch):
     calls = []
 
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
+        params = kwargs.get("params")
+        headers = kwargs.get("headers", {})
         calls.append((url, params, headers.get("Accept") if headers else None))
         if url.endswith("/dataflow/IT1/22_289"):
-            return _FakeResponse(200, DATAFLOW_XML, url)
+            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
         if url.endswith("/data/IT1,22_289,1.5/all"):
-            return _FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url)
+            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
         if url.endswith("/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99"):
-            return _FakeResponse(200, DATA_JSON, url)
+            return _ok(_FakeResponse(200, DATA_JSON, url))
         raise AssertionError(f"Unexpected URL {url}")
 
-    monkeypatch.setattr("toolkit.plugins.sdmx.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     payload, origin = SdmxSource(retries=1).fetch(
         "IT1",
@@ -127,12 +136,12 @@ def test_sdmx_fetch_normalizes_csv(monkeypatch):
 
 
 def test_sdmx_fetch_blocks_version_mismatch(monkeypatch):
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         if url.endswith("/dataflow/IT1/22_289"):
-            return _FakeResponse(200, DATAFLOW_XML, url)
+            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
         raise AssertionError(f"Unexpected URL {url}")
 
-    monkeypatch.setattr("toolkit.plugins.sdmx.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
         SdmxSource().fetch("IT1", "22_289", "1.0", {"FREQ": "A"})
@@ -143,14 +152,14 @@ def test_sdmx_fetch_blocks_version_mismatch(monkeypatch):
 
 
 def test_sdmx_fetch_rejects_unknown_filter_dimension(monkeypatch):
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         if url.endswith("/dataflow/IT1/22_289"):
-            return _FakeResponse(200, DATAFLOW_XML, url)
+            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
         if url.endswith("/data/IT1,22_289,1.5/all"):
-            return _FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url)
-        return _FakeResponse(404, "not found", url)
+            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
+        return _ok(_FakeResponse(404, "not found", url))
 
-    monkeypatch.setattr("toolkit.plugins.sdmx.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
         SdmxSource().fetch("IT1", "22_289", "1.5", {"NOT_A_VALID_DIM": "X"})
@@ -164,19 +173,19 @@ def test_sdmx_fetch_rejects_unknown_filter_dimension(monkeypatch):
 def test_sdmx_fetch_falls_back_on_metadata_timeout(monkeypatch):
     calls = []
 
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         calls.append(url)
         if url == "https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
-            raise requests.exceptions.Timeout("metadata timeout")
+            return HttpResult(response=None, err=requests.exceptions.Timeout("metadata timeout"))
         if url == "https://esploradati.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
-            return _FakeResponse(200, DATAFLOW_XML, url)
+            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
-            return _FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url)
+            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
-            return _FakeResponse(200, DATA_JSON, url)
+            return _ok(_FakeResponse(200, DATA_JSON, url))
         raise AssertionError(f"Unexpected URL {url}")
 
-    monkeypatch.setattr("toolkit.plugins.sdmx.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     payload, origin = SdmxSource(retries=1).fetch(
         "IT1",
@@ -201,14 +210,14 @@ def test_sdmx_fetch_falls_back_on_metadata_timeout(monkeypatch):
 
 
 def test_sdmx_fetch_rejects_invalid_filter_value(monkeypatch):
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         if url.endswith("/dataflow/IT1/22_289"):
-            return _FakeResponse(200, DATAFLOW_XML, url)
+            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
         if url.endswith("/data/IT1,22_289,1.5/all"):
-            return _FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url)
-        return _FakeResponse(404, "not found", url)
+            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
+        return _ok(_FakeResponse(404, "not found", url))
 
-    monkeypatch.setattr("toolkit.plugins.sdmx.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
         SdmxSource().fetch("IT1", "22_289", "1.5", {"FREQ": "X"})
@@ -220,14 +229,14 @@ def test_sdmx_fetch_rejects_invalid_filter_value(monkeypatch):
 
 
 def test_sdmx_fetch_rejects_invalid_filter_value_list(monkeypatch):
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         if url.endswith("/dataflow/IT1/22_289"):
-            return _FakeResponse(200, DATAFLOW_XML, url)
+            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
         if url.endswith("/data/IT1,22_289,1.5/all"):
-            return _FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url)
+            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
         raise AssertionError(f"Unexpected URL {url}")
 
-    monkeypatch.setattr("toolkit.plugins.sdmx.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
         SdmxSource().fetch("IT1", "22_289", "1.5", {"REF_AREA": ["001001", "999999"]})
@@ -241,14 +250,14 @@ def test_sdmx_fetch_rejects_invalid_filter_value_list(monkeypatch):
 def test_sdmx_fetch_empty_response(monkeypatch):
     empty_data_json = '{"dataSets":[{"series":{}}],"structure":{"dimensions":{"series":[{"id":"FREQ","values":[{"id":"A","name":"annual"}]}]}}}'
 
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         if url.endswith("/dataflow/IT1/22_289"):
-            return _FakeResponse(200, DATAFLOW_XML, url)
+            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
         if url.endswith("/data/IT1,22_289,1.5/all"):
-            return _FakeResponse(200, empty_data_json, url)
-        return _FakeResponse(200, '{"dataSets":[{"series":{}}],"structure":{"dimensions":{"series":[{"id":"FREQ","values":[{"id":"A","name":"annual"}]}]}}}', url)
+            return _ok(_FakeResponse(200, empty_data_json, url))
+        return _ok(_FakeResponse(200, empty_data_json, url))
 
-    monkeypatch.setattr("toolkit.plugins.sdmx.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
         SdmxSource().fetch("IT1", "22_289", "1.5", {"FREQ": "A"})
@@ -261,21 +270,21 @@ def test_sdmx_fetch_empty_response(monkeypatch):
 def test_sdmx_fetch_falls_back_on_data_5xx(monkeypatch):
     calls = []
 
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         calls.append(url)
         if url == "https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
-            return _FakeResponse(200, DATAFLOW_XML, url)
+            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
-            return _FakeResponse(500, "boom", url)
+            return _ok(_FakeResponse(500, "boom", url))
         if url == "https://sdmx.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
-            return _FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url)
+            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
-            return _FakeResponse(500, "boom", url)
+            return _ok(_FakeResponse(500, "boom", url))
         if url == "https://sdmx.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
-            return _FakeResponse(200, DATA_JSON, url)
+            return _ok(_FakeResponse(200, DATA_JSON, url))
         raise AssertionError(f"Unexpected URL {url}")
 
-    monkeypatch.setattr("toolkit.plugins.sdmx.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     payload, origin = SdmxSource(
         retries=1,
@@ -300,16 +309,16 @@ def test_sdmx_fetch_falls_back_on_data_5xx(monkeypatch):
 
 
 def test_sdmx_fetch_does_not_fallback_on_404(monkeypatch):
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         if url == "https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
-            return _FakeResponse(200, DATAFLOW_XML, url)
+            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
-            return _FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url)
+            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
-            return _FakeResponse(404, "not found", url)
+            return _ok(_FakeResponse(404, "not found", url))
         raise AssertionError(f"Unexpected URL {url}")
 
-    monkeypatch.setattr("toolkit.plugins.sdmx.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
         SdmxSource(
@@ -338,17 +347,19 @@ def test_sdmx_fetch_does_not_fallback_on_404(monkeypatch):
 def test_sdmx_fetch_does_not_fallback_on_connection_error(monkeypatch):
     calls = []
 
-    def _fake_get(url, params=None, timeout=None, headers=None):
+    def _fake_get(self, url, **kwargs):
         calls.append(url)
         if url == "https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
-            return _FakeResponse(200, DATAFLOW_XML, url)
+            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
-            return _FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url)
+            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
-            raise requests.exceptions.ConnectionError("tls handshake failed")
+            return HttpResult(
+                response=None, err=requests.exceptions.ConnectionError("tls handshake failed")
+            )
         raise AssertionError(f"Unexpected URL {url}")
 
-    monkeypatch.setattr("toolkit.plugins.sdmx.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
         SdmxSource(

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -8,6 +8,8 @@ from typing import Iterable
 
 import requests
 
+from lab_connectors.http import HttpClient
+
 from toolkit.core.exceptions import DownloadError
 
 SDMX_NS = {
@@ -51,6 +53,11 @@ class SdmxSource:
         )
         self.metadata_base_url = _normalize_base_url(
             metadata_base_url or ISTAT_SDMX_BASE
+        )
+        self._client = HttpClient(
+            timeout=timeout,
+            max_retries=retries,
+            user_agent=self.user_agent,
         )
 
     def _candidate_base_urls(self, agency: str, primary: str, alternate: str) -> list[str]:
@@ -102,38 +109,36 @@ class SdmxSource:
         accept: str | None = None,
         params: dict[str, str] | None = None,
     ) -> tuple[str, str]:
-        headers = {"User-Agent": self.user_agent}
-        if accept:
-            headers["Accept"] = accept
-
         url = f"{_normalize_base_url(base_url)}/{path.lstrip('/')}"
-        last_err: Exception | None = None
-        for _ in range(max(1, self.retries)):
-            try:
-                response = requests.get(url, params=params, timeout=self.timeout, headers=headers)
-                if response.status_code != 200:
-                    if response.status_code == 404:
-                        raise DownloadError(
-                            f"SDMX query not found (HTTP 404) for {response.url}"
-                        )
-                    if 500 <= response.status_code <= 599:
-                        raise DownloadError(
-                            f"SDMX endpoint error (HTTP {response.status_code}) for {response.url}"
-                        )
-                    raise DownloadError(f"SDMX HTTP {response.status_code} for {response.url}")
-                return response.text, response.url
-            except requests.exceptions.Timeout as exc:
-                last_err = DownloadError(f"SDMX endpoint timeout for {url}: {exc}")
-            except requests.exceptions.ConnectionError as exc:
-                last_err = DownloadError(
-                    f"SDMX endpoint connection error for {url}: {exc}"
-                )
-            except Exception as exc:
-                if isinstance(exc, DownloadError):
-                    last_err = exc
-                else:
-                    last_err = DownloadError(str(exc))
-        raise last_err or DownloadError(f"Failed to fetch {url}")
+        custom_headers: dict[str, str] = {}
+        if accept:
+            custom_headers["Accept"] = accept
+
+        result = self._client.get(url, params=params, headers=custom_headers)
+
+        if result.is_ok and result.response is not None:
+            response = result.response
+            if response.status_code != 200:
+                if response.status_code == 404:
+                    raise DownloadError(
+                        f"SDMX query not found (HTTP 404) for {response.url}"
+                    )
+                if 500 <= response.status_code <= 599:
+                    raise DownloadError(
+                        f"SDMX endpoint error (HTTP {response.status_code}) for {response.url}"
+                    )
+                raise DownloadError(f"SDMX HTTP {response.status_code} for {response.url}")
+            return response.text, response.url
+
+        err = result.err
+        if err is None:
+            raise DownloadError(f"Failed to fetch {url}")
+        # Preserve SDMX-specific diagnostics for timeout/connection errors
+        if isinstance(err, requests.exceptions.Timeout):
+            raise DownloadError(f"SDMX endpoint timeout for {url}: {err}")
+        if isinstance(err, requests.exceptions.ConnectionError):
+            raise DownloadError(f"SDMX endpoint connection error for {url}: {err}")
+        raise DownloadError(str(err))
 
     def _get_json(
         self,


### PR DESCRIPTION
## Scope
- Package centralizzato: lab_connectors.http (HttpClient, HttpResult)
- Consumer migrato: toolkit/plugins/sdmx.py (SdmxSource)
- Aggiunto: test di integrazione reale per http_file (marcato @adapter)

## Codice locale rimosso
- _get_text: retry loop manuale (~35 righe) sostituito da HttpClient.get (~20 righe)
- Diagnostica 404/5xx preservata
- Messaggi DownloadError per timeout e connection error preservati con isinstance check su requests.exceptions.Timeout / ConnectionError

## Contratto preservato
- SdmxSource.fetch() — API pubblica invariata
- URL fallback tra candidati ISTAT (metadata_base_url / data_base_url) — invariato
- _is_retryable_fallback_error basato sui messaggi DownloadError — invariato
- Accept header passato a HttpClient.get via kwargs

## Test
- 10 test SDMX: 10/10 passati (monkeypatch su HttpClient.get)
- 1 test integrazione http_file (reale HTTPS): passato
- Full suite: 619/619 passati

## Fuori scope
- SPARQL plugin (non toccato)
- cmd_url_inspect.py (non toccato)
