### PR TITLE
refactor: unifica run init in init --config, rimuovi run init

### DIFF
--- a/tests/test_cli_run_init.py
+++ b/tests/test_cli_run_init.py
@@ -1,4 +1,4 @@
-"""Tests for ``toolkit run init`` command."""
+"""Tests for ``toolkit init --config`` command (ex ``toolkit run init``)."""
 
 from pathlib import Path
 
@@ -121,7 +121,7 @@ def test_run_init_fails_when_raw_has_no_profile_and_no_clean_sql(tmp_path: Path,
     )
 
     # Profile is NOT pre-created; clean.sql does NOT exist.
-    result = runner.invoke(app, ["run", "init", "-c", str(yml)])
+    result = runner.invoke(app, ["init", "--config", str(yml)])
 
     assert result.exit_code != 0
     assert "profilo" in result.output.lower() or "profile" in result.output.lower()
@@ -143,7 +143,7 @@ def test_run_init_reports_correct_scaffold_message_when_pre_existing(tmp_path: P
     # Pre-create clean.sql
     _scaffold_clean_sql(tmp_path, dataset, year)
 
-    result = runner.invoke(app, ["run", "init", "-c", str(yml)])
+    result = runner.invoke(app, ["init", "--config", str(yml)])
 
     assert result.exit_code == 0
     # Must report "gia esistente", NOT "scaffoldato"
@@ -168,7 +168,7 @@ def test_run_init_dry_run_validates_config(tmp_path: Path):
         encoding="utf-8",
     )
 
-    result = runner.invoke(app, ["run", "init", "-c", str(yml), "--dry-run"])
+    result = runner.invoke(app, ["init", "--config", str(yml), "--dry-run"])
 
     # Should fail during validation (not silently succeed with a static plan)
     assert result.exit_code != 0

--- a/tests/test_run_dry_run.py
+++ b/tests/test_run_dry_run.py
@@ -694,4 +694,4 @@ def test_run_all_fails_with_bootstrap_hint_when_clean_sql_missing(tmp_path: Path
     assert result.exit_code != 0
     exc_text = str(result.exception)
     assert "CLEAN SQL file not found" in exc_text
-    assert "toolkit run init" in exc_text
+    assert "toolkit init --config" in exc_text

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -355,7 +355,7 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
                         if raw_probe_reason:
                             merged_warnings.append(
                                 f"[scaffold] falling back to read_csv(auto_detect=true) — "
-                                f"reason: {raw_probe_reason}. Run 'toolkit run init' to generate a profile."
+                                f"reason: {raw_probe_reason}. Run 'toolkit init --config' to generate a profile."
                             )
                     _col_rows = _con.execute(_query).fetchall()
                     _actual_raw_col_names = [str(r[0]) for r in _col_rows]
@@ -385,7 +385,7 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
         raw_probe_source = "unavailable"
         merged_warnings.append(
             "[scaffold] Profilo raw non disponibile — impossibile verificare coverage colonne raw. "
-            "Considera eseguire 'toolkit run init' per generare il profilo."
+            "Considera eseguire 'toolkit init --config' per generare il profilo."
         )
 
     row_drop_pct = (

--- a/toolkit/cli/cmd_init.py
+++ b/toolkit/cli/cmd_init.py
@@ -367,7 +367,7 @@ def init(
     dataset.yml completo con sql/clean.sql e sql/mart.sql placeholder.
     Pronto per toolkit run all --config dataset.yml.
 
-    Con --config: come run init (run raw + scaffold clean.sql).
+    Con --config: run raw + scaffold clean.sql se assente.
     """
     if url and config:
         typer.echo("error: specificare --url o --config, non entrambi", err=True)

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -77,7 +77,7 @@ def _validate_execution_plan(cfg, step: str) -> list[str]:
             raise ValueError(
                 f"CLEAN SQL file not found: {clean_sql}\n"
                 f"This config is not bootstrapped yet.\n"
-                f"Run: toolkit run init --config <config> --years <year>\n"
+                f"Run: toolkit init --config <config> --years <year>\n"
                 f"Then review sql/clean.sql and run: toolkit run all ..."
             )
 
@@ -516,6 +516,5 @@ def register(app: typer.Typer) -> None:
     run_sub.command("all")(run_all_cmd)
     run_sub.command("cross_year")(run_cross_year_cmd)
     run_sub.command("cross-year")(run_cross_year_cmd)  # alias hyphen
-    run_sub.command("init")(run_init)
     run_sub.command("full")(run_full)
     app.add_typer(run_sub, name="run", help="Esegue la pipeline RAW → CLEAN → MART per un dataset.")


### PR DESCRIPTION
## Summary

Elimina il naming clash tra `run init` e `init --config`. Erano due comandi con identico comportamento. `run init` rimosso, `init --config` resta.

## Cosa cambia

### Prima
- `toolkit run init --config dataset.yml` — bootstrap candidate
- `toolkit init --config dataset.yml` — **stessa identica cosa**
- `toolkit init --url <URL>` — scout da URL

### Dopo
- `toolkit init --config dataset.yml` — bootstrap candidate (unico)
- `toolkit init --url <URL>` — scout da URL (invariato)

### Dettaglio
- La funzione `run_init()` esiste ancora in `cmd_run.py` (chiamata da `init --config`)
- Solo la registrazione come subcomando CLI `run init` è stata rimossa
- Messaggi di errore aggiornati: `toolkit run init` → `toolkit init --config`
- Test aggiornati

## Verifica

- 613 test passati (su main, con test_cli_blocker_hints.py ancora presente)
- `run --help` non mostra più `init`
- `init --help` mostra `--config` e `--url`

## Branch

`chore/unify-run-init-init`