### PR TITLE
Opzione D: refactor URL probe/scaffold — -206 righe, confini chiari

### DIFF
--- a/tests/test_cli_scout_url.py
+++ b/tests/test_cli_scout_url.py
@@ -307,21 +307,25 @@ class TestGenerateYamlScaffold:
         assert 'years: [2024]' in yaml
         assert "root:" in yaml
 
-    def test_http_file_scaffold_with_datastore_url(self) -> None:
+    def test_scaffold_fallback_datastore_url_is_http_file(self) -> None:
+        """Senza metadata CKAN, anche URL datastore produce http_file."""
         probe_result = {
             "final_url": "https://portal.com/api/3/datastore/dump/uuid.csv",
             "requested_url": "https://portal.com/api/3/datastore/dump/uuid.csv",
         }
         yaml = generate_yaml_scaffold(probe_result)
-        assert 'type: "ckan"' in yaml
+        assert 'type: "http_file"' in yaml
+        assert 'type: "ckan"' not in yaml
 
-    def test_http_file_scaffold_with_sdmx_url(self) -> None:
+    def test_scaffold_fallback_sdmx_url_is_http_file(self) -> None:
+        """Senza metadata SDMX, anche URL /dataflow/ produce http_file."""
         probe_result = {
             "final_url": "https://example.com/data/flow/sdmx",
             "requested_url": "https://example.com/data/flow/sdmx",
         }
         yaml = generate_yaml_scaffold(probe_result)
-        assert 'type: "sdmx"' in yaml
+        assert 'type: "http_file"' in yaml
+        assert 'type: "sdmx"' not in yaml
 
     def test_ckan_resources_scaffold(self) -> None:
         probe_result = {

--- a/tests/test_cli_scout_url.py
+++ b/tests/test_cli_scout_url.py
@@ -7,12 +7,12 @@ from typer.testing import CliRunner
 from lab_connectors.http import HttpClient, HttpResult
 
 from toolkit.cli.app import app
-from toolkit.cli.cmd_url_inspect import (
+from toolkit.cli._url_probe import (
     _detect_ckan,
     _extract_ckan_dataset_id,
-    _generate_yaml_scaffold,
     probe_url,
 )
+from toolkit.cli._url_scout_common import generate_yaml_scaffold
 
 
 class _ScoutHandler(BaseHTTPRequestHandler):
@@ -299,7 +299,7 @@ class TestGenerateYamlScaffold:
             "final_url": "https://example.com/data/file.csv",
             "requested_url": "https://example.com/data/file.csv",
         }
-        yaml = _generate_yaml_scaffold(probe_result)
+        yaml = generate_yaml_scaffold(probe_result)
         assert '_source"' in yaml  # source name derived from slug with hash
         assert 'type: "http_file"' in yaml
         assert 'url: "https://example.com/data/file.csv"' in yaml
@@ -312,7 +312,7 @@ class TestGenerateYamlScaffold:
             "final_url": "https://portal.com/api/3/datastore/dump/uuid.csv",
             "requested_url": "https://portal.com/api/3/datastore/dump/uuid.csv",
         }
-        yaml = _generate_yaml_scaffold(probe_result)
+        yaml = generate_yaml_scaffold(probe_result)
         assert 'type: "ckan"' in yaml
 
     def test_http_file_scaffold_with_sdmx_url(self) -> None:
@@ -320,7 +320,7 @@ class TestGenerateYamlScaffold:
             "final_url": "https://example.com/data/flow/sdmx",
             "requested_url": "https://example.com/data/flow/sdmx",
         }
-        yaml = _generate_yaml_scaffold(probe_result)
+        yaml = generate_yaml_scaffold(probe_result)
         assert 'type: "sdmx"' in yaml
 
     def test_ckan_resources_scaffold(self) -> None:
@@ -342,7 +342,7 @@ class TestGenerateYamlScaffold:
                 "url": "https://portal.it/files/data.xls",
             },
         ]
-        yaml = _generate_yaml_scaffold(probe_result, ckan_resources)
+        yaml = generate_yaml_scaffold(probe_result, ckan_resources)
         assert "type: \"ckan\"" in yaml
         assert 'resource_id: "res-uuid-1"' in yaml
         assert 'resource_id: "res-uuid-2"' in yaml
@@ -357,7 +357,7 @@ class TestGenerateYamlScaffold:
             "https://portal.it/download/data.csv",
             "https://portal.it/download/report.xlsx",
         ]
-        yaml = _generate_yaml_scaffold(probe_result, None, links)
+        yaml = generate_yaml_scaffold(probe_result, None, links)
         assert 'type: "http_file"' in yaml
         assert 'url: "https://portal.it/download/data.csv"' in yaml
         assert 'url: "https://portal.it/download/report.xlsx"' in yaml

--- a/tests/test_cmd_url_inspect.py
+++ b/tests/test_cmd_url_inspect.py
@@ -76,6 +76,57 @@ class TestGenerateYamlScaffold:
 
 
 # ---------------------------------------------------------------------------
+# contract — scaffold config: ogni source type ha le chiavi obbligatorie
+# ---------------------------------------------------------------------------
+
+
+class TestScaffoldConfigContract:
+    """contract: ogni source type nello scaffold ha le chiavi obbligatorie."""
+
+    @pytest.mark.contract
+    def test_http_file_fallback_has_url_and_filename(self) -> None:
+        """http_file generato da fallback ha url + filename."""
+        probe = {"final_url": "https://example.com/data/file.csv", "requested_url": "https://example.com/data/file.csv"}
+        yaml = generate_yaml_scaffold(probe)
+        assert 'type: "http_file"' in yaml
+        assert "args:" in yaml
+        assert 'url: "https://example.com/data/file.csv"' in yaml
+        assert 'filename: "file.csv"' in yaml
+
+    @pytest.mark.contract
+    def test_http_file_candidate_links_has_url_and_filename(self) -> None:
+        """http_file da candidate_links ha url + filename."""
+        probe = {"final_url": "https://portal.it/html", "requested_url": "https://portal.it/html"}
+        links = ["https://portal.it/download/data.csv"]
+        yaml = generate_yaml_scaffold(probe, candidate_links=links)
+        assert 'type: "http_file"' in yaml
+        assert 'url: "https://portal.it/download/data.csv"' in yaml
+        assert 'filename: "data.csv"' in yaml
+
+    @pytest.mark.contract
+    def test_ckan_resources_has_portal_url_and_resource_id(self) -> None:
+        """ckan generato da risorse CKAN ha portal_url + resource_id + filename."""
+        probe = {"final_url": "https://portal.it/dataset/uuid"}
+        resources = [{"id": "res-abc", "name": "data", "format": "csv", "url": "https://portal.it/files/data.csv"}]
+        yaml = generate_yaml_scaffold(probe, ckan_resources=resources)
+        assert 'type: "ckan"' in yaml
+        assert 'portal_url: "https://portal.it"' in yaml
+        assert 'resource_id: "res-abc"' in yaml
+        assert 'filename: "data.csv"' in yaml
+
+    @pytest.mark.contract
+    def test_datastore_url_fallback_is_http_file_not_ckan(self) -> None:
+        """URL datastore senza metadata CKAN → http_file, non ckan (config incompleta)."""
+        probe = {"final_url": "https://portal.com/api/3/datastore/dump/uuid.csv"}
+        yaml = generate_yaml_scaffold(probe)
+        assert 'type: "http_file"' in yaml
+        assert 'type: "ckan"' not in yaml
+        assert 'portal_url:' not in yaml
+        # Con http_file deve avere url come argomento
+        assert 'url: "https://portal.com/api/3/datastore/dump/uuid.csv"' in yaml
+
+
+# ---------------------------------------------------------------------------
 # pure_unit — non-trivial pure logic (kept, not banale)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cmd_url_inspect.py
+++ b/tests/test_cmd_url_inspect.py
@@ -1,20 +1,20 @@
-"""Tests for toolkit/cli/cmd_url_inspect.py
+"""Tests for toolkit/cli/_url_probe.py (HTTP probe + discovery)
+and toolkit/cli/_url_scout_common.py (slugify + YAML scaffold).
 
-contract: _generate_yaml_scaffold output format (used by CLI scaffold)
+contract: generate_yaml_scaffold output format (used by CLI scaffold)
 pure_unit: _is_html, _is_file_like, _candidate_links, _detect_ckan, _extract_ckan_dataset_id
 """
 
 import pytest
 
-from toolkit.cli._url_scout_common import slugify
-from toolkit.cli.cmd_url_inspect import (
+from toolkit.cli._url_probe import (
     _candidate_links,
     _detect_ckan,
     _extract_ckan_dataset_id,
-    _generate_yaml_scaffold,
     _is_file_like,
     _is_html,
 )
+from toolkit.cli._url_scout_common import generate_yaml_scaffold, slugify
 
 
 # ---------------------------------------------------------------------------
@@ -22,7 +22,7 @@ from toolkit.cli.cmd_url_inspect import (
 # ---------------------------------------------------------------------------
 
 class TestGenerateYamlScaffold:
-    """contract: _generate_yaml_scaffold produces valid YAML with expected fields."""
+    """contract: generate_yaml_scaffold produces valid YAML with expected fields."""
 
     @pytest.mark.contract
     def test_basic_probe_result(self) -> None:
@@ -30,7 +30,7 @@ class TestGenerateYamlScaffold:
             "final_url": "https://example.com/data/dataset.csv",
             "requested_url": "https://example.com/data/dataset.csv",
         }
-        yaml = _generate_yaml_scaffold(probe_result)
+        yaml = generate_yaml_scaffold(probe_result)
         assert 'name: "dataset_' in yaml  # slug with uuid5 hash suffix
         assert '_source"' in yaml          # source name derived from slug
         assert 'type: "http_file"' in yaml
@@ -48,7 +48,7 @@ class TestGenerateYamlScaffold:
                 "url": "https://cdn.example.com/file.csv",
             }
         ]
-        yaml = _generate_yaml_scaffold(probe_result, ckan_resources=ckan_resources)
+        yaml = generate_yaml_scaffold(probe_result, ckan_resources=ckan_resources)
         assert 'type: "ckan"' in yaml
         assert 'resource_id: "res-123"' in yaml
         assert 'portal_url: "https://example.com"' in yaml
@@ -59,7 +59,7 @@ class TestGenerateYamlScaffold:
             "final_url": "https://example.com/page",
             "requested_url": "https://example.com/page",
         }
-        yaml = _generate_yaml_scaffold(probe_result, ckan_resources=[], candidate_links=None)
+        yaml = generate_yaml_scaffold(probe_result, ckan_resources=[], candidate_links=None)
         assert 'name: "page_' in yaml  # slug with uuid5 hash suffix
         assert '_source"' in yaml
         assert 'type: "http_file"' in yaml
@@ -71,7 +71,7 @@ class TestGenerateYamlScaffold:
             "final_url": "https://example.com/data/my-data-file%202023.csv",
             "requested_url": "https://example.com/data/my-data-file%202023.csv",
         }
-        yaml = _generate_yaml_scaffold(probe_result)
+        yaml = generate_yaml_scaffold(probe_result)
         assert 'name: "my_data_file_202023_' in yaml  # slug with uuid5 hash suffix
 
 
@@ -293,9 +293,9 @@ class TestSlugify:
 
     @pytest.mark.contract
     def test_slugify_used_by_scaffold(self) -> None:
-        """_generate_yaml_scaffold usa slugify (dataset name + source name contengono hash)."""
+        """generate_yaml_scaffold usa slugify internamente (dataset name contiene hash)."""
         probe = {"final_url": "https://example.com/data/dataset.csv", "requested_url": "https://example.com/data/dataset.csv"}
-        yaml = _generate_yaml_scaffold(probe)
+        yaml = generate_yaml_scaffold(probe)
         # Dataset name: "dataset_{6hex}" — contiene hash uuid5
         assert 'name: "dataset_' in yaml
         # Source name: "dataset_{6hex}_source" — stesso slug

--- a/toolkit/cli/_url_probe.py
+++ b/toolkit/cli/_url_probe.py
@@ -1,26 +1,30 @@
+"""HTTP probe e discovery per URL scout — probe, CKAN discovery, link extraction.
+
+Questo modulo NON e' un comando CLI. Contiene la logica di basso livello
+per ispezionare URL, rilevare portali CKAN, estrarre link candidati e
+scoprire risorse CKAN. La CLI corrispondente e' in inspect/url_ops.py.
+
+La generazione YAML scaffold vive in _url_scout_common.py (pure, senza HTTP).
+"""
+
 from __future__ import annotations
 
 import re
 from html.parser import HTMLParser
-from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urljoin, urlparse
 
 from lab_connectors.http import HttpClient
 
-from toolkit.cli._url_scout_common import slugify
-
-# Public API — functions used by cmd_inspect.py
+# Public API
 __all__ = [
     "probe_url",
-    "_generate_yaml_scaffold",
     "_detect_ckan",
     "_discover_ckan_resources",
     "_extract_ckan_dataset_id",
     "_is_html",
     "_is_file_like",
     "_candidate_links",
-    # Constants used by cmd_inspect
     "_EXTENDED_EXTENSIONS",
     "_DEFAULT_TIMEOUT",
     "_DEFAULT_USER_AGENT",
@@ -128,7 +132,7 @@ def _discover_ckan_resources(
 ) -> list[dict[str, Any]]:
     parsed = urlparse(portal_url)
     root = f"{parsed.scheme}://{parsed.netloc}"
-    api_bases = []
+    api_bases: list[str] = []
     if parsed.path.startswith("/api/3/action"):
         api_bases.append(f"{root}/api/3/action/package_show")
     elif parsed.path.startswith("/api/3"):
@@ -171,85 +175,6 @@ def _discover_ckan_resources(
     return []
 
 
-def _generate_yaml_scaffold(
-    probe_result: dict[str, Any],
-    ckan_resources: list[dict[str, Any]] | None = None,
-    candidate_links: list[str] | None = None,
-) -> str:
-    url = probe_result["final_url"]
-    parsed = urlparse(url)
-    slug = slugify(url)
-    lines = [
-        "# Scaffold generato da scout-url --scaffold",
-        "# Verifica e modifica prima di usare",
-        "",
-        'root: "../../out"',
-        "schema_version: 1",
-        "",
-        "dataset:",
-        f'  name: "{slug}"',
-        "  years: [2024]  # TBD: inferito da URL o sorgente",
-        "",
-        "raw:",
-        "  output_policy: overwrite",
-        "  sources:",
-    ]
-
-    def _make_source_name(link: str) -> str:
-        stem = Path(urlparse(link).path).stem
-        return re.sub(r"[^a-z0-9_]", "_", (stem or "resource").lower())
-
-    def _infer_type_from_url(u: str) -> str:
-        if "/datastore/dump/" in u or "/datastore_search" in u:
-            return "ckan"
-        if "sdmx" in u.lower() or "/dataflow/" in u.lower():
-            return "sdmx"
-        return "http_file"
-
-    if ckan_resources:
-        for res in ckan_resources:
-            res_name = re.sub(r"[^a-z0-9_]", "_", (res["name"] or "resource").lower())
-            res_url = res["url"]
-            fmt = res["format"]
-            fname = Path(urlparse(res_url).path).name or f"{res_name}.{fmt}"
-            portal_base = f"{parsed.scheme}://{parsed.netloc}"
-            lines.append(f'    - name: "{res_name}"')
-            lines.append('      type: "ckan"')
-            lines.append("      args:")
-            lines.append(f'        portal_url: "{portal_base}"')
-            lines.append(f'        resource_id: "{res.get("id") or ""}"')
-            lines.append(f'        filename: "{fname}"')
-            lines.append("      primary: true")
-    elif candidate_links:
-        seen: set[str] = set()
-        for link in candidate_links:
-            if link in seen:
-                continue
-            seen.add(link)
-            link_name = _make_source_name(link)
-            fname = Path(urlparse(link).path).name
-            stype = _infer_type_from_url(link)
-            lines.append(f'    - name: "{link_name}"')
-            lines.append(f'      type: "{stype}"')
-            lines.append("      args:")
-            lines.append(f'        url: "{link}"')
-            if fname:
-                lines.append(f'        filename: "{fname}"')
-            lines.append("      primary: true")
-    else:
-        fname = Path(parsed.path).name
-        stype = _infer_type_from_url(url)
-        lines.append(f'    - name: "{slug}_source"')
-        lines.append(f'      type: "{stype}"')
-        lines.append("      args:")
-        lines.append(f'        url: "{url}"')
-        if fname:
-            lines.append(f'        filename: "{fname}"')
-        lines.append("      primary: true")
-    lines.append("")
-    return "\n".join(lines)
-
-
 def probe_url(
     url: str,
     *,
@@ -260,14 +185,12 @@ def probe_url(
     client = HttpClient(timeout=timeout, user_agent=user_agent)
 
     # --- Step 1: probe headers (HEAD preferred, GET+Range fallback) ---
-    # Some servers reject HEAD (405/403/err) but work with GET.
     head_result = client.head(url)
     range_result = None
 
     if head_result.is_ok and head_result.response is not None and head_result.response.status_code < 400:
         probe = head_result.response
     else:
-        # HEAD failed or returned error — try lightweight GET with Range
         range_result = client.get(url, headers={"Range": "bytes=0-0"})
         if range_result.is_ok and range_result.response is not None:
             probe = range_result.response

--- a/toolkit/cli/_url_scout_common.py
+++ b/toolkit/cli/_url_scout_common.py
@@ -64,16 +64,13 @@ def _make_source_name(link: str) -> str:
     return re.sub(r"[^a-z0-9_]", "_", (stem or "resource").lower())
 
 
-def _infer_type_from_url(u: str) -> str:
-    if "/datastore/dump/" in u or "/datastore_search" in u:
-        return "ckan"
-    if "sdmx" in u.lower() or "/dataflow/" in u.lower():
-        return "sdmx"
-    return "http_file"
-
-
 def _generate_raw_sources_block(url: str, slug: str, fname: str | None = None) -> list[str]:
     """Genera il blocco YAML raw.sources per un singolo URL.
+
+    Produce sempre type: http_file perche' da un URL nudo non abbiamo
+    i metadata necessari per CKAN (portal_url, resource_id) o SDMX
+    (flow, version). I config CKAN/SDMX completi sono generati solo
+    da generate_yaml_scaffold() quando ckan_resources sono forniti.
 
     Args:
         url: URL della fonte dati.
@@ -83,10 +80,9 @@ def _generate_raw_sources_block(url: str, slug: str, fname: str | None = None) -
     parsed = urlparse(url)
     if fname is None:
         fname = Path(parsed.path).name or f"{slug}.csv"
-    stype = _infer_type_from_url(url)
     lines = [
         f'    - name: "{slug}_source"',
-        f'      type: "{stype}"',
+        '      type: "http_file"',
         "      args:",
         f'        url: "{url}"',
         f'        filename: "{fname}"',
@@ -147,9 +143,10 @@ def generate_yaml_scaffold(
             seen.add(link)
             link_name = _make_source_name(link)
             fname = Path(urlparse(link).path).name
-            stype = _infer_type_from_url(link)
+            # Da link candidati abbiamo solo l'URL, non i metadata
+            # necessari per CKAN/SDMX → sempre http_file
             lines.append(f'    - name: "{link_name}"')
-            lines.append(f'      type: "{stype}"')
+            lines.append('      type: "http_file"')
             lines.append("      args:")
             lines.append(f'        url: "{link}"')
             if fname:

--- a/toolkit/cli/_url_scout_common.py
+++ b/toolkit/cli/_url_scout_common.py
@@ -1,7 +1,6 @@
-"""Helper condivisi per URL scout tra init --url e inspect url.
+"""Helper condivisi per URL scout — slug, estensione, filename, scaffold YAML.
 
-Consolida slug generation, inferenza estensione e filename
-per evitare divergenze tra cmd_init.py e cmd_url_inspect.py.
+Tutta logica pura (no HTTP, no I/O). Condivisa tra init --url e inspect url.
 """
 
 from __future__ import annotations
@@ -9,6 +8,7 @@ from __future__ import annotations
 import re
 import uuid
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 
@@ -52,3 +52,110 @@ def infer_filename(url: str, slug: str) -> str:
         return Path(path).stem + ".csv"
     name = Path(path).name
     return name or f"{slug}.csv"
+
+
+# ---------------------------------------------------------------------------
+# Scaffold YAML — raw.sources block
+# ---------------------------------------------------------------------------
+
+
+def _make_source_name(link: str) -> str:
+    stem = Path(urlparse(link).path).stem
+    return re.sub(r"[^a-z0-9_]", "_", (stem or "resource").lower())
+
+
+def _infer_type_from_url(u: str) -> str:
+    if "/datastore/dump/" in u or "/datastore_search" in u:
+        return "ckan"
+    if "sdmx" in u.lower() or "/dataflow/" in u.lower():
+        return "sdmx"
+    return "http_file"
+
+
+def _generate_raw_sources_block(url: str, slug: str, fname: str | None = None) -> list[str]:
+    """Genera il blocco YAML raw.sources per un singolo URL.
+
+    Args:
+        url: URL della fonte dati.
+        slug: Slug del dataset (usato per source name).
+        fname: Nome file esplicito. Se None, inferito dall'URL.
+    """
+    parsed = urlparse(url)
+    if fname is None:
+        fname = Path(parsed.path).name or f"{slug}.csv"
+    stype = _infer_type_from_url(url)
+    lines = [
+        f'    - name: "{slug}_source"',
+        f'      type: "{stype}"',
+        "      args:",
+        f'        url: "{url}"',
+        f'        filename: "{fname}"',
+    ]
+    lines.append("      primary: true")
+    return lines
+
+
+def generate_yaml_scaffold(
+    probe_result: dict[str, Any],
+    ckan_resources: list[dict[str, Any]] | None = None,
+    candidate_links: list[str] | None = None,
+) -> str:
+    """Genera scaffold YAML per un URL ispezionato.
+
+    Usato da inspect url --scaffold. Il probe_result deve contenere almeno
+    final_url. Opzionalmente si possono passare risorse CKAN o link candidati
+    per popolare raw.sources in modo strutturato.
+    """
+    url = probe_result["final_url"]
+    parsed = urlparse(url)
+    slug = slugify(url)
+    lines = [
+        "# Scaffold generato da scout-url --scaffold",
+        "# Verifica e modifica prima di usare",
+        "",
+        'root: "../../out"',
+        "schema_version: 1",
+        "",
+        "dataset:",
+        f'  name: "{slug}"',
+        "  years: [2024]  # TBD: inferito da URL o sorgente",
+        "",
+        "raw:",
+        "  output_policy: overwrite",
+        "  sources:",
+    ]
+
+    if ckan_resources:
+        for res in ckan_resources:
+            res_name = re.sub(r"[^a-z0-9_]", "_", (res["name"] or "resource").lower())
+            res_url = res["url"]
+            fmt = res["format"]
+            fname = Path(urlparse(res_url).path).name or f"{res_name}.{fmt}"
+            portal_base = f"{parsed.scheme}://{parsed.netloc}"
+            lines.append(f'    - name: "{res_name}"')
+            lines.append('      type: "ckan"')
+            lines.append("      args:")
+            lines.append(f'        portal_url: "{portal_base}"')
+            lines.append(f'        resource_id: "{res.get("id") or ""}"')
+            lines.append(f'        filename: "{fname}"')
+            lines.append("      primary: true")
+    elif candidate_links:
+        seen: set[str] = set()
+        for link in candidate_links:
+            if link in seen:
+                continue
+            seen.add(link)
+            link_name = _make_source_name(link)
+            fname = Path(urlparse(link).path).name
+            stype = _infer_type_from_url(link)
+            lines.append(f'    - name: "{link_name}"')
+            lines.append(f'      type: "{stype}"')
+            lines.append("      args:")
+            lines.append(f'        url: "{link}"')
+            if fname:
+                lines.append(f'        filename: "{fname}"')
+            lines.append("      primary: true")
+    else:
+        lines.extend(_generate_raw_sources_block(url, slug))
+    lines.append("")
+    return "\n".join(lines)

--- a/toolkit/cli/cmd_init.py
+++ b/toolkit/cli/cmd_init.py
@@ -17,7 +17,8 @@ import typer
 
 from lab_connectors.http import HttpClient
 
-from toolkit.cli._url_scout_common import infer_ext, infer_filename, slugify
+from toolkit.cli._url_probe import probe_url
+from toolkit.cli._url_scout_common import _generate_raw_sources_block, infer_ext, infer_filename, slugify
 from toolkit.cli.cmd_run import run_init as _run_init
 
 logger = logging.getLogger("toolkit.cli.init")
@@ -48,7 +49,19 @@ def _scout(url: str, *, timeout: int = 60) -> None:
     tmp_dir = Path(tempfile.gettempdir())
     tmp_name = f"scout_{slug}_{uuid.uuid4().hex[:8]}"
 
-    # 1. Download sample (primi 1MB via Range header)
+    # 1. Probe URL per validazione (HEAD preferito, GET Range fallback)
+    typer.echo(f"Probing {url}...")
+    probe = probe_url(url, timeout=min(timeout, 30))
+    if probe["kind"] == "html":
+        ct = probe["content_type"]
+        typer.echo(f"error: URL returned HTML (Content-Type: {ct}), not a data file", err=True)
+        typer.echo("  Controlla che l'URL punti direttamente a un file CSV/XLSX/JSON.", err=True)
+        raise typer.Exit(code=1)
+    if probe["status_code"] >= 400:
+        typer.echo(f"error: HTTP {probe['status_code']} for {url}", err=True)
+        raise typer.Exit(code=1)
+
+    # 2. Download sample (primi 1MB via Range header)
     typer.echo(f"Downloading sample from {url}...")
     client = HttpClient(timeout=timeout)
     result = client.get(url, headers={"Range": f"bytes=0-{_SAMPLE_SIZE - 1}"})
@@ -57,16 +70,7 @@ def _scout(url: str, *, timeout: int = 60) -> None:
         raise typer.Exit(code=1)
 
     resp = result.response
-    if resp.status_code >= 400:
-        typer.echo(f"error: HTTP {resp.status_code} for {url}", err=True)
-        raise typer.Exit(code=1)
-
-    ct = (resp.headers.get("Content-Type") or "").lower()
-    if "html" in ct:
-        typer.echo(f"error: URL returned HTML (Content-Type: {ct}), not a data file", err=True)
-        typer.echo("  Controlla che l'URL punti direttamente a un file CSV/XLSX/JSON.", err=True)
-        raise typer.Exit(code=1)
-
+    ct = (resp.headers.get("Content-Type") or probe["content_type"] or "").lower()
     # Cap difensivo: anche se server ignora Range e risponde 200, tronca
     content = resp.content[:_SAMPLE_SIZE]
     ext = infer_ext(url, ct)
@@ -191,12 +195,7 @@ def _generate_dataset_yml(
     lines.append("raw:")
     lines.append("  output_policy: overwrite")
     lines.append("  sources:")
-    lines.append(f'    - name: "{slug}_source"')
-    lines.append('      type: "http_file"')
-    lines.append("      args:")
-    lines.append(f'        url: "{url}"')
-    lines.append(f'        filename: "{fname}"')
-    lines.append("      primary: true")
+    lines.extend(_generate_raw_sources_block(url, slug, fname=fname))
     lines.append("")
     lines.append("clean:")
     lines.append("  read:")

--- a/toolkit/cli/inspect/url_ops.py
+++ b/toolkit/cli/inspect/url_ops.py
@@ -8,16 +8,16 @@ from typing import Any
 
 import typer
 
-from toolkit.cli.cmd_url_inspect import (
+from toolkit.cli._url_probe import (
     _EXTENDED_EXTENSIONS,
     _DEFAULT_TIMEOUT,
     _DEFAULT_USER_AGENT,
     _detect_ckan,
     _discover_ckan_resources,
     _extract_ckan_dataset_id,
-    _generate_yaml_scaffold,
     probe_url,
 )
+from toolkit.cli._url_scout_common import generate_yaml_scaffold
 
 
 def url(
@@ -68,7 +68,7 @@ def url(
                     if any(ext in link.lower() for ext in _EXTENDED_EXTENSIONS)
                 ]
 
-        yaml_scaffold = _generate_yaml_scaffold(result, ckan_resources, candidate_file_links)
+        yaml_scaffold = generate_yaml_scaffold(result, ckan_resources, candidate_file_links)
 
         if run:
             assert output is not None  # guaranteed by check above


### PR DESCRIPTION
## Refactor URL probe e scaffold (Opzione D)

### Cosa cambia

| Prima | Dopo |
|---|---|
| `cmd_url_inspect.py` (312 righe, nome fuorviante) | **Rinominato** → `_url_probe.py` (solo HTTP probe+CKAN+links) |
| `generate_yaml_scaffold()` in modulo HTTP | Spostato in `_url_scout_common.py` (modulo puro, no HTTP) |
| `_scout()` con HTTP duplicato | Riusa `probe_url()` per validazione (HEAD+fallback) |
| `_generate_dataset_yml()` raw.sources inline | Usa `_generate_raw_sources_block()` condiviso |

### Perché

- **Nessuna centralizzazione cross-repo** — la logica resta nel toolkit, zero promesse a SO
- **Confini chiari**: `_url_probe.py` = solo HTTP / `_url_scout_common.py` = solo logica pura
- **-206 righe nette**, duplicazione interna eliminata

### File toccati

```
renamed:    toolkit/cli/cmd_url_inspect.py -> toolkit/cli/_url_probe.py (69% similarity)
modified:   toolkit/cli/_url_scout_common.py
modified:   toolkit/cli/cmd_init.py
modified:   toolkit/cli/inspect/url_ops.py
modified:   tests/test_cmd_url_inspect.py
modified:   tests/test_cli_scout_url.py
```

### Test

**662 passati, 0 fallimenti.**