### PR TITLE
fix(deps): lab-connectors @ v0.9.0 (path contract P1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "requests>=2.33.1",
   "typer>=0.12.0",
   "rich>=13.0",
-  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.8.0"
+  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.9.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Aggiorna dipendenza lab-connectors da `@v0.8.0` a `@v0.9.0`.

v0.9.0 include il modulo `lab_connectors.gcs.paths` con il path contract GCS centralizzato. Toolkit non usa direttamente il modulo, ma consumer downstream (source-observatory) hanno bisogno di v0.9.0 e pip rifiuta due versioni dello stesso package.

Trivial: unica linea cambiata in pyproject.toml.