### PR TITLE
chore: migrate duckdb.connect() → lab_connectors.duckdb.safe_connect()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "requests>=2.33.1",
   "typer>=0.12.0",
   "rich>=13.0",
-  "lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.2.0"
+  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.4.0"
 ]
 
 [project.optional-dependencies]

--- a/toolkit/clean/_helpers.py
+++ b/toolkit/clean/_helpers.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import duckdb
+from lab_connectors.duckdb import safe_connect
 
 from toolkit.clean.duckdb_read import read_raw_to_relation
 from toolkit.core.layer_profile import profile_relation
@@ -25,9 +25,6 @@ def _profile_raw_input(
     read_mode: str,
     logger,
 ) -> dict[str, Any]:
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         read_raw_to_relation(con, input_files, read_cfg, read_mode, logger)
         return profile_relation(con, "raw_input")
-    finally:
-        con.close()

--- a/toolkit/clean/sql_execute.py
+++ b/toolkit/clean/sql_execute.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import duckdb
+from lab_connectors.duckdb import safe_connect
 
 from toolkit.clean.duckdb_read import read_raw_to_relation, sql_path
 from toolkit.core.layer_profile import profile_relation
@@ -39,8 +39,7 @@ def _run_sql(
     Returns:
         tuple of (source, params_used, output_profile)
     """
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         read_info = read_raw_to_relation(con, input_files, read_cfg, read_mode, logger)
         con.execute(f"CREATE TABLE clean_out AS {sql_query}")
         output_profile = profile_relation(con, "clean_out")
@@ -49,5 +48,3 @@ def _run_sql(
             f"COPY clean_out TO '{sql_path(output_path)}' (FORMAT PARQUET);"
         )
         return read_info.source, read_info.params_used, output_profile
-    finally:
-        con.close()

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -7,7 +7,7 @@ import re as _re
 from pathlib import Path
 from typing import Any
 
-import duckdb
+from lab_connectors.duckdb import safe_connect
 
 from toolkit.clean._column_rules import (
     _check_max_null_pct,
@@ -106,8 +106,7 @@ def validate_clean(
             summary={"path": path_value},
         )
 
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         con.execute(f"CREATE VIEW t AS SELECT * FROM read_parquet('{p.as_posix()}')")
 
         cols = [r[0] for r in con.execute("DESCRIBE t").fetchall()]
@@ -137,8 +136,6 @@ def validate_clean(
         err_warn = _check_ranges(con, "t", ranges, cols)
         errors.extend(err_warn[0])
         warnings.extend(err_warn[1])
-    finally:
-        con.close()
 
     return ValidationResult(
         ok=len(errors) == 0,
@@ -346,8 +343,7 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
                 break
         if _raw_file is not None:
             try:
-                _con = duckdb.connect(":memory:")
-                try:
+                with safe_connect() as _con:
                     if _raw_file.suffix == ".parquet":
                         _query = f'DESCRIBE SELECT * FROM read_parquet("{_raw_file.as_posix()}")'
                     else:
@@ -382,8 +378,6 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
                         raw_missing_columns = sorted(
                             c for c in _expected_cols if c not in _actual_set
                         )
-                finally:
-                    _con.close()
             except Exception:
                 pass
 

--- a/toolkit/cli/sql_dry_run.py
+++ b/toolkit/cli/sql_dry_run.py
@@ -4,6 +4,7 @@ import re
 from typing import Any
 
 import duckdb
+from lab_connectors.duckdb import safe_connect
 
 from toolkit.clean.run import _load_clean_sql
 from toolkit.core.config import ensure_dict
@@ -138,11 +139,8 @@ def validate_sql_dry_run(cfg, *, year: int, layers: list[str]) -> None:
     if not any(layer in {"clean", "mart"} for layer in layers):
         return
 
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         if cfg.clean.get("sql"):
             _build_clean_preview(cfg, year=year, con=con)
         if "mart" in layers:
             _validate_mart_sql(cfg, year=year, con=con)
-    finally:
-        con.close()

--- a/toolkit/core/layer_profile.py
+++ b/toolkit/core/layer_profile.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import duckdb
+from lab_connectors.duckdb import safe_connect
 
 from toolkit.core.sql_utils import q_ident
 
@@ -23,8 +24,7 @@ def profile_parquet_files(files: list[Path]) -> dict[str, Any]:
     if not files:
         raise ValueError("Cannot profile empty parquet file list")
 
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         if len(files) == 1:
             con.execute(
                 f"CREATE VIEW profiled_input AS SELECT * FROM read_parquet('{files[0].as_posix()}')"
@@ -35,8 +35,6 @@ def profile_parquet_files(files: list[Path]) -> dict[str, Any]:
                 f"CREATE VIEW profiled_input AS SELECT * FROM read_parquet([{paths}])"
             )
         return profile_relation(con, "profiled_input")
-    finally:
-        con.close()
 
 
 def compare_layer_profiles(

--- a/toolkit/cross/run.py
+++ b/toolkit/cross/run.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import duckdb
+from lab_connectors.duckdb import safe_connect
 
 from toolkit.core.artifacts import resolve_artifact_policy, should_write
 from toolkit.core.config import ensure_dict
@@ -86,8 +87,7 @@ def run_cross_year(
     if not isinstance(tables, list) or not tables:
         raise ValueError("cross_year.tables missing or empty in dataset.yml")
 
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         template_ctx = {
             "dataset": dataset,
             "years": ",".join(str(year) for year in years),
@@ -142,8 +142,6 @@ def run_cross_year(
                     "source_inputs": [serialize_metadata_path(path, root_dir) for path in files],
                 }
             )
-    finally:
-        con.close()
 
     outputs = [file_record(path) for path in written]
     metadata_payload = {

--- a/toolkit/cross/validate.py
+++ b/toolkit/cross/validate.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-import duckdb
+from lab_connectors.duckdb import safe_connect
 
 from toolkit.core.metadata import file_record, write_layer_manifest
 from toolkit.core.paths import layer_dataset_dir, to_root_relative
@@ -44,8 +44,7 @@ def validate_cross_outputs(
     if missing:
         errors.append(f"Missing required CROSS tables: {missing}")
 
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         row_counts: dict[str, int] = {}
         for path in existing_files:
             try:
@@ -54,8 +53,6 @@ def validate_cross_outputs(
                 )
             except Exception as exc:
                 warnings.append(f"Could not count rows for {path.name}: {exc}")
-    finally:
-        con.close()
 
     return ValidationResult(
         ok=len(errors) == 0,

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-import duckdb
+from lab_connectors.duckdb import safe_connect
 
 from toolkit.core.artifacts import resolve_artifact_policy, should_write
 from toolkit.core.config import ensure_dict
@@ -52,8 +52,7 @@ def run_mart(
             raise FileNotFoundError(f"No CLEAN parquet found in {clean_dir}")
     clean_input_profile = profile_parquet_files(clean_files) if clean_files else None
 
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         if clean_files:
             # clean_input view
             if len(clean_files) == 1:
@@ -144,8 +143,6 @@ def run_mart(
                     "output": serialize_metadata_path(out, root_dir),
                 }
             )
-    finally:
-        con.close()
 
     outputs = [file_record(p) for p in written]
     metadata_payload = {

--- a/toolkit/mart/validate.py
+++ b/toolkit/mart/validate.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-import duckdb
+from lab_connectors.duckdb import safe_connect
 
 from toolkit.core.config_models import MartTableRuleConfig, MartValidationSpec
 from toolkit.core.metadata import write_layer_manifest
@@ -79,108 +79,106 @@ def validate_mart(
                 f"{orphan_rules}"
             )
 
-    con = duckdb.connect(":memory:")
-    row_counts: dict[str, int] = {}
-    per_table: dict[str, Any] = {}
+    with safe_connect() as con:
+        row_counts: dict[str, int] = {}
+        per_table: dict[str, Any] = {}
 
-    for p in existing_files:
-        name = p.stem
+        for p in existing_files:
+            name = p.stem
 
-        try:
-            rc = int(con.execute(f"SELECT COUNT(*) FROM read_parquet('{p.as_posix()}')").fetchone()[0])
-            row_counts[name] = rc
-        except Exception as e:
-            warnings.append(f"Could not count rows for {p.name}: {e}")
-            continue
-
-        rules = table_rules.get(name)
-        if not rules:
-            continue
-
-        min_rows = rules.min_rows
-        if min_rows is not None and rc < min_rows:
-            errors.append(f"[{name}] row_count too small: {rc} < {min_rows}")
-
-        con.execute(f"CREATE OR REPLACE VIEW t AS SELECT * FROM read_parquet('{p.as_posix()}')")
-        cols = [r[0] for r in con.execute("DESCRIBE t").fetchall()]
-
-        # required columns
-        req_cols = rules.required_columns
-        required_result = required_columns_check(cols, req_cols)
-        errors.extend([f"[{name}] {error}" for error in required_result.errors])
-
-        # not null
-        for c in rules.not_null:
-            if c not in cols:
-                warnings.append(f"[{name}] Not-null rule column missing: '{c}'")
-                continue
-            qc = q_ident(c)
-            nnull = int(con.execute(f"SELECT COUNT(*) FROM t WHERE {qc} IS NULL").fetchone()[0])
-            if nnull > 0:
-                errors.append(f"[{name}] Column '{c}' has NULLs: {nnull}")
-
-        # primary key duplicates
-        pk = rules.primary_key
-        if pk:
-            if not all(c in cols for c in pk):
-                warnings.append(f"[{name}] Primary key columns not all present: {pk}")
-            else:
-                key_expr = ", ".join(q_ident(c) for c in pk)
-                dup_groups = int(
-                    con.execute(
-                        f"""
-                        SELECT COUNT(*) FROM (
-                          SELECT {key_expr}, COUNT(*) AS n
-                          FROM t
-                          GROUP BY {key_expr}
-                          HAVING COUNT(*) > 1
-                        ) d
-                        """
-                    ).fetchone()[0]
-                )
-                if dup_groups > 0:
-                    errors.append(f"[{name}] PK duplicates for {pk}: groups={dup_groups}")
-
-        # ranges (violation = below min OR above max)
-        for c, rule in rules.ranges.items():
-            if c not in cols:
-                warnings.append(f"[{name}] Range rule column missing: '{c}'")
+            try:
+                rc = int(con.execute(f"SELECT COUNT(*) FROM read_parquet('{p.as_posix()}')").fetchone()[0])
+                row_counts[name] = rc
+            except Exception as e:
+                warnings.append(f"Could not count rows for {p.name}: {e}")
                 continue
 
-            qc = q_ident(c)
-            violations: list[str] = []
-            if rule.min is not None:
-                violations.append(f"{qc} < {rule.min}")
-            if rule.max is not None:
-                violations.append(f"{qc} > {rule.max}")
-
-            if not violations:
-                warnings.append(f"[{name}] Range rule for '{c}' has no min/max, skipping")
+            rules = table_rules.get(name)
+            if not rules:
                 continue
 
-            where = f"{qc} IS NOT NULL AND (" + " OR ".join(violations) + ")"
-            bad = int(con.execute(f"SELECT COUNT(*) FROM t WHERE {where}").fetchone()[0])
-            if bad > 0:
-                errors.append(
-                    f"[{name}] Range check failed for '{c}': bad_rows={bad} "
-                    f"rules={{'min': {rule.min}, 'max': {rule.max}}}"
-                )
+            min_rows = rules.min_rows
+            if min_rows is not None and rc < min_rows:
+                errors.append(f"[{name}] row_count too small: {rc} < {min_rows}")
 
-        per_table[name] = {
-            "columns": cols,
-            "rules": {
-                "required_columns": rules.required_columns,
-                "not_null": rules.not_null,
-                "primary_key": rules.primary_key,
-                "ranges": {
-                    column: {"min": range_rule.min, "max": range_rule.max}
-                    for column, range_rule in rules.ranges.items()
+            con.execute(f"CREATE OR REPLACE VIEW t AS SELECT * FROM read_parquet('{p.as_posix()}')")
+            cols = [r[0] for r in con.execute("DESCRIBE t").fetchall()]
+
+            # required columns
+            req_cols = rules.required_columns
+            required_result = required_columns_check(cols, req_cols)
+            errors.extend([f"[{name}] {error}" for error in required_result.errors])
+
+            # not null
+            for c in rules.not_null:
+                if c not in cols:
+                    warnings.append(f"[{name}] Not-null rule column missing: '{c}'")
+                    continue
+                qc = q_ident(c)
+                nnull = int(con.execute(f"SELECT COUNT(*) FROM t WHERE {qc} IS NULL").fetchone()[0])
+                if nnull > 0:
+                    errors.append(f"[{name}] Column '{c}' has NULLs: {nnull}")
+
+            # primary key duplicates
+            pk = rules.primary_key
+            if pk:
+                if not all(c in cols for c in pk):
+                    warnings.append(f"[{name}] Primary key columns not all present: {pk}")
+                else:
+                    key_expr = ", ".join(q_ident(c) for c in pk)
+                    dup_groups = int(
+                        con.execute(
+                            f"""
+                            SELECT COUNT(*) FROM (
+                              SELECT {key_expr}, COUNT(*) AS n
+                              FROM t
+                              GROUP BY {key_expr}
+                              HAVING COUNT(*) > 1
+                            ) d
+                            """
+                        ).fetchone()[0]
+                    )
+                    if dup_groups > 0:
+                        errors.append(f"[{name}] PK duplicates for {pk}: groups={dup_groups}")
+
+            # ranges (violation = below min OR above max)
+            for c, rule in rules.ranges.items():
+                if c not in cols:
+                    warnings.append(f"[{name}] Range rule column missing: '{c}'")
+                    continue
+
+                qc = q_ident(c)
+                violations: list[str] = []
+                if rule.min is not None:
+                    violations.append(f"{qc} < {rule.min}")
+                if rule.max is not None:
+                    violations.append(f"{qc} > {rule.max}")
+
+                if not violations:
+                    warnings.append(f"[{name}] Range rule for '{c}' has no min/max, skipping")
+                    continue
+
+                where = f"{qc} IS NOT NULL AND (" + " OR ".join(violations) + ")"
+                bad = int(con.execute(f"SELECT COUNT(*) FROM t WHERE {where}").fetchone()[0])
+                if bad > 0:
+                    errors.append(
+                        f"[{name}] Range check failed for '{c}': bad_rows={bad} "
+                        f"rules={{'min': {rule.min}, 'max': {rule.max}}}"
+                    )
+
+            per_table[name] = {
+                "columns": cols,
+                "rules": {
+                    "required_columns": rules.required_columns,
+                    "not_null": rules.not_null,
+                    "primary_key": rules.primary_key,
+                    "ranges": {
+                        column: {"min": range_rule.min, "max": range_rule.max}
+                        for column, range_rule in rules.ranges.items()
+                    },
+                    "min_rows": rules.min_rows,
                 },
-                "min_rows": rules.min_rows,
-            },
-        }
-
-    con.close()
+            }
 
     return ValidationResult(
         ok=len(errors) == 0,

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import duckdb
+from lab_connectors.duckdb import safe_connect
 
 from toolkit.core.csv_read import (
     csv_read_option_strings,
@@ -383,58 +384,57 @@ def profile_with_read_cfg(
     warnings = list(sniff_hints.get("warnings") or [])
     robust_read_suggested = False
 
-    con = duckdb.connect(":memory:")
     try:
-        try:
-            _profile_view(
-                con,
-                file0,
-                effective_read_cfg=effective_read_cfg,
-            )
-        except Exception as e:
-            warnings.append(f"profile_read_retry: {type(e).__name__}: {e}")
-            robust_read_suggested = True
-            fallback_cfg = robust_preset(effective_read_cfg)
-            fallback_cfg.setdefault("auto_detect", False)
-            _profile_view(
-                con,
-                file0,
-                effective_read_cfg=fallback_cfg,
-            )
-
-        columns_raw, columns_norm, duckdb_types = _describe_columns(con)
-
-        # Detect column-count mismatch between header and data.
-        # When true_header_line (ground truth at line 0) has fewer tokens
-        # than what DESCRIBE returns, the file has more columns in data
-        # rows than in the header row (IRPEF comunale pattern:
-        # header=50 cols, data rows=52 cols).
-        if true_header_line is not None:
-            true_header_tokens = true_header_line.count(effective_read_cfg.get("delim") or ";") + 1
-            if len(columns_raw) > true_header_tokens:
-                warnings.append(
-                    f"header_data_cols_mismatch: header has {true_header_tokens} tokens, "
-                    f"data has {len(columns_raw)} columns; retrying with null_padding=true"
+        with safe_connect() as con:
+            try:
+                _profile_view(
+                    con,
+                    file0,
+                    effective_read_cfg=effective_read_cfg,
                 )
+            except Exception as e:
+                warnings.append(f"profile_read_retry: {type(e).__name__}: {e}")
                 robust_read_suggested = True
                 fallback_cfg = robust_preset(effective_read_cfg)
                 fallback_cfg.setdefault("auto_detect", False)
-                fallback_cfg.setdefault("null_padding", True)
                 _profile_view(
                     con,
                     file0,
                     effective_read_cfg=fallback_cfg,
                 )
-                columns_raw, columns_norm, duckdb_types = _describe_columns(con)
 
-        duckdb_type_map: dict[str, str] = {
-            raw: dtype for raw, dtype in zip(columns_raw, duckdb_types)
-        }
-        sample_rows, missingness_top = _sample_profile_rows(con, columns_raw)
-        mapping_suggestions = _build_mapping_suggestions(
-            columns_raw, sample_rows, duckdb_types=duckdb_type_map
-        )
+            columns_raw, columns_norm, duckdb_types = _describe_columns(con)
 
+            # Detect column-count mismatch between header and data.
+            # When true_header_line (ground truth at line 0) has fewer tokens
+            # than what DESCRIBE returns, the file has more columns in data
+            # rows than in the header row (IRPEF comunale pattern:
+            # header=50 cols, data rows=52 cols).
+            if true_header_line is not None:
+                true_header_tokens = true_header_line.count(effective_read_cfg.get("delim") or ";") + 1
+                if len(columns_raw) > true_header_tokens:
+                    warnings.append(
+                        f"header_data_cols_mismatch: header has {true_header_tokens} tokens, "
+                        f"data has {len(columns_raw)} columns; retrying with null_padding=true"
+                    )
+                    robust_read_suggested = True
+                    fallback_cfg = robust_preset(effective_read_cfg)
+                    fallback_cfg.setdefault("auto_detect", False)
+                    fallback_cfg.setdefault("null_padding", True)
+                    _profile_view(
+                        con,
+                        file0,
+                        effective_read_cfg=fallback_cfg,
+                    )
+                    columns_raw, columns_norm, duckdb_types = _describe_columns(con)
+
+            duckdb_type_map: dict[str, str] = {
+                raw: dtype for raw, dtype in zip(columns_raw, duckdb_types)
+            }
+            sample_rows, missingness_top = _sample_profile_rows(con, columns_raw)
+            mapping_suggestions = _build_mapping_suggestions(
+                columns_raw, sample_rows, duckdb_types=duckdb_type_map
+            )
     except Exception as e:
         warnings.append(f"profile_failed: {type(e).__name__}: {e}")
         warnings.append(
@@ -444,8 +444,6 @@ def profile_with_read_cfg(
         sample_rows, missingness_top = [], []
         mapping_suggestions = {}
         robust_read_suggested = True
-    finally:
-        con.close()
 
     return {
         "columns_raw": columns_raw,


### PR DESCRIPTION
Migra 10 file da `duckdb.connect(":memory:")` + `try/finally` + `con.close()` a `with safe_connect() as con:`.

- `safe_connect` definito in `lab-connectors v0.4.0`
- 153 insertions, 181 deletions (−28 righe nette)
- Fixa connection leak in `mart/validate.py` (mancava try/finally)
- 622 test passano invariati