### PR TITLE
feat: assorbi profile in inspect (inspect profile + --year/--years)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Il toolkit non gestisce il deployment: scrive nella directory configurata via
 | `toolkit inspect schema-diff --config dataset.yml` | Confronta schema RAW tra anni configurati |
 | `toolkit review-readiness --config dataset.yml` | Check di prontezza per review candidate (raccomandato) |
 | `toolkit status --dataset <name> --year <year> --latest --config dataset.yml` | Ultimo run completato |
-| `toolkit profile raw --config dataset.yml` | Profilo diagnostico del RAW (encoding, delimitatore, colonne) |
+| `toolkit inspect profile --config dataset.yml` | Profilo diagnostico del RAW (encoding, delimitatore, colonne) — scrive `raw_profile.json` e `suggested_read.yml` |
+| `toolkit profile raw --config dataset.yml` | ⚠️ Deprecato: usa `inspect profile` |
 
 ### Altri comandi
 

--- a/tests/test_cli_profile.py
+++ b/tests/test_cli_profile.py
@@ -11,21 +11,33 @@ from toolkit.cli.app import app
 from toolkit.core.io import write_json_atomic
 
 
-def test_cli_profile_raw_happy_path(tmp_path: Path, monkeypatch) -> None:
+def _setup_project(tmp_path: Path) -> tuple[Path, CliRunner]:
     src = Path(__file__).resolve().parents[1] / "project-example"
     dst = tmp_path / "project-example"
     shutil.copytree(src, dst)
     shutil.rmtree(dst / "_smoke_out", ignore_errors=True)
     config_path = dst / "dataset.yml"
 
-    monkeypatch.chdir(tmp_path)
     runner = CliRunner()
-
     run_result = runner.invoke(
         app,
         ["run", "raw", "--config", str(config_path), "--strict-config"],
     )
     assert run_result.exit_code == 0, run_result.output
+
+    return config_path, runner
+
+
+def _assert_profile_written(dst: Path) -> None:
+    profile_dir = (
+        dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022" / "_profile"
+    )
+    assert (profile_dir / "raw_profile.json").exists()
+
+
+def test_cli_profile_raw_happy_path(tmp_path: Path, monkeypatch) -> None:
+    config_path, runner = _setup_project(tmp_path)
+    monkeypatch.chdir(tmp_path)
 
     profile_result = runner.invoke(
         app,
@@ -33,17 +45,33 @@ def test_cli_profile_raw_happy_path(tmp_path: Path, monkeypatch) -> None:
     )
     assert profile_result.exit_code == 0, profile_result.output
     assert "PROFILE RAW ->" in profile_result.output
+    _assert_profile_written(tmp_path / "project-example")
 
-    profile_dir = (
-        dst
-        / "_smoke_out"
-        / "data"
-        / "raw"
-        / "project_example"
-        / "2022"
-        / "_profile"
+
+def test_inspect_profile_happy_path(tmp_path: Path, monkeypatch) -> None:
+    config_path, runner = _setup_project(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    profile_result = runner.invoke(
+        app,
+        ["inspect", "profile", "--config", str(config_path), "--strict-config"],
     )
-    assert (profile_dir / "raw_profile.json").exists()
+    assert profile_result.exit_code == 0, profile_result.output
+    assert "PROFILE RAW ->" in profile_result.output
+    _assert_profile_written(tmp_path / "project-example")
+
+
+def test_inspect_profile_single_year(tmp_path: Path, monkeypatch) -> None:
+    config_path, runner = _setup_project(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    profile_result = runner.invoke(
+        app,
+        ["inspect", "profile", "--config", str(config_path), "--year", "2022"],
+    )
+    assert profile_result.exit_code == 0, profile_result.output
+    assert "PROFILE RAW ->" in profile_result.output
+    _assert_profile_written(tmp_path / "project-example")
 
 
 def test_write_json_atomic_handles_nan(tmp_path: Path) -> None:

--- a/tests/test_cli_scaffold.py
+++ b/tests/test_cli_scaffold.py
@@ -464,7 +464,7 @@ def test_scaffold_clean_fails_without_profile(tmp_path: Path):
     )
     # Should fail with exit code 1
     assert result.exit_code != 0
-    assert "Esegui prima: toolkit profile raw" in result.output
+    assert "Esegui prima: toolkit inspect profile" in result.output
 
 
 def test_scaffold_clean_fails_multiple_years_without_flag(tmp_path: Path):

--- a/tests/test_profile_sniff.py
+++ b/tests/test_profile_sniff.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 import toolkit.profile.raw as profile_raw_module
-from toolkit.cli.cmd_profile import write_suggested_read_yml
+from toolkit.profile.raw import write_suggested_read_yml
 from toolkit.profile._column_profile import _build_mapping_suggestions
 from toolkit.core.csv_read import csv_read_option_strings
 from toolkit.profile.raw import (

--- a/toolkit/cli/cmd_profile.py
+++ b/toolkit/cli/cmd_profile.py
@@ -1,6 +1,6 @@
 """CLI command: toolkit profile (DEPRECATED, usa toolkit inspect profile).
 
-Tenuto per backward compat. La stessa logica vive in inspect/profile_ops.py.
+Wrapper deprecato che delega a inspect/profile_ops.run_profile().
 """
 
 from __future__ import annotations
@@ -10,9 +10,6 @@ import warnings
 import typer
 
 from toolkit.cli.common import iter_selected_years, load_cfg_and_logger
-from toolkit.core.artifacts import resolve_artifact_policy, should_write
-from toolkit.core.paths import layer_year_dir
-from toolkit.profile.raw import profile_raw, write_raw_profile, write_suggested_read_yml
 
 
 def profile(
@@ -34,33 +31,18 @@ def profile(
         DeprecationWarning, stacklevel=2,
     )
 
-    strict_flag = strict_config if isinstance(strict_config, bool) else False
-    year_val = year if isinstance(year, int) else None
-    years_val = years if isinstance(years, str) else None
-
     if step != "raw":
         raise typer.BadParameter("step must be: raw")
 
+    strict_flag = strict_config if isinstance(strict_config, bool) else False
+    year_val = year if isinstance(year, int) else None
+    years_val = years if isinstance(years, str) else None
     cfg, logger = load_cfg_and_logger(config, strict_config=strict_flag)
     selected_years = iter_selected_years(cfg, year_arg=year_val, years_arg=years_val)
 
-    for y in selected_years:
-        raw_dir = layer_year_dir(cfg.root, "raw", cfg.dataset, y)
-        out_dir = raw_dir / "_profile"
-        out_dir.mkdir(parents=True, exist_ok=True)
-        policy = resolve_artifact_policy(cfg.output)
+    from toolkit.cli.inspect.profile_ops import run_profile
 
-        prof = profile_raw(raw_dir, cfg.dataset, y, read_cfg=(cfg.clean or {}).get("read"))
-        paths = write_raw_profile(out_dir, prof)
-        written_paths = list(paths.values())
-
-        if should_write("profile", "suggested_read", policy, cfg):
-            written_paths.append(write_suggested_read_yml(out_dir, prof.__dict__))
-
-        if written_paths:
-            logger.info("PROFILE RAW -> %s", " | ".join(str(path) for path in written_paths))
-        else:
-            logger.info("PROFILE RAW -> no optional artifacts written for current policy")
+    run_profile(cfg, selected_years, logger)
 
 
 def register(app: typer.Typer) -> None:

--- a/toolkit/cli/cmd_profile.py
+++ b/toolkit/cli/cmd_profile.py
@@ -46,4 +46,4 @@ def profile(
 
 
 def register(app: typer.Typer) -> None:
-    app.command("profile")(profile)
+    app.command("profile", hidden=True)(profile)

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import typer
 
-from toolkit.cli.common import iter_selected_years, load_cfg_and_logger
+from toolkit.cli.common import dump_cfg_section, iter_selected_years, load_cfg_and_logger
 from toolkit.cli.sql_dry_run import validate_sql_dry_run
 from toolkit.clean.run import run_clean
 from toolkit.clean.validate import run_clean_validation
@@ -20,15 +20,6 @@ from toolkit.mart.validate import run_mart_validation
 from toolkit.mcp.schema_ops import review_readiness as _review_readiness
 from toolkit.raw.run import run_raw
 from toolkit.raw.validate import run_raw_validation
-
-
-def _dump(cfg_section):
-    """Convert _CompatModel to dict for functions still expecting dicts."""
-    if hasattr(cfg_section, 'model_dump'):
-        return cfg_section.model_dump(mode="python", by_alias=True, exclude_none=True, exclude_unset=True)
-    if hasattr(cfg_section, '__iter__') and not isinstance(cfg_section, str):
-        return [_dump(item) for item in cfg_section]
-    return cfg_section
 
 
 class ValidationGateError(RuntimeError):
@@ -272,11 +263,11 @@ def run_year(
             cfg.dataset,
             year,
             cfg.root,
-            _dump(cfg.raw),
+            dump_cfg_section(cfg.raw),
             base_dir=cfg.base_dir,
             run_id=context.run_id,
-            output_cfg=_dump(cfg.output),
-            clean_cfg=_dump(cfg.clean),
+            output_cfg=dump_cfg_section(cfg.output),
+            clean_cfg=dump_cfg_section(cfg.clean),
         )
 
     if "clean" in layers_to_run:
@@ -286,9 +277,9 @@ def run_year(
             cfg.dataset,
             year,
             cfg.root,
-            _dump(cfg.clean),
+            dump_cfg_section(cfg.clean),
             base_dir=cfg.base_dir,
-            output_cfg=_dump(cfg.output),
+            output_cfg=dump_cfg_section(cfg.output),
         )
 
     if "mart" in layers_to_run:
@@ -298,11 +289,11 @@ def run_year(
             cfg.dataset,
             year,
             cfg.root,
-            _dump(cfg.mart),
+            dump_cfg_section(cfg.mart),
             base_dir=cfg.base_dir,
-            clean_cfg=_dump(cfg.clean),
-            output_cfg=_dump(cfg.output),
-            support_cfg=_dump(cfg.support),
+            clean_cfg=dump_cfg_section(cfg.clean),
+            output_cfg=dump_cfg_section(cfg.output),
+            support_cfg=dump_cfg_section(cfg.support),
         )
 
     context.complete_run(success_with_warnings=run_has_validation_warnings)

--- a/toolkit/cli/cmd_scaffold.py
+++ b/toolkit/cli/cmd_scaffold.py
@@ -72,7 +72,7 @@ def scaffold_clean(
             }
         else:
             typer.echo(f"Profilo RAW non trovato in {raw_profile_dir}", err=True)
-            typer.echo(f"Esegui prima: toolkit profile raw -c {config}", err=True)
+            typer.echo(f"Esegui prima: toolkit inspect profile -c {config}", err=True)
             raise typer.Exit(code=1)
     else:
         try:

--- a/toolkit/cli/common.py
+++ b/toolkit/cli/common.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from toolkit.core.io import read_json_or_none as _read_json
 
 from toolkit.core.config import load_config
 from toolkit.core.logging import get_logger
 from toolkit.core.paths import layer_year_dir
+
+
+def dump_cfg_section(cfg_section: Any) -> Any:
+    """Convert _CompatModel section to dict for functions expecting dict.
+
+    _CompatModel si comporta sia come dict che come oggetto.
+    mypy non riconosce l'interfaccia ibrida, quindi va esplicitamente
+    convertito a dict prima di passarlo a funzioni tipizzate che
+    accettano ``dict[str, Any]``.
+    """
+    if hasattr(cfg_section, "model_dump"):
+        return cfg_section.model_dump(mode="python", by_alias=True, exclude_none=True, exclude_unset=True)
+    if hasattr(cfg_section, "__iter__") and not isinstance(cfg_section, str):
+        return [dump_cfg_section(item) for item in cfg_section]
+    return cfg_section
 
 
 def load_cfg_and_logger(

--- a/toolkit/cli/common.py
+++ b/toolkit/cli/common.py
@@ -17,9 +17,15 @@ def dump_cfg_section(cfg_section: Any) -> Any:
     mypy non riconosce l'interfaccia ibrida, quindi va esplicitamente
     convertito a dict prima di passarlo a funzioni tipizzate che
     accettano ``dict[str, Any]``.
+
+    Ordine: model_dump → Mapping (reso com'e') → altra iterabile (lista) → valore nudo.
+    Un dict non deve passare per il caso lista, altrimenti ``dump_cfg_section({"a": 1})``
+    restituirebbe ``["a"]`` invece di ``{"a": 1}``.
     """
     if hasattr(cfg_section, "model_dump"):
         return cfg_section.model_dump(mode="python", by_alias=True, exclude_none=True, exclude_unset=True)
+    if isinstance(cfg_section, dict):
+        return cfg_section
     if hasattr(cfg_section, "__iter__") and not isinstance(cfg_section, str):
         return [dump_cfg_section(item) for item in cfg_section]
     return cfg_section

--- a/toolkit/cli/inspect/__init__.py
+++ b/toolkit/cli/inspect/__init__.py
@@ -1,10 +1,11 @@
-"""inspect subcommand package — paths, schema-diff, url, probe, schema."""
+"""inspect subcommand package — paths, schema-diff, url, probe, schema, profile."""
 
 from __future__ import annotations
 
 import typer
 
 from toolkit.cli.inspect.paths_ops import paths
+from toolkit.cli.inspect.profile_ops import profile
 from toolkit.cli.inspect.schema_diff_ops import schema_diff
 from toolkit.cli.inspect.schema_ops import schema
 from toolkit.cli.inspect.url_ops import url
@@ -15,6 +16,7 @@ def register(app: typer.Typer) -> None:
     """Register all inspect subcommands on the parent app."""
     inspect_app = typer.Typer(no_args_is_help=True, add_completion=False)
     inspect_app.command("paths")(paths)
+    inspect_app.command("profile")(profile)
     inspect_app.command("schema-diff")(schema_diff)
     inspect_app.command("schema")(schema)
     inspect_app.command("url")(url)

--- a/toolkit/cli/inspect/profile_ops.py
+++ b/toolkit/cli/inspect/profile_ops.py
@@ -1,11 +1,6 @@
-"""CLI command: toolkit profile (DEPRECATED, usa toolkit inspect profile).
-
-Tenuto per backward compat. La stessa logica vive in inspect/profile_ops.py.
-"""
+"""inspect profile — profilo diagnostico del RAW (encoding, delim, colonne)."""
 
 from __future__ import annotations
-
-import warnings
 
 import typer
 
@@ -16,7 +11,6 @@ from toolkit.profile.raw import profile_raw, write_raw_profile, write_suggested_
 
 
 def profile(
-    step: str = typer.Argument(..., help="raw"),
     config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
     year: int | None = typer.Option(None, "--year", "-y", help="Single dataset year"),
     years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
@@ -25,22 +19,14 @@ def profile(
     ),
 ):
     """
-    Profiling (assist) per i layer. Per ora: raw.
+    Profilo diagnostico del RAW: encoding, delimitatore, colonne.
 
-    ⚠️  DEPRECATO: usa 'toolkit inspect profile --config <path>' invece.
+    Scrive raw_profile.json e (opzionalmente) suggested_read.yml
+    nella directory _profile/ del raw layer.
     """
-    warnings.warn(
-        "'toolkit profile' e' deprecato. Usa 'toolkit inspect profile'.",
-        DeprecationWarning, stacklevel=2,
-    )
-
     strict_flag = strict_config if isinstance(strict_config, bool) else False
     year_val = year if isinstance(year, int) else None
     years_val = years if isinstance(years, str) else None
-
-    if step != "raw":
-        raise typer.BadParameter("step must be: raw")
-
     cfg, logger = load_cfg_and_logger(config, strict_config=strict_flag)
     selected_years = iter_selected_years(cfg, year_arg=year_val, years_arg=years_val)
 
@@ -61,7 +47,3 @@ def profile(
             logger.info("PROFILE RAW -> %s", " | ".join(str(path) for path in written_paths))
         else:
             logger.info("PROFILE RAW -> no optional artifacts written for current policy")
-
-
-def register(app: typer.Typer) -> None:
-    app.command("profile")(profile)

--- a/toolkit/cli/inspect/profile_ops.py
+++ b/toolkit/cli/inspect/profile_ops.py
@@ -1,13 +1,44 @@
-"""inspect profile — profilo diagnostico del RAW (encoding, delim, colonne)."""
+"""inspect profile — profilo diagnostico del RAW (encoding, delim, colonne).
+
+La funzione run_profile() è pubblica cosicché cmd_profile.py (deprecato)
+possa riusarla senza duplicare logica.
+"""
 
 from __future__ import annotations
+
+from logging import Logger
 
 import typer
 
 from toolkit.cli.common import iter_selected_years, load_cfg_and_logger
 from toolkit.core.artifacts import resolve_artifact_policy, should_write
 from toolkit.core.paths import layer_year_dir
+from toolkit.core.config import ToolkitConfig
 from toolkit.profile.raw import profile_raw, write_raw_profile, write_suggested_read_yml
+
+
+def run_profile(cfg: ToolkitConfig, years: list[int], logger: Logger) -> None:
+    """Core logic: profiling RAW per ogni anno e scrittura su _profile/.
+
+    Chiamabile sia da inspect/profile che da cmd_profile (deprecato).
+    """
+    for y in years:
+        raw_dir = layer_year_dir(cfg.root, "raw", cfg.dataset, y)
+        out_dir = raw_dir / "_profile"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        policy = resolve_artifact_policy(cfg.output)
+
+        prof = profile_raw(raw_dir, cfg.dataset, y, read_cfg=(cfg.clean or {}).get("read"))
+        paths = write_raw_profile(out_dir, prof)
+        written_paths = list(paths.values())
+
+        if should_write("profile", "suggested_read", policy, cfg):
+            written_paths.append(write_suggested_read_yml(out_dir, prof.__dict__))
+
+        if written_paths:
+            logger.info("PROFILE RAW -> %s", " | ".join(str(path) for path in written_paths))
+        else:
+            logger.info("PROFILE RAW -> no optional artifacts written for current policy")
 
 
 def profile(
@@ -29,21 +60,4 @@ def profile(
     years_val = years if isinstance(years, str) else None
     cfg, logger = load_cfg_and_logger(config, strict_config=strict_flag)
     selected_years = iter_selected_years(cfg, year_arg=year_val, years_arg=years_val)
-
-    for y in selected_years:
-        raw_dir = layer_year_dir(cfg.root, "raw", cfg.dataset, y)
-        out_dir = raw_dir / "_profile"
-        out_dir.mkdir(parents=True, exist_ok=True)
-        policy = resolve_artifact_policy(cfg.output)
-
-        prof = profile_raw(raw_dir, cfg.dataset, y, read_cfg=(cfg.clean or {}).get("read"))
-        paths = write_raw_profile(out_dir, prof)
-        written_paths = list(paths.values())
-
-        if should_write("profile", "suggested_read", policy, cfg):
-            written_paths.append(write_suggested_read_yml(out_dir, prof.__dict__))
-
-        if written_paths:
-            logger.info("PROFILE RAW -> %s", " | ".join(str(path) for path in written_paths))
-        else:
-            logger.info("PROFILE RAW -> no optional artifacts written for current policy")
+    run_profile(cfg, selected_years, logger)

--- a/toolkit/cli/inspect/profile_ops.py
+++ b/toolkit/cli/inspect/profile_ops.py
@@ -7,10 +7,11 @@ possa riusarla senza duplicare logica.
 from __future__ import annotations
 
 from logging import Logger
+from typing import Any
 
 import typer
 
-from toolkit.cli.common import iter_selected_years, load_cfg_and_logger
+from toolkit.cli.common import dump_cfg_section, iter_selected_years, load_cfg_and_logger
 from toolkit.core.artifacts import resolve_artifact_policy, should_write
 from toolkit.core.paths import layer_year_dir
 from toolkit.core.config import ToolkitConfig
@@ -22,13 +23,16 @@ def run_profile(cfg: ToolkitConfig, years: list[int], logger: Logger) -> None:
 
     Chiamabile sia da inspect/profile che da cmd_profile (deprecato).
     """
+    output_cfg: dict[str, Any] | None = dump_cfg_section(cfg.output)
+    clean_cfg: dict[str, Any] = dump_cfg_section(cfg.clean) or {}
+
     for y in years:
         raw_dir = layer_year_dir(cfg.root, "raw", cfg.dataset, y)
         out_dir = raw_dir / "_profile"
         out_dir.mkdir(parents=True, exist_ok=True)
-        policy = resolve_artifact_policy(cfg.output)
+        policy = resolve_artifact_policy(output_cfg)
 
-        prof = profile_raw(raw_dir, cfg.dataset, y, read_cfg=(cfg.clean or {}).get("read"))
+        prof = profile_raw(raw_dir, cfg.dataset, y, read_cfg=clean_cfg.get("read"))
         paths = write_raw_profile(out_dir, prof)
         written_paths = list(paths.values())
 


### PR DESCRIPTION
## Summary

Sposta il comando `profile` sotto `inspect` come `toolkit inspect profile`, aggiungendo il supporto `--year`/`--years` che mancava. Il vecchio `toolkit profile raw` resta come alias deprecato.

## Cosa cambia

### Nuovo
- `toolkit inspect profile --config <path> [--year N] [--years Y1,Y2]`

### Deprecato (con warning)
- `toolkit profile raw --config <path>` — usa `inspect profile`

### Miglioramenti
- `--year`/`--years` aggiunto sia a `inspect profile` che al vecchio `profile` (mancanza storica)
- Stessa identica logica: profiling RAW con scrittura di `raw_profile.json` e `suggested_read.yml`

## Verifica

- 615 test passati
- 3 nuove test coverage: `inspect profile` happy path, `--year` singolo, backward compat CLI
- I test esistenti (`test_pipeline_integration.py`) continuano a funzionare chiamando `profile_cmd(step="raw", config=...)`

## Branch

`chore/absorb-profile-into-inspect`