### PR TITLE
feat: batch --years/--validate (sostituisce run_support_datasets.py #246)

### DIFF
--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -269,6 +269,28 @@ def test_batch_stdin_requires_config_path(tmp_path: Path) -> None:
     assert "config_path" in str(result.exception) or "config_path" in result.output
 
 
+def test_batch_stdin_accepts_config_alias(tmp_path: Path) -> None:
+    """batch --stdin accetta 'config' come alias di 'config_path' (formato DI)."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "config_alias", 2024)
+
+    stdin_data = json.dumps([
+        {"config": str(project / "dataset.yml"), "years": [2024]},
+    ])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--stdin", "--step", "all"],
+        input=stdin_data,
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "config_alias" in result.output
+    assert (project / "out" / "data" / "mart" / "config_alias" / "2024" / "mart_totali.parquet").exists()
+
+
 def test_batch_stdin_mutually_exclusive_with_configs(tmp_path: Path) -> None:
     """batch --stdin e --configs insieme danno errore."""
     runner = CliRunner()

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import textwrap
 from pathlib import Path
 

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import textwrap
 from pathlib import Path
 
@@ -204,6 +205,79 @@ def test_batch_validate_respects_step(tmp_path: Path) -> None:
     # Clean/mart validation NON deve esistere (non richiesti da --step raw)
     assert not (root / "data" / "clean" / "step_raw" / str(year) / "_validate" / "clean_validation.json").exists()
     assert not (root / "data" / "mart" / "step_raw" / str(year) / "_validate" / "mart_validation.json").exists()
+
+
+def test_batch_stdin_reads_json_array(tmp_path: Path) -> None:
+    """batch --stdin legge JSON array da stdin."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "stdin_test", 2024)
+
+    configs_file = tmp_path / "configs.txt"
+    configs_file.write_text("project/dataset.yml\n", encoding="utf-8")
+
+    stdin_data = json.dumps([
+        {"config_path": str(project / "dataset.yml"), "years": [2024]},
+    ])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--stdin", "--step", "all"],
+        input=stdin_data,
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Batch Report" in result.output
+    assert "stdin_test" in result.output
+    assert (project / "out" / "data" / "mart" / "stdin_test" / "2024" / "mart_totali.parquet").exists()
+
+
+def test_batch_stdin_with_validate(tmp_path: Path) -> None:
+    """batch --stdin --validate esegue validazione con years per-config."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "stdin_val", 2024)
+
+    stdin_data = json.dumps([
+        {"config_path": str(project / "dataset.yml"), "years": [2024]},
+    ])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--stdin", "--step", "all", "--validate"],
+        input=stdin_data,
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Batch Report" in result.output
+    assert "passed" in result.output
+    root = project / "out"
+    assert (root / "data" / "raw" / "stdin_val" / "2024" / "raw_validation.json").exists()
+
+
+def test_batch_stdin_requires_config_path(tmp_path: Path) -> None:
+    """batch --stdin fallisce su JSON senza config_path."""
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--stdin"],
+        input=json.dumps([{"years": [2024]}]),
+    )
+    assert result.exit_code != 0
+    assert "config_path" in str(result.exception) or "config_path" in result.output
+
+
+def test_batch_stdin_mutually_exclusive_with_configs(tmp_path: Path) -> None:
+    """batch --stdin e --configs insieme danno errore."""
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--stdin", "--configs", "list.txt"],
+    )
+    assert result.exit_code != 0
+    assert "non entrambi" in result.output
 
 
 def test_batch_validate_failure_exits_nonzero(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import textwrap
 from pathlib import Path
 
@@ -121,3 +122,61 @@ def test_batch_runs_configs_in_sequence_and_prints_report(tmp_path: Path) -> Non
 
     assert (project_a / "out" / "data" / "mart" / "batch_a" / "2022" / "mart_totali.parquet").exists()
     assert (project_b / "out" / "data" / "mart" / "batch_b" / "2023" / "mart_totali.parquet").exists()
+
+
+def test_batch_with_years_filter(tmp_path: Path) -> None:
+    """batch --years filtra gli anni processati."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "multi_year", 2022)
+    # Aggiunge un secondo anno alla config
+    yml_path = project / "dataset.yml"
+    content = yml_path.read_text(encoding="utf-8")
+    content = content.replace("years: [2022]", "years: [2022, 2023]")
+    yml_path.write_text(content, encoding="utf-8")
+
+    configs_file = tmp_path / "configs.txt"
+    configs_file.write_text("project/dataset.yml\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "all", "--years", "2022"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Batch Report" in result.output
+    # Solo 2022 processato, non 2023
+    assert "2022" in result.output
+    assert "2023" not in result.output
+    assert (project / "out" / "data" / "mart" / "multi_year" / "2022" / "mart_totali.parquet").exists()
+    # 2023 non deve essere stato processato
+    assert not (project / "out" / "data" / "mart" / "multi_year" / "2023" / "mart_totali.parquet").exists()
+
+
+def test_batch_with_validate(tmp_path: Path) -> None:
+    """batch --validate esegue validazione dopo ogni run."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "validated", 2024)
+
+    configs_file = tmp_path / "configs.txt"
+    configs_file.write_text("project/dataset.yml\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "all", "--validate"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Batch Report" in result.output
+    assert "validate" in result.output
+    assert "passed" in result.output
+
+    # I file di validazione devono esistere
+    root = project / "out"
+    year = 2024
+    assert (root / "data" / "raw" / "validated" / str(year) / "raw_validation.json").exists()
+    assert (root / "data" / "clean" / "validated" / str(year) / "_validate" / "clean_validation.json").exists()
+    assert (root / "data" / "mart" / "validated" / str(year) / "_validate" / "mart_validation.json").exists()

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -179,3 +179,63 @@ def test_batch_with_validate(tmp_path: Path) -> None:
     assert (root / "data" / "raw" / "validated" / str(year) / "raw_validation.json").exists()
     assert (root / "data" / "clean" / "validated" / str(year) / "_validate" / "clean_validation.json").exists()
     assert (root / "data" / "mart" / "validated" / str(year) / "_validate" / "mart_validation.json").exists()
+
+
+def test_batch_validate_respects_step(tmp_path: Path) -> None:
+    """batch --validate --step raw valida solo raw, non clean/mart."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "step_raw", 2024)
+
+    configs_file = tmp_path / "configs.txt"
+    configs_file.write_text("project/dataset.yml\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "raw", "--validate"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    root = project / "out"
+    year = 2024
+    # Raw validation esiste
+    assert (root / "data" / "raw" / "step_raw" / str(year) / "raw_validation.json").exists()
+    # Clean/mart validation NON deve esistere (non richiesti da --step raw)
+    assert not (root / "data" / "clean" / "step_raw" / str(year) / "_validate" / "clean_validation.json").exists()
+    assert not (root / "data" / "mart" / "step_raw" / str(year) / "_validate" / "mart_validation.json").exists()
+
+
+def test_batch_validate_failure_exits_nonzero(tmp_path: Path, monkeypatch) -> None:
+    """batch --validate esce con codice 1 se una validazione fallisce."""
+    from toolkit.clean import validate as clean_validate
+
+    project = tmp_path / "project"
+    _write_batch_project(project, "failing", 2024)
+
+    configs_file = tmp_path / "configs.txt"
+    configs_file.write_text("project/dataset.yml\n", encoding="utf-8")
+
+    # Forza run_clean_validation a tornare failed.
+    # Il nome locale in cmd_batch e' un alias: va patchato per nome qualificato.
+    original = clean_validate.run_clean_validation
+
+    def mock_validate(cfg, year, logger):
+        result = original(cfg, year, logger)
+        result["passed"] = False
+        return result
+
+    monkeypatch.setattr("toolkit.clean.validate.run_clean_validation", mock_validate)
+    monkeypatch.setattr("toolkit.cli.cmd_batch.run_clean_validation", mock_validate)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "all", "--validate"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1, f"expected exit 1, got {result.exit_code}: {result.output}"
+    assert "Failures" in result.output
+    assert "validation failed" in result.output
+    assert "failing" in result.output

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -55,6 +55,8 @@ def _read_config_list(configs_file: Path) -> list[Path]:
 def _read_stdin() -> list[tuple[Path, list[int] | None]]:
     """Legge JSON array da stdin: [{"config_path": ..., "years": [...]}, ...].
 
+    Supporta sia ``config_path`` (preferred) che ``config`` (alias usato da
+    ``resolve_sample_run.py`` e ``run_support_datasets.py`` in DI).
     Ogni entry puo' avere years opzionale (per-config override).
     """
     raw = sys.stdin.read()
@@ -72,9 +74,11 @@ def _read_stdin() -> list[tuple[Path, list[int] | None]]:
     for entry in entries:
         if not isinstance(entry, dict):
             raise ValueError(f"Ogni elemento deve essere un oggetto JSON, got {type(entry).__name__}")
-        cp = entry.get("config_path")
+        cp = entry.get("config_path") or entry.get("config")
         if not cp or not isinstance(cp, str):
-            raise ValueError(f"Ogni elemento deve avere 'config_path' stringa, got {cp!r}")
+            raise ValueError(
+                f"Ogni elemento deve avere 'config_path' (o 'config') stringa, got {cp!r}"
+            )
         path = Path(cp)
         if not path.is_absolute():
             path = path.resolve()
@@ -121,6 +125,7 @@ def _validate_layers(cfg, year: int, layers: tuple[str, ...], logger=None) -> st
     """Run validation for the given layers only. Returns 'passed' or 'failed'.
 
     layers e' una tupla come _STEP_LAYERS[step].
+    Se nessun layer e' validabile (es. cross_year), torna '-'.
     """
     from toolkit.core.logging import get_logger
     log = logger or get_logger()
@@ -132,6 +137,8 @@ def _validate_layers(cfg, year: int, layers: tuple[str, ...], logger=None) -> st
             checks.append(run_clean_validation(cfg, year, log).get("passed"))
         elif layer == "mart":
             checks.append(run_mart_validation(cfg, year, log).get("passed"))
+    if not checks:
+        return "-"
     return "passed" if all(checks) else "failed"
 
 

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -11,7 +11,7 @@ from time import perf_counter
 
 import typer
 
-from toolkit.cli.common import dump_cfg_section, iter_selected_years, load_cfg_and_logger
+from toolkit.cli.common import iter_selected_years, load_cfg_and_logger
 from toolkit.cli.cmd_run import run_cross_year_step, run_year
 from toolkit.clean.validate import run_clean_validation
 from toolkit.mart.validate import run_mart_validation

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -2,12 +2,16 @@
 
 Con --validate esegue anche la validazione post-step (rispetta lo step).
 Con --years filtra gli anni da processare.
+Con --stdin legge config con anni per-config da JSON array.
 """
 
 from __future__ import annotations
 
+import json
+import sys
 from pathlib import Path
 from time import perf_counter
+from typing import Any
 
 import typer
 
@@ -19,7 +23,7 @@ from toolkit.raw.validate import run_raw_validation
 
 _ALLOWED_STEPS = {"raw", "clean", "mart", "cross_year", "all"}
 
-# Layernames che ogni step valida. L'ordine non conta.
+# Layer che ogni step valida.
 _STEP_LAYERS: dict[str, tuple[str, ...]] = {
     "raw": ("raw",),
     "clean": ("clean",),
@@ -38,7 +42,6 @@ def _read_config_list(configs_file: Path) -> list[Path]:
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
-
         config_path = Path(line)
         if not config_path.is_absolute():
             config_path = (configs_file.parent / config_path).resolve()
@@ -46,8 +49,43 @@ def _read_config_list(configs_file: Path) -> list[Path]:
 
     if not config_paths:
         raise ValueError(f"No config paths found in {configs_file}")
-
     return config_paths
+
+
+def _read_stdin() -> list[tuple[Path, list[int] | None]]:
+    """Legge JSON array da stdin: [{"config_path": ..., "years": [...]}, ...].
+
+    Ogni entry puo' avere years opzionale (per-config override).
+    """
+    raw = sys.stdin.read()
+    if not raw.strip():
+        raise ValueError("Nessun input ricevuto da stdin")
+    try:
+        entries: list[dict[str, Any]] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"JSON malformato su stdin: {exc}")
+
+    if not isinstance(entries, list):
+        raise ValueError("Lo stdin deve contenere un array JSON")
+
+    result: list[tuple[Path, list[int] | None]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError(f"Ogni elemento deve essere un oggetto JSON, got {type(entry).__name__}")
+        cp = entry.get("config_path")
+        if not cp or not isinstance(cp, str):
+            raise ValueError(f"Ogni elemento deve avere 'config_path' stringa, got {cp!r}")
+        path = Path(cp)
+        if not path.is_absolute():
+            path = path.resolve()
+        years_raw = entry.get("years")
+        years: list[int] | None = None
+        if years_raw is not None:
+            if not isinstance(years_raw, list):
+                raise ValueError(f"'years' deve essere una lista di interi, got {years_raw!r}")
+            years = [int(y) for y in years_raw]
+        result.append((path, years))
+    return result
 
 
 def _format_years(years: list[int] | None) -> str:
@@ -97,158 +135,187 @@ def _validate_layers(cfg, year: int, layers: tuple[str, ...], logger=None) -> st
     return "passed" if all(checks) else "failed"
 
 
-def batch(
-    configs: str = typer.Option(
-        ..., "--configs", help="Path to a text file with one dataset.yml path per line"
-    ),
-    step: str = typer.Option("all", "--step", help="raw | clean | mart | cross_year | all"),
-    years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
-    validate: bool = typer.Option(False, "--validate", help="Run validation after each step"),
-    strict_config: bool = typer.Option(
-        False, "--strict-config", help="Treat deprecated config forms as errors"
-    ),
-):
-    """
-    Esegue più config in sequenza e stampa un report aggregato finale.
+def _run_one_config(
+    config_path: Path,
+    *,
+    step: str,
+    years_override: list[int] | None,
+    global_years: str | None,
+    do_validate: bool,
+    validate_layers: tuple[str, ...],
+    strict_config_flag: bool,
+    failures: list[dict[str, str]],
+    rows: list[dict[str, str]],
+) -> None:
+    """Process a single config: run step + optionally validate."""
+    config_started_at = perf_counter()
+    dataset_label = config_path.stem
+    try:
+        cfg, logger = load_cfg_and_logger(str(config_path), strict_config=strict_config_flag)
+        dataset_label = cfg.dataset
 
-    --validate esegue la validazione solo per i layer corrispondenti allo step
-    (raw per --step raw, clean per --step clean, tutti per --step all).
+        if years_override is not None:
+            # Per-config years from stdin: must be subset of cfg.years
+            invalid = [y for y in years_override if y not in cfg.years]
+            if invalid:
+                raise ValueError(
+                    f"Years {invalid} non dichiarati in dataset.yml "
+                    f"(config: {cfg.years})"
+                )
+            selected_years = years_override
+        else:
+            selected_years = iter_selected_years(cfg, years_arg=global_years)
 
-    --years filtra gli anni dichiarati in ogni config.
-
-    Esempio (sostituisce run_support_datasets.py):
-        toolkit batch --configs support_list.txt --step all --validate --years 2023,2024
-    """
-    if step not in _ALLOWED_STEPS:
-        raise typer.BadParameter("step must be one of: raw, clean, mart, cross_year, all")
-
-    configs_file = Path(configs)
-    config_paths = _read_config_list(configs_file)
-    strict_config_flag = strict_config if isinstance(strict_config, bool) else False
-    years_val = years if isinstance(years, str) else None
-    validate_layers = _STEP_LAYERS[step]
-
-    rows: list[dict[str, str]] = []
-    failures: list[dict[str, str]] = []
-
-    for config_path in config_paths:
-        config_started_at = perf_counter()
-        dataset_label = config_path.stem
-        try:
-            cfg, logger = load_cfg_and_logger(str(config_path), strict_config=strict_config_flag)
-            dataset_label = cfg.dataset
-            selected_years = iter_selected_years(cfg, years_arg=years_val)
-
-            if step == "cross_year":
+        if step == "cross_year":
+            run_started_at = perf_counter()
+            status = "FAILED"
+            validate_status = "-"
+            try:
+                run_cross_year_step(cfg, logger=logger)
+                status = "SUCCESS"
+                if do_validate:
+                    validate_status = _validate_layers(
+                        cfg, selected_years[0], validate_layers, logger
+                    ) if selected_years else "-"
+                    if validate_status == "failed":
+                        failures.append({
+                            "config": str(config_path),
+                            "dataset": dataset_label,
+                            "years": _format_years(selected_years),
+                            "error": "validation failed",
+                        })
+            except Exception as exc:
+                failures.append({
+                    "config": str(config_path),
+                    "dataset": dataset_label,
+                    "years": _format_years(selected_years),
+                    "error": str(exc),
+                })
+            finally:
+                rows.append({
+                    "dataset": dataset_label,
+                    "years": _format_years(selected_years),
+                    "step": step,
+                    "status": status,
+                    "validate": validate_status,
+                    "duration": _format_duration(perf_counter() - run_started_at),
+                })
+        else:
+            for year in selected_years:
                 run_started_at = perf_counter()
                 status = "FAILED"
                 validate_status = "-"
                 try:
-                    run_cross_year_step(cfg, logger=logger)
-                    status = "SUCCESS"
-                    if validate:
-                        validate_status = _validate_layers(
-                            cfg, selected_years[0], validate_layers, logger
-                        ) if selected_years else "-"
-                        if validate_status == "failed":
-                            failures.append(
-                                {
+                    context = run_year(cfg, year, step=step, logger=logger)
+                    status = context.status
+                except Exception as exc:
+                    failures.append({
+                        "config": str(config_path),
+                        "dataset": dataset_label,
+                        "years": str(year),
+                        "error": str(exc),
+                    })
+                else:
+                    if do_validate and status == "SUCCESS":
+                        try:
+                            validate_status = _validate_layers(cfg, year, validate_layers, logger)
+                            if validate_status == "failed":
+                                failures.append({
                                     "config": str(config_path),
                                     "dataset": dataset_label,
-                                    "years": _format_years(selected_years),
+                                    "years": str(year),
                                     "error": "validation failed",
-                                }
-                            )
-                except Exception as exc:
-                    failures.append(
-                        {
-                            "config": str(config_path),
-                            "dataset": dataset_label,
-                            "years": _format_years(selected_years),
-                            "error": str(exc),
-                        }
-                    )
-                finally:
-                    rows.append(
-                        {
-                            "dataset": dataset_label,
-                            "years": _format_years(selected_years),
-                            "step": step,
-                            "status": status,
-                            "validate": validate_status,
-                            "duration": _format_duration(perf_counter() - run_started_at),
-                        }
-                    )
-            else:
-                for year in selected_years:
-                    run_started_at = perf_counter()
-                    status = "FAILED"
-                    validate_status = "-"
-                    try:
-                        context = run_year(cfg, year, step=step, logger=logger)
-                        status = context.status
-                    except Exception as exc:
-                        failures.append(
-                            {
+                                })
+                        except Exception as exc:
+                            validate_status = "failed"
+                            failures.append({
                                 "config": str(config_path),
                                 "dataset": dataset_label,
                                 "years": str(year),
-                                "error": str(exc),
-                            }
-                        )
-                    else:
-                        if validate and status == "SUCCESS":
-                            try:
-                                validate_status = _validate_layers(cfg, year, validate_layers, logger)
-                                if validate_status == "failed":
-                                    failures.append(
-                                        {
-                                            "config": str(config_path),
-                                            "dataset": dataset_label,
-                                            "years": str(year),
-                                            "error": "validation failed",
-                                        }
-                                    )
-                            except Exception as exc:
-                                validate_status = "failed"
-                                failures.append(
-                                    {
-                                        "config": str(config_path),
-                                        "dataset": dataset_label,
-                                        "years": str(year),
-                                        "error": f"validate: {exc}",
-                                    }
-                                )
-                    finally:
-                        rows.append(
-                            {
-                                "dataset": dataset_label,
-                                "years": str(year),
-                                "step": step,
-                                "status": status,
-                                "validate": validate_status,
-                                "duration": _format_duration(perf_counter() - run_started_at),
-                            }
-                        )
-        except Exception as exc:
-            failures.append(
-                {
-                    "config": str(config_path),
-                    "dataset": dataset_label,
-                    "years": "-",
-                    "error": str(exc),
-                }
-            )
-            rows.append(
-                {
-                    "dataset": dataset_label,
-                    "years": "-",
-                    "step": step,
-                    "status": "FAILED",
-                    "validate": "-",
-                    "duration": _format_duration(perf_counter() - config_started_at),
-                }
-            )
+                                "error": f"validate: {exc}",
+                            })
+                finally:
+                    rows.append({
+                        "dataset": dataset_label,
+                        "years": str(year),
+                        "step": step,
+                        "status": status,
+                        "validate": validate_status,
+                        "duration": _format_duration(perf_counter() - run_started_at),
+                    })
+    except Exception as exc:
+        failures.append({
+            "config": str(config_path),
+            "dataset": dataset_label,
+            "years": "-",
+            "error": str(exc),
+        })
+        rows.append({
+            "dataset": dataset_label,
+            "years": "-",
+            "step": step,
+            "status": "FAILED",
+            "validate": "-",
+            "duration": _format_duration(perf_counter() - config_started_at),
+        })
+
+
+def batch(
+    configs: str | None = typer.Option(None, "--configs", "-c", help="Path to a text file with one dataset.yml path per line"),
+    stdin: bool = typer.Option(False, "--stdin", help="Read config list from stdin (JSON array with config_path and optional years)"),
+    step: str = typer.Option("all", "--step", help="raw | clean | mart | cross_year | all"),
+    years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years (global filter)"),
+    validate: bool = typer.Option(False, "--validate", help="Run validation after each step"),
+    strict_config: bool = typer.Option(False, "--strict-config", help="Treat deprecated config forms as errors"),
+):
+    """
+    Esegue più config in sequenza e stampa un report aggregato finale.
+
+    --configs <file>  : file di testo con un path dataset.yml per riga
+    --stdin           : JSON array da stdin: [{"config_path": ..., "years": [...]}]
+                        (years opzionale: sovrascrive --years per quella config)
+
+    --validate esegue la validazione solo per i layer corrispondenti allo step.
+    --years filtra/limita gli anni (globale, salvo override da --stdin per-config).
+
+    Esempi:
+        toolkit batch --configs list.txt --step all --validate --years 2024
+        echo '[{"config_path": "support/a/dataset.yml", "years": [2024]}]' | toolkit batch --stdin --validate
+    """
+    if step not in _ALLOWED_STEPS:
+        raise typer.BadParameter("step must be one of: raw, clean, mart, cross_year, all")
+    if not configs and not stdin:
+        raise typer.BadParameter("Specificare --configs o --stdin")
+    if configs and stdin:
+        raise typer.BadParameter("Usare --configs o --stdin, non entrambi")
+
+    strict_config_flag = strict_config if isinstance(strict_config, bool) else False
+    years_val = years if isinstance(years, str) else None
+    validate_layers = _STEP_LAYERS[step]
+
+    # Risolvi la lista di (config_path, years_override_or_None)
+    if stdin:
+        config_entries = _read_stdin()
+    else:
+        configs_file = Path(configs)  # type: ignore[arg-type]
+        config_paths = _read_config_list(configs_file)
+        config_entries = [(p, None) for p in config_paths]
+
+    rows: list[dict[str, str]] = []
+    failures: list[dict[str, str]] = []
+
+    for config_path, years_override in config_entries:
+        _run_one_config(
+            config_path,
+            step=step,
+            years_override=years_override,
+            global_years=years_val,
+            do_validate=validate,
+            validate_layers=validate_layers,
+            strict_config_flag=strict_config_flag,
+            failures=failures,
+            rows=rows,
+        )
 
     _print_table(rows)
 

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -1,6 +1,6 @@
 """CLI command: toolkit batch — esegue piu' config in sequenza.
 
-Con --validate esegue anche la validazione dopo ogni step.
+Con --validate esegue anche la validazione post-step (rispetta lo step).
 Con --years filtra gli anni da processare.
 """
 
@@ -18,6 +18,15 @@ from toolkit.mart.validate import run_mart_validation
 from toolkit.raw.validate import run_raw_validation
 
 _ALLOWED_STEPS = {"raw", "clean", "mart", "cross_year", "all"}
+
+# Layernames che ogni step valida. L'ordine non conta.
+_STEP_LAYERS: dict[str, tuple[str, ...]] = {
+    "raw": ("raw",),
+    "clean": ("clean",),
+    "mart": ("mart",),
+    "all": ("raw", "clean", "mart"),
+    "cross_year": ("cross_year",),
+}
 
 
 def _read_config_list(configs_file: Path) -> list[Path]:
@@ -70,15 +79,22 @@ def _print_table(rows: list[dict[str, str]]) -> None:
         typer.echo(_render(row))
 
 
-def _validate_year(cfg, year: int, logger=None) -> str:
-    """Run validation for all layers. Returns 'passed' or 'failed'."""
+def _validate_layers(cfg, year: int, layers: tuple[str, ...], logger=None) -> str:
+    """Run validation for the given layers only. Returns 'passed' or 'failed'.
+
+    layers e' una tupla come _STEP_LAYERS[step].
+    """
     from toolkit.core.logging import get_logger
     log = logger or get_logger()
-    val_raw = run_raw_validation(cfg.root, cfg.dataset, year, log)
-    val_clean = run_clean_validation(cfg, year, log)
-    val_mart = run_mart_validation(cfg, year, log)
-    all_passed = all(r.get("passed") for r in [val_raw, val_clean, val_mart])
-    return "passed" if all_passed else "failed"
+    checks: list[bool | None] = []
+    for layer in layers:
+        if layer == "raw":
+            checks.append(run_raw_validation(cfg.root, cfg.dataset, year, log).get("passed"))
+        elif layer == "clean":
+            checks.append(run_clean_validation(cfg, year, log).get("passed"))
+        elif layer == "mart":
+            checks.append(run_mart_validation(cfg, year, log).get("passed"))
+    return "passed" if all(checks) else "failed"
 
 
 def batch(
@@ -95,10 +111,10 @@ def batch(
     """
     Esegue più config in sequenza e stampa un report aggregato finale.
 
-    Con --validate esegue anche raw_validation, clean_validation e mart_validation
-    dopo ogni run (equivalente a run full ma su piu' config).
+    --validate esegue la validazione solo per i layer corrispondenti allo step
+    (raw per --step raw, clean per --step clean, tutti per --step all).
 
-    Con --years filtra gli anni dichiarati in ogni config.
+    --years filtra gli anni dichiarati in ogni config.
 
     Esempio (sostituisce run_support_datasets.py):
         toolkit batch --configs support_list.txt --step all --validate --years 2023,2024
@@ -110,6 +126,7 @@ def batch(
     config_paths = _read_config_list(configs_file)
     strict_config_flag = strict_config if isinstance(strict_config, bool) else False
     years_val = years if isinstance(years, str) else None
+    validate_layers = _STEP_LAYERS[step]
 
     rows: list[dict[str, str]] = []
     failures: list[dict[str, str]] = []
@@ -130,7 +147,18 @@ def batch(
                     run_cross_year_step(cfg, logger=logger)
                     status = "SUCCESS"
                     if validate:
-                        validate_status = _validate_year(cfg, selected_years[0], logger) if selected_years else "-"
+                        validate_status = _validate_layers(
+                            cfg, selected_years[0], validate_layers, logger
+                        ) if selected_years else "-"
+                        if validate_status == "failed":
+                            failures.append(
+                                {
+                                    "config": str(config_path),
+                                    "dataset": dataset_label,
+                                    "years": _format_years(selected_years),
+                                    "error": "validation failed",
+                                }
+                            )
                 except Exception as exc:
                     failures.append(
                         {
@@ -171,7 +199,16 @@ def batch(
                     else:
                         if validate and status == "SUCCESS":
                             try:
-                                validate_status = _validate_year(cfg, year, logger)
+                                validate_status = _validate_layers(cfg, year, validate_layers, logger)
+                                if validate_status == "failed":
+                                    failures.append(
+                                        {
+                                            "config": str(config_path),
+                                            "dataset": dataset_label,
+                                            "years": str(year),
+                                            "error": "validation failed",
+                                        }
+                                    )
                             except Exception as exc:
                                 validate_status = "failed"
                                 failures.append(

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -1,3 +1,9 @@
+"""CLI command: toolkit batch — esegue piu' config in sequenza.
+
+Con --validate esegue anche la validazione dopo ogni step.
+Con --years filtra gli anni da processare.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -5,8 +11,11 @@ from time import perf_counter
 
 import typer
 
-from toolkit.cli.common import load_cfg_and_logger
+from toolkit.cli.common import dump_cfg_section, iter_selected_years, load_cfg_and_logger
 from toolkit.cli.cmd_run import run_cross_year_step, run_year
+from toolkit.clean.validate import run_clean_validation
+from toolkit.mart.validate import run_mart_validation
+from toolkit.raw.validate import run_raw_validation
 
 _ALLOWED_STEPS = {"raw", "clean", "mart", "cross_year", "all"}
 
@@ -45,7 +54,7 @@ def _format_duration(seconds: float | None) -> str:
 
 
 def _print_table(rows: list[dict[str, str]]) -> None:
-    headers = ["dataset", "years", "step", "status", "duration"]
+    headers = ["dataset", "years", "step", "status", "validate", "duration"]
     widths = {header: len(header) for header in headers}
     for row in rows:
         for header in headers:
@@ -61,17 +70,38 @@ def _print_table(rows: list[dict[str, str]]) -> None:
         typer.echo(_render(row))
 
 
+def _validate_year(cfg, year: int, logger=None) -> str:
+    """Run validation for all layers. Returns 'passed' or 'failed'."""
+    from toolkit.core.logging import get_logger
+    log = logger or get_logger()
+    val_raw = run_raw_validation(cfg.root, cfg.dataset, year, log)
+    val_clean = run_clean_validation(cfg, year, log)
+    val_mart = run_mart_validation(cfg, year, log)
+    all_passed = all(r.get("passed") for r in [val_raw, val_clean, val_mart])
+    return "passed" if all_passed else "failed"
+
+
 def batch(
     configs: str = typer.Option(
         ..., "--configs", help="Path to a text file with one dataset.yml path per line"
     ),
     step: str = typer.Option("all", "--step", help="raw | clean | mart | cross_year | all"),
+    years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
+    validate: bool = typer.Option(False, "--validate", help="Run validation after each step"),
     strict_config: bool = typer.Option(
         False, "--strict-config", help="Treat deprecated config forms as errors"
     ),
 ):
     """
     Esegue più config in sequenza e stampa un report aggregato finale.
+
+    Con --validate esegue anche raw_validation, clean_validation e mart_validation
+    dopo ogni run (equivalente a run full ma su piu' config).
+
+    Con --years filtra gli anni dichiarati in ogni config.
+
+    Esempio (sostituisce run_support_datasets.py):
+        toolkit batch --configs support_list.txt --step all --validate --years 2023,2024
     """
     if step not in _ALLOWED_STEPS:
         raise typer.BadParameter("step must be one of: raw, clean, mart, cross_year, all")
@@ -79,6 +109,7 @@ def batch(
     configs_file = Path(configs)
     config_paths = _read_config_list(configs_file)
     strict_config_flag = strict_config if isinstance(strict_config, bool) else False
+    years_val = years if isinstance(years, str) else None
 
     rows: list[dict[str, str]] = []
     failures: list[dict[str, str]] = []
@@ -89,19 +120,23 @@ def batch(
         try:
             cfg, logger = load_cfg_and_logger(str(config_path), strict_config=strict_config_flag)
             dataset_label = cfg.dataset
+            selected_years = iter_selected_years(cfg, years_arg=years_val)
 
             if step == "cross_year":
                 run_started_at = perf_counter()
                 status = "FAILED"
+                validate_status = "-"
                 try:
                     run_cross_year_step(cfg, logger=logger)
                     status = "SUCCESS"
+                    if validate:
+                        validate_status = _validate_year(cfg, selected_years[0], logger) if selected_years else "-"
                 except Exception as exc:
                     failures.append(
                         {
                             "config": str(config_path),
                             "dataset": dataset_label,
-                            "years": _format_years(list(cfg.years)),
+                            "years": _format_years(selected_years),
                             "error": str(exc),
                         }
                     )
@@ -109,16 +144,18 @@ def batch(
                     rows.append(
                         {
                             "dataset": dataset_label,
-                            "years": _format_years(list(cfg.years)),
+                            "years": _format_years(selected_years),
                             "step": step,
                             "status": status,
+                            "validate": validate_status,
                             "duration": _format_duration(perf_counter() - run_started_at),
                         }
                     )
             else:
-                for year in cfg.years:
+                for year in selected_years:
                     run_started_at = perf_counter()
                     status = "FAILED"
+                    validate_status = "-"
                     try:
                         context = run_year(cfg, year, step=step, logger=logger)
                         status = context.status
@@ -131,6 +168,20 @@ def batch(
                                 "error": str(exc),
                             }
                         )
+                    else:
+                        if validate and status == "SUCCESS":
+                            try:
+                                validate_status = _validate_year(cfg, year, logger)
+                            except Exception as exc:
+                                validate_status = "failed"
+                                failures.append(
+                                    {
+                                        "config": str(config_path),
+                                        "dataset": dataset_label,
+                                        "years": str(year),
+                                        "error": f"validate: {exc}",
+                                    }
+                                )
                     finally:
                         rows.append(
                             {
@@ -138,6 +189,7 @@ def batch(
                                 "years": str(year),
                                 "step": step,
                                 "status": status,
+                                "validate": validate_status,
                                 "duration": _format_duration(perf_counter() - run_started_at),
                             }
                         )
@@ -156,6 +208,7 @@ def batch(
                     "years": "-",
                     "step": step,
                     "status": "FAILED",
+                    "validate": "-",
                     "duration": _format_duration(perf_counter() - config_started_at),
                 }
             )


### PR DESCRIPTION
## Summary

Arricchisce `toolkit batch` con `--validate` e `--years` per sostituire `dataset-incubator/scripts/run_support_datasets.py` Closes #246

## Cosa cambia

### `toolkit batch` (nuove opzioni)

```bash
# Filtra anni
toolkit batch --configs list.txt --step all --years 2023,2024

# Esegui validazione dopo ogni run
toolkit batch --configs list.txt --step all --validate

# Combinato (= sostituisce run_support_datasets.py)
toolkit batch --configs list.txt --step all --validate --years 2023,2024
```

### Report

Il report tabellare ora include una colonna `validate`:
- `passed` — tutte le validazioni OK
- `failed` — almeno una validazione fallita
- `-` — `--validate` non richiesto

## Dettaglio tecnico

- `--years` usa `iter_selected_years()` (stessa logica degli altri comandi CLI)
- `--validate` chiama `run_raw_validation` + `run_clean_validation` + `run_mart_validation` (stessa logica di `run full`)
- La validazione fallita non blocca il batch (viene registrata come failure ma si continua con le altre config)
- `--years` e `--validate` funzionano anche con `--step cross_year`

## Verifica

- 3 test batch (classico + years + validate) passati
- 610 test totali passati
- mypy: zero nuovi errori
- Breakage: zero (nuove opzioni, firma batch() backward compat)

## Branch

`feat/batch-years-validate`