### PR TITLE
refactor(mcp): migra a lab_connectors.mcp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "requests>=2.33.1",
   "typer>=0.12.0",
   "rich>=13.0",
-  "lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.1.2"
+  "lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.2.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,8 +6,7 @@ from pathlib import Path
 import pytest
 
 from toolkit.mcp import server as mcp_server
-from toolkit.mcp.errors import ErrorCode
-from toolkit.mcp.toolkit_client import ToolkitClientError
+from toolkit.mcp.errors import ErrorCode, ToolkitClientError
 
 
 def test_mcp_server_registers_expected_tools() -> None:
@@ -43,8 +42,6 @@ def test_tool_error_has_error_code_and_message(monkeypatch: pytest.MonkeyPatch) 
 
     The error dict must have 'error' (code string) and 'message' keys.
     """
-    from toolkit.mcp.errors import ToolkitClientError
-
     def raising_impl(config_path: str, year: int | None) -> dict[str, object]:
         raise ToolkitClientError("config non trovato", code=ErrorCode.CONFIG_NOT_FOUND)
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from lab_connectors.mcp import guard
+
 from toolkit.mcp import server as mcp_server
 from toolkit.mcp.toolkit_client import ToolkitClientError
 
@@ -27,22 +29,26 @@ def test_mcp_server_registers_expected_tools() -> None:
 
 
 def test_guard_returns_payload_on_success() -> None:
-    assert mcp_server._guard(lambda x: {"ok": x}, 123) == {"ok": 123}
+    assert guard(lambda x: {"ok": x}, 123) == {"ok": 123}
 
 
 def test_guard_wraps_toolkit_client_error() -> None:
     def boom() -> dict[str, str]:
         raise ToolkitClientError("errore client")
 
-    assert mcp_server._guard(boom) == {"error": "errore client"}
+    result = guard(boom)
+    assert result["error"] == "unexpected_error"
+    assert "errore client" in result["message"]
 
 
 def test_guard_does_not_swallow_unexpected_errors() -> None:
+    """guard() cattura OGNI eccezione e restituisce dict, non propaga."""
     def boom() -> dict[str, str]:
         raise ValueError("unexpected")
 
-    with pytest.raises(ValueError, match="unexpected"):
-        mcp_server._guard(boom)
+    result = guard(boom)
+    assert result["error"] == "unexpected_error"
+    assert "unexpected" in result["message"]
 
 
 def test_toolkit_inspect_paths_passes_none_when_year_zero(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,9 +5,8 @@ from pathlib import Path
 
 import pytest
 
-from lab_connectors.mcp import guard
-
 from toolkit.mcp import server as mcp_server
+from toolkit.mcp.errors import ErrorCode
 from toolkit.mcp.toolkit_client import ToolkitClientError
 
 
@@ -28,27 +27,49 @@ def test_mcp_server_registers_expected_tools() -> None:
     }
 
 
-def test_guard_returns_payload_on_success() -> None:
-    assert guard(lambda x: {"ok": x}, 123) == {"ok": 123}
+def test_tool_returns_payload_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Through a real tool implementation, guard passes payload through unchanged."""
+
+    def fake_impl(config_path: str, year: int | None) -> dict[str, object]:
+        return {"ok": True, "config_path": config_path, "year": year}
+
+    monkeypatch.setattr(mcp_server, "inspect_paths_impl", fake_impl)
+    result = mcp_server.toolkit_inspect_paths("dataset.yml", 2024)
+    assert result == {"ok": True, "config_path": "dataset.yml", "year": 2024}
 
 
-def test_guard_wraps_toolkit_client_error() -> None:
-    def boom() -> dict[str, str]:
-        raise ToolkitClientError("errore client")
+def test_tool_error_has_error_code_and_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ToolkitClientError raised by impl is caught by guard and returned as dict.
 
-    result = guard(boom)
+    The error dict must have 'error' (code string) and 'message' keys.
+    """
+    from toolkit.mcp.errors import ToolkitClientError
+
+    def raising_impl(config_path: str, year: int | None) -> dict[str, object]:
+        raise ToolkitClientError("config non trovato", code=ErrorCode.CONFIG_NOT_FOUND)
+
+    monkeypatch.setattr(mcp_server, "inspect_paths_impl", raising_impl)
+    result = mcp_server.toolkit_inspect_paths("dataset.yml", 2024)
+
+    assert "error" in result
+    assert "message" in result
+    assert result["error"] == "config_not_found"
+    assert "config non trovato" in result["message"]
+
+
+def test_unexpected_error_becomes_unexpected_with_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Any unexpected exception (not ToolkitClientError) is caught by guard and
+    returned as 'unexpected_error' with the original message.
+    """
+
+    def raising_impl(config_path: str, year: int | None) -> dict[str, object]:
+        raise ValueError("unexpected value")
+
+    monkeypatch.setattr(mcp_server, "inspect_paths_impl", raising_impl)
+    result = mcp_server.toolkit_inspect_paths("dataset.yml", 2024)
+
     assert result["error"] == "unexpected_error"
-    assert "errore client" in result["message"]
-
-
-def test_guard_does_not_swallow_unexpected_errors() -> None:
-    """guard() cattura OGNI eccezione e restituisce dict, non propaga."""
-    def boom() -> dict[str, str]:
-        raise ValueError("unexpected")
-
-    result = guard(boom)
-    assert result["error"] == "unexpected_error"
-    assert "unexpected" in result["message"]
+    assert "unexpected value" in result["message"]
 
 
 def test_toolkit_inspect_paths_passes_none_when_year_zero(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/toolkit/mcp/_schema_utils.py
+++ b/toolkit/mcp/_schema_utils.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import duckdb
 
+from lab_connectors.mcp.errors import ErrorCode
 from toolkit.mcp.errors import ToolkitClientError
 
 
@@ -27,7 +28,7 @@ def _schema_from_parquet(parquet_path: Path) -> dict[str, Any]:
         ToolkitClientError: if the file doesn't exist or can't be read.
     """
     if not parquet_path.exists():
-        raise ToolkitClientError(f"Parquet non trovato: {parquet_path}")
+        raise ToolkitClientError(f"Parquet non trovato: {parquet_path}", code=ErrorCode.PARQUET_NOT_FOUND)
     relation = f"read_parquet('{_sql_literal(str(parquet_path))}')"
     try:
         with duckdb.connect(database=":memory:") as conn:
@@ -35,7 +36,8 @@ def _schema_from_parquet(parquet_path: Path) -> dict[str, Any]:
             describe_rows = conn.execute(f"DESCRIBE SELECT * FROM {relation}").fetchall()
     except Exception as exc:
         raise ToolkitClientError(
-            f"Lettura schema parquet fallita per {parquet_path}: {exc}"
+            f"Lettura schema parquet fallita per {parquet_path}: {exc}",
+            code=ErrorCode.DUCKDB_ERROR,
         ) from exc
 
     columns = [{"name": row[0], "type": row[1]} for row in describe_rows]

--- a/toolkit/mcp/cli_adapter.py
+++ b/toolkit/mcp/cli_adapter.py
@@ -10,7 +10,7 @@ from typing import cast
 
 from toolkit.cli.inspect._helpers import _payload_for_year
 from toolkit.mcp.contracts import InspectPathsResult
-from lab_connectors.mcp.errors import McpError, ErrorCode
+from lab_connectors.mcp.errors import ErrorCode
 
 from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.path_safety import _safe_path

--- a/toolkit/mcp/cli_adapter.py
+++ b/toolkit/mcp/cli_adapter.py
@@ -10,6 +10,8 @@ from typing import cast
 
 from toolkit.cli.inspect._helpers import _payload_for_year
 from toolkit.mcp.contracts import InspectPathsResult
+from lab_connectors.mcp.errors import McpError, ErrorCode
+
 from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.path_safety import _safe_path
 from toolkit.core.config import load_config
@@ -29,11 +31,12 @@ def inspect_paths(config_path: str, year: int | None = None) -> InspectPathsResu
         if len(years) > 1:
             raise ToolkitClientError(
                 "year è obbligatorio per dataset multi-year. "
-                f"Trovati {len(years)} anni: {years}. Usa --year per specificarne uno."
+                f"Trovati {len(years)} anni: {years}. Usa --year per specificarne uno.",
+                code=ErrorCode.INVALID_PARAMS,
             )
         year = years[0] if years else None
 
     if year is None:
-        raise ToolkitClientError("Nessun anno configurato nel dataset")
+        raise ToolkitClientError("Nessun anno configurato nel dataset", code=ErrorCode.CONFIG_NOT_FOUND)
 
     return cast(InspectPathsResult, _payload_for_year(cfg, year))

--- a/toolkit/mcp/errors.py
+++ b/toolkit/mcp/errors.py
@@ -15,8 +15,15 @@ class ToolkitClientError(McpError):
 
     Ponte verso lab_connectors.mcp: eredita McpError, quindi
     ``guard()`` lo cattura come McpError e produce
-    ``{"error": "unexpected_error", "message": "..."}``.
+    ``{"error": code.value, "message": "..."}``.
+
+    Args:
+        message: human-readable description of the error.
+        code: tassonomic error code. Defaults to UNEXPECTED (conservative).
+              Call sites should use the most specific code available.
     """
 
-    def __init__(self, message: str) -> None:
-        super().__init__(ErrorCode.UNEXPECTED, message)
+    def __init__(
+        self, message: str, code: ErrorCode = ErrorCode.UNEXPECTED
+    ) -> None:
+        super().__init__(code, message)

--- a/toolkit/mcp/errors.py
+++ b/toolkit/mcp/errors.py
@@ -1,9 +1,22 @@
-"""Error types for the MCP toolkit client."""
+"""Error types for the MCP toolkit client.
+
+ToolkitClientError è un ponte verso lab_connectors.mcp.
+Tutte le eccezioni interne diventano McpError con codice UNEXPECTED
+e vengono gestite da `guard()` in server.py.
+"""
 
 from __future__ import annotations
 
+from lab_connectors.mcp.errors import McpError, ErrorCode
 
-class ToolkitClientError(RuntimeError):
-    """Raised when the toolkit CLI fails or returns an unexpected result."""
 
-    pass
+class ToolkitClientError(McpError):
+    """Raised when the toolkit CLI fails or returns an unexpected result.
+
+    Ponte verso lab_connectors.mcp: eredita McpError, quindi
+    ``guard()`` lo cattura come McpError e produce
+    ``{"error": "unexpected_error", "message": "..."}``.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(ErrorCode.UNEXPECTED, message)

--- a/toolkit/mcp/path_safety.py
+++ b/toolkit/mcp/path_safety.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from lab_connectors.mcp.errors import McpError, ErrorCode
+from lab_connectors.mcp.errors import ErrorCode
 
 from toolkit.core.config import load_config
 from toolkit.mcp.errors import ToolkitClientError

--- a/toolkit/mcp/path_safety.py
+++ b/toolkit/mcp/path_safety.py
@@ -12,6 +12,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from lab_connectors.mcp.errors import McpError, ErrorCode
+
 from toolkit.core.config import load_config
 from toolkit.mcp.errors import ToolkitClientError
 
@@ -28,7 +30,7 @@ def _safe_path(config_path: str | Path) -> Path:
     if not path.is_absolute():
         path = (WORKSPACE_ROOT / path).resolve()
     if not path.exists():
-        raise ToolkitClientError(f"Config non trovata: {path}")
+        raise ToolkitClientError(f"Config non trovata: {path}", code=ErrorCode.CONFIG_NOT_FOUND)
     return path
 
 
@@ -37,5 +39,5 @@ def _load_cfg(config_path: str | Path) -> tuple[Path, Any]:
     try:
         cfg = load_config(str(config), strict_config=False)
     except Exception as exc:
-        raise ToolkitClientError(f"Load config fallito per {config}: {exc}") from exc
+        raise ToolkitClientError(f"Load config fallito per {config}: {exc}", code=ErrorCode.CONFIG_NOT_FOUND) from exc
     return config, cfg

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -24,7 +24,7 @@ from toolkit.mcp._schema_utils import (
     _schema_from_parquet,
     _validation_summary_for_layer,
 )
-from lab_connectors.mcp.errors import McpError, ErrorCode
+from lab_connectors.mcp.errors import ErrorCode
 
 from toolkit.mcp.cli_adapter import inspect_paths
 from toolkit.mcp.errors import ToolkitClientError
@@ -97,7 +97,7 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
         except json.JSONDecodeError as exc:
             raise ToolkitClientError(
                 f"raw_profile.json malformato in {raw_profile_json}: {exc}",
-                code=ErrorCode.FILE_FORMAT_ERROR,
+                code=ErrorCode.ARTIFACT_UNREADABLE,
             ) from exc
     elif suggested_read_yml.exists():
         # Fallback: suggested_read.yml contains the same hints in YAML form
@@ -108,7 +108,7 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
         except yaml.YAMLError as exc:
             raise ToolkitClientError(
                 f"suggested_read.yml non valido in {suggested_read_yml}: {exc}",
-                code=ErrorCode.FILE_FORMAT_ERROR,
+                code=ErrorCode.ARTIFACT_UNREADABLE,
             ) from exc
         clean_section = raw_yaml.get("clean", {}) if isinstance(raw_yaml, dict) else {}
         read_section = clean_section.get("read", {}) if isinstance(clean_section, dict) else {}
@@ -130,7 +130,7 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
         raise ToolkitClientError(
             f"Profilo raw non trovato in {profile_path}. "
             "Nessun file raw_profile.json ne suggested_read.yml.",
-            code=ErrorCode.FILE_NOT_FOUND,
+            code=ErrorCode.ARTIFACT_NOT_FOUND,
         )
 
     # Ritorna un sottoinsieme leggibile: evita di restituire sample_rows intere
@@ -230,7 +230,7 @@ def list_runs(
             since_dt = datetime.fromisoformat(raw)
             if since_dt.tzinfo is None:
                 since_dt = since_dt.replace(tzinfo=timezone.utc)
-        except ValueError:
+        except ValueError as exc:
             raise ToolkitClientError(f"since must be a valid ISO datetime, got: {since}", code=ErrorCode.INVALID_PARAMS) from exc
 
     until_dt = None
@@ -240,7 +240,7 @@ def list_runs(
             until_dt = datetime.fromisoformat(raw)
             if until_dt.tzinfo is None:
                 until_dt = until_dt.replace(tzinfo=timezone.utc)
-        except ValueError:
+        except ValueError as exc:
             raise ToolkitClientError(f"until must be a valid ISO datetime, got: {until}", code=ErrorCode.INVALID_PARAMS) from exc
 
     valid_statuses = {"SUCCESS", "FAILED", "RUNNING", "DRY_RUN"}
@@ -310,7 +310,7 @@ def run_summary(
             since_dt = datetime.fromisoformat(raw)
             if since_dt.tzinfo is None:
                 since_dt = since_dt.replace(tzinfo=timezone.utc)
-        except ValueError:
+        except ValueError as exc:
             raise ToolkitClientError(f"since must be a valid ISO datetime, got: {since}", code=ErrorCode.INVALID_PARAMS) from exc
 
     until_dt: datetime | None = None
@@ -320,7 +320,7 @@ def run_summary(
             until_dt = datetime.fromisoformat(raw)
             if until_dt.tzinfo is None:
                 until_dt = until_dt.replace(tzinfo=timezone.utc)
-        except ValueError:
+        except ValueError as exc:
             raise ToolkitClientError(f"until must be a valid ISO datetime, got: {until}", code=ErrorCode.INVALID_PARAMS) from exc
 
     all_records = list_runs(run_dir, since=since_dt, until=until_dt, limit=None)
@@ -798,7 +798,7 @@ def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
 
     path = _safe_path(csv_path)
     if not path.exists():
-        raise ToolkitClientError(f"CSV non trovato: {path}")
+        raise ToolkitClientError(f"CSV non trovato: {path}", code=ErrorCode.ARTIFACT_NOT_FOUND)
 
     # Phase 1: pure sniff — same pipeline as profile_raw
     sniff_hints = sniff_source_file(path)
@@ -882,4 +882,4 @@ def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
                 ),
             }
     except Exception as exc:
-        raise ToolkitClientError(f"Lettura CSV fallita per {path}: {exc}", code=ErrorCode.FILE_FORMAT_ERROR) from exc
+        raise ToolkitClientError(f"Lettura CSV fallita per {path}: {exc}", code=ErrorCode.ARTIFACT_UNREADABLE) from exc

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -24,6 +24,8 @@ from toolkit.mcp._schema_utils import (
     _schema_from_parquet,
     _validation_summary_for_layer,
 )
+from lab_connectors.mcp.errors import McpError, ErrorCode
+
 from toolkit.mcp.cli_adapter import inspect_paths
 from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.path_safety import _load_cfg, _safe_path
@@ -35,7 +37,7 @@ def show_schema(config_path: str, layer: str = "clean", year: int | None = None)
     config, _cfg = _load_cfg(config_path)
     safe_layer = (layer or "clean").strip().lower()
     if safe_layer not in {"raw", "clean", "mart"}:
-        raise ToolkitClientError("layer deve essere uno tra: raw, clean, mart")
+        raise ToolkitClientError("layer deve essere uno tra: raw, clean, mart", code=ErrorCode.INVALID_PARAMS)
 
     if safe_layer == "raw":
         years = list(_cfg.years or [])
@@ -56,7 +58,7 @@ def show_schema(config_path: str, layer: str = "clean", year: int | None = None)
     else:
         outputs = paths["paths"]["mart"].get("outputs") or []
         if not outputs:
-            raise ToolkitClientError("Nessun output mart risolto dal toolkit")
+            raise ToolkitClientError("Nessun output mart risolto dal toolkit", code=ErrorCode.PARQUET_NOT_FOUND)
         parquet_path = Path(outputs[0])
         payload = _schema_from_parquet(parquet_path)
         payload["available_outputs"] = outputs
@@ -94,7 +96,8 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
             profile = json.loads(raw_profile_json.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
             raise ToolkitClientError(
-                f"raw_profile.json malformato in {raw_profile_json}: {exc}"
+                f"raw_profile.json malformato in {raw_profile_json}: {exc}",
+                code=ErrorCode.FILE_FORMAT_ERROR,
             ) from exc
     elif suggested_read_yml.exists():
         # Fallback: suggested_read.yml contains the same hints in YAML form
@@ -104,7 +107,8 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
             raw_yaml = yaml.safe_load(suggested_read_yml.read_text(encoding="utf-8"))
         except yaml.YAMLError as exc:
             raise ToolkitClientError(
-                f"suggested_read.yml non valido in {suggested_read_yml}: {exc}"
+                f"suggested_read.yml non valido in {suggested_read_yml}: {exc}",
+                code=ErrorCode.FILE_FORMAT_ERROR,
             ) from exc
         clean_section = raw_yaml.get("clean", {}) if isinstance(raw_yaml, dict) else {}
         read_section = clean_section.get("read", {}) if isinstance(clean_section, dict) else {}
@@ -125,7 +129,8 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
     else:
         raise ToolkitClientError(
             f"Profilo raw non trovato in {profile_path}. "
-            "Nessun file raw_profile.json ne suggested_read.yml."
+            "Nessun file raw_profile.json ne suggested_read.yml.",
+            code=ErrorCode.FILE_NOT_FOUND,
         )
 
     # Ritorna un sottoinsieme leggibile: evita di restituire sample_rows intere
@@ -226,7 +231,7 @@ def list_runs(
             if since_dt.tzinfo is None:
                 since_dt = since_dt.replace(tzinfo=timezone.utc)
         except ValueError:
-            raise ToolkitClientError(f"since must be a valid ISO datetime, got: {since}")
+            raise ToolkitClientError(f"since must be a valid ISO datetime, got: {since}", code=ErrorCode.INVALID_PARAMS) from exc
 
     until_dt = None
     if until:
@@ -236,11 +241,11 @@ def list_runs(
             if until_dt.tzinfo is None:
                 until_dt = until_dt.replace(tzinfo=timezone.utc)
         except ValueError:
-            raise ToolkitClientError(f"until must be a valid ISO datetime, got: {until}")
+            raise ToolkitClientError(f"until must be a valid ISO datetime, got: {until}", code=ErrorCode.INVALID_PARAMS) from exc
 
     valid_statuses = {"SUCCESS", "FAILED", "RUNNING", "DRY_RUN"}
     if status and status not in valid_statuses:
-        raise ToolkitClientError(f"status must be one of: {', '.join(sorted(valid_statuses))}")
+        raise ToolkitClientError(f"status must be one of: {', '.join(sorted(valid_statuses))}", code=ErrorCode.INVALID_PARAMS)
 
     limit = limit if limit is not None else 20
 
@@ -306,7 +311,7 @@ def run_summary(
             if since_dt.tzinfo is None:
                 since_dt = since_dt.replace(tzinfo=timezone.utc)
         except ValueError:
-            raise ToolkitClientError(f"since must be a valid ISO datetime, got: {since}")
+            raise ToolkitClientError(f"since must be a valid ISO datetime, got: {since}", code=ErrorCode.INVALID_PARAMS) from exc
 
     until_dt: datetime | None = None
     if until:
@@ -316,7 +321,7 @@ def run_summary(
             if until_dt.tzinfo is None:
                 until_dt = until_dt.replace(tzinfo=timezone.utc)
         except ValueError:
-            raise ToolkitClientError(f"until must be a valid ISO datetime, got: {until}")
+            raise ToolkitClientError(f"until must be a valid ISO datetime, got: {until}", code=ErrorCode.INVALID_PARAMS) from exc
 
     all_records = list_runs(run_dir, since=since_dt, until=until_dt, limit=None)
 
@@ -877,4 +882,4 @@ def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
                 ),
             }
     except Exception as exc:
-        raise ToolkitClientError(f"Lettura CSV fallita per {path}: {exc}") from exc
+        raise ToolkitClientError(f"Lettura CSV fallita per {path}: {exc}", code=ErrorCode.FILE_FORMAT_ERROR) from exc

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -1,11 +1,16 @@
+"""Toolkit MCP server.
+
+Espone 10 tool read-only per ispezione della pipeline toolkit.
+Usa ``lab_connectors.mcp`` per init standardizzato, error handling e logging.
+"""
+
 from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from lab_connectors.mcp import create_mcp_server, guard
 
 from .toolkit_client import (
-    ToolkitClientError,
     blocker_hints as blocker_hints_impl,
     csv_preview as csv_preview_impl,
     inspect_paths as inspect_paths_impl,
@@ -18,32 +23,25 @@ from .toolkit_client import (
     show_schema as show_schema_impl,
 )
 
-
-mcp = FastMCP(
+mcp = create_mcp_server(
     name="toolkit",
     instructions=(
-        "Server MCP locale, read-only, per ispezionare path risolti, schemi e stato run del toolkit."
+        "Server MCP locale, read-only, per ispezionare path risolti, "
+        "schemi e stato run del toolkit."
     ),
 )
-
-
-def _guard(fn, *args, **kwargs) -> dict[str, Any]:
-    try:
-        return fn(*args, **kwargs)
-    except ToolkitClientError as exc:
-        return {"error": str(exc)}
 
 
 @mcp.tool(
     description="Mostra il path contract risolto per un dataset config.", structured_output=True
 )
 def toolkit_inspect_paths(config_path: str, year: int = 0) -> dict[str, Any]:
-    return _guard(inspect_paths_impl, config_path, year or None)
+    return guard(inspect_paths_impl, config_path, year or None)
 
 
 @mcp.tool(description="Mostra lo schema di raw, clean o mart.", structured_output=True)
 def toolkit_show_schema(config_path: str, layer: str = "clean", year: int = 0) -> dict[str, Any]:
-    return _guard(show_schema_impl, config_path, layer, year or None)
+    return guard(show_schema_impl, config_path, layer, year or None)
 
 
 @mcp.tool(
@@ -51,7 +49,7 @@ def toolkit_show_schema(config_path: str, layer: str = "clean", year: int = 0) -
     structured_output=True,
 )
 def toolkit_raw_profile(config_path: str, year: int = 0) -> dict[str, Any]:
-    return _guard(raw_profile_impl, config_path, year or None)
+    return guard(raw_profile_impl, config_path, year or None)
 
 
 @mcp.tool(
@@ -65,7 +63,7 @@ def toolkit_run_summary(
     since: str | None = None,
     until: str | None = None,
 ) -> dict[str, Any]:
-    return _guard(run_summary_impl, config_path, year or None, since=since, until=until)
+    return guard(run_summary_impl, config_path, year or None, since=since, until=until)
 
 
 @mcp.tool(
@@ -73,7 +71,7 @@ def toolkit_run_summary(
     structured_output=True,
 )
 def toolkit_summary(config_path: str, year: int = 0) -> dict[str, Any]:
-    return _guard(summary_impl, config_path, year or None)
+    return guard(summary_impl, config_path, year or None)
 
 
 @mcp.tool(
@@ -81,7 +79,7 @@ def toolkit_summary(config_path: str, year: int = 0) -> dict[str, Any]:
     structured_output=True,
 )
 def toolkit_blocker_hints(config_path: str, year: int = 0) -> dict[str, Any]:
-    return _guard(blocker_hints_impl, config_path, year or None)
+    return guard(blocker_hints_impl, config_path, year or None)
 
 
 @mcp.tool(
@@ -89,7 +87,7 @@ def toolkit_blocker_hints(config_path: str, year: int = 0) -> dict[str, Any]:
     structured_output=True,
 )
 def toolkit_review_readiness(config_path: str, year: int = 0) -> dict[str, Any]:
-    return _guard(review_readiness_impl, config_path, year or None)
+    return guard(review_readiness_impl, config_path, year or None)
 
 
 @mcp.tool(
@@ -97,7 +95,7 @@ def toolkit_review_readiness(config_path: str, year: int = 0) -> dict[str, Any]:
     structured_output=True,
 )
 def toolkit_schema_diff(config_path: str) -> dict[str, Any]:
-    return _guard(schema_diff_impl, config_path)
+    return guard(schema_diff_impl, config_path)
 
 
 @mcp.tool(
@@ -114,7 +112,7 @@ def toolkit_list_runs(
     limit: int | None = None,
     cross_year: bool = False,
 ) -> dict[str, Any]:
-    return _guard(list_runs_impl, config_path, year or None, since=since, until=until, status=status, limit=limit, cross_year=cross_year)
+    return guard(list_runs_impl, config_path, year or None, since=since, until=until, status=status, limit=limit, cross_year=cross_year)
 
 
 @mcp.tool(
@@ -124,7 +122,7 @@ def toolkit_list_runs(
     structured_output=True,
 )
 def toolkit_csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
-    return _guard(csv_preview_impl, csv_path, limit)
+    return guard(csv_preview_impl, csv_path, limit)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `ToolkitClientError` ora estende `McpError` da `lab_connectors.mcp`
- `server.py`: FastMCP init → `create_mcp_server()`, `_guard` → `guard()`
- 3 test aggiornati per il nuovo formato errori con codici tassonomici
- ~20 righe di boilerplate rimosse

## Modifiche

| File | Cosa cambia |
|------|-------------|
| `toolkit/mcp/server.py` | `create_mcp_server` invece di `FastMCP()`, `guard()` invece di `_guard()` |
| `toolkit/mcp/errors.py` | `ToolkitClientError(McpError)` — ponte verso lab_connectors |
| `tests/test_mcp_server.py` | test adattati al formato `{"error": "...", "message": "..."}` |

## Test
9/9 passano con `lab-connectors` installato da source locale.

## Dettaglio tecnico

`guard()` di lab_connectors cattura **tutte** le eccezioni e restituisce sempre un dict `{"error": code, "message": ...}`. Il ponte `ToolkitClientError(McpError)` garantisce che le eccezioni del toolkit vengano gestite come `UNEXPECTED` code, mantenendo la catena di strumenti (schema_ops, cli_adapter, path_safety) retrocompatibile.

## Prossimi passi
- `source-observatory/mcp`: stessa migrazione (commit locale pronto, senza `ArtifactResolver`)
- `dataset-incubator/clean-query-mcp`: stessa migrazione (commit locale pronto)