### PR TITLE
feat: aggiungere source type http_post_file per download via POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ esegue le trasformazioni SQL su DuckDB e produce output in `root/data/`.
 | `raw.sources[].type` | Fonte |
 |---|---|
 | `http_file` | File da URL HTTP(S), anche zippato |
+| `http_post_file` | File da URL HTTP(S) via POST con form-encoded body |
 | `local_file` | File sul filesystem locale |
 | `ckan` | Dataset da portali CKAN (via API) |
 | `sdmx` | Flussi SDMX (es. ISTAT) |

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -110,6 +110,31 @@ Note pratiche per `sdmx`:
 - in v1 i `filters` sono supportati solo sulle dimensioni di serie, non su `TIME_PERIOD`
 - il filtro temporale va applicato nel layer `clean.sql` (per esempio `WHERE TIME_PERIOD = '2024'`), non in `raw.sources[].args.filters`
 - il plugin restituisce un CSV normalizzato con colonne `DIM`, `DIM_label` e `value`
+
+Esempio `http_post_file`:
+
+```yaml
+raw:
+  sources:
+    - name: pensioni_dag
+      type: http_post_file
+      client:
+        timeout: 120
+        retries: 2
+      args:
+        url: "https://datipensioni.mef.gov.it/datipensioni/downloadFile"
+        post_data:
+          filename: "Dati_Tipo_Pensione_totale.csv"
+          categoria: "pensioni"
+        filename: "Dati_Tipo_Pensione_totale.csv"
+      primary: true
+```
+
+Note pratiche per `http_post_file`:
+
+- i parametri del form POST si dichiarano in `args.post_data` come coppie chiave-valore
+- il retry è sicuro solo per endpoint idempotenti (download file): per POST non-idempotenti impostare `client.retries: 0`
+- il resto del comportamento (infer estensione, extractor, caching) è identico a `http_file`
 ## clean
 
 | Campo | Tipo | Default |

--- a/docs/feature-stability.md
+++ b/docs/feature-stability.md
@@ -28,7 +28,7 @@ Lettura equivalente a livello package:
 - advanced tooling: `toolkit.profile`, `resume`, run parziali, `cross_year`, `inspect schema-diff`
 - compatibility only: config legacy e alias storici
 
-Sorgenti builtin supportate dal runtime canonico: `local_file`, `http_file`, `ckan`, `sdmx`, `sparql`. Il runtime può conservare `.xlsx` e `.xls` in RAW e leggerli in CLEAN — il file originale resta l'artefatto sorgente.
+Sorgenti builtin supportate dal runtime canonico: `local_file`, `http_file`, `http_post_file`, `ckan`, `sdmx`, `sparql`. Il runtime può conservare `.xlsx` e `.xls` in RAW e leggerli in CLEAN — il file originale resta l'artefatto sorgente.
 
 Regola pratica:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "requests>=2.33.1",
   "typer>=0.12.0",
   "rich>=13.0",
-  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.4.0"
+  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.5.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_http_post_file_plugin.py
+++ b/tests/test_http_post_file_plugin.py
@@ -1,0 +1,135 @@
+"""Tests for HttpPostFileSource — adapter over lab_connectors.http.
+
+Tests mock the public boundary (HttpClient.post / HttpResult), not
+internal HTTP details. Retry and SSL fallback logic lives in
+lab-connectors and is tested there.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lab_connectors.http import HttpClient, HttpResult
+
+from toolkit.core.exceptions import DownloadError
+from toolkit.plugins.http_post_file import HttpPostFileSource
+
+
+class _FakeResponse:
+    """Minimal response stub duck-typing requests.Response properties."""
+
+    def __init__(self, status_code: int = 200, content: bytes = b"ok") -> None:
+        self.status_code = status_code
+        self.content = content
+
+
+def test_fetch_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HttpResult ok → fetch returns bytes."""
+    results: list[tuple[str, dict | None, dict]] = []
+
+    def fake_post(self, url: str, data: dict | None = None, **kwargs):
+        results.append((url, data, kwargs))
+        return HttpResult(response=_FakeResponse(200, b"payload"), err=None)
+
+    monkeypatch.setattr(HttpClient, "post", fake_post)
+
+    source = HttpPostFileSource(timeout=15, retries=2, user_agent="ua-test")
+    payload = source.fetch("https://example.test/download", data={"key": "val"})
+
+    assert payload == b"payload"
+    assert len(results) == 1
+    assert results[0][0] == "https://example.test/download"
+    assert results[0][1] == {"key": "val"}
+
+
+def test_fetch_without_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fetch without data passes None."""
+    results: list[tuple[str, dict | None, dict]] = []
+
+    def fake_post(self, url: str, data: dict | None = None, **kwargs):
+        results.append((url, data, kwargs))
+        return HttpResult(response=_FakeResponse(200, b"no-data"), err=None)
+
+    monkeypatch.setattr(HttpClient, "post", fake_post)
+
+    source = HttpPostFileSource()
+    payload = source.fetch("https://example.test/download")
+
+    assert payload == b"no-data"
+    assert len(results) == 1
+    assert results[0][1] is None
+
+
+def test_fetch_http_status_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-200 HTTP status → DownloadError with status code in message."""
+
+    def fake_post(self, url: str, data: dict | None = None, **kwargs):
+        return HttpResult(response=_FakeResponse(503, b"service unavailable"), err=None)
+
+    monkeypatch.setattr(HttpClient, "post", fake_post)
+
+    source = HttpPostFileSource(retries=1)
+    with pytest.raises(DownloadError, match="HTTP 503"):
+        source.fetch("https://example.test/unavailable")
+
+
+def test_fetch_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HttpResult with err → DownloadError."""
+
+    def fake_post(self, url: str, data: dict | None = None, **kwargs):
+        return HttpResult(response=None, err=ConnectionError("connection refused"))
+
+    monkeypatch.setattr(HttpClient, "post", fake_post)
+
+    source = HttpPostFileSource(retries=2)
+    with pytest.raises(DownloadError, match="connection refused"):
+        source.fetch("https://example.test/fail")
+
+
+def test_fetch_passes_params() -> None:
+    """HttpPostFileSource init params are forwarded to HttpClient constructor."""
+    source = HttpPostFileSource(timeout=42, retries=5, user_agent="custom-agent/1.0")
+    assert source._client.timeout == 42
+    assert source._client.max_retries == 5
+    assert source._client.user_agent == "custom-agent/1.0"
+
+    # Default user_agent when not specified
+    source2 = HttpPostFileSource()
+    assert source2._client.user_agent == "dataciviclab-toolkit/0.1"
+
+
+@pytest.mark.policy
+def test_ssl_fallback_semantics_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ssl_fallback_used=True in HttpResult is transparent to caller."""
+
+    def fake_post(self, url: str, data: dict | None = None, **kwargs):
+        return HttpResult(
+            response=_FakeResponse(200, b"ssl-fallback-data"),
+            err=None,
+            ssl_fallback_used=True,
+        )
+
+    monkeypatch.setattr(HttpClient, "post", fake_post)
+
+    source = HttpPostFileSource(retries=1)
+    payload = source.fetch("https://example.test/ssl-expired")
+
+    assert payload == b"ssl-fallback-data"
+
+
+@pytest.mark.policy
+def test_ssl_fallback_failure_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HttpResult with ssl_fallback_used=False and err → DownloadError."""
+
+    def fake_post(self, url: str, data: dict | None = None, **kwargs):
+        return HttpResult(
+            response=None,
+            err=ConnectionError("fallback failed"),
+            ssl_fallback_used=False,
+        )
+
+    monkeypatch.setattr(HttpClient, "post", fake_post)
+
+    source = HttpPostFileSource(retries=1)
+    with pytest.raises(DownloadError, match="fallback failed"):
+        source.fetch("https://example.test/ssl-fail")

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -38,7 +38,7 @@ def test_raw_exports() -> None:
 
 
 def test_plugins_exports() -> None:
-    assert plugins_pkg.__all__ == ["LocalFileSource", "HttpFileSource", "CkanSource", "SdmxSource", "SparqlSource"]
+    assert plugins_pkg.__all__ == ["LocalFileSource", "HttpFileSource", "HttpPostFileSource", "CkanSource", "SdmxSource", "SparqlSource"]
     assert LocalFileSource.__name__ == "LocalFileSource"
     assert HttpFileSource.__name__ == "HttpFileSource"
     assert CkanSource.__name__ == "CkanSource"

--- a/toolkit/core/registry.py
+++ b/toolkit/core/registry.py
@@ -57,6 +57,13 @@ _BUILTIN_PLUGINS: tuple[dict[str, Any], ...] = (
         "factory": lambda cls: (lambda **client: cls(**client)),
     },
     {
+        "name": "http_post_file",
+        "module": "toolkit.plugins.http_post_file",
+        "class_name": "HttpPostFileSource",
+        "optional": False,
+        "factory": lambda cls: (lambda **client: cls(**client)),
+    },
+    {
         "name": "local_file",
         "module": "toolkit.plugins.local_file",
         "class_name": "LocalFileSource",

--- a/toolkit/plugins/__init__.py
+++ b/toolkit/plugins/__init__.py
@@ -6,6 +6,7 @@ Builtin stable sources exposed by the default runtime:
 
 - `local_file`
 - `http_file`
+- `http_post_file`
 - `ckan`
 - `sdmx`
 - `sparql`
@@ -13,6 +14,7 @@ Builtin stable sources exposed by the default runtime:
 
 from toolkit.plugins.ckan import CkanSource
 from toolkit.plugins.http_file import HttpFileSource
+from toolkit.plugins.http_post_file import HttpPostFileSource
 from toolkit.plugins.local_file import LocalFileSource
 from toolkit.plugins.sdmx import SdmxSource
 from toolkit.plugins.sparql import SparqlSource
@@ -20,6 +22,7 @@ from toolkit.plugins.sparql import SparqlSource
 __all__ = [
     "LocalFileSource",
     "HttpFileSource",
+    "HttpPostFileSource",
     "CkanSource",
     "SdmxSource",
     "SparqlSource",

--- a/toolkit/plugins/http_post_file.py
+++ b/toolkit/plugins/http_post_file.py
@@ -1,0 +1,72 @@
+"""HTTP POST file source plugin.
+
+Downloads a file via HTTP POST with form-encoded body data.
+Built on lab_connectors.http.HttpClient which provides SSL fallback
+and configurable retry.
+
+Usage in dataset.yml::
+
+    raw:
+      sources:
+        - type: http_post_file
+          args:
+            url: "https://example.com/download"
+            post_data:
+              filename: "report.csv"
+              category: "data"
+"""
+
+from __future__ import annotations
+
+import logging
+
+from lab_connectors.http import HttpClient
+
+from toolkit.core.exceptions import DownloadError
+
+logger = logging.getLogger("toolkit.plugins.http_post_file")
+
+
+class HttpPostFileSource:
+    """Download a file via HTTP POST with form-encoded data.
+
+    Adapter over lab_connectors.http.HttpClient that translates
+    HttpResult into toolkit's DownloadError contract.
+
+    .. caution::
+       Retry on POST is safe only for **idempotent** endpoints
+       (file download queries). For state-mutating endpoints,
+       set ``max_retries=0`` in ``raw.sources[].client``.
+    """
+
+    def __init__(self, timeout: int = 60, retries: int = 2, user_agent: str | None = None):
+        self.timeout = timeout
+        self.retries = retries
+        self.user_agent = user_agent or "dataciviclab-toolkit/0.1"
+        self._client = HttpClient(
+            timeout=timeout,
+            max_retries=retries,
+            user_agent=self.user_agent,
+        )
+
+    def fetch(self, url: str, data: dict | None = None) -> bytes:
+        """Execute a POST request and return response bytes.
+
+        Args:
+            url: Target URL.
+            data: Form-encoded POST body (dict of key-value pairs).
+
+        Returns:
+            Raw response bytes.
+
+        Raises:
+            DownloadError: on network error or non-200 HTTP status.
+
+        """
+        result = self._client.post(url, data=data)
+        if result.is_ok and result.response is not None:
+            if result.response.status_code != 200:
+                raise DownloadError(f"HTTP {result.response.status_code} for {url}")
+            return result.response.content
+        err = result.err
+        raise DownloadError(str(err) if err else f"Failed to fetch {url}")

--- a/toolkit/plugins/http_post_file.py
+++ b/toolkit/plugins/http_post_file.py
@@ -63,7 +63,8 @@ class HttpPostFileSource:
             DownloadError: on network error or non-200 HTTP status.
 
         """
-        result = self._client.post(url, data=data)
+        # File download via POST is idempotent — safe to retry
+        result = self._client.post(url, data=data, retries=self.retries)
         if result.is_ok and result.response is not None:
             if result.response.status_code != 200:
                 raise DownloadError(f"HTTP {result.response.status_code} for {url}")

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -45,7 +45,7 @@ def _infer_ext(stype: str, formatted_args: dict, origin: str | None = None) -> s
     if stype in {"sdmx", "sparql"}:
         return ".csv"
 
-    if stype in {"http_file", "ckan"}:
+    if stype in {"http_file", "http_post_file", "ckan"}:
         url = origin or formatted_args.get("url", "")
         return _infer_from_url(url)
 
@@ -134,6 +134,14 @@ def _fetch_sparql(stype: str, client: dict, formatted_args: dict) -> tuple[bytes
 def _fetch_http_file(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
     src = registry.create(stype, **(client or {}))
     payload = src.fetch(formatted_args["url"])
+    return payload, formatted_args["url"]
+
+
+@_register_fetch("http_post_file")
+def _fetch_http_post_file(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
+    src = registry.create(stype, **(client or {}))
+    post_data = formatted_args.get("post_data")
+    payload = src.fetch(formatted_args["url"], data=post_data)
     return payload, formatted_args["url"]
 
 


### PR DESCRIPTION
## Problema

Closes #183.

Il toolkit non ha un source type per download via HTTP POST. I candidate che usano endpoint POST (es. MEF DAG datipensioni) sono costretti a script locali di staging fuori dal toolkit.

## Cosa fa questa PR

Aggiunge il plugin `http_post_file` per download via HTTP POST con body form-encoded:

```yaml
raw:
  sources:
    - type: http_post_file
      args:
        url: "https://example.com/download"
        post_data:
          filename: "report.csv"
          categoria: "pensioni"
```

Basato su `HttpClient.post()` aggiunto in `dataciviclab/lab-connectors#9` (prerequisito).

### Files modificati

- `toolkit/plugins/http_post_file.py` — nuovo plugin (65 righe)
- `toolkit/plugins/__init__.py` — import + __all__
- `toolkit/core/registry.py` — registrazione builtin
- `toolkit/raw/_fetch_utils.py` — dispatch fetch + infer_ext
- `tests/test_http_post_file_plugin.py` — 7 test (110 righe)
- `tests/test_public_api_contracts.py` — fix __all__ contract

## Test

7 test: successo con/senza data, HTTP error, connection error, passaggio parametri, SSL fallback semantics. Tutti mockano `HttpClient.post` (non `requests`).

## Dipendenza

**Questa PR dipende dal merge di `dataciviclab/lab-connectors#9`** — il nuovo `HttpClient.post()` deve essere disponibile in runtime per il plugin.