### PR TITLE
test: migrare 5 file test a lab_connectors.testing

### DIFF
--- a/tests/test_ckan_plugin.py
+++ b/tests/test_ckan_plugin.py
@@ -1,25 +1,10 @@
 from __future__ import annotations
 
-from lab_connectors.http import HttpClient, HttpResult
+from lab_connectors.http import HttpClient
+from lab_connectors.testing import http_ok
 
 from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.ckan import CkanSource
-
-
-class _FakeResponse:
-    def __init__(self, status_code: int, *, json_data=None, content: bytes = b"", url: str = "https://example.org"):
-        self.status_code = status_code
-        self._json_data = json_data
-        self.content = content
-        self.url = url
-
-    def json(self):
-        return self._json_data
-
-
-def _ok(result, err=None):
-    """Helper: wrap _FakeResponse in HttpResult."""
-    return HttpResult(response=result, err=err)
 
 
 def test_ckan_fetch_resource_show_forces_https(monkeypatch):
@@ -28,19 +13,19 @@ def test_ckan_fetch_resource_show_forces_https(monkeypatch):
     def _fake_get(self, url, **kwargs):
         calls.append((url, kwargs.get("params")))
         if "resource_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
                     "result": {"url": "http://portal.example.org/export/data.csv"},
                 },
                 url=f"{url}?id=abc",
-            ))
-        return _ok(_FakeResponse(
+            )
+        return http_ok(
             200,
             content=b"a,b\n1,2\n",
             url="https://portal.example.org/export/data.csv",
-        ))
+        )
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 
@@ -57,9 +42,9 @@ def test_ckan_fetch_falls_back_to_package_show(monkeypatch):
     def _fake_get(self, url, **kwargs):
         calls.append((url, kwargs.get("params")))
         if "resource_show" in url:
-            return _ok(_FakeResponse(404, json_data={}, url=f"{url}?id=33344"))
+            return http_ok(404, json_data={}, url=f"{url}?id=33344")
         if "package_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
@@ -75,12 +60,12 @@ def test_ckan_fetch_falls_back_to_package_show(monkeypatch):
                     },
                 },
                 url=f"{url}?id=dataset-id",
-            ))
-        return _ok(_FakeResponse(
+            )
+        return http_ok(
             200,
             content=b"a,b\n1,2\n",
             url="https://portal.example.org/api/3/datastore/dump/dataset.csv",
-        ))
+        )
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 
@@ -111,7 +96,7 @@ def test_ckan_fetch_falls_back_to_second_resource_when_first_fails(monkeypatch):
     def _fake_get(self, url, **kwargs):
         calls.append((url, kwargs.get("params")))
         if "package_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
@@ -133,12 +118,12 @@ def test_ckan_fetch_falls_back_to_second_resource_when_first_fails(monkeypatch):
                     },
                 },
                 url=f"{url}?id=dataset-id",
-            ))
+            )
         # Simulate first URL failing with 404, second succeeding
         if "first.csv" in url:
-            return _ok(_FakeResponse(404, content=b"", url=url))
+            return http_ok(404, content=b"", url=url)
         if "second.csv" in url:
-            return _ok(_FakeResponse(200, content=b"ok,second", url=url))
+            return http_ok(200, content=b"ok,second", url=url)
         raise AssertionError(f"Unexpected request to {url}")
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
@@ -159,7 +144,7 @@ def test_ckan_fetch_falls_back_to_second_resource_when_first_fails(monkeypatch):
 def test_ckan_fetch_package_show_by_resource_name_raises_when_missing(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if "package_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
@@ -175,7 +160,7 @@ def test_ckan_fetch_package_show_by_resource_name_raises_when_missing(monkeypatc
                     },
                 },
                 url=f"{url}?id=dataset-id",
-            ))
+            )
         raise AssertionError(f"Unexpected download request to {url}")
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
@@ -195,9 +180,9 @@ def test_ckan_fetch_package_show_by_resource_name_raises_when_missing(monkeypatc
 def test_ckan_fetch_rejects_package_fallback_when_resource_id_missing(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if "resource_show" in url:
-            return _ok(_FakeResponse(404, json_data={}, url=f"{url}?id=99999"))
+            return http_ok(404, json_data={}, url=f"{url}?id=99999")
         if "package_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
@@ -213,7 +198,7 @@ def test_ckan_fetch_rejects_package_fallback_when_resource_id_missing(monkeypatc
                     },
                 },
                 url=f"{url}?id=dataset-id",
-            ))
+            )
         raise AssertionError(f"Unexpected download request to {url}")
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
@@ -234,15 +219,15 @@ def test_ckan_download_bytes_retries_then_succeeds(monkeypatch):
     """Retry behavior is now in HttpClient; test end-to-end success."""
     def _fake_get(self, url, **kwargs):
         if "resource_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
                     "result": {"url": "https://portal.example.org/export/retry.csv"},
                 },
                 url=f"{url}?id=abc",
-            ))
-        return _ok(_FakeResponse(200, content=b"ok-after-retry", url=url))
+            )
+        return http_ok(200, content=b"ok-after-retry", url=url)
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 
@@ -257,15 +242,15 @@ def test_ckan_download_bytes_retries_then_succeeds(monkeypatch):
 def test_ckan_download_bytes_raises_on_http_error(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if "resource_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
                     "result": {"url": "https://portal.example.org/export/unavailable.csv"},
                 },
                 url=f"{url}?id=abc",
-            ))
-        return _ok(_FakeResponse(503, content=b"", url=url))
+            )
+        return http_ok(503, content=b"", url=url)
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 
@@ -283,7 +268,7 @@ def test_ckan_fetch_datastore_active_uses_datastore_search(monkeypatch):
     def _fake_get(self, url, **kwargs):
         calls.append((url, kwargs.get("params")))
         if "resource_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
@@ -294,9 +279,9 @@ def test_ckan_fetch_datastore_active_uses_datastore_search(monkeypatch):
                     },
                 },
                 url=f"{url}?id=res-123",
-            ))
+            )
         if "datastore_search" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
@@ -309,12 +294,12 @@ def test_ckan_fetch_datastore_active_uses_datastore_search(monkeypatch):
                     },
                 },
                 url=url,
-            ))
-        return _ok(_FakeResponse(
+            )
+        return http_ok(
             200,
             content=b"fallback csv content",
             url="http://portal.example.org/api/3/dump.csv",
-        ))
+        )
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 
@@ -335,7 +320,7 @@ def test_ckan_fetch_datastore_fallback_to_url_on_empty_records(monkeypatch):
     def _fake_get(self, url, **kwargs):
         calls.append((url, kwargs.get("params")))
         if "resource_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
@@ -346,14 +331,14 @@ def test_ckan_fetch_datastore_fallback_to_url_on_empty_records(monkeypatch):
                     },
                 },
                 url=f"{url}?id=res-456",
-            ))
+            )
         if "datastore_search" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={"success": True, "result": {"fields": [], "records": []}},
                 url=url,
-            ))
-        return _ok(_FakeResponse(200, content=b"csv-from-url", url=url))
+            )
+        return http_ok(200, content=b"csv-from-url", url=url)
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 
@@ -368,23 +353,23 @@ def test_ckan_fetch_datastore_fallback_to_url_on_empty_records(monkeypatch):
 def test_ckan_fetch_resource_no_url_no_datastore_raises(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if "resource_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
                     "result": {"id": "no-url-res", "datastore_active": False},
                 },
                 url=f"{url}?id=no-url-res",
-            ))
+            )
         if "package_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
                     "result": {"id": "no-url-res", "resources": []},
                 },
                 url=f"{url}?id=no-url-res",
-            ))
+            )
         raise AssertionError(f"Unexpected request to {url}")
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
@@ -403,14 +388,14 @@ def test_ckan_fetch_malformed_json_falls_back_to_package_show(monkeypatch):
     def _fake_get(self, url, **kwargs):
         calls.append((url, kwargs.get("params")))
         if "resource_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data=None,
                 content=b"not json at all",
                 url=f"{url}?id=malformed",
-            ))
+            )
         if "package_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
@@ -427,8 +412,8 @@ def test_ckan_fetch_malformed_json_falls_back_to_package_show(monkeypatch):
                     },
                 },
                 url=f"{url}?id=malformed",
-            ))
-        return _ok(_FakeResponse(200, content=b"a,b\n1,2\n", url="http://portal.example.org/data.csv"))
+            )
+        return http_ok(200, content=b"a,b\n1,2\n", url="http://portal.example.org/data.csv")
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 
@@ -442,11 +427,11 @@ def test_ckan_fetch_malformed_json_falls_back_to_package_show(monkeypatch):
 def test_ckan_fetch_package_no_resources_raises(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if "package_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={"success": True, "result": {"id": "empty-pkg", "resources": []}},
                 url=f"{url}?id=empty-pkg",
-            ))
+            )
         raise AssertionError(f"Unexpected request to {url}")
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
@@ -465,7 +450,7 @@ def test_ckan_fetch_prefer_datastore_false_skips_datastore(monkeypatch):
     def _fake_get(self, url, **kwargs):
         calls.append((url, kwargs.get("params")))
         if "resource_show" in url:
-            return _ok(_FakeResponse(
+            return http_ok(
                 200,
                 json_data={
                     "success": True,
@@ -476,8 +461,8 @@ def test_ckan_fetch_prefer_datastore_false_skips_datastore(monkeypatch):
                     },
                 },
                 url=f"{url}?id=ds-res",
-            ))
-        return _ok(_FakeResponse(200, content=b"csv-via-url", url=url))
+            )
+        return http_ok(200, content=b"csv-via-url", url=url)
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 

--- a/tests/test_cmd_init.py
+++ b/tests/test_cmd_init.py
@@ -6,18 +6,11 @@ from pathlib import Path
 import pytest
 import yaml
 
-from lab_connectors.http import HttpClient, HttpResult
+from lab_connectors.http import HttpClient
+from lab_connectors.testing import http_ok
 
 from toolkit.cli.app import app
 from typer.testing import CliRunner
-
-
-class _FakeResp:
-    def __init__(self, content: bytes = b"", headers: dict | None = None, status_code: int = 200, url: str = ""):
-        self.content = content
-        self.headers = headers or {}
-        self.status_code = status_code
-        self.url = url
 
 
 @pytest.mark.policy
@@ -26,14 +19,10 @@ def test_init_url_generates_dataset_yml(monkeypatch, tmp_path: Path) -> None:
     csv_content = b"nome,eta,citta\nMario,30,Roma\nLucia,25,Milano\n"
 
     def fake_get(self, url, **kwargs):
-        return HttpResult(
-            response=_FakeResp(
-                content=csv_content,
-                headers={"Content-Type": "text/csv"},
-                status_code=200,
-                url=url,
-            ),
-            err=None,
+        return http_ok(
+            content=csv_content,
+            headers={"Content-Type": "text/csv"},
+            url=url,
         )
 
     monkeypatch.setattr(HttpClient, "get", fake_get)

--- a/tests/test_http_file_plugin.py
+++ b/tests/test_http_file_plugin.py
@@ -9,16 +9,10 @@ from __future__ import annotations
 import pytest
 
 from lab_connectors.http import HttpClient, HttpResult
+from lab_connectors.testing import http_ok
 
 from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.http_file import HttpFileSource
-
-
-class _FakeResponse:
-    """Minimal response stub duck-typing requests.Response properties."""
-    def __init__(self, status_code: int = 200, content: bytes = b"ok") -> None:
-        self.status_code = status_code
-        self.content = content
 
 
 def test_fetch_success(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -27,7 +21,7 @@ def test_fetch_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(self, url: str, **kwargs):
         results.append((url, kwargs))
-        return HttpResult(response=_FakeResponse(200, b"payload"), err=None)
+        return http_ok(200, b"payload")
 
     monkeypatch.setattr(HttpClient, "get", fake_get)
 
@@ -42,7 +36,7 @@ def test_fetch_success(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_fetch_http_status_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """Non-200 HTTP status → DownloadError with status code in message."""
     def fake_get(self, url: str, **kwargs):
-        return HttpResult(response=_FakeResponse(503, b"service unavailable"), err=None)
+        return http_ok(503, b"service unavailable")
 
     monkeypatch.setattr(HttpClient, "get", fake_get)
 
@@ -80,7 +74,7 @@ def test_ssl_fallback_semantics_preserved(monkeypatch: pytest.MonkeyPatch) -> No
     """ssl_fallback_used=True in HttpResult is transparent to caller."""
     def fake_get(self, url: str, **kwargs):
         return HttpResult(
-            response=_FakeResponse(200, b"ssl-fallback-data"),
+            response=http_ok(200, b"ssl-fallback-data").response,
             err=None,
             ssl_fallback_used=True,
         )

--- a/tests/test_http_post_file_plugin.py
+++ b/tests/test_http_post_file_plugin.py
@@ -10,17 +10,10 @@ from __future__ import annotations
 import pytest
 
 from lab_connectors.http import HttpClient, HttpResult
+from lab_connectors.testing import http_ok
 
 from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.http_post_file import HttpPostFileSource
-
-
-class _FakeResponse:
-    """Minimal response stub duck-typing requests.Response properties."""
-
-    def __init__(self, status_code: int = 200, content: bytes = b"ok") -> None:
-        self.status_code = status_code
-        self.content = content
 
 
 def test_fetch_success(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -29,7 +22,7 @@ def test_fetch_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_post(self, url: str, data: dict | None = None, **kwargs):
         results.append((url, data, kwargs))
-        return HttpResult(response=_FakeResponse(200, b"payload"), err=None)
+        return http_ok(200, b"payload")
 
     monkeypatch.setattr(HttpClient, "post", fake_post)
 
@@ -48,7 +41,7 @@ def test_fetch_without_data(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_post(self, url: str, data: dict | None = None, **kwargs):
         results.append((url, data, kwargs))
-        return HttpResult(response=_FakeResponse(200, b"no-data"), err=None)
+        return http_ok(200, b"no-data")
 
     monkeypatch.setattr(HttpClient, "post", fake_post)
 
@@ -64,7 +57,7 @@ def test_fetch_http_status_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """Non-200 HTTP status → DownloadError with status code in message."""
 
     def fake_post(self, url: str, data: dict | None = None, **kwargs):
-        return HttpResult(response=_FakeResponse(503, b"service unavailable"), err=None)
+        return http_ok(503, b"service unavailable")
 
     monkeypatch.setattr(HttpClient, "post", fake_post)
 
@@ -104,7 +97,7 @@ def test_ssl_fallback_semantics_preserved(monkeypatch: pytest.MonkeyPatch) -> No
 
     def fake_post(self, url: str, data: dict | None = None, **kwargs):
         return HttpResult(
-            response=_FakeResponse(200, b"ssl-fallback-data"),
+            response=http_ok(200, b"ssl-fallback-data").response,
             err=None,
             ssl_fallback_used=True,
         )

--- a/tests/test_sdmx_plugin.py
+++ b/tests/test_sdmx_plugin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import requests
 
 from lab_connectors.http import HttpClient, HttpResult
+from lab_connectors.testing import http_ok
 
 from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.sdmx import SdmxSource
@@ -90,10 +91,6 @@ PREVIEW_JSON_WITH_VALUES = """
 """
 
 
-def _ok(result, err=None):
-    return HttpResult(response=result, err=err)
-
-
 def test_sdmx_fetch_normalizes_csv(monkeypatch):
     calls = []
 
@@ -102,11 +99,11 @@ def test_sdmx_fetch_normalizes_csv(monkeypatch):
         headers = kwargs.get("headers", {})
         calls.append((url, params, headers.get("Accept") if headers else None))
         if url.endswith("/dataflow/IT1/22_289"):
-            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
+            return http_ok(200, text=DATAFLOW_XML, url=url)
         if url.endswith("/data/IT1,22_289,1.5/all"):
-            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
+            return http_ok(200, text=PREVIEW_JSON_WITH_VALUES, url=url)
         if url.endswith("/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99"):
-            return _ok(_FakeResponse(200, DATA_JSON, url))
+            return http_ok(200, text=DATA_JSON, url=url)
         raise AssertionError(f"Unexpected URL {url}")
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
@@ -138,7 +135,7 @@ def test_sdmx_fetch_normalizes_csv(monkeypatch):
 def test_sdmx_fetch_blocks_version_mismatch(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if url.endswith("/dataflow/IT1/22_289"):
-            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
+            return http_ok(200, text=DATAFLOW_XML, url=url)
         raise AssertionError(f"Unexpected URL {url}")
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
@@ -154,10 +151,10 @@ def test_sdmx_fetch_blocks_version_mismatch(monkeypatch):
 def test_sdmx_fetch_rejects_unknown_filter_dimension(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if url.endswith("/dataflow/IT1/22_289"):
-            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
+            return http_ok(200, text=DATAFLOW_XML, url=url)
         if url.endswith("/data/IT1,22_289,1.5/all"):
-            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
-        return _ok(_FakeResponse(404, "not found", url))
+            return http_ok(200, text=PREVIEW_JSON_WITH_VALUES, url=url)
+        return http_ok(404, text="not found", url=url)
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 
@@ -178,11 +175,11 @@ def test_sdmx_fetch_falls_back_on_metadata_timeout(monkeypatch):
         if url == "https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
             return HttpResult(response=None, err=requests.exceptions.Timeout("metadata timeout"))
         if url == "https://esploradati.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
-            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
+            return http_ok(200, text=DATAFLOW_XML, url=url)
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
-            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
+            return http_ok(200, text=PREVIEW_JSON_WITH_VALUES, url=url)
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
-            return _ok(_FakeResponse(200, DATA_JSON, url))
+            return http_ok(200, text=DATA_JSON, url=url)
         raise AssertionError(f"Unexpected URL {url}")
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
@@ -212,10 +209,10 @@ def test_sdmx_fetch_falls_back_on_metadata_timeout(monkeypatch):
 def test_sdmx_fetch_rejects_invalid_filter_value(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if url.endswith("/dataflow/IT1/22_289"):
-            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
+            return http_ok(200, text=DATAFLOW_XML, url=url)
         if url.endswith("/data/IT1,22_289,1.5/all"):
-            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
-        return _ok(_FakeResponse(404, "not found", url))
+            return http_ok(200, text=PREVIEW_JSON_WITH_VALUES, url=url)
+        return http_ok(404, text="not found", url=url)
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 
@@ -231,9 +228,9 @@ def test_sdmx_fetch_rejects_invalid_filter_value(monkeypatch):
 def test_sdmx_fetch_rejects_invalid_filter_value_list(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if url.endswith("/dataflow/IT1/22_289"):
-            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
+            return http_ok(200, text=DATAFLOW_XML, url=url)
         if url.endswith("/data/IT1,22_289,1.5/all"):
-            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
+            return http_ok(200, text=PREVIEW_JSON_WITH_VALUES, url=url)
         raise AssertionError(f"Unexpected URL {url}")
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
@@ -252,10 +249,10 @@ def test_sdmx_fetch_empty_response(monkeypatch):
 
     def _fake_get(self, url, **kwargs):
         if url.endswith("/dataflow/IT1/22_289"):
-            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
+            return http_ok(200, text=DATAFLOW_XML, url=url)
         if url.endswith("/data/IT1,22_289,1.5/all"):
-            return _ok(_FakeResponse(200, empty_data_json, url))
-        return _ok(_FakeResponse(200, empty_data_json, url))
+            return http_ok(200, text=empty_data_json, url=url)
+        return http_ok(200, text=empty_data_json, url=url)
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 
@@ -273,15 +270,15 @@ def test_sdmx_fetch_falls_back_on_data_5xx(monkeypatch):
     def _fake_get(self, url, **kwargs):
         calls.append(url)
         if url == "https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
-            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
+            return http_ok(200, text=DATAFLOW_XML, url=url)
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
-            return _ok(_FakeResponse(500, "boom", url))
+            return http_ok(500, text="boom", url=url)
         if url == "https://sdmx.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
-            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
+            return http_ok(200, text=PREVIEW_JSON_WITH_VALUES, url=url)
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
-            return _ok(_FakeResponse(500, "boom", url))
+            return http_ok(500, text="boom", url=url)
         if url == "https://sdmx.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
-            return _ok(_FakeResponse(200, DATA_JSON, url))
+            return http_ok(200, text=DATA_JSON, url=url)
         raise AssertionError(f"Unexpected URL {url}")
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
@@ -311,11 +308,11 @@ def test_sdmx_fetch_falls_back_on_data_5xx(monkeypatch):
 def test_sdmx_fetch_does_not_fallback_on_404(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if url == "https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
-            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
+            return http_ok(200, text=DATAFLOW_XML, url=url)
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
-            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
+            return http_ok(200, text=PREVIEW_JSON_WITH_VALUES, url=url)
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
-            return _ok(_FakeResponse(404, "not found", url))
+            return http_ok(404, text="not found", url=url)
         raise AssertionError(f"Unexpected URL {url}")
 
     monkeypatch.setattr(HttpClient, "get", _fake_get)
@@ -350,9 +347,9 @@ def test_sdmx_fetch_does_not_fallback_on_connection_error(monkeypatch):
     def _fake_get(self, url, **kwargs):
         calls.append(url)
         if url == "https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
-            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
+            return http_ok(200, text=DATAFLOW_XML, url=url)
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
-            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
+            return http_ok(200, text=PREVIEW_JSON_WITH_VALUES, url=url)
         if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
             return HttpResult(
                 response=None, err=requests.exceptions.ConnectionError("tls handshake failed")


### PR DESCRIPTION
## Cosa
Migrati 5 file di test da `_FakeResponse` reinventata a `http_ok()` dal nuovo modulo condiviso `lab_connectors.testing` (lab-connectors PR #17).

## File migrati
| File | Righe prima | Righe dopo | Delta |
|------|------------|------------|-------|
| test_ckan_plugin.py | 492 | 477 | -15 |
| test_sdmx_plugin.py | 391 | 380 | -11 |
| test_cmd_init.py | 101 | 91 | -10 |
| test_http_file_plugin.py | 110 | 103 | -7 |
| test_http_post_file_plugin.py | 135 | 128 | -7 |
| **Totale** | **1229** | **1179** | **-50** |

## Compatibilita
Richiede lab-connectors con PR #17 mergiata (modulo `lab_connectors.testing`).

## Test
40 passed, 0 failed.