### PR TITLE
feat: source_id opzionale in DatasetBlock per cross-referenza SO

### DIFF
--- a/toolkit/core/config_models/shared_models.py
+++ b/toolkit/core/config_models/shared_models.py
@@ -106,6 +106,7 @@ class DatasetBlock(BaseModel):
 
     name: str
     years: list[int]
+    source_id: str | None = None
     time_coverage: TimeCoverage | None = None
 
 


### PR DESCRIPTION
## Cosa cambia

- `toolkit/core/config_models/shared_models.py`: aggiunto `source_id: str | None = None` a `DatasetBlock`

### Perché

I `dataset.yml` dei candidati ora possono dichiarare `source_id` per collegare il dataset alla fonte corrispondente in source-observatory. Es:

```yaml
dataset:
  name: "aifa_spesa_consumo"
  source_id: "aifa"
  years: [2018, 2019, 2020, 2021, 2022, 2023, 2024]
```

Il `DatasetBlock` aveva `extra="forbid"`, quindi `source_id` causava `ValidationError` ("Extra inputs are not permitted").

### Dipendenze

- PR dataset-incubator #286 (aggiunge source_id ad AIFA)
- PR dataset-incubator #285 (enrichment in build_clean_catalog)