### PR TITLE
fix: _safe_path risolve directory in dataset.yml

### DIFF
--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -624,6 +624,61 @@ def test_safe_path_slug_not_found_raises_clean_error(tmp_path: Path, monkeypatch
         _safe_path("totally-nonexistent-slug")
 
 
+def test_safe_path_directory_resolves_to_dataset_yml(tmp_path: Path) -> None:
+    """_safe_path con path directory deve restituire directory/dataset.yml se esiste."""
+    from toolkit.mcp.path_safety import _safe_path
+
+    # Crea directory con dataset.yml dentro
+    d = tmp_path / "candidates" / "test-dataset"
+    d.mkdir(parents=True)
+    yml = d / "dataset.yml"
+    yml.write_text("dataset:\n  name: test\n")
+
+    result = _safe_path(str(d))
+    assert result == yml.resolve(), (
+        f"Dovrebbe restituire {yml.resolve()}, invece ha restituito {result}"
+    )
+    assert result.suffix in (".yml", ".yaml")
+
+
+def test_safe_path_directory_without_dataset_yml_raises_error(tmp_path: Path) -> None:
+    """_safe_path con directory senza dataset.yml deve alzare ToolkitClientError,
+    non restituire la directory."""
+    from toolkit.mcp.path_safety import _safe_path
+    from toolkit.mcp.errors import ToolkitClientError
+
+    empty_dir = tmp_path / "empty-dir"
+    empty_dir.mkdir()
+
+    with pytest.raises(ToolkitClientError, match="non contiene dataset"):
+        _safe_path(str(empty_dir))
+
+
+def test_safe_path_directory_without_dataset_yml_falls_back_to_slug(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """_safe_path con directory senza dataset.yml deve tentare risoluzione slug
+    prima di alzare errore."""
+    from toolkit.mcp import path_safety as _ps_mod
+    from toolkit.mcp.path_safety import _safe_path
+
+    # Crea slug risolvibile: dataset-incubator/candidates/{slug}/dataset.yml
+    slug = "test-slug-resolved"
+    candidate_dir = tmp_path / "dataset-incubator" / "candidates" / slug
+    candidate_dir.mkdir(parents=True)
+    yml = candidate_dir / "dataset.yml"
+    yml.write_text("dataset:\n  name: resolved\n")
+
+    monkeypatch.setattr(_ps_mod, "WORKSPACE_ROOT", tmp_path)
+
+    # Una directory senza dataset.yml con lo stesso nome dello slug
+    some_dir = tmp_path / "some-other-dir"
+    some_dir.mkdir()
+
+    # _safe_path("some-other-dir") non dovrebbe risolversi
+    # _safe_path(slug) dovrebbe risolversi via slug
+    result = _safe_path(slug)
+    assert result == yml.resolve()
+
+
 def test_list_candidates_status_filter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """list_candidates(status_filter='SUCCESS') deve filtrare per last_run_status."""
     from toolkit.mcp import discovery as _discmod

--- a/toolkit/mcp/path_safety.py
+++ b/toolkit/mcp/path_safety.py
@@ -29,6 +29,14 @@ def _safe_path(config_path: str | Path) -> Path:
     path = Path(config_path).expanduser()
     if not path.is_absolute():
         path = (WORKSPACE_ROOT / path).resolve()
+
+    # Se il path è una directory, prova dataset.yml al suo interno,
+    # in modo che i tool accettino anche path di directory (es. da list_candidates).
+    if path.is_dir():
+        probe = path / "dataset.yml"
+        if probe.exists():
+            return probe
+
     if not path.exists():
         # Fallback: tenta risoluzione come slug
         resolved = _resolve_dataset(str(config_path))

--- a/toolkit/mcp/path_safety.py
+++ b/toolkit/mcp/path_safety.py
@@ -32,10 +32,19 @@ def _safe_path(config_path: str | Path) -> Path:
 
     # Se il path è una directory, prova dataset.yml al suo interno,
     # in modo che i tool accettino anche path di directory (es. da list_candidates).
+    # Se manca dataset.yml, non restituire la directory: tenta risoluzione slug.
     if path.is_dir():
         probe = path / "dataset.yml"
         if probe.exists():
             return probe
+        resolved = _resolve_dataset(str(config_path))
+        if resolved is not None:
+            return resolved
+        raise ToolkitClientError(
+            f"Config non trovata: {path}. "
+            f"È una directory ma non contiene dataset.yml.",
+            code=ErrorCode.CONFIG_NOT_FOUND,
+        )
 
     if not path.exists():
         # Fallback: tenta risoluzione come slug


### PR DESCRIPTION
## Problema

I tool MCP (`dataset_info`, `inspect_paths`, `summary`, ecc.) fallivano quando si passava un path directory, esattamente come restituito da `list_candidates`. Es:

```
toolkit_dataset_info(config_path="dataset-incubator/candidates/terna-capacita-rinnovabile")
→ "Impossibile leggere YAML: [Errno 21] Is a directory: '.../terna-capacita-rinnovabile'"
```

## Causa

`_safe_path()` (in `path_safety.py`) verificava solo `path.exists()`, ma non controllava se il path era una directory. Quando lo era, il successivo `read_text()` su di essa produceva `IsADirectoryError`.

## Fix

In `_safe_path()`, dopo aver risolto il path assoluto, se il path è una directory, prova `path/dataset.yml`. Se esiste, lo restituisce. Altrimenti continua con il normale flusso (fallback slug, errore).

Aggiunte 8 righe, invariate le logiche esistenti.

## Verifica

- **653 test preesistenti**: OK
- **Verifica manuale**:

| Chiamata | Prima | Dopo |
|---|---|---|
| `_safe_path('.../aifa-spesa-consumo')` | IsADirectoryError | `.../dataset.yml` |
| `_safe_path('.../dataset.yml')` | OK | OK (invariato) |
| `_safe_path('terna-capacita-rinnovabile')` | OK (slug) | OK (slug, invariato) |
| `_safe_path('non-esiste')` | Config non trovata | Config non trovata (invariato) |

Files toccati: `toolkit/mcp/path_safety.py` (+8 righe)