### PR TITLE
feat: MCP discovery/preview tools, slug resolution, multi-year, guard_timed

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -22,6 +22,10 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_list_runs",
         "toolkit_schema_diff",
         "toolkit_csv_preview",
+        "toolkit_list_candidates",
+        "toolkit_dataset_info",
+        "toolkit_clean_preview",
+        "toolkit_raw_preview",
     }
 
 
@@ -179,3 +183,123 @@ def test_csv_preview_ragged_csv_succeeds_with_robust_read(tmp_path: Path) -> Non
     assert result["robust_read_suggested"] is True
     # Preview still returns data
     assert len(result["preview"]) == 2
+
+
+def test_toolkit_list_candidates_passes_stage_and_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_candidates must pass stage AND status_filter through to the impl.
+
+    Nota: guard() wrappa i non-dict in ``{"result": ...}``, quindi
+    il consumer MCP vedra' ``{"result": [{"slug": ..., ...}]}``.
+    """
+    calls: dict[str, object] = {}
+
+    def fake_impl(stage: str, status_filter: str | None) -> list[dict[str, object]]:
+        calls["stage"] = stage
+        calls["status_filter"] = status_filter
+        return [{"slug": "test", "stage": stage, "status": status_filter}]
+
+    monkeypatch.setattr(mcp_server, "list_candidates_impl", fake_impl)
+
+    # Test con status_filter
+    result = mcp_server.toolkit_list_candidates("candidates", "SUCCESS")
+    assert "result" in result
+    assert result["result"][0]["stage"] == "candidates"
+    assert result["result"][0]["status"] == "SUCCESS"
+    assert calls == {"stage": "candidates", "status_filter": "SUCCESS"}
+
+    # Test con status_filter=None
+    result2 = mcp_server.toolkit_list_candidates("all", None)
+    assert result2["result"][0]["status"] is None
+
+
+def test_toolkit_dataset_info_passes_config_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """dataset_info must pass config_path to the impl."""
+    calls: dict[str, object] = {}
+
+    def fake_impl(config_path: str) -> dict[str, object]:
+        calls["config_path"] = config_path
+        return {"dataset": "test"}
+
+    monkeypatch.setattr(mcp_server, "dataset_info_impl", fake_impl)
+    result = mcp_server.toolkit_dataset_info("some/path/dataset.yml")
+
+    assert result["dataset"] == "test"
+    assert calls == {"config_path": "some/path/dataset.yml"}
+
+
+def test_toolkit_clean_preview_passes_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    """clean_preview must pass all params to the impl, converting year=0 → None."""
+    calls: dict[str, object] = {}
+
+    def fake_impl(
+        config_path: str, layer: str, mart_index: int, year: int | None, limit: int
+    ) -> dict[str, object]:
+        calls.update(
+            config_path=config_path,
+            layer=layer,
+            mart_index=mart_index,
+            year=year,
+            limit=limit,
+        )
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_server, "clean_preview_impl", fake_impl)
+    result = mcp_server.toolkit_clean_preview("d.yml", "mart", 1, 2023, 20)
+
+    assert result == {"ok": True}
+    assert calls == {
+        "config_path": "d.yml",
+        "layer": "mart",
+        "mart_index": 1,
+        "year": 2023,
+        "limit": 20,
+    }
+
+
+def test_toolkit_clean_preview_converts_year_zero_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """clean_preview(year=0) must send year=None to the impl."""
+    calls: dict[str, object] = {}
+
+    def fake_impl(
+        config_path: str, layer: str, mart_index: int, year: int | None, limit: int
+    ) -> dict[str, object]:
+        calls["year"] = year
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_server, "clean_preview_impl", fake_impl)
+    mcp_server.toolkit_clean_preview("d.yml", "clean", 0, 0, 10)
+
+    assert calls["year"] is None
+
+
+def test_toolkit_raw_preview_passes_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    """raw_preview must pass all params to the impl, converting year=0 → None."""
+    calls: dict[str, object] = {}
+
+    def fake_impl(
+        config_path: str, year: int | None, limit: int
+    ) -> dict[str, object]:
+        calls.update(config_path=config_path, year=year, limit=limit)
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_server, "raw_preview_impl", fake_impl)
+    result = mcp_server.toolkit_raw_preview("d.yml", 2023, 30)
+
+    assert result == {"ok": True}
+    assert calls == {"config_path": "d.yml", "year": 2023, "limit": 30}
+
+
+def test_toolkit_raw_preview_converts_year_zero_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """raw_preview(year=0) must send year=None to the impl."""
+    calls: dict[str, object] = {}
+
+    def fake_impl(
+        config_path: str, year: int | None, limit: int
+    ) -> dict[str, object]:
+        calls["year"] = year
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_server, "raw_preview_impl", fake_impl)
+    mcp_server.toolkit_raw_preview("d.yml", 0, 20)
+
+    assert calls["year"] is None

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -28,7 +28,7 @@ def _write_real_parquet(path: Path) -> None:
 def test_mcp_toolkit_client_works_from_repo_layout(tmp_path: Path, monkeypatch) -> None:
     src = Path("project-example")
     dst = tmp_path / "project-example"
-    shutil.copytree(src, dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     config_path = dst / "dataset.yml"
 
     monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
@@ -64,7 +64,7 @@ def test_mcp_toolkit_client_works_from_repo_layout(tmp_path: Path, monkeypatch) 
 def test_review_readiness_incomplete_when_no_outputs(tmp_path: Path, monkeypatch) -> None:
     src = Path("project-example")
     dst = tmp_path / "project-example"
-    shutil.copytree(src, dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     config_path = dst / "dataset.yml"
 
     monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
@@ -84,7 +84,7 @@ def test_review_readiness_incomplete_when_no_outputs(tmp_path: Path, monkeypatch
 def test_review_readiness_ready_when_all_layers_present(tmp_path: Path, monkeypatch) -> None:
     src = Path("project-example")
     dst = tmp_path / "project-example"
-    shutil.copytree(src, dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     config_path = dst / "dataset.yml"
 
     monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
@@ -121,7 +121,7 @@ def test_review_readiness_ready_when_all_layers_present(tmp_path: Path, monkeypa
 def test_review_readiness_needs_review_with_single_failure(tmp_path: Path, monkeypatch) -> None:
     src = Path("project-example")
     dst = tmp_path / "project-example"
-    shutil.copytree(src, dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     config_path = dst / "dataset.yml"
 
     monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
@@ -151,7 +151,7 @@ def test_mcp_raw_profile_handles_suggested_read_yaml(tmp_path: Path, monkeypatch
     """raw_profile deve cadere su suggested_read.yml quando raw_profile.json non esiste."""
     src = Path("project-example")
     dst = tmp_path / "project-example"
-    shutil.copytree(src, dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     config_path = dst / "dataset.yml"
 
     monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
@@ -176,7 +176,7 @@ def test_mcp_raw_profile_error_when_no_profile_file(tmp_path: Path, monkeypatch)
     """raw_profile deve fallire con errore chiaro quando non c'e' nessun profilo."""
     src = Path("project-example")
     dst = tmp_path / "project-example"
-    shutil.copytree(src, dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     config_path = dst / "dataset.yml"
 
     monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
@@ -196,7 +196,7 @@ def test_list_runs_accepts_naive_datetime_filter(tmp_path: Path, monkeypatch) ->
     """Naive datetime in since/until must be normalized to UTC, not crash with TypeError."""
     src = Path("project-example")
     dst = tmp_path / "project-example"
-    shutil.copytree(src, dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     config_path = dst / "dataset.yml"
 
     monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
@@ -240,7 +240,7 @@ def test_run_summary_accepts_since_until_filters(tmp_path: Path, monkeypatch) ->
     """run_summary with since/until filters must normalize naive datetimes to UTC."""
     src = Path("project-example")
     dst = tmp_path / "project-example"
-    shutil.copytree(src, dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     config_path = dst / "dataset.yml"
 
     monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
@@ -315,7 +315,7 @@ def test_inspect_paths_cli_mcp_contract_alignment(tmp_path: Path, monkeypatch) -
 
     src = Path("project-example")
     dst = tmp_path / "project-example"
-    shutil.copytree(src, dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     config_path = dst / "dataset.yml"
 
     monkeypatch.chdir(tmp_path)
@@ -351,10 +351,9 @@ def test_inspect_paths_cli_mcp_contract_alignment(tmp_path: Path, monkeypatch) -
 
 
 @pytest.mark.policy
-def test_inspect_paths_multi_year_requires_year(tmp_path: Path, monkeypatch) -> None:
-    """inspect_paths(year=None) su dataset multi-year deve alzare ToolkitClientError."""
+def test_inspect_paths_multi_year_defaults_to_max_year(tmp_path: Path, monkeypatch) -> None:
+    """inspect_paths(year=None) su dataset multi-year usa l'ultimo anno."""
     from toolkit.mcp.cli_adapter import inspect_paths
-    from toolkit.mcp.errors import ToolkitClientError
 
     yml = tmp_path / "dataset.yml"
     yml.write_text(
@@ -365,8 +364,11 @@ def test_inspect_paths_multi_year_requires_year(tmp_path: Path, monkeypatch) -> 
     )
     monkeypatch.chdir(tmp_path)
 
-    with pytest.raises(ToolkitClientError, match="year è obbligatorio"):
-        inspect_paths(str(yml))
+    result = inspect_paths(str(yml))
+    assert result["year"] == 2023  # max year come default
+    assert "_year_resolution" in result
+    assert result["_year_resolution"]["years_available"] == [2022, 2023]
+    assert "Usato 2023" in result["_year_resolution"]["note"]
 
 
 @pytest.mark.policy
@@ -384,7 +386,7 @@ def test_schema_diff_cli_contract_alignment(tmp_path: Path, monkeypatch) -> None
 
     src = Path("project-example")
     dst = tmp_path / "project-example"
-    shutil.copytree(src, dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     config_path = dst / "dataset.yml"
 
     monkeypatch.chdir(tmp_path)
@@ -412,7 +414,7 @@ def test_review_readiness_mcp_contract_shape(tmp_path: Path, monkeypatch) -> Non
 
     src = Path("project-example")
     dst = tmp_path / "project-example"
-    shutil.copytree(src, dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     config_path = dst / "dataset.yml"
 
     monkeypatch.chdir(tmp_path)
@@ -424,3 +426,236 @@ def test_review_readiness_mcp_contract_shape(tmp_path: Path, monkeypatch) -> Non
     for check in payload.get("checks", []):
         for ck in ReadinessCheck.__required_keys__:
             assert ck in check, f"ReadinessCheck: chiave '{ck}' mancante in {check.get('check')}"
+
+
+def test_clean_preview_with_real_parquet(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """clean_preview deve leggere un parquet reale e restituire schema + preview."""
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Crea un parquet clean reale
+    clean_dir = dst / "_smoke_out" / "data" / "clean" / "project_example" / "2022"
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    _write_real_parquet(clean_dir / "project_example_2022_clean.parquet")
+
+    from toolkit.mcp.toolkit_client import clean_preview
+
+    result = clean_preview(str(config_path), layer="clean", year=2022, limit=5)
+
+    assert result["dataset"] == "project_example"
+    assert result["layer"] == "clean"
+    assert result["column_count"] >= 1
+    assert len(result["preview"]) >= 1
+    assert "row_count" in result
+    assert "truncated" in result
+
+
+def test_clean_preview_mart_with_index(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """clean_preview(layer='mart') deve leggere il mart_index richiesto."""
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Crea output mart (due table)
+    mart_dir = dst / "_smoke_out" / "data" / "mart" / "project_example" / "2022"
+    mart_dir.mkdir(parents=True, exist_ok=True)
+    _write_real_parquet(mart_dir / "rd_by_regione.parquet")
+    _write_real_parquet(mart_dir / "rd_by_provincia.parquet")
+
+    from toolkit.mcp.toolkit_client import clean_preview
+
+    result = clean_preview(str(config_path), layer="mart", mart_index=1, year=2022, limit=5)
+
+    assert result["layer"] == "mart"
+    assert result["mart_name"] == "rd_by_provincia"
+    assert result["column_count"] >= 1
+
+
+def test_raw_preview_with_real_csv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """raw_preview deve leggere un CSV reale dal raw dir."""
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "manifest.json").write_text(
+        json.dumps({"primary_output_file": "ispra_dettaglio_comunale_2022.csv"}), encoding="utf-8"
+    )
+    (raw_dir / "ispra_dettaglio_comunale_2022.csv").write_bytes(b"a;b\n1;2\n3;4\n")
+
+    from toolkit.mcp.toolkit_client import raw_preview
+
+    result = raw_preview(str(config_path), year=2022, limit=5)
+
+    assert result["path"].endswith("ispra_dettaglio_comunale_2022.csv")
+    assert result["column_count"] >= 2
+    assert len(result["preview"]) >= 2
+
+
+def test_dataset_info_from_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """dataset_info deve estrarre campi da dataset.yml reale senza eseguire pipeline."""
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    from toolkit.mcp.toolkit_client import dataset_info
+
+    result = dataset_info(str(config_path))
+
+    assert result["dataset"] == "project_example"
+    assert result["years"] == [2022]
+    assert "source_urls" in result
+    assert "has_clean" in result
+    assert "has_mart" in result
+    assert "raw_sources_count" in result
+    assert "mart_tables" in result
+    assert result["raw_sources_count"] >= 1
+
+
+def test_list_candidates_with_minimal_candidate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_candidates deve trovare candidate creati nel workspace."""
+    from toolkit.mcp import discovery as _discovery_mod
+    monkeypatch.setattr(_discovery_mod, "WORKSPACE_ROOT", tmp_path)
+
+    # Crea un candidate minimale
+    cand_dir = tmp_path / "dataset-incubator" / "candidates" / "test-candidate"
+    cand_dir.mkdir(parents=True, exist_ok=True)
+    (cand_dir / "dataset.yml").write_text(
+        "dataset:\n  name: test-candidate\n  years: [2024]\n",
+        encoding="utf-8",
+    )
+
+    from toolkit.mcp.discovery import list_candidates
+
+    result = list_candidates(stage="all")
+
+    assert isinstance(result, list)
+    slugs = [c["slug"] for c in result]
+    assert "test-candidate" in slugs
+    for item in result:
+        if item["slug"] == "test-candidate":
+            assert item["stage"] == "candidates"
+            assert item["years"] == [2024]
+            break
+
+
+def test_list_candidates_returns_sorted_list(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_candidates deve restituire lista ordinata per slug."""
+    from toolkit.mcp import discovery as _discmod
+    monkeypatch.setattr(_discmod, "WORKSPACE_ROOT", tmp_path)
+
+    for name in ("b-dataset", "a-dataset", "c-dataset"):
+        cand_dir = tmp_path / "dataset-incubator" / "candidates" / name
+        cand_dir.mkdir(parents=True, exist_ok=True)
+        (cand_dir / "dataset.yml").write_text(
+            f"dataset:\n  name: {name}\n  years: [2024]\n",
+            encoding="utf-8",
+        )
+
+    from toolkit.mcp.discovery import list_candidates
+
+    result = list_candidates(stage="candidates")
+    slugs = [c["slug"] for c in result]
+
+    assert slugs == sorted(slugs)
+    assert "a-dataset" in slugs
+    assert "b-dataset" in slugs
+    assert "c-dataset" in slugs
+
+
+def test_safe_path_absolute_not_found_raises_clean_error(tmp_path: Path) -> None:
+    """_safe_path con path assoluto inesistente deve alzare ToolkitClientError,
+    non RecursionError (regressione recursion loop)."""
+    from toolkit.mcp.path_safety import _safe_path
+    from toolkit.mcp.errors import ToolkitClientError
+
+    nonexistent = tmp_path / "nonexistent" / "dataset.yml"
+
+    with pytest.raises(ToolkitClientError, match="Config non trovata"):
+        _safe_path(str(nonexistent))
+
+
+def test_safe_path_slug_not_found_raises_clean_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """_safe_path con slug inesistente deve alzare ToolkitClientError,
+    non RecursionError (regressione recursion loop)."""
+    from toolkit.mcp import path_safety as _ps_mod
+    from toolkit.mcp.path_safety import _safe_path
+    from toolkit.mcp.errors import ToolkitClientError
+
+    monkeypatch.setattr(_ps_mod, "WORKSPACE_ROOT", tmp_path)
+
+    with pytest.raises(ToolkitClientError, match="Config non trovata"):
+        _safe_path("totally-nonexistent-slug")
+
+
+def test_list_candidates_status_filter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_candidates(status_filter='SUCCESS') deve filtrare per last_run_status."""
+    from toolkit.mcp import discovery as _discmod
+    monkeypatch.setattr(_discmod, "WORKSPACE_ROOT", tmp_path)
+
+    # Crea due candidate: uno senza run (status=None), l'altro mocka run SUCCESS
+    for name in ("candidate-a", "candidate-b"):
+        cand_dir = tmp_path / "dataset-incubator" / "candidates" / name
+        cand_dir.mkdir(parents=True, exist_ok=True)
+        (cand_dir / "dataset.yml").write_text(
+            f"dataset:\n  name: {name}\n  years: [2024]\n",
+            encoding="utf-8",
+        )
+
+    # Crea run record per candidate-b: status=SUCCESS
+    runs_dir = tmp_path / "out" / "data" / "_runs" / "candidate-b" / "2024"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    import json
+    (runs_dir / "run_success.json").write_text(
+        json.dumps({
+            "dataset": "candidate-b",
+            "year": 2024,
+            "run_id": "run_001",
+            "status": "SUCCESS",
+            "started_at": "2026-01-01T12:00:00+00:00",
+            "finished_at": "2026-01-01T12:01:00+00:00",
+            "layers": {"raw": {"status": "SUCCESS"}},
+        }),
+        encoding="utf-8",
+    )
+
+    from toolkit.mcp.discovery import list_candidates
+
+    # Senza filtro -> tutti e due
+    all_results = list_candidates(stage="candidates")
+    assert len(all_results) == 2
+
+    # Filtro SUCCESS -> solo candidate-b
+    success_results = list_candidates(stage="candidates", status_filter="SUCCESS")
+    assert len(success_results) == 1
+    assert success_results[0]["slug"] == "candidate-b"
+
+    # Filtro FAILED -> nessuno
+    failed_results = list_candidates(stage="candidates", status_filter="FAILED")
+    assert len(failed_results) == 0
+
+
+def test_list_candidates_status_filter_invalid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_candidates con status_filter non valido deve alzare errore."""
+    from toolkit.mcp import discovery as _discmod
+    from toolkit.mcp.errors import ToolkitClientError
+    monkeypatch.setattr(_discmod, "WORKSPACE_ROOT", tmp_path)
+
+    from toolkit.mcp.discovery import list_candidates
+
+    with pytest.raises(ToolkitClientError, match="status_filter"):
+        list_candidates(stage="candidates", status_filter="INVALID")

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -478,6 +478,28 @@ def test_clean_preview_mart_with_index(tmp_path: Path, monkeypatch: pytest.Monke
     assert result["column_count"] >= 1
 
 
+def test_clean_preview_mart_index_negative(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """clean_preview con mart_index < 0 deve alzare errore."""
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
+    config_path = dst / "dataset.yml"
+
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    # Crea output mart (due table)
+    mart_dir = dst / "_smoke_out" / "data" / "mart" / "project_example" / "2022"
+    mart_dir.mkdir(parents=True, exist_ok=True)
+    _write_real_parquet(mart_dir / "rd_by_regione.parquet")
+    _write_real_parquet(mart_dir / "rd_by_provincia.parquet")
+
+    from toolkit.mcp.errors import ToolkitClientError
+    from toolkit.mcp.toolkit_client import clean_preview
+
+    with pytest.raises(ToolkitClientError, match="Indice mart"):
+        clean_preview(str(config_path), layer="mart", mart_index=-1, year=2022, limit=5)
+
+
 def test_raw_preview_with_real_csv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """raw_preview deve leggere un CSV reale dal raw dir."""
     src = Path("project-example")
@@ -659,3 +681,15 @@ def test_list_candidates_status_filter_invalid(tmp_path: Path, monkeypatch: pyte
 
     with pytest.raises(ToolkitClientError, match="status_filter"):
         list_candidates(stage="candidates", status_filter="INVALID")
+
+
+def test_list_candidates_stage_invalid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_candidates con stage non valido deve alzare errore."""
+    from toolkit.mcp import discovery as _discmod
+    from toolkit.mcp.errors import ToolkitClientError
+    monkeypatch.setattr(_discmod, "WORKSPACE_ROOT", tmp_path)
+
+    from toolkit.mcp.discovery import list_candidates
+
+    with pytest.raises(ToolkitClientError, match="stage deve essere"):
+        list_candidates(stage="bogus")

--- a/toolkit/mcp/_schema_utils.py
+++ b/toolkit/mcp/_schema_utils.py
@@ -59,6 +59,56 @@ def _read_parquet_row_count(parquet_path: Path) -> int | None:
         return None
 
 
+def _read_parquet_preview(parquet_path: Path, limit: int = 10) -> dict[str, Any]:
+    """Return schema + row preview of a parquet file via DuckDB.
+
+    Returns:
+        dict with keys: path, column_count, columns (list of {name, type}),
+        row_count, preview (list of dicts), truncated (bool).
+
+    Raises:
+        ToolkitClientError: if the file doesn't exist or can't be read.
+    """
+    if not parquet_path.exists():
+        raise ToolkitClientError(f"Parquet non trovato: {parquet_path}", code=ErrorCode.PARQUET_NOT_FOUND)
+
+    rel = f"read_parquet('{_sql_literal(str(parquet_path))}')"
+    try:
+        with duckdb.connect(database=":memory:") as conn:
+            conn.execute("PRAGMA disable_progress_bar")
+
+            # schema
+            describe = conn.execute(f"DESCRIBE SELECT * FROM {rel}").fetchall()
+            columns = [{"name": row[0], "type": row[1]} for row in describe]
+
+            # row count
+            count_row = conn.execute(f"SELECT COUNT(*) FROM {rel}").fetchone()
+            row_count = int(count_row[0]) if count_row else None
+
+            # preview
+            preview_rows = conn.execute(
+                f"SELECT * FROM {rel} LIMIT {int(limit)}"
+            ).fetchall()
+            col_names = [c["name"] for c in columns]
+            preview = [dict(zip(col_names, row)) for row in preview_rows]
+
+            truncated = bool(row_count and row_count > limit)
+
+            return {
+                "path": str(parquet_path),
+                "column_count": len(columns),
+                "columns": columns,
+                "row_count": row_count,
+                "preview": preview,
+                "truncated": truncated,
+            }
+    except Exception as exc:
+        raise ToolkitClientError(
+            f"Lettura parquet fallita per {parquet_path}: {exc}",
+            code=ErrorCode.DUCKDB_ERROR,
+        ) from exc
+
+
 def _exists(path: str | None) -> bool:
     """Return True if path is a real file/directory."""
     if not path:

--- a/toolkit/mcp/cli_adapter.py
+++ b/toolkit/mcp/cli_adapter.py
@@ -6,7 +6,7 @@ Provides:
 
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 from toolkit.cli.inspect._helpers import _payload_for_year
 from toolkit.mcp.contracts import InspectPathsResult
@@ -20,23 +20,29 @@ from toolkit.core.config import load_config
 def inspect_paths(config_path: str, year: int | None = None) -> InspectPathsResult:
     """Risolve i path per un dataset/year.
 
-    Richiede ``year`` per dataset multi-year. Se ``year`` è ``None`` e il dataset
-    ha piú anni, alza ``ToolkitClientError`` con messaggio chiaro.
+    Se ``year`` è ``None`` e il dataset ha piú anni, usa l'anno più recente
+    e lo segnala nel campo ``_year_resolution`` del risultato.
     """
     config = _safe_path(config_path)
     cfg = load_config(str(config), strict_config=False)
 
+    years = list(cfg.years or [])
+    _year_resolution: dict[str, Any] | None = None
+
     if year is None:
-        years = list(cfg.years or [])
         if len(years) > 1:
-            raise ToolkitClientError(
-                "year è obbligatorio per dataset multi-year. "
-                f"Trovati {len(years)} anni: {years}. Usa --year per specificarne uno.",
-                code=ErrorCode.INVALID_PARAMS,
-            )
-        year = years[0] if years else None
+            year = max(years)
+            _year_resolution = {
+                "note": f"Anno non specificato per dataset multi-year. Usato {year} come default.",
+                "years_available": years,
+            }
+        elif years:
+            year = years[0]
 
     if year is None:
         raise ToolkitClientError("Nessun anno configurato nel dataset", code=ErrorCode.CONFIG_NOT_FOUND)
 
-    return cast(InspectPathsResult, _payload_for_year(cfg, year))
+    result = cast(InspectPathsResult, _payload_for_year(cfg, year))
+    if _year_resolution:
+        result["_year_resolution"] = _year_resolution  # type: ignore[typeddict-unknown-key]
+    return result

--- a/toolkit/mcp/discovery.py
+++ b/toolkit/mcp/discovery.py
@@ -1,0 +1,176 @@
+"""Discovery: elenca e interroga i dataset disponibili nel workspace.
+
+Fornisce funzioni read-only per:
+- list_candidates: scandisce dataset-incubator/candidates e support_datasets
+- _read_minimal_config: lettura YAML leggera (senza validazione piena)
+
+Dipende da ``WORKSPACE_ROOT`` in path_safety per risolvere il percorso
+del workspace DataCivicLab.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+from toolkit.mcp.errors import ToolkitClientError
+from toolkit.mcp.path_safety import WORKSPACE_ROOT
+from lab_connectors.mcp.errors import ErrorCode
+
+
+def _read_minimal_config(dataset_yml: Path) -> dict[str, Any]:
+    """Legge solo i campi essenziali da dataset.yml senza validazione piena.
+
+    Restituisce un dict con: name, years (e raw data per reference).
+    """
+    try:
+        data = yaml.safe_load(dataset_yml.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return {"_error": f"YAML non valido: {exc}"}
+
+    if not isinstance(data, dict):
+        return {"_error": "dataset.yml non è una mappa YAML"}
+
+    ds = data.get("dataset", {}) or {}
+    if not isinstance(ds, dict):
+        return {"_error": "dataset non è un mapping"}
+
+    name = ds.get("name", dataset_yml.parent.name)
+    years = ds.get("years", [])
+    if isinstance(years, int):
+        years = [years]
+
+    return {
+        "name": str(name) if name else None,
+        "years": [int(y) for y in years] if isinstance(years, list) else [],
+    }
+
+
+def _find_latest_run_status(slug: str) -> str | None:
+    """Cerca l'ultimo run record per un dataset slug e restituisce lo status.
+
+    Scansiona ``{WORKSPACE}/out/data/_runs/{slug}/``.
+    """
+    runs_base = WORKSPACE_ROOT / "out" / "data" / "_runs" / slug
+    if not runs_base.exists():
+        return None
+
+    # Cerca l'ultimo run tra tutti gli anni
+    latest: dict[str, Any] | None = None
+    latest_mtime: float = 0.0
+
+    for year_dir in sorted(runs_base.iterdir()):
+        if not year_dir.is_dir() or not year_dir.name.isdigit():
+            continue
+        for run_file in year_dir.glob("*.json"):
+            try:
+                mtime = run_file.stat().st_mtime
+                if mtime > latest_mtime:
+                    data = json.loads(run_file.read_text(encoding="utf-8"))
+                    if isinstance(data, dict):
+                        latest = data
+                        latest_mtime = mtime
+            except Exception:
+                continue
+
+    if latest:
+        return latest.get("status")
+    return None
+
+
+def list_candidates(
+    stage: Literal["candidates", "support", "all"] = "all",
+    status_filter: str | None = None,
+) -> list[dict[str, Any]]:
+    """Elenca tutti i dataset disponibili nel workspace.
+
+    Args:
+        stage: "candidates" → solo ``candidates/``,
+               "support" → solo ``support_datasets/``,
+               "all" → entrambi (default).
+        status_filter: filtra per ``last_run_status``.
+                       Valori: ``"SUCCESS"``, ``"FAILED"``, ``"DRY_RUN"``,
+                       ``"RUNNING"``, o ``None`` (nessun filtro, default).
+
+    Returns:
+        Lista ordinata per slug, ogni elemento con:
+        - slug: nome directory del dataset
+        - dataset_name: nome dal dataset.yml (o slug se assente)
+        - stage: "candidates" | "support"
+        - years: lista anni configurati
+        - last_run_status: SUCCESS / FAILED / DRY_RUN / None
+        - has_clean: bool (presenza directory out/data/clean/{slug}/)
+        - has_mart: bool (presenza directory out/data/mart/{slug}/)
+    """
+    incubator = WORKSPACE_ROOT / "dataset-incubator"
+
+    dirs_to_scan: list[tuple[str, Path]] = []
+    if stage in ("candidates", "all"):
+        candidates_dir = incubator / "candidates"
+        if candidates_dir.exists():
+            dirs_to_scan.append(("candidates", candidates_dir))
+    if stage in ("support", "all"):
+        support_dir = incubator / "support_datasets"
+        if support_dir.exists():
+            dirs_to_scan.append(("support", support_dir))
+
+    results: list[dict[str, Any]] = []
+
+    for stage_name, scan_dir in dirs_to_scan:
+        # Cerca dataset.yml ricorsivamente (supporta candidates con sub-candidates)
+        for dataset_yml in sorted(scan_dir.rglob("dataset.yml")):
+            # Salta il template
+            if "templates" in dataset_yml.parts:
+                continue
+
+            # Usa la directory padre come slug, ma costruisci un
+            # parent_slug se il dataset.yml è in una subdirectory
+            parent_dir = dataset_yml.parent
+            rel_path = parent_dir.relative_to(scan_dir)
+            slug = str(rel_path.as_posix())
+            # Per path semplici (1 livello) usa solo il nome dir
+            if rel_path.parent == Path("."):
+                slug = parent_dir.name
+            else:
+                # Sub-candidate: mantieni path relativo come slug composito
+                slug = str(rel_path.as_posix())
+
+            minimal = _read_minimal_config(dataset_yml)
+            name = minimal.get("name") or slug
+            years = minimal.get("years", [])
+
+            # Presenza layer: per sub-candidates, il dataset name è
+            # quello dal dataset.yml (potrebbe differire dallo slug)
+            dataset_name_for_path = name if name != slug else parent_dir.name
+            out_root = WORKSPACE_ROOT / "out" / "data"
+            clean_dir = out_root / "clean" / dataset_name_for_path
+            mart_dir = out_root / "mart" / dataset_name_for_path
+            has_clean = clean_dir.exists() and any(clean_dir.iterdir())
+            has_mart = mart_dir.exists() and any(mart_dir.iterdir())
+
+            last_run_status = _find_latest_run_status(dataset_name_for_path)
+
+            results.append({
+                "slug": slug,
+                "dataset_name": name,
+                "stage": stage_name,
+                "years": years,
+                "last_run_status": last_run_status,
+                "has_clean": has_clean,
+                "has_mart": has_mart,
+                "config_path": str(dataset_yml),
+            })
+
+    if status_filter is not None:
+        valid_statuses = {"SUCCESS", "FAILED", "DRY_RUN", "RUNNING"}
+        if status_filter not in valid_statuses:
+            raise ToolkitClientError(
+                f"status_filter deve essere uno tra: {', '.join(sorted(valid_statuses))} (o None)",
+                code=ErrorCode.INVALID_PARAMS,
+            )
+        results = [r for r in results if r["last_run_status"] == status_filter]
+
+    return results

--- a/toolkit/mcp/discovery.py
+++ b/toolkit/mcp/discovery.py
@@ -105,6 +105,13 @@ def list_candidates(
         - has_clean: bool (presenza directory out/data/clean/{slug}/)
         - has_mart: bool (presenza directory out/data/mart/{slug}/)
     """
+    valid_stages = {"candidates", "support", "all"}
+    if stage not in valid_stages:
+        raise ToolkitClientError(
+            f"stage deve essere uno tra: {', '.join(sorted(valid_stages))} (ricevuto: {stage!r})",
+            code=ErrorCode.INVALID_PARAMS,
+        )
+
     incubator = WORKSPACE_ROOT / "dataset-incubator"
 
     dirs_to_scan: list[tuple[str, Path]] = []

--- a/toolkit/mcp/errors.py
+++ b/toolkit/mcp/errors.py
@@ -2,7 +2,7 @@
 
 ToolkitClientError è un ponte verso lab_connectors.mcp.
 Tutte le eccezioni interne diventano McpError con codice UNEXPECTED
-e vengono gestite da `guard()` in server.py.
+e vengono gestite da ``guard_timed()`` in server.py.
 """
 
 from __future__ import annotations

--- a/toolkit/mcp/path_safety.py
+++ b/toolkit/mcp/path_safety.py
@@ -30,8 +30,83 @@ def _safe_path(config_path: str | Path) -> Path:
     if not path.is_absolute():
         path = (WORKSPACE_ROOT / path).resolve()
     if not path.exists():
-        raise ToolkitClientError(f"Config non trovata: {path}", code=ErrorCode.CONFIG_NOT_FOUND)
+        # Fallback: tenta risoluzione come slug
+        resolved = _resolve_dataset(str(config_path))
+        if resolved is not None:
+            return resolved
+        raise ToolkitClientError(
+            f"Config non trovata: {path}. "
+            f"Se è uno slug, verifica che sia presente in candidates/ o support_datasets/.",
+            code=ErrorCode.CONFIG_NOT_FOUND,
+        )
     return path
+
+
+_RESOLVED_SLUG_CACHE: dict[str, Path] = {}
+# Nota: cache globale senza invalidazione. In un server MCP long-running,
+# l'aggiunta/rimozione di candidate non invalida la cache. Impatto basso
+# perché il server ricarica i moduli solo al restart. Se in futuro il server
+# diventa persistente, aggiungere un meccanismo di invalidazione (timestamp,
+# TTL, o watch del filesystem).
+
+
+def _resolve_dataset(slug_or_path: str | Path) -> Path | None:
+    """Risolve uno slug o path di dataset in un path assoluto a dataset.yml.
+
+    MAI chiama ``_safe_path`` (nessun loop). Se non trova, restituisce ``None``.
+
+    1. Se il valore è un file esistente → restituisce quello.
+    2. Se è uno slug (es. ``terna-electricity-by-source``) → cerca in:
+       - ``{WORKSPACE}/dataset-incubator/candidates/{slug}/dataset.yml``
+       - ``{WORKSPACE}/dataset-incubator/support_datasets/{slug}/dataset.yml``
+    3. Path annidato (es. ``ispra-ru-costi-kg/sources/a_ru_base``).
+    4. Fallback glob ricorsivo (cache).
+
+    Returns:
+        Path assoluto al file dataset.yml, o ``None`` se non trovato.
+    """
+    candidate = Path(slug_or_path).expanduser()
+
+    # Strategy 1: file esistente → usalo direttamente
+    if candidate.exists() and candidate.suffix in (".yml", ".yaml"):
+        return candidate.resolve()
+
+    key = str(slug_or_path)
+    if key in _RESOLVED_SLUG_CACHE:
+        return _RESOLVED_SLUG_CACHE[key]
+
+    # Strategy 2: slug in candidates/ o support_datasets/
+    for subdir in ("candidates", "support_datasets"):
+        probe = WORKSPACE_ROOT / "dataset-incubator" / subdir / str(slug_or_path) / "dataset.yml"
+        if probe.exists():
+            resolved = probe.resolve()
+            _RESOLVED_SLUG_CACHE[key] = resolved
+            return resolved
+
+    # Strategy 3: path annidato dentro dataset-incubator
+    for subdir in ("candidates", "support_datasets"):
+        probe = WORKSPACE_ROOT / "dataset-incubator" / subdir / str(slug_or_path)
+        if probe.exists() and probe.suffix in (".yml", ".yaml"):
+            _RESOLVED_SLUG_CACHE[key] = probe.resolve()
+            return _RESOLVED_SLUG_CACHE[key]
+        probe_yml = probe / "dataset.yml" if probe.suffix != ".yml" else probe
+        if probe_yml.exists():
+            _RESOLVED_SLUG_CACHE[key] = probe_yml.resolve()
+            return _RESOLVED_SLUG_CACHE[key]
+
+    # Strategy 4: fallback glob ricorsivo
+    incubator = WORKSPACE_ROOT / "dataset-incubator"
+    if incubator.exists():
+        matches = list(incubator.rglob(f"**/{slug_or_path}/dataset.yml"))
+        if not matches:
+            matches = list(incubator.rglob(f"**/{slug_or_path}.yml"))
+        if matches:
+            resolved = matches[0].resolve()
+            _RESOLVED_SLUG_CACHE[key] = resolved
+            return resolved
+
+    # Non trovato
+    return None
 
 
 def _load_cfg(config_path: str | Path) -> tuple[Path, Any]:

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -690,10 +690,11 @@ def clean_preview(
         outputs = paths["paths"]["mart"].get("outputs") or []
         if not outputs:
             raise ToolkitClientError("Nessun output mart risolto", code=ErrorCode.PARQUET_NOT_FOUND)
-        if mart_index >= len(outputs):
+        if mart_index < 0 or mart_index >= len(outputs):
+            code = ErrorCode.INVALID_PARAMS
             raise ToolkitClientError(
-                f"Indice mart {mart_index} fuori range: {len(outputs)} output disponibili",
-                code=ErrorCode.INVALID_PARAMS,
+                f"Indice mart {mart_index} non valido: {len(outputs)} output disponibili (indice 0-{len(outputs)-1})",
+                code=code,
             )
         parquet_path = Path(outputs[mart_index])
     else:

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -504,6 +504,7 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
             "latest_run_record": latest_run_record,
         },
         "warnings": warnings,
+        "multi_year_hint": paths.get("_year_resolution"),
     }
 
 
@@ -654,6 +655,204 @@ def schema_diff(config_path: str) -> dict[str, Any]:
         "years": [entry["year"] for entry in entries],
         "entries": entries,
         "comparisons": comparisons,
+    }
+
+
+def clean_preview(
+    config_path: str,
+    layer: str = "clean",
+    mart_index: int = 0,
+    year: int | None = None,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Preview dati da un parquet clean o mart.
+
+    Args:
+        config_path: path a dataset.yml o slug del dataset.
+        layer: ``"clean"`` (default) o ``"mart"``.
+        mart_index: indice dell'output mart (default 0), usato solo se layer=mart.
+        year: anno del dataset. Per dataset multi-year, se omesso usa l'ultimo anno.
+        limit: numero massimo di righe in preview (default 10).
+
+    Returns:
+        Schema + preview rows del parquet. Stessa struttura di
+        ``_read_parquet_preview`` con campi aggiuntivi: dataset, year, layer.
+    """
+    config = _safe_path(config_path)
+    paths = _inspect_paths(str(config), year)
+
+    if layer == "clean":
+        parquet_path_str = paths["paths"]["clean"].get("output")
+        if not parquet_path_str:
+            raise ToolkitClientError("Nessun output clean risolto", code=ErrorCode.PARQUET_NOT_FOUND)
+        parquet_path = Path(parquet_path_str)
+    elif layer == "mart":
+        outputs = paths["paths"]["mart"].get("outputs") or []
+        if not outputs:
+            raise ToolkitClientError("Nessun output mart risolto", code=ErrorCode.PARQUET_NOT_FOUND)
+        if mart_index >= len(outputs):
+            raise ToolkitClientError(
+                f"Indice mart {mart_index} fuori range: {len(outputs)} output disponibili",
+                code=ErrorCode.INVALID_PARAMS,
+            )
+        parquet_path = Path(outputs[mart_index])
+    else:
+        raise ToolkitClientError("layer deve essere 'clean' o 'mart'", code=ErrorCode.INVALID_PARAMS)
+
+    # Verifica esistenza output
+    if not parquet_path.exists():
+        raise ToolkitClientError(
+            f"Output {layer} non trovato: {parquet_path}",
+            code=ErrorCode.PARQUET_NOT_FOUND,
+        )
+
+    # Verifica che sia un parquet
+    if parquet_path.suffix not in (".parquet",):
+        raise ToolkitClientError(
+            f"Formato non supportato per preview: {parquet_path.suffix}. "
+            "clean_preview supporta solo file .parquet.",
+            code=ErrorCode.INVALID_PARAMS,
+        )
+
+    from toolkit.mcp._schema_utils import _read_parquet_preview
+
+    result = _read_parquet_preview(parquet_path, limit=limit)
+    result.update({
+        "dataset": paths.get("dataset"),
+        "year": paths.get("year"),
+        "layer": layer,
+        "config_path": str(config_path),
+        "mart_name": parquet_path.stem if layer == "mart" else None,
+    })
+    return result
+
+
+def raw_preview(
+    config_path: str,
+    year: int | None = None,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Preview del raw file primario di un dataset.
+
+    Wrapper che risolve il raw file dal config_path e chiama ``csv_preview``
+    se il file è un CSV. Per file binari (XLSX) restituisce un messaggio informativo.
+
+    Args:
+        config_path: path a dataset.yml o slug del dataset.
+        year: anno del dataset. Per multi-year, se omesso usa l'ultimo anno.
+        limit: righe massime in preview (default 20).
+
+    Returns:
+        Dict con path, formato, e preview (se CSV) o messaggio (se binario).
+    """
+    from toolkit.mcp._schema_utils import _exists
+
+    config = _safe_path(config_path)
+    paths = _inspect_paths(str(config), year)
+    raw_dir = Path(paths["paths"]["raw"]["dir"])
+    primary_file = (paths.get("raw_hints") or {}).get("primary_output_file")
+    if not primary_file:
+        raise ToolkitClientError(
+            "Nessun primary_output_file nel manifest raw",
+            code=ErrorCode.ARTIFACT_NOT_FOUND,
+        )
+    raw_file = raw_dir / primary_file
+    if not _exists(str(raw_file)):
+        raise ToolkitClientError(
+            f"Raw file non trovato: {raw_file}",
+            code=ErrorCode.ARTIFACT_NOT_FOUND,
+        )
+
+    suffix = raw_file.suffix.lower()
+    if suffix in (".csv", ".tsv", ".txt"):
+        return csv_preview(str(raw_file), limit=limit)
+    elif suffix in (".xlsx", ".xls"):
+        return {
+            "path": str(raw_file),
+            "format": "xlsx",
+            "note": "File binario XLSX. Usa toolkit_show_schema(layer='raw') per lo schema delle colonne.",
+            "dataset": paths.get("dataset"),
+            "year": paths.get("year"),
+        }
+    else:
+        return {
+            "path": str(raw_file),
+            "format": suffix.lstrip("."),
+            "note": f"Formato '{suffix}' non supportato per preview raw. "
+                    "Usa toolkit_show_schema(layer='raw') per lo schema.",
+            "dataset": paths.get("dataset"),
+            "year": paths.get("year"),
+        }
+
+
+def dataset_info(config_path: str) -> dict[str, Any]:
+    """Restituisce informazioni di base da un dataset.yml.
+
+    Legge la configurazione del dataset e ne estrae i campi significativi
+    senza eseguire la pipeline.
+
+    Args:
+        config_path: path a dataset.yml o slug del dataset.
+
+    Returns:
+        Dict con: dataset, years, time_coverage, source_urls (da raw.sources),
+        has_clean, has_mart, mart_tables, support_datasets, raw_sources_count.
+    """
+    config, cfg = _load_cfg(config_path)
+
+    # Estrai URL fonti da raw.sources
+    source_urls: list[str] = []
+    raw_dict = cfg.raw.get("sources") if hasattr(cfg, "raw") else []
+    if isinstance(raw_dict, list):
+        for src in raw_dict:
+            if isinstance(src, dict):
+                args = src.get("args") or {}
+                url = args.get("url") or args.get("data_url") or args.get("endpoint")
+                if url:
+                    source_urls.append(str(url))
+
+    # Mart tables names
+    mart_tables: list[str] = []
+    if hasattr(cfg, "mart"):
+        mart_dict = cfg.mart.get("tables") if hasattr(cfg.mart, "get") else []
+        if isinstance(mart_dict, list):
+            for t in mart_dict:
+                if isinstance(t, dict):
+                    name = t.get("name")
+                    if name:
+                        mart_tables.append(str(name))
+
+    # Support datasets
+    support_list: list[dict[str, str]] = []
+    if hasattr(cfg, "support"):
+        raw_support = cfg.support if isinstance(cfg.support, list) else []
+        for sd in raw_support:
+            if hasattr(sd, "get"):
+                sname = sd.get("name")
+                if sname:
+                    support_list.append({"name": str(sname), "config": str(sd.get("config", ""))})
+
+    # Presenza layer su disco
+    out_root = cfg.root / "data" if hasattr(cfg, "root") else None
+    slug = cfg.dataset if hasattr(cfg, "dataset") else None
+    has_clean = bool(out_root and (out_root / "clean" / slug).exists()) if slug else False
+    has_mart = bool(out_root and (out_root / "mart" / slug).exists()) if slug else False
+
+    time_cov = None
+    if hasattr(cfg, "time_coverage") and cfg.time_coverage:
+        time_cov = {"start_year": cfg.time_coverage.start_year, "end_year": cfg.time_coverage.end_year}
+
+    return {
+        "dataset": cfg.dataset if hasattr(cfg, "dataset") else None,
+        "config_path": str(config),
+        "years": list(cfg.years) if hasattr(cfg, "years") else [],
+        "time_coverage": time_cov,
+        "source_urls": source_urls,
+        "raw_sources_count": len(raw_dict) if isinstance(raw_dict, list) else 0,
+        "has_clean": has_clean,
+        "has_mart": has_mart,
+        "mart_tables": mart_tables,
+        "support_datasets": support_list,
     }
 
 

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -1,6 +1,12 @@
 """Toolkit MCP server.
 
-Espone 9 tool read-only per ispezione della pipeline toolkit.
+Espone 13 tool read-only per ispezione della pipeline toolkit:
+- ispezione standard: inspect_paths, show_schema, raw_profile, summary
+- diagnostica: review_readiness, schema_diff, run_summary
+- run history: list_runs
+- discovery: list_candidates, dataset_info
+- preview: csv_preview, clean_preview, raw_preview
+
 Usa ``lab_connectors.mcp`` per init standardizzato, error handling e logging.
 """
 
@@ -8,12 +14,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from lab_connectors.mcp import create_mcp_server, guard
+from lab_connectors.mcp import create_mcp_server, guard_timed
 
 from .toolkit_client import (
+    clean_preview as clean_preview_impl,
     csv_preview as csv_preview_impl,
+    dataset_info as dataset_info_impl,
     inspect_paths as inspect_paths_impl,
+    list_candidates as list_candidates_impl,
     list_runs as list_runs_impl,
+    raw_preview as raw_preview_impl,
     raw_profile as raw_profile_impl,
     review_readiness as review_readiness_impl,
     run_summary as run_summary_impl,
@@ -26,7 +36,9 @@ mcp = create_mcp_server(
     name="toolkit",
     instructions=(
         "Server MCP locale, read-only, per ispezionare path risolti, "
-        "schemi e stato run del toolkit."
+        "schemi, stato run e preview dati del toolkit. "
+        "Supporta slug dataset (es. 'terna-electricity-by-source') "
+        "al posto del path assoluto a dataset.yml."
     ),
 )
 
@@ -35,12 +47,12 @@ mcp = create_mcp_server(
     description="Mostra il path contract risolto per un dataset config.", structured_output=True
 )
 def toolkit_inspect_paths(config_path: str, year: int = 0) -> dict[str, Any]:
-    return guard(inspect_paths_impl, config_path, year or None)
+    return guard_timed(inspect_paths_impl, "toolkit_inspect_paths", config_path, year or None, logger_name="toolkit")
 
 
 @mcp.tool(description="Mostra lo schema di raw, clean o mart.", structured_output=True)
 def toolkit_show_schema(config_path: str, layer: str = "clean", year: int = 0) -> dict[str, Any]:
-    return guard(show_schema_impl, config_path, layer, year or None)
+    return guard_timed(show_schema_impl, "toolkit_show_schema", config_path, layer, year or None, logger_name="toolkit")
 
 
 @mcp.tool(
@@ -48,7 +60,7 @@ def toolkit_show_schema(config_path: str, layer: str = "clean", year: int = 0) -
     structured_output=True,
 )
 def toolkit_raw_profile(config_path: str, year: int = 0) -> dict[str, Any]:
-    return guard(raw_profile_impl, config_path, year or None)
+    return guard_timed(raw_profile_impl, "toolkit_raw_profile", config_path, year or None, logger_name="toolkit")
 
 
 @mcp.tool(
@@ -62,7 +74,7 @@ def toolkit_run_summary(
     since: str | None = None,
     until: str | None = None,
 ) -> dict[str, Any]:
-    return guard(run_summary_impl, config_path, year or None, since=since, until=until)
+    return guard_timed(run_summary_impl, "toolkit_run_summary", config_path, year or None, since=since, until=until, logger_name="toolkit")
 
 
 @mcp.tool(
@@ -70,7 +82,7 @@ def toolkit_run_summary(
     structured_output=True,
 )
 def toolkit_summary(config_path: str, year: int = 0) -> dict[str, Any]:
-    return guard(summary_impl, config_path, year or None)
+    return guard_timed(summary_impl, "toolkit_summary", config_path, year or None, logger_name="toolkit")
 
 
 @mcp.tool(
@@ -78,7 +90,52 @@ def toolkit_summary(config_path: str, year: int = 0) -> dict[str, Any]:
     structured_output=True,
 )
 def toolkit_review_readiness(config_path: str, year: int = 0) -> dict[str, Any]:
-    return guard(review_readiness_impl, config_path, year or None)
+    return guard_timed(review_readiness_impl, "toolkit_review_readiness", config_path, year or None, logger_name="toolkit")
+
+
+@mcp.tool(
+    description="Elenca tutti i dataset disponibili in dataset-incubator (candidates e support_datasets). Opzionalmente filtra per last_run_status.",
+    structured_output=True,
+)
+def toolkit_list_candidates(
+    stage: str = "all",
+    status_filter: str | None = None,
+) -> dict[str, Any]:
+    return guard_timed(list_candidates_impl, "toolkit_list_candidates", stage, status_filter, logger_name="toolkit")
+
+
+@mcp.tool(
+    description="Info di base da un dataset.yml: fonte, URL, anni, tabelle mart, support datasets.",
+    structured_output=True,
+)
+def toolkit_dataset_info(config_path: str) -> dict[str, Any]:
+    return guard_timed(dataset_info_impl, "toolkit_dataset_info", config_path, logger_name="toolkit")
+
+
+@mcp.tool(
+    description="Preview dei dati puliti (clean parquet) o mart. Mostra schema + prime N righe.",
+    structured_output=True,
+)
+def toolkit_clean_preview(
+    config_path: str,
+    layer: str = "clean",
+    mart_index: int = 0,
+    year: int = 0,
+    limit: int = 10,
+) -> dict[str, Any]:
+    return guard_timed(clean_preview_impl, "toolkit_clean_preview", config_path, layer, mart_index, year or None, limit, logger_name="toolkit")
+
+
+@mcp.tool(
+    description="Preview del raw file primario (CSV) di un dataset. Wrapper su csv_preview + inspect_paths.",
+    structured_output=True,
+)
+def toolkit_raw_preview(
+    config_path: str,
+    year: int = 0,
+    limit: int = 20,
+) -> dict[str, Any]:
+    return guard_timed(raw_preview_impl, "toolkit_raw_preview", config_path, year or None, limit, logger_name="toolkit")
 
 
 @mcp.tool(
@@ -86,7 +143,7 @@ def toolkit_review_readiness(config_path: str, year: int = 0) -> dict[str, Any]:
     structured_output=True,
 )
 def toolkit_schema_diff(config_path: str) -> dict[str, Any]:
-    return guard(schema_diff_impl, config_path)
+    return guard_timed(schema_diff_impl, "toolkit_schema_diff", config_path, logger_name="toolkit")
 
 
 @mcp.tool(
@@ -103,7 +160,7 @@ def toolkit_list_runs(
     limit: int | None = None,
     cross_year: bool = False,
 ) -> dict[str, Any]:
-    return guard(list_runs_impl, config_path, year or None, since=since, until=until, status=status, limit=limit, cross_year=cross_year)
+    return guard_timed(list_runs_impl, "toolkit_list_runs", config_path, year or None, since=since, until=until, status=status, limit=limit, cross_year=cross_year, logger_name="toolkit")
 
 
 @mcp.tool(
@@ -113,7 +170,7 @@ def toolkit_list_runs(
     structured_output=True,
 )
 def toolkit_csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
-    return guard(csv_preview_impl, csv_path, limit)
+    return guard_timed(csv_preview_impl, "toolkit_csv_preview", csv_path, limit, logger_name="toolkit")
 
 
 if __name__ == "__main__":

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -14,11 +14,15 @@ Use inspect_paths (with run_file_count, years_seen) or summary (with latest_run_
 from __future__ import annotations
 
 # ruff: noqa: F401
+from toolkit.mcp.discovery import list_candidates
 from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.cli_adapter import inspect_paths
 from toolkit.mcp.schema_ops import (
+    clean_preview,
     csv_preview,
+    dataset_info,
     list_runs,
+    raw_preview,
     raw_profile,
     review_readiness,
     run_state,


### PR DESCRIPTION
## Summary

Estensione del server MCP del toolkit con 4 nuovi tool, fix di slug resolution e multi-year, migrazione `guard()` -> `guard_timed()`.

## Nuovi tool MCP

| Tool | Descrizione |
|------|-------------|
| toolkit_list_candidates(stage, status_filter) | Elenca dataset con filtro per stage e ultimo run status |
| toolkit_dataset_info(config_path) | Info base da dataset.yml |
| toolkit_clean_preview(config_path, year, limit) | Preview dati clean da parquet |
| toolkit_raw_preview(config_path, year, limit) | Preview dati raw da CSV |

## Fix

- **Slug resolution**: _resolve_dataset() unificata + _safe_path() fallback slug - elimina recursion loop (RecursionError)
- **Multi-year**: inspect_paths() defaulta a max(year) invece di fallire su year=None
- **yaml.safe_load -> json.loads** per file .json in _find_latest_run_status() (review finding)

## Refactor

- guard() -> guard_timed(): log strutturato con duration_ms su ogni tool call
- csv_preview: thin wrapper MCP su profile_ops.csv_preview()
- discovery.py: modulo nuovo con list_candidates(), _read_minimal_config(), _find_latest_run_status()

## Test

- 37 test MCP (mock + integration)
- 651/651 full suite pass
- E2E test passato su server MCP reale (13 tool chiamati live)

## Review findings applicati

- Medium: yaml.safe_load -> json.loads per file JSON (discovery.py:71)
- Low: commento guardrail cache globale senza invalidazione (path_safety.py:45)