### PR TITLE
feat: SparqlSource migrato a HttpClient.post(retries=2)

### DIFF
--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -1,54 +1,47 @@
+"""Tests for SparqlSource — mocks HttpClient, not raw requests."""
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
+from lab_connectors.http import HttpResult
 
 from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.sparql import SparqlSource, _sparql_json_to_csv
 
 
-class _FakeSparqlResponse:
-    def __init__(
-        self,
-        status_code: int = 200,
-        text: str = "",
-        content: bytes | None = None,
-        headers: dict[str, str | bytes] | None = None,
-    ):
-        self.status_code = status_code
-        self.text = text
-        self.content = content if content is not None else text.encode("utf-8")
-        self.headers = headers or {}
+def _http_ok(status=200, text="", headers=None):
+    """Build success HttpResult for sparql responses."""
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = text
+    resp.content = text.encode("utf-8")
+    resp.headers = headers or {}
+    return HttpResult(response=resp, err=None)
 
 
-def test_sparql_fetch_csv_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[dict[object, object]] = []
-
-    def fake_post(url: str, data: dict, headers: dict, timeout: int):
-        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
-        return _FakeSparqlResponse(
-            status_code=200,
+def test_sparql_fetch_csv_success():
+    """CSV response is returned as bytes."""
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=200,
             text="name,value\nfoo,123\nbar,456\n",
             headers={"Content-Type": "text/csv"},
         )
-
-    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
-
-    source = SparqlSource(timeout=30)
-    payload, origin = source.fetch(
-        "https://example.test/sparql",
-        "SELECT ?name ?value WHERE { }",
-        accept_format="csv",
-    )
+        source = SparqlSource(timeout=30)
+        payload, origin = source.fetch(
+            "https://example.test/sparql",
+            "SELECT ?name ?value WHERE { }",
+            accept_format="csv",
+        )
 
     assert origin == "https://example.test/sparql"
     assert b"name,value" in payload
     assert b"foo,123" in payload
-    assert len(calls) == 1
-    assert calls[0]["url"] == "https://example.test/sparql"
-    assert calls[0]["timeout"] == 30
 
 
-def test_sparql_fetch_json_success(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sparql_fetch_json_success():
+    """SPARQL JSON response is converted to CSV."""
     json_response = """{
   "head": { "vars": ["name", "value"] },
   "results": {
@@ -58,24 +51,18 @@ def test_sparql_fetch_json_success(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
   }
 }"""
-    calls: list[dict[object, object]] = []
-
-    def fake_post(url: str, data: dict, headers: dict, timeout: int):
-        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
-        return _FakeSparqlResponse(
-            status_code=200,
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=200,
             text=json_response,
             headers={"Content-Type": "application/sparql-results+json"},
         )
-
-    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
-
-    source = SparqlSource()
-    payload, origin = source.fetch(
-        "https://example.test/sparql",
-        "SELECT ?name ?value WHERE { }",
-        accept_format="sparql-results+json",
-    )
+        source = SparqlSource()
+        payload, origin = source.fetch(
+            "https://example.test/sparql",
+            "SELECT ?name ?value WHERE { }",
+            accept_format="sparql-results+json",
+        )
 
     assert origin == "https://example.test/sparql"
     lines = payload.decode("utf-8").splitlines()
@@ -84,86 +71,81 @@ def test_sparql_fetch_json_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Bob,7" in payload.decode("utf-8")
 
 
-def test_sparql_fetch_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_post(url: str, data: dict, headers: dict, timeout: int):
-        return _FakeSparqlResponse(status_code=500, text="Internal Server Error")
-
-    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
-
-    source = SparqlSource()
-    with pytest.raises(DownloadError, match="HTTP 500"):
-        source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
-
-
-def test_sparql_fetch_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_post(url: str, data: dict, headers: dict, timeout: int):
-        raise Exception("connection refused")
-
-    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
-
-    source = SparqlSource()
-    with pytest.raises(DownloadError, match="connection refused"):
-        source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
+def test_sparql_fetch_http_error():
+    """Non-200 response raises DownloadError."""
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=500, text="Internal Server Error",
+        )
+        source = SparqlSource()
+        with pytest.raises(DownloadError, match="HTTP 500"):
+            source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
 
 
-def test_sparql_fetch_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_post(url: str, data: dict, headers: dict, timeout: int):
-        return _FakeSparqlResponse(
-            status_code=200,
+def test_sparql_fetch_network_error():
+    """Network error raises DownloadError."""
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = HttpResult(
+            response=None, err=Exception("connection refused"),
+        )
+        source = SparqlSource()
+        with pytest.raises(DownloadError, match="connection refused"):
+            source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
+
+
+def test_sparql_fetch_empty_results():
+    """Empty SPARQL results raise DownloadError."""
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=200,
             text='{"head":{"vars":["name"]},"results":{"bindings":[]}}',
             headers={"Content-Type": "application/sparql-results+json"},
         )
-
-    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
-
-    source = SparqlSource()
-    with pytest.raises(DownloadError, match="no results"):
-        source.fetch(
-            "https://example.test/sparql",
-            "SELECT ?name WHERE { }",
-            accept_format="sparql-results+json",
-        )
+        source = SparqlSource()
+        with pytest.raises(DownloadError, match="no results"):
+            source.fetch(
+                "https://example.test/sparql",
+                "SELECT ?name WHERE { }",
+                accept_format="sparql-results+json",
+            )
 
 
-def test_sparql_fetch_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_post(url: str, data: dict, headers: dict, timeout: int):
-        return _FakeSparqlResponse(
-            status_code=200,
+def test_sparql_fetch_invalid_json():
+    """Invalid SPARQL JSON raises DownloadError."""
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=200,
             text="not json at all",
             headers={"Content-Type": "application/sparql-results+json"},
         )
-
-    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
-
-    source = SparqlSource()
-    with pytest.raises(DownloadError, match="Invalid SPARQL JSON"):
-        source.fetch(
-            "https://example.test/sparql",
-            "SELECT * WHERE { }",
-            accept_format="sparql-results+json",
-        )
+        source = SparqlSource()
+        with pytest.raises(DownloadError, match="Invalid SPARQL JSON"):
+            source.fetch(
+                "https://example.test/sparql",
+                "SELECT * WHERE { }",
+                accept_format="sparql-results+json",
+            )
 
 
-def test_sparql_fetch_unsupported_content_type_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_post(url: str, data: dict, headers: dict, timeout: int):
-        return _FakeSparqlResponse(
-            status_code=200,
+def test_sparql_fetch_unsupported_content_type_raises():
+    """Unsupported Content-Type raises DownloadError."""
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=200,
             text="<xml>not supported</xml>",
             headers={"Content-Type": "application/xml"},
         )
-
-    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
-
-    source = SparqlSource()
-    with pytest.raises(DownloadError, match="Unsupported Content-Type"):
-        source.fetch(
-            "https://example.test/sparql",
-            "SELECT * WHERE { }",
-            accept_format="csv",
-        )
+        source = SparqlSource()
+        with pytest.raises(DownloadError, match="Unsupported Content-Type"):
+            source.fetch(
+                "https://example.test/sparql",
+                "SELECT * WHERE { }",
+                accept_format="csv",
+            )
 
 
-def test_sparql_fetch_unsupported_accept_format_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sparql_fetch_unsupported_accept_format_raises():
+    """Unsupported accept_format raises DownloadError early (no HTTP)."""
     source = SparqlSource()
     with pytest.raises(DownloadError, match="Unsupported accept_format"):
         source.fetch(
@@ -173,19 +155,21 @@ def test_sparql_fetch_unsupported_accept_format_raises(monkeypatch: pytest.Monke
         )
 
 
-def test_sparql_fetch_missing_endpoint_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sparql_fetch_missing_endpoint_raises():
+    """Missing endpoint raises DownloadError early."""
     source = SparqlSource()
     with pytest.raises(DownloadError, match="requires endpoint URL"):
         source.fetch("", "SELECT * WHERE { }")
 
 
-def test_sparql_fetch_missing_query_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sparql_fetch_missing_query_raises():
+    """Missing query raises DownloadError early."""
     source = SparqlSource()
     with pytest.raises(DownloadError, match="requires a query"):
         source.fetch("https://example.test/sparql", "")
 
 
-def test_sparql_json_to_csv_binding_types(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sparql_json_to_csv_binding_types():
     """URI and literal bindings are both converted to their string value."""
     json_response = """{
   "head": { "vars": ["person", "age"] },
@@ -204,7 +188,8 @@ def test_sparql_json_to_csv_binding_types(monkeypatch: pytest.MonkeyPatch) -> No
     assert "http://example.org/Alice,30" in csv_text
 
 
-def test_sparql_probe_returns_schema_and_stats(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sparql_probe_returns_schema_and_stats():
+    """Probe returns schema, stats, and warnings."""
     json_response = """{
   "head": { "vars": ["name", "value"] },
   "results": {
@@ -215,24 +200,18 @@ def test_sparql_probe_returns_schema_and_stats(monkeypatch: pytest.MonkeyPatch) 
     ]
   }
 }"""
-    calls: list[dict[object, object]] = []
-
-    def fake_post(url: str, data: dict, headers: dict, timeout: int):
-        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
-        return _FakeSparqlResponse(
-            status_code=200,
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=200,
             text=json_response,
             headers={"Content-Type": "application/sparql-results+json"},
         )
-
-    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
-
-    source = SparqlSource(timeout=30)
-    result = source.probe(
-        "https://example.test/sparql",
-        "SELECT ?name ?value WHERE { }",
-        limit=10,
-    )
+        source = SparqlSource(timeout=30)
+        result = source.probe(
+            "https://example.test/sparql",
+            "SELECT ?name ?value WHERE { }",
+            limit=10,
+        )
 
     assert result["endpoint"] == "https://example.test/sparql"
     assert result["variables"] == ["name", "value"]
@@ -246,65 +225,56 @@ def test_sparql_probe_returns_schema_and_stats(monkeypatch: pytest.MonkeyPatch) 
     assert result["query_time_ms"] >= 0
 
 
-def test_sparql_probe_adds_limit_if_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[dict[object, object]] = []
-
-    def fake_post(url: str, data: dict, headers: dict, timeout: int):
-        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
-        return _FakeSparqlResponse(
-            status_code=200,
+def test_sparql_probe_adds_limit_if_missing():
+    """Probe appends LIMIT if not in query."""
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=200,
             text='{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"literal","value":"1"}}]}}',
             headers={"Content-Type": "application/sparql-results+json"},
         )
+        source = SparqlSource()
+        source.probe("https://example.test/sparql", "SELECT ?x WHERE { }", limit=50)
 
-    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
-
-    source = SparqlSource()
-    source.probe("https://example.test/sparql", "SELECT ?x WHERE { }", limit=50)
-
-    sent_query = calls[0]["data"]["query"]
-    assert "LIMIT 50" in sent_query.upper()
+        sent_query = mock_cls.return_value.post.call_args[1]["data"]["query"]
+        assert "LIMIT 50" in sent_query.upper()
 
 
-def test_sparql_probe_preserves_existing_limit(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[dict[object, object]] = []
-
-    def fake_post(url: str, data: dict, headers: dict, timeout: int):
-        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
-        return _FakeSparqlResponse(
-            status_code=200,
+def test_sparql_probe_preserves_existing_limit():
+    """Probe does not double-LIMIT."""
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=200,
             text='{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"literal","value":"1"}}]}}',
             headers={"Content-Type": "application/sparql-results+json"},
         )
+        source = SparqlSource()
+        source.probe("https://example.test/sparql", "SELECT ?x WHERE { } LIMIT 10", limit=50)
 
-    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
-
-    source = SparqlSource()
-    source.probe("https://example.test/sparql", "SELECT ?x WHERE { } LIMIT 10", limit=50)
-
-    sent_query = calls[0]["data"]["query"]
-    # Should not double-limit
-    assert sent_query.upper().count("LIMIT") == 1
+        sent_query = mock_cls.return_value.post.call_args[1]["data"]["query"]
+        assert sent_query.upper().count("LIMIT") == 1
 
 
-def test_sparql_probe_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_post(url: str, data: dict, headers: dict, timeout: int):
-        return _FakeSparqlResponse(status_code=500, text="Internal Server Error")
+def test_sparql_probe_http_error():
+    """Non-200 during probe raises DownloadError."""
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=500, text="Internal Server Error",
+        )
+        source = SparqlSource()
+        with pytest.raises(DownloadError, match="HTTP 500"):
+            source.probe("https://example.test/sparql", "SELECT * WHERE { }")
 
-    monkeypatch.setattr("toolkit.plugins.sparql.requests.post", fake_post)
 
-    source = SparqlSource()
-    with pytest.raises(DownloadError, match="HTTP 500"):
-        source.probe("https://example.test/sparql", "SELECT * WHERE { }")
-
-
-def test_sparql_probe_missing_endpoint_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sparql_probe_missing_endpoint_raises():
+    """Missing endpoint raises DownloadError early."""
     source = SparqlSource()
     with pytest.raises(DownloadError, match="requires endpoint URL"):
         source.probe("", "SELECT * WHERE { }")
 
 
-def test_sparql_probe_missing_query_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sparql_probe_missing_query_raises():
+    """Missing query raises DownloadError early."""
     source = SparqlSource()
     with pytest.raises(DownloadError, match="requires a query"):
         source.probe("https://example.test/sparql", "")

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -10,16 +10,20 @@ import csv
 import io
 from typing import Any
 
-import requests
+from lab_connectors.http import HttpClient
 
 from toolkit.core.exceptions import DownloadError
 
 
 class SparqlSource:
-    """Query a SPARQL endpoint and return results as CSV bytes."""
+    """Query a SPARQL endpoint and return results as CSV bytes.
 
-    def __init__(self, timeout: int = 60):
-        self.timeout = timeout
+    Uses HttpClient.post() with retries=2 (safe because SPARQL POST
+    is idempotent: same query → same result).
+    """
+
+    def __init__(self, timeout: int = 60, retries: int = 2):
+        self._client = HttpClient(timeout=timeout, max_retries=retries)
 
     def fetch(
         self,
@@ -56,16 +60,18 @@ class SparqlSource:
         }
         params: dict[str, Any] = {"query": query}
 
-        try:
-            r = requests.post(
-                endpoint,
-                data=params,
-                headers=headers,
-                timeout=self.timeout,
-            )
-        except Exception as e:
-            raise DownloadError(f"SPARQL request failed for {endpoint}: {e}") from e
+        result = self._client.post(
+            endpoint,
+            data=params,
+            headers=headers,
+            retries=2,
+        )
+        if result.is_error:
+            raise DownloadError(
+                f"SPARQL request failed for {endpoint}: {result.err}"
+            ) from result.err
 
+        r = result.response
         if r.status_code != 200:
             raise DownloadError(
                 f"SPARQL endpoint returned HTTP {r.status_code} for {endpoint}: {r.text[:200]}"
@@ -125,16 +131,18 @@ class SparqlSource:
         params: dict[str, Any] = {"query": safe_query}
 
         start = time.monotonic()
-        try:
-            r = requests.post(
-                endpoint,
-                data=params,
-                headers=headers,
-                timeout=self.timeout,
-            )
-        except Exception as e:
-            raise DownloadError(f"SPARQL probe failed for {endpoint}: {e}") from e
+        result = self._client.post(
+            endpoint,
+            data=params,
+            headers=headers,
+            retries=0,
+        )
+        if result.is_error:
+            raise DownloadError(
+                f"SPARQL probe failed for {endpoint}: {result.err}"
+            ) from result.err
 
+        r = result.response
         query_time_ms = int((time.monotonic() - start) * 1000)
 
         if r.status_code != 200:

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -22,8 +22,8 @@ class SparqlSource:
     is idempotent: same query → same result).
     """
 
-    def __init__(self, timeout: int = 60, retries: int = 2):
-        self._client = HttpClient(timeout=timeout, max_retries=retries)
+    def __init__(self, timeout: int = 60):
+        self._client = HttpClient(timeout=timeout)
 
     def fetch(
         self,


### PR DESCRIPTION
## Cosa

Migrazione di `toolkit/plugins/sparql.py` da `requests.post()` diretto a `HttpClient.post(retries=2)`.

### Perché

- SPARQL POST è idempotente (stessa query → stesso risultato) → `retries=2` è safe
- `HttpClient` ora ha backoff esponenziale e gestione 429 — il retry è più robusto
- Centralizzazione: unico punto di trasporto HTTP invece di raw requests

### Test

- 17 test, tutti verdi
- Test mockano `HttpClient`, non `requests` — disaccoppiati dal trasporto

## Issue collegate

Parte di dataciviclab/lab-connectors#10