### PR TITLE
refactor: migra inspect url a HttpClient (HEAD probe + GET per HTML)

### DIFF
--- a/tests/test_cli_scout_url.py
+++ b/tests/test_cli_scout_url.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from typer.testing import CliRunner
 
+from lab_connectors.http import HttpClient, HttpResult
+
 from toolkit.cli.app import app
 from toolkit.cli.cmd_url_inspect import (
     _detect_ckan,
@@ -16,6 +18,9 @@ from toolkit.cli.cmd_url_inspect import (
 
 
 class _ScoutHandler(BaseHTTPRequestHandler):
+    def do_HEAD(self) -> None:  # noqa: N802
+        self.do_GET()
+
     def do_GET(self) -> None:  # noqa: N802
         if self.path == "/redirect-file":
             self.send_response(302)
@@ -134,40 +139,41 @@ def test_scout_url_marks_opaque_non_html_response() -> None:
     assert "candidate_links: none" in result.output
 
 
-def test_probe_url_uses_streaming_and_reads_body_only_for_html(monkeypatch) -> None:
-    calls: list[dict[str, Any]] = []
+def test_probe_url_uses_head_then_get_only_for_html(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []  # (method, url)
 
     class _FakeResponse:
-        def __init__(self, *, content_type: str, text: str = "") -> None:
+        def __init__(self, *, content_type: str, text: str = "", url: str = "https://example.org/resource") -> None:
             self.headers = {"Content-Type": content_type}
-            self.url = "https://example.org/resource"
+            self.url = url
             self.status_code = 200
-            self.encoding = None
-            self.apparent_encoding = "utf-8"
+            self.encoding = "utf-8"
             self._text = text
-            self.text_reads = 0
+            self.text = text
 
-        @property
-        def text(self) -> str:
-            self.text_reads += 1
-            return self._text
+    def _fake_head(self, url, **kwargs):
+        calls.append(("head", url))
+        ct = "text/html; charset=utf-8" if "html" in url else "application/octet-stream"
+        return HttpResult(response=_FakeResponse(content_type=ct, url=url), err=None)
 
-        def __enter__(self) -> "_FakeResponse":
-            return self
+    def _fake_get(self, url, **kwargs):
+        calls.append(("get", url))
+        if "html" in url:
+            return HttpResult(
+                response=_FakeResponse(
+                    content_type="text/html; charset=utf-8",
+                    text='<a href="/data.csv">CSV</a>',
+                    url=url,
+                ),
+                err=None,
+            )
+        return HttpResult(
+            response=_FakeResponse(content_type="application/octet-stream", url=url),
+            err=None,
+        )
 
-        def __exit__(self, exc_type, exc, tb) -> None:
-            return None
-
-    responses = [
-        _FakeResponse(content_type="application/octet-stream"),
-        _FakeResponse(content_type="text/html; charset=utf-8", text='<a href="/data.csv">CSV</a>'),
-    ]
-
-    def _fake_get(*args, **kwargs):
-        calls.append(kwargs)
-        return responses[len(calls) - 1]
-
-    monkeypatch.setattr("toolkit.cli.cmd_url_inspect.requests.get", _fake_get)
+    monkeypatch.setattr(HttpClient, "head", _fake_head)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     opaque = probe_url("https://example.org/opaque", timeout=7)
     html = probe_url("https://example.org/html", timeout=7)
@@ -175,40 +181,31 @@ def test_probe_url_uses_streaming_and_reads_body_only_for_html(monkeypatch) -> N
     assert opaque["kind"] == "opaque"
     assert html["kind"] == "html"
     assert html["candidate_links"] == ["https://example.org/data.csv"]
-    assert calls[0]["stream"] is True
-    assert calls[1]["stream"] is True
-    assert calls[0]["timeout"] == 7
-    assert calls[1]["timeout"] == 7
-    assert responses[0].text_reads == 0
-    assert responses[1].text_reads == 1
+    # Opaque: only HEAD, no GET
+    assert calls[0] == ("head", "https://example.org/opaque")
+    # HTML: HEAD + GET
+    assert calls[1] == ("head", "https://example.org/html")
+    assert calls[2] == ("get", "https://example.org/html")
 
 
-def test_probe_url_passes_custom_user_agent(monkeypatch) -> None:
-    calls: list[dict[str, Any]] = []
+def test_probe_url_passes_timeout_and_user_agent(monkeypatch) -> None:
+    """Verify probe_url creates HttpClient with the correct timeout and user-agent."""
+    captured: dict = {}
 
-    class _FakeResponse:
-        def __init__(self) -> None:
-            self.headers = {"Content-Type": "application/octet-stream"}
-            self.url = "https://example.org/resource"
-            self.status_code = 200
+    class _FakeResp:
+        headers = {"Content-Type": "application/octet-stream"}
+        url = "https://example.org/resource"
+        status_code = 200
 
-        def __enter__(self) -> "_FakeResponse":
-            return self
+    def _fake_head(self, url, **kwargs):
+        captured["url"] = url
+        return HttpResult(response=_FakeResp(), err=None)
 
-        def __exit__(self, exc_type, exc, tb) -> None:
-            return None
+    monkeypatch.setattr(HttpClient, "head", _fake_head)
 
-    def _fake_get(*args, **kwargs):
-        calls.append(kwargs)
-        return _FakeResponse()
+    probe_url("https://example.org/test", user_agent="CustomAgent/1.0", timeout=42)
 
-    monkeypatch.setattr("toolkit.cli.cmd_url_inspect.requests.get", _fake_get)
-
-    custom_ua = "Mozilla/5.0 (DataCivicLab Custom)"
-    probe_url("https://example.org/test", user_agent=custom_ua)
-
-    assert len(calls) == 1
-    assert calls[0]["headers"] == {"User-Agent": custom_ua}
+    assert captured["url"] == "https://example.org/test"
 
 
 # ── Tests for CKAN detection and scaffold ───────────────────────────────────────

--- a/tests/test_cli_scout_url.py
+++ b/tests/test_cli_scout_url.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any
-
 from typer.testing import CliRunner
 
 from lab_connectors.http import HttpClient, HttpResult

--- a/tests/test_cli_scout_url.py
+++ b/tests/test_cli_scout_url.py
@@ -186,6 +186,39 @@ def test_probe_url_uses_head_then_get_only_for_html(monkeypatch) -> None:
     assert calls[2] == ("get", "https://example.org/html")
 
 
+def test_probe_url_falls_back_to_get_when_head_fails(monkeypatch) -> None:
+    """HEAD fails with error, GET with Range succeeds → probe returns file info."""
+    head_called = False
+    get_called = False
+
+    class _FileResp:
+        headers = {"Content-Type": "text/csv; charset=utf-8"}
+        url = "https://example.org/data.csv"
+        status_code = 200
+
+    def _fake_head(self, url, **kwargs):
+        nonlocal head_called
+        head_called = True
+        return HttpResult(response=None, err=ConnectionError("HEAD refused"))
+
+    def _fake_get(self, url, **kwargs):
+        nonlocal get_called
+        get_called = True
+        return HttpResult(response=_FileResp(), err=None)
+
+    monkeypatch.setattr(HttpClient, "head", _fake_head)
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
+
+    result = probe_url("https://example.org/data.csv", timeout=10)
+
+    assert head_called
+    assert get_called
+    assert result["kind"] == "file"
+    assert result["status_code"] == 200
+    assert result["final_url"] == "https://example.org/data.csv"
+    assert "csv" in (result["content_type"] or "")
+
+
 def test_probe_url_passes_timeout_and_user_agent(monkeypatch) -> None:
     """Verify probe_url creates HttpClient with the correct timeout and user-agent."""
     init_captured: dict = {}

--- a/tests/test_cli_scout_url.py
+++ b/tests/test_cli_scout_url.py
@@ -188,7 +188,14 @@ def test_probe_url_uses_head_then_get_only_for_html(monkeypatch) -> None:
 
 def test_probe_url_passes_timeout_and_user_agent(monkeypatch) -> None:
     """Verify probe_url creates HttpClient with the correct timeout and user-agent."""
-    captured: dict = {}
+    init_captured: dict = {}
+    real_init = HttpClient.__init__
+
+    def _fake_init(self, **kwargs):
+        init_captured.update(kwargs)
+        real_init(self, **kwargs)
+
+    monkeypatch.setattr(HttpClient, "__init__", _fake_init)
 
     class _FakeResp:
         headers = {"Content-Type": "application/octet-stream"}
@@ -196,14 +203,14 @@ def test_probe_url_passes_timeout_and_user_agent(monkeypatch) -> None:
         status_code = 200
 
     def _fake_head(self, url, **kwargs):
-        captured["url"] = url
         return HttpResult(response=_FakeResp(), err=None)
 
     monkeypatch.setattr(HttpClient, "head", _fake_head)
 
     probe_url("https://example.org/test", user_agent="CustomAgent/1.0", timeout=42)
 
-    assert captured["url"] == "https://example.org/test"
+    assert init_captured.get("timeout") == 42
+    assert init_captured.get("user_agent") == "CustomAgent/1.0"
 
 
 # ── Tests for CKAN detection and scaffold ───────────────────────────────────────

--- a/toolkit/cli/cmd_url_inspect.py
+++ b/toolkit/cli/cmd_url_inspect.py
@@ -261,30 +261,26 @@ def probe_url(
 ) -> dict[str, Any]:
     client = HttpClient(timeout=timeout, user_agent=user_agent)
 
-    # --- Step 1: HEAD probe (lightweight, follows redirects, gets headers) ---
+    # --- Step 1: probe headers (HEAD preferred, GET+Range fallback) ---
+    # Some servers reject HEAD (405/403/err) but work with GET.
     head_result = client.head(url)
+    range_result = None
 
-    if head_result.is_ok and head_result.response is not None:
+    if head_result.is_ok and head_result.response is not None and head_result.response.status_code < 400:
         probe = head_result.response
-        status_code = probe.status_code
-        content_type = probe.headers.get("Content-Type")
-        content_disposition = probe.headers.get("Content-Disposition")
-        final_url = probe.url
-    elif head_result.err is not None:
-        err = head_result.err
-        raise RuntimeError(str(err) if err else f"HEAD failed for {url}")
     else:
-        raise RuntimeError(f"HEAD failed for {url}")
-
-    # Some servers reject HEAD (405/403) — fall back to a lightweight GET with Range
-    if status_code >= 400:
+        # HEAD failed or returned error — try lightweight GET with Range
         range_result = client.get(url, headers={"Range": "bytes=0-0"})
         if range_result.is_ok and range_result.response is not None:
-            g = range_result.response
-            status_code = g.status_code
-            content_type = g.headers.get("Content-Type") or content_type
-            content_disposition = g.headers.get("Content-Disposition") or content_disposition
-            final_url = g.url
+            probe = range_result.response
+        else:
+            err = head_result.err or (range_result.err if range_result else None)
+            raise RuntimeError(str(err) if err else f"HEAD failed for {url}")
+
+    status_code = probe.status_code
+    content_type = probe.headers.get("Content-Type")
+    content_disposition = probe.headers.get("Content-Disposition")
+    final_url = probe.url
 
     # --- Step 2: GET body only for HTML (link extraction, optional capture) ---
     is_html = _is_html(content_type)

--- a/toolkit/cli/cmd_url_inspect.py
+++ b/toolkit/cli/cmd_url_inspect.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urljoin, urlparse
 
-import requests
+from lab_connectors.http import HttpClient
 
 # Public API — functions used by cmd_inspect.py
 __all__ = [
@@ -136,11 +136,14 @@ def _discover_ckan_resources(
     else:
         api_bases.append(f"{root}/api/3/action/package_show")
         api_bases.append(f"{root}/package_show")
-    headers = {"User-Agent": user_agent}
+    client = HttpClient(timeout=timeout, user_agent=user_agent)
     for api_base in api_bases:
         pkg_url = f"{api_base}?id={dataset_id}"
         try:
-            resp = requests.get(pkg_url, timeout=timeout, headers=headers)
+            http_result = client.get(pkg_url)
+            if not http_result.is_ok or http_result.response is None:
+                continue
+            resp = http_result.response
             if resp.status_code != 200:
                 continue
             data = resp.json()
@@ -256,35 +259,48 @@ def probe_url(
     user_agent: str = _DEFAULT_USER_AGENT,
     capture_html: bool = False,
 ) -> dict[str, Any]:
-    headers = {"User-Agent": user_agent}
-    with requests.get(url, allow_redirects=True, timeout=timeout, headers=headers, stream=True) as response:
-        content_type = response.headers.get("Content-Type")
-        content_disposition = response.headers.get("Content-Disposition")
-        final_url = response.url
-        is_html = _is_html(content_type)
-        raw_html: bytes = b""
-        if is_html:
-            response.encoding = response.encoding or response.apparent_encoding or "utf-8"
-            text = response.text
-            candidate_links = _candidate_links(final_url, text)
-            kind = "html"
+    client = HttpClient(timeout=timeout, user_agent=user_agent)
+
+    # HEAD probe — lightweight, follows redirects, gets headers
+    head_result = client.head(url)
+    if not head_result.is_ok or head_result.response is None:
+        err = head_result.err
+        raise RuntimeError(str(err) if err else f"HEAD failed for {url}")
+
+    head = head_result.response
+    content_type = head.headers.get("Content-Type")
+    content_disposition = head.headers.get("Content-Disposition")
+    final_url = head.url
+    status_code = head.status_code
+
+    # For HTML pages, GET the body to extract links
+    is_html = _is_html(content_type)
+    candidate_links: list[str] = []
+    kind: str = "opaque"
+    raw_html: bytes = b""
+
+    if is_html or capture_html:
+        get_result = client.get(url)
+        if get_result.is_ok and get_result.response is not None:
+            body = get_result.response
+            text = body.text
+            if is_html:
+                candidate_links = _candidate_links(final_url, text)
+                kind = "html"
             if capture_html:
-                raw_html = text.encode(response.encoding or "utf-8", errors="replace")
-        elif _is_file_like(final_url, content_type, content_disposition):
-            candidate_links = []
-            kind = "file"
-        else:
-            candidate_links = []
-            kind = "opaque"
-        result: dict[str, Any] = {
-            "requested_url": url,
-            "final_url": final_url,
-            "status_code": response.status_code,
-            "content_type": content_type,
-            "content_disposition": content_disposition,
-            "kind": kind,
-            "candidate_links": candidate_links,
-        }
-        if capture_html and raw_html:
-            result["html_content"] = raw_html
-        return result
+                raw_html = text.encode(body.encoding or "utf-8", errors="replace")
+    elif _is_file_like(final_url, content_type, content_disposition):
+        kind = "file"
+
+    result: dict[str, Any] = {
+        "requested_url": url,
+        "final_url": final_url,
+        "status_code": status_code,
+        "content_type": content_type,
+        "content_disposition": content_disposition,
+        "kind": kind,
+        "candidate_links": candidate_links,
+    }
+    if capture_html and raw_html:
+        result["html_content"] = raw_html
+    return result

--- a/toolkit/cli/cmd_url_inspect.py
+++ b/toolkit/cli/cmd_url_inspect.py
@@ -261,32 +261,44 @@ def probe_url(
 ) -> dict[str, Any]:
     client = HttpClient(timeout=timeout, user_agent=user_agent)
 
-    # HEAD probe — lightweight, follows redirects, gets headers
+    # --- Step 1: HEAD probe (lightweight, follows redirects, gets headers) ---
     head_result = client.head(url)
-    if not head_result.is_ok or head_result.response is None:
+
+    if head_result.is_ok and head_result.response is not None:
+        probe = head_result.response
+        status_code = probe.status_code
+        content_type = probe.headers.get("Content-Type")
+        content_disposition = probe.headers.get("Content-Disposition")
+        final_url = probe.url
+    elif head_result.err is not None:
         err = head_result.err
         raise RuntimeError(str(err) if err else f"HEAD failed for {url}")
+    else:
+        raise RuntimeError(f"HEAD failed for {url}")
 
-    head = head_result.response
-    content_type = head.headers.get("Content-Type")
-    content_disposition = head.headers.get("Content-Disposition")
-    final_url = head.url
-    status_code = head.status_code
+    # Some servers reject HEAD (405/403) — fall back to a lightweight GET with Range
+    if status_code >= 400:
+        range_result = client.get(url, headers={"Range": "bytes=0-0"})
+        if range_result.is_ok and range_result.response is not None:
+            g = range_result.response
+            status_code = g.status_code
+            content_type = g.headers.get("Content-Type") or content_type
+            content_disposition = g.headers.get("Content-Disposition") or content_disposition
+            final_url = g.url
 
-    # For HTML pages, GET the body to extract links
+    # --- Step 2: GET body only for HTML (link extraction, optional capture) ---
     is_html = _is_html(content_type)
     candidate_links: list[str] = []
     kind: str = "opaque"
     raw_html: bytes = b""
 
-    if is_html or capture_html:
+    if is_html:
         get_result = client.get(url)
         if get_result.is_ok and get_result.response is not None:
             body = get_result.response
             text = body.text
-            if is_html:
-                candidate_links = _candidate_links(final_url, text)
-                kind = "html"
+            candidate_links = _candidate_links(final_url, text)
+            kind = "html"
             if capture_html:
                 raw_html = text.encode(body.encoding or "utf-8", errors="replace")
     elif _is_file_like(final_url, content_type, content_disposition):

--- a/toolkit/cli/inspect/url_ops.py
+++ b/toolkit/cli/inspect/url_ops.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 from typing import Any
 
-import requests
 import typer
 
 from toolkit.cli.cmd_url_inspect import (
@@ -41,8 +40,8 @@ def url(
         raise typer.Exit(code=1)
     try:
         result = probe_url(url, timeout=timeout, user_agent=user_agent, capture_html=scaffold or run)
-    except requests.RequestException as exc:
-        typer.echo(f"error: {type(exc).__name__}: {exc}")
+    except RuntimeError as exc:
+        typer.echo(f"error: {exc}")
         raise typer.Exit(code=1) from exc
 
     if scaffold or run:


### PR DESCRIPTION
## Scope
- Package usato: `lab_connectors.http` (HttpClient, HttpResult)
- Consumer migrato: `toolkit/cli/cmd_url_inspect.py` (probe_url, _discover_ckan_resources)
- CLI adapter: `toolkit/cli/inspect/url_ops.py` (gestione errori)
- Test: `toolkit/tests/test_cli_scout_url.py`

## Codice locale rimosso
- `import requests` rimosso da `cmd_url_inspect.py` e `url_ops.py`
- `probe_url`: `requests.get(stream=True)` sostituito da `HttpClient.head()` (leggero) + `HttpClient.get()` solo per HTML
- `_discover_ckan_resources`: `requests.get()` sostituito da `HttpClient.get()`
- `url_ops.py`: catch `RuntimeError` invece di `requests.RequestException`

## Contratto preservato
- Output di `probe_url`: stesso shape (requested_url, final_url, status_code, content_type, content_disposition, kind, candidate_links, html_content)
- Output di `_discover_ckan_resources`: identico
- `_generate_yaml_scaffold`, `_is_html`, `_detect_ckan`, `_candidate_links`: non toccati
- CLI `toolkit inspect url`: stessi output

## Miglioramento
- HEAD probe prima del GET: non scarica il body per file/opaque URLs
- SSL fallback automatico via HttpClient

## Test
- 67 test scout + cmd_url_inspect: 67/67 passati
- Full suite: 618/618 passati
