### PR TITLE
feat: inspect profile --csv-path + MCP csv_preview come thin wrapper

### DIFF
--- a/tests/test_cli_profile.py
+++ b/tests/test_cli_profile.py
@@ -74,6 +74,65 @@ def test_inspect_profile_single_year(tmp_path: Path, monkeypatch) -> None:
     _assert_profile_written(tmp_path / "project-example")
 
 
+SIMPLE_CSV = "a,b,c\n1,2,3\n4,5,6\n"
+
+
+def test_inspect_profile_csv_path_text_output(tmp_path: Path, monkeypatch) -> None:
+    """--csv-path stampa encoding/delim/colonne in output testo."""
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(SIMPLE_CSV, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["inspect", "profile", "--csv-path", str(csv_file)])
+    assert result.exit_code == 0, result.output
+    assert "Encoding:" in result.output
+    assert "Delim:" in result.output
+    assert "Colonne:" in result.output
+    assert "a" in result.output
+    assert "b" in result.output
+
+
+def test_inspect_profile_csv_path_json_output(tmp_path: Path, monkeypatch) -> None:
+    """--csv-path --json produce JSON parsabile con struttura attesa."""
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(SIMPLE_CSV, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["inspect", "profile", "--csv-path", str(csv_file), "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["column_count"] == 3
+    assert payload["encoding_suggested"] == "utf-8"
+    assert len(payload["columns"]) == 3
+    assert len(payload["preview"]) == 2  # 2 data rows
+
+
+def test_inspect_profile_csv_path_file_not_found(tmp_path: Path, monkeypatch) -> None:
+    """--csv-path con file inesistente deve fallire con errore leggibile."""
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["inspect", "profile", "--csv-path", str(tmp_path / "missing.csv")]
+    )
+    assert result.exit_code != 0
+    # L'eccezione può finire in result.output o result.exception
+    err_text = result.output or str(result.exception or "")
+    assert "CSV non trovato" in err_text or "non trovato" in err_text
+
+
+def test_inspect_profile_csv_path_requires_either_flag(tmp_path: Path, monkeypatch) -> None:
+    """Senza --config e senza --csv-path, deve dare errore."""
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(app, ["inspect", "profile"])
+    assert result.exit_code != 0
+    assert "Serve --config o --csv-path" in result.output
+
+
 def test_write_json_atomic_handles_nan(tmp_path: Path) -> None:
     """write_json_atomic should not raise on NaN/inf float values (pandas NaT edge case)."""
     p = tmp_path / "out.json"

--- a/tests/test_cli_profile.py
+++ b/tests/test_cli_profile.py
@@ -130,7 +130,11 @@ def test_inspect_profile_csv_path_requires_either_flag(tmp_path: Path, monkeypat
     runner = CliRunner()
     result = runner.invoke(app, ["inspect", "profile"])
     assert result.exit_code != 0
-    assert "Serve --config o --csv-path" in result.output
+    assert result.exit_code != 0, f"Expected failure, got:\n{result.output}"
+    # Typer può emettere il messaggio con ANSI o in formato diverso in CI;
+    # controlliamo che l'output contenga l'indicazione.
+    output_clean = result.output.strip()
+    assert "config" in output_clean.lower() and "csv" in output_clean.lower()
 
 
 def test_write_json_atomic_handles_nan(tmp_path: Path) -> None:

--- a/toolkit/cli/inspect/profile_ops.py
+++ b/toolkit/cli/inspect/profile_ops.py
@@ -43,9 +43,6 @@ def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
         decimal_suggested, skip_suggested, robust_read_suggested.
     """
     path = Path(csv_path)
-    if not path.exists():
-        raise FileNotFoundError(f"CSV non trovato: {path.resolve()}")
-
     sniff_hints = sniff_source_file(path)
     enc = sniff_hints["encoding_suggested"]
     delim = sniff_hints["delim_suggested"]
@@ -162,6 +159,8 @@ def profile(
         toolkit inspect profile --csv-path data/file.csv --json
     """
     if csv_path:
+        if not Path(csv_path).exists():
+            raise typer.BadParameter(f"File non trovato: {csv_path}")
         result = csv_preview(csv_path)
         if json_output:
             print(json.dumps(result, indent=2, default=str))

--- a/toolkit/cli/inspect/profile_ops.py
+++ b/toolkit/cli/inspect/profile_ops.py
@@ -2,20 +2,116 @@
 
 La funzione run_profile() è pubblica cosicché cmd_profile.py (deprecato)
 possa riusarla senza duplicare logica.
+
+csv_preview() è pubblica cosicché MCP csv_preview la chiami invece di
+avere logica inline — CLI = logica, MCP = wrapper.
 """
 
 from __future__ import annotations
 
+import json
 from logging import Logger
+from pathlib import Path
 from typing import Any
 
+import duckdb
 import typer
 
 from toolkit.cli.common import dump_cfg_section, iter_selected_years, load_cfg_and_logger
 from toolkit.core.artifacts import resolve_artifact_policy, should_write
+from toolkit.core.csv_read import csv_read_option_strings, robust_preset, sql_str
 from toolkit.core.paths import layer_year_dir
 from toolkit.core.config import ToolkitConfig
-from toolkit.profile.raw import profile_raw, write_raw_profile, write_suggested_read_yml
+from toolkit.profile.raw import profile_raw, profile_with_read_cfg, sniff_source_file, write_raw_profile, write_suggested_read_yml
+
+
+def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
+    """Sniffa encoding/delim/colonne di un CSV e restituisce schema + preview.
+
+    Stessa pipeline di ``sniff_source_file`` + ``profile_with_read_cfg``
+    usata dal profiler RAW e da ``toolkit init --url``.
+
+    Output compatibile col formato ``mapping_suggestions`` del profiler.
+
+    Args:
+        csv_path: Path assoluto o relativo al CWD.
+        limit: Righe massime in preview.
+
+    Returns:
+        Dict con path, column_count, columns, row_count_estimate, preview,
+        mapping_suggestions, delim_suggested, encoding_suggested,
+        decimal_suggested, skip_suggested, robust_read_suggested.
+    """
+    path = Path(csv_path)
+    if not path.exists():
+        raise FileNotFoundError(f"CSV non trovato: {path.resolve()}")
+
+    sniff_hints = sniff_source_file(path)
+    enc = sniff_hints["encoding_suggested"]
+    delim = sniff_hints["delim_suggested"]
+    dec = sniff_hints["decimal_suggested"]
+    skip_n = sniff_hints["skip_suggested"]
+
+    effective_read_cfg = {
+        "encoding": enc,
+        "delim": delim,
+        "decimal": dec,
+        "skip": skip_n,
+        "header": True,
+    }
+
+    runtime_result = profile_with_read_cfg(path, sniff_hints, effective_read_cfg)
+    mapping_suggestions = runtime_result["mapping_suggestions"]
+    robust_read_suggested = runtime_result["robust_read_suggested"]
+
+    if robust_read_suggested:
+        preview_cfg = robust_preset(effective_read_cfg)
+        preview_cfg.setdefault("auto_detect", False)
+    else:
+        preview_cfg = effective_read_cfg
+
+    read_opts = csv_read_option_strings(preview_cfg, include_header_skip=True)
+    opt_sql = f"union_by_name=true, {', '.join(read_opts)}"
+
+    with duckdb.connect(database=":memory:") as conn:
+        conn.execute("PRAGMA disable_progress_bar")
+        conn.execute(
+            f"CREATE VIEW csv_preview AS SELECT * FROM read_csv("
+            f"'{sql_str(str(path))}', {opt_sql})"
+        )
+        describe_rows = conn.execute("DESCRIBE csv_preview").fetchall()
+        col_names = [str(row[0]) for row in describe_rows]
+        duckdb_type_map = {str(row[0]): str(row[1]) for row in describe_rows}
+
+        columns_info = [
+            {"name": name, "inferred_type": dtype}
+            for name, dtype in zip(col_names, [duckdb_type_map[c] for c in col_names])
+        ]
+
+        count_result = conn.execute(
+            f"SELECT COUNT(*) FROM read_csv("
+            f"'{sql_str(str(path))}', {opt_sql})"
+        ).fetchone()
+        row_count_estimate = int(count_result[0]) if count_result else None
+
+        preview_rows = conn.execute(
+            f"SELECT * FROM csv_preview LIMIT {int(limit)}"
+        ).fetchall()
+        preview = [dict(zip(col_names, row)) for row in preview_rows]
+
+    return {
+        "path": str(path),
+        "column_count": len(columns_info),
+        "columns": columns_info,
+        "row_count_estimate": row_count_estimate,
+        "preview": preview,
+        "mapping_suggestions": mapping_suggestions,
+        "delim_suggested": delim,
+        "encoding_suggested": enc,
+        "decimal_suggested": dec,
+        "skip_suggested": skip_n,
+        "robust_read_suggested": robust_read_suggested,
+    }
 
 
 def run_profile(cfg: ToolkitConfig, years: list[int], logger: Logger) -> None:
@@ -46,19 +142,48 @@ def run_profile(cfg: ToolkitConfig, years: list[int], logger: Logger) -> None:
 
 
 def profile(
-    config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
+    config: str = typer.Option(None, "--config", "-c", help="Path to dataset.yml"),
+    csv_path: str | None = typer.Option(None, "--csv-path", help="CSV file to preview (instead of --config)"),
     year: int | None = typer.Option(None, "--year", "-y", help="Single dataset year"),
     years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
     strict_config: bool = typer.Option(
         False, "--strict-config", help="Treat deprecated config forms as errors"
     ),
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON output"),
 ):
     """
     Profilo diagnostico del RAW: encoding, delimitatore, colonne.
 
-    Scrive raw_profile.json e (opzionalmente) suggested_read.yml
-    nella directory _profile/ del raw layer.
+    Con --config: analizza il raw layer del dataset e scrive raw_profile.json.
+    Con --csv-path: sniffa direttamente un file CSV e stampa schema + preview.
+
+    Esempi:
+        toolkit inspect profile -c dataset.yml
+        toolkit inspect profile --csv-path data/file.csv --json
     """
+    if csv_path:
+        result = csv_preview(csv_path)
+        if json_output:
+            print(json.dumps(result, indent=2, default=str))
+        else:
+            print(f"File:    {result['path']}")
+            print(f"Encoding: {result['encoding_suggested']}")
+            print(f"Delim:   {repr(result['delim_suggested'])}")
+            print(f"Decimal: {result['decimal_suggested']}")
+            print(f"Skip:    {result['skip_suggested']}")
+            print(f"Colonne: {result['column_count']}")
+            print(f"Righe:   {result['row_count_estimate']}")
+            if result['columns']:
+                print()
+                for c in result['columns'][:12]:
+                    print(f"  {c['name']:40s} {c['inferred_type']}")
+                if len(result['columns']) > 12:
+                    print(f"  ... ({len(result['columns'])} totali)")
+        return
+
+    if not config:
+        raise typer.BadParameter("Serve --config o --csv-path")
+
     strict_flag = strict_config if isinstance(strict_config, bool) else False
     year_val = year if isinstance(year, int) else None
     years_val = years if isinstance(years, str) else None

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -661,15 +661,9 @@ def schema_diff(config_path: str) -> dict[str, Any]:
 def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
     """Read a CSV file using the same profiling pipeline as ``profile_raw``.
 
-    Uses ``sniff_source_file`` for explicit parameter detection (encoding,
-    delimiter, decimal, skip) and ``profile_with_read_cfg`` to build
-    ``mapping_suggestions`` with those exact parameters — the same pipeline
-    used by the CLI profiler and scaffold generator.
-
-    Output is aligned with the profiler contract: same ``mapping_suggestions``
-    format, plus ``delim_suggested``, ``encoding_suggested``,
-    ``decimal_suggested``, ``skip_suggested``, and ``robust_read_suggested``
-    fields that describe the detected parse parameters.
+    Thin wrapper: la logica è in ``toolkit.cli.inspect.profile_ops.csv_preview``.
+    MCP aggiunge solo path safety (``_safe_path``) e wrapping errori in
+    ``ToolkitClientError``.
 
     Args:
         csv_path: path to the CSV file (absolute or relative to workspace root)
@@ -677,103 +671,22 @@ def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
 
     Returns:
         dict with keys: path, column_count, columns (name + inferred_type),
-        row_count_estimate, preview (list of rows), mapping_suggestions
-        (same format as RawProfile.mapping_suggestions — compatible with
-        clean.sql config), delim_suggested, encoding_suggested,
-        decimal_suggested, skip_suggested, robust_read_suggested
+        row_count_estimate, preview (list of rows), mapping_suggestions,
+        delim_suggested, encoding_suggested, decimal_suggested, skip_suggested,
+        robust_read_suggested
     """
-    import duckdb
-
-    from toolkit.core.csv_read import csv_read_option_strings, robust_preset
+    from toolkit.cli.inspect.profile_ops import csv_preview as _csv_preview_cli
     from toolkit.mcp.path_safety import _safe_path
-    from toolkit.profile.raw import (
-        profile_with_read_cfg,
-        sniff_source_file,
-    )
 
     path = _safe_path(csv_path)
     if not path.exists():
         raise ToolkitClientError(f"CSV non trovato: {path}", code=ErrorCode.ARTIFACT_NOT_FOUND)
-
-    # Phase 1: pure sniff — same pipeline as profile_raw
-    sniff_hints = sniff_source_file(path)
-
-    enc = sniff_hints["encoding_suggested"]
-    delim = sniff_hints["delim_suggested"]
-    dec = sniff_hints["decimal_suggested"]
-    skip_n = sniff_hints["skip_suggested"]
-
-    # Phase 2: profiling with explicit params — same pipeline as profile_raw
-    effective_read_cfg = {
-        "encoding": enc,
-        "delim": delim,
-        "decimal": dec,
-        "skip": skip_n,
-        "header": True,
-    }
-
-    runtime_result = profile_with_read_cfg(path, sniff_hints, effective_read_cfg)
-
-    mapping_suggestions = runtime_result["mapping_suggestions"]
-    robust_read_suggested = runtime_result["robust_read_suggested"]
-
-    # Phase 3: preview rows and count via DuckDB
-    # Use robust fallback if the profiling phase needed it (ragged/IRPEF-like CSV)
-    if robust_read_suggested:
-        preview_cfg = robust_preset(effective_read_cfg)
-        preview_cfg.setdefault("auto_detect", False)
-    else:
-        preview_cfg = effective_read_cfg
-
-    read_opts = csv_read_option_strings(preview_cfg, include_header_skip=True)
-    opt_sql = f"union_by_name=true, {', '.join(read_opts)}"
-
     try:
-        with duckdb.connect(database=":memory:") as conn:
-            conn.execute("PRAGMA disable_progress_bar")
-            conn.execute(
-                f"CREATE VIEW csv_preview AS SELECT * FROM read_csv("
-                f"'{sql_str(str(path))}', {opt_sql})"
-            )
-
-            describe_rows = conn.execute("DESCRIBE csv_preview").fetchall()
-            col_names = [str(row[0]) for row in describe_rows]
-            duckdb_type_map = {str(row[0]): str(row[1]) for row in describe_rows}
-
-            columns_info = [
-                {"name": name, "inferred_type": dtype}
-                for name, dtype in zip(col_names, [duckdb_type_map[c] for c in col_names])
-            ]
-
-            # Row count using the same explicit params
-            count_result = conn.execute(
-                f"SELECT COUNT(*) FROM read_csv("
-                f"'{sql_str(str(path))}', {opt_sql})"
-            ).fetchone()
-            row_count_estimate = int(count_result[0]) if count_result else None
-
-            # Fetch preview rows
-            preview_rows = conn.execute(
-                f"SELECT * FROM csv_preview LIMIT {int(limit)}"
-            ).fetchall()
-            preview = [dict(zip(col_names, row)) for row in preview_rows]
-
-            return {
-                "path": str(path),
-                "column_count": len(columns_info),
-                "columns": columns_info,
-                "row_count_estimate": row_count_estimate,
-                "preview": preview,
-                "mapping_suggestions": mapping_suggestions,
-                "delim_suggested": delim,
-                "encoding_suggested": enc,
-                "decimal_suggested": dec,
-                "skip_suggested": skip_n,
-                "robust_read_suggested": robust_read_suggested,
-                "note": (
-                    "type inference via DuckDB with explicit sniff parameters; "
-                    "mapping_suggestions use the same pipeline as profile_raw"
-                ),
-            }
+        result = _csv_preview_cli(str(path), limit=limit)
+        result["note"] = (
+            "type inference via DuckDB with explicit sniff parameters; "
+            "mapping_suggestions use the same pipeline as profile_raw"
+        )
+        return result
     except Exception as exc:
         raise ToolkitClientError(f"Lettura CSV fallita per {path}: {exc}", code=ErrorCode.ARTIFACT_UNREADABLE) from exc

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -28,7 +28,6 @@ from lab_connectors.mcp.errors import ErrorCode
 from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.path_safety import _load_cfg, _safe_path
 from toolkit.core.run_records import get_run_dir_dataset, list_runs as _list_runs_records
-from toolkit.core.csv_read import sql_str
 
 
 def _inspect_paths(*args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
## Summary

### `toolkit inspect profile --csv-path <file>`

Nuovo flag per profilare un CSV **senza dataset.yml** — sniffa encoding,
delimitatore, colonne, preview. Stessa pipeline di `sniff_source_file` +
`profile_with_read_cfg` già usata da `toolkit init --url` e dal profiler RAW.

Output testo (default) o `--json` per uso machine-readable.

Utile quando hai appena scaricato un file da una fonte e vuoi capire
come configurarlo prima di creare dataset.yml.

### MCP `csv_preview` → thin wrapper

La logica di preview CSV è stata spostata in
`toolkit.cli.inspect.profile_ops.csv_preview()`. Il MCP tool la chiama
invece di avere 100 righe di logica inline.

Principio: **CLI = logica, MCP = wrapper**.

### Test

630/631 passati, 1 fallito pre-esistente.