### PR TITLE
feat: conftest con fixture condivise + helpers — -254 righe di boilerplate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "requests>=2.33.1",
   "typer>=0.12.0",
   "rich>=13.0",
-  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@feat/testing-module"
+  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "requests>=2.33.1",
   "typer>=0.12.0",
   "rich>=13.0",
-  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.9.0"
+  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@feat/testing-module"
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 
@@ -53,3 +55,49 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             item.add_marker(pytest.mark.advanced)
         elif name in COMPAT_TESTS:
             item.add_marker(pytest.mark.compat)
+
+
+# ------------------------------------------------------------------
+# Shared fixtures
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner():
+    """CLI runner for Typer/Click commands.
+
+    Usage::
+
+        def test_something(runner):
+            result = runner.invoke(app, ["run", "--help"])
+            assert result.exit_code == 0
+    """
+    from typer.testing import CliRunner
+
+    return CliRunner()
+
+
+@pytest.fixture
+def project_example(tmp_path: Path) -> Path:
+    """Copy ``project-example/`` to a temp directory.
+
+    Returns the path to the copy. The ``_smoke_out`` directory is
+    excluded to avoid stale artifacts in CI.
+    """
+    import shutil
+
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
+    return dst
+
+
+@pytest.fixture
+def chdir_tmp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Chdir to a clean temp directory for the duration of the test.
+
+    Equivalent to ``monkeypatch.chdir(tmp_path)`` — saves a line in
+    every test that needs a clean working directory.
+    """
+    monkeypatch.chdir(tmp_path)
+    return tmp_path

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,101 @@
+"""Shared test helpers for toolkit tests.
+
+Functions here are importable by any test file::
+
+    from tests.helpers import make_dataset_yml, make_standard_sql, write_text
+
+Fixtures belong in ``conftest.py``; pure helpers that take arguments
+and return values belong here.
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any
+
+
+def write_text(path: Path, content: str) -> None:
+    """Write *content* (dedented, stripped, newline-terminated) to *path*.
+
+    Creates parent directories as needed.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content).strip() + "\n", encoding="utf-8")
+
+
+def make_standard_sql(base_dir: Path, /) -> dict[str, Path]:
+    """Create standard ``sql/clean.sql`` and ``sql/mart/mart_example.sql``.
+
+    Returns dict with keys ``clean``, ``mart_dir``, ``mart``.
+    """
+    sql_dir = base_dir / "sql" / "mart"
+    sql_dir.mkdir(parents=True, exist_ok=True)
+    clean = base_dir / "sql" / "clean.sql"
+    clean.write_text("select 1 as value", encoding="utf-8")
+    mart = sql_dir / "mart_example.sql"
+    mart.write_text("select * from clean_input", encoding="utf-8")
+    return {"clean": clean, "mart_dir": sql_dir, "mart": mart}
+
+
+def make_dataset_yml(
+    path: Path,
+    *,
+    name: str = "demo_ds",
+    root: Path | None = None,
+    years: list[int] | None = None,
+    clean_sql: str = "sql/clean.sql",
+    mart_tables: list[tuple[str, str]] | None = None,
+    extra: str | None = None,
+) -> Path:
+    """Write a minimal ``dataset.yml`` config file.
+
+    Args:
+        path: Output path.
+        name: Dataset slug (``dataset: name``).
+        root: Root directory (defaults to parent of *path* + ``out``).
+        years: List of years (default ``[2022]``).
+        clean_sql: Relative path to clean SQL.
+        mart_tables: ``[(table_name, sql_path), ...]``.
+        extra: Extra raw YAML lines appended before closing newline.
+
+    Returns:
+        *path* for chaining.
+
+    Example::
+
+        yml = make_dataset_yml(
+            tmp_path / "dataset.yml",
+            name="demo",
+            mart_tables=[("m1", "sql/m1.sql")],
+        )
+    """
+    root_val = root or (path.parent / "out")
+    yml_years = years or [2022]
+    yml_years_str = ", ".join(str(y) for y in yml_years)
+
+    lines: list[str] = [
+        f'root: "{root_val.as_posix()}"',
+        "dataset:",
+        f'  name: "{name}"',
+        f"  years: [{yml_years_str}]",
+        "raw: {}",
+    ]
+
+    if clean_sql is not None:
+        lines.append("clean:")
+        lines.append(f'  sql: "{clean_sql}"')
+
+    if mart_tables:
+        lines.append("mart:")
+        lines.append("  tables:")
+        for table_name, table_sql in mart_tables:
+            lines.append(f'    - name: "{table_name}"')
+            lines.append(f'      sql: "{table_sql}"')
+
+    if extra:
+        lines.append(extra)
+
+    body = "\n".join(lines) + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path

--- a/tests/test_http_file_plugin.py
+++ b/tests/test_http_file_plugin.py
@@ -1,64 +1,62 @@
 """Tests for HttpFileSource — adapter over lab_connectors.http.
 
-Tests mock the public boundary (HttpClient.get / HttpResult), not
-internal HTTP details. Retry and SSL fallback logic lives in
-lab-connectors and is tested there.
+Tests use ``FakeHttpClient`` from ``lab_connectors.testing`` instead of
+monkeypatching ``HttpClient.get``. Retry, backoff, and SSL fallback
+logic lives in lab-connectors and is tested there.
 """
 from __future__ import annotations
 
 import pytest
 
-from lab_connectors.http import HttpClient, HttpResult
+from lab_connectors.http import HttpResult
+from lab_connectors.testing import FakeHttpClient, fake_response
 
 from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.http_file import HttpFileSource
 
 
-class _FakeResponse:
-    """Minimal response stub duck-typing requests.Response properties."""
-    def __init__(self, status_code: int = 200, content: bytes = b"ok") -> None:
-        self.status_code = status_code
-        self.content = content
-
-
-def test_fetch_success(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fetch_success() -> None:
     """HttpResult ok → fetch returns bytes."""
-    results: list[tuple[str, dict]] = []
-
-    def fake_get(self, url: str, **kwargs):
-        results.append((url, kwargs))
-        return HttpResult(response=_FakeResponse(200, b"payload"), err=None)
-
-    monkeypatch.setattr(HttpClient, "get", fake_get)
+    fake = FakeHttpClient()
+    fake.responses["https://example.test/data.csv"] = HttpResult(
+        response=fake_response(200, "payload"), err=None,
+    )
 
     source = HttpFileSource(timeout=15, retries=2, user_agent="ua-test")
+    source._client = fake  # inject fake
+
     payload = source.fetch("https://example.test/data.csv")
 
     assert payload == b"payload"
-    assert len(results) == 1
-    assert results[0][0] == "https://example.test/data.csv"
+    assert len(fake.requests) == 1
+    assert fake.requests[0][0] == "GET"
+    assert fake.requests[0][1] == "https://example.test/data.csv"
 
 
-def test_fetch_http_status_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fetch_http_status_error() -> None:
     """Non-200 HTTP status → DownloadError with status code in message."""
-    def fake_get(self, url: str, **kwargs):
-        return HttpResult(response=_FakeResponse(503, b"service unavailable"), err=None)
-
-    monkeypatch.setattr(HttpClient, "get", fake_get)
+    fake = FakeHttpClient()
+    fake.responses["https://example.test/unavailable"] = HttpResult(
+        response=fake_response(503, "service unavailable"), err=None,
+    )
 
     source = HttpFileSource(retries=1)
+    source._client = fake
+
     with pytest.raises(DownloadError, match="HTTP 503"):
         source.fetch("https://example.test/unavailable")
 
 
-def test_fetch_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fetch_connection_error() -> None:
     """HttpResult with err → DownloadError."""
-    def fake_get(self, url: str, **kwargs):
-        return HttpResult(response=None, err=ConnectionError("connection refused"))
-
-    monkeypatch.setattr(HttpClient, "get", fake_get)
+    fake = FakeHttpClient()
+    fake.responses["https://example.test/fail"] = HttpResult(
+        response=None, err=ConnectionError("connection refused"),
+    )
 
     source = HttpFileSource(retries=2)
+    source._client = fake
+
     with pytest.raises(DownloadError, match="connection refused"):
         source.fetch("https://example.test/fail")
 
@@ -76,35 +74,34 @@ def test_fetch_passes_params() -> None:
 
 
 @pytest.mark.policy
-def test_ssl_fallback_semantics_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_ssl_fallback_semantics_preserved() -> None:
     """ssl_fallback_used=True in HttpResult is transparent to caller."""
-    def fake_get(self, url: str, **kwargs):
-        return HttpResult(
-            response=_FakeResponse(200, b"ssl-fallback-data"),
-            err=None,
-            ssl_fallback_used=True,
-        )
-
-    monkeypatch.setattr(HttpClient, "get", fake_get)
+    fake = FakeHttpClient()
+    fake.responses["https://example.test/ssl-expired"] = HttpResult(
+        response=fake_response(200, "ssl-fallback-data"),
+        err=None,
+        ssl_fallback_used=True,
+    )
 
     source = HttpFileSource(retries=1)
-    payload = source.fetch("https://example.test/ssl-expired")
+    source._client = fake
 
+    payload = source.fetch("https://example.test/ssl-expired")
     assert payload == b"ssl-fallback-data"
 
 
 @pytest.mark.policy
-def test_ssl_fallback_failure_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_ssl_fallback_failure_propagates() -> None:
     """HttpResult with ssl_fallback_used=False and err → DownloadError."""
-    def fake_get(self, url: str, **kwargs):
-        return HttpResult(
-            response=None,
-            err=ConnectionError("fallback failed"),
-            ssl_fallback_used=False,
-        )
-
-    monkeypatch.setattr(HttpClient, "get", fake_get)
+    fake = FakeHttpClient()
+    fake.responses["https://example.test/ssl-fail"] = HttpResult(
+        response=None,
+        err=ConnectionError("fallback failed"),
+        ssl_fallback_used=False,
+    )
 
     source = HttpFileSource(retries=1)
+    source._client = fake
+
     with pytest.raises(DownloadError, match="fallback failed"):
         source.fetch("https://example.test/ssl-fail")

--- a/tests/test_run_dry_run.py
+++ b/tests/test_run_dry_run.py
@@ -1,3 +1,4 @@
+"""Tests for ``toolkit run --dry-run``."""
 from __future__ import annotations
 
 import json
@@ -6,42 +7,27 @@ from pathlib import Path
 
 import duckdb
 import pytest
-from typer.testing import CliRunner
 
 from toolkit.cli.app import app
 from toolkit.cli.cmd_run import run_year
 from toolkit.core.config import load_config
+from tests.helpers import make_dataset_yml, make_standard_sql
+
+
+# ── Basic patterns ──────────────────────────────────────────────────────────
 
 
 @pytest.mark.policy
-def test_run_dry_run_prints_plan_and_creates_only_run_record(tmp_path: Path) -> None:
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
-
-    config_path = tmp_path / "dataset.yml"
-    root_dir = tmp_path / "out"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "demo_ds"',
-                "  years: [2022]",
-                "raw: {}",
-                "clean:",
-                '  sql: "sql/clean.sql"',
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart/mart_example.sql"',
-            ]
-        ),
-        encoding="utf-8",
+def test_run_dry_run_prints_plan_and_creates_only_run_record(
+    tmp_path: Path, runner,
+) -> None:
+    make_standard_sql(tmp_path)
+    config_path = make_dataset_yml(
+        tmp_path / "dataset.yml",
+        mart_tables=[("mart_example", "sql/mart/mart_example.sql")],
     )
+    root_dir = tmp_path / "out"
 
-    runner = CliRunner()
     result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run"])
 
     assert result.exit_code == 0
@@ -64,34 +50,16 @@ def test_run_dry_run_prints_plan_and_creates_only_run_record(tmp_path: Path) -> 
 
 
 @pytest.mark.policy
-def test_run_dry_run_fails_on_clean_sql_syntax_error(tmp_path: Path) -> None:
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
+def test_run_dry_run_fails_on_clean_sql_syntax_error(tmp_path: Path, runner) -> None:
+    make_standard_sql(tmp_path)
+    # Replace clean.sql with syntax error
     (tmp_path / "sql" / "clean.sql").write_text("select from raw_input", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
 
-    config_path = tmp_path / "dataset.yml"
-    root_dir = tmp_path / "out"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "demo_ds"',
-                "  years: [2022]",
-                "raw: {}",
-                "clean:",
-                '  sql: "sql/clean.sql"',
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart/mart_example.sql"',
-            ]
-        ),
-        encoding="utf-8",
+    config_path = make_dataset_yml(
+        tmp_path / "dataset.yml",
+        mart_tables=[("mart_example", "sql/mart/mart_example.sql")],
     )
 
-    runner = CliRunner()
     result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run"])
 
     assert result.exit_code != 0
@@ -99,37 +67,21 @@ def test_run_dry_run_fails_on_clean_sql_syntax_error(tmp_path: Path) -> None:
 
 
 @pytest.mark.policy
-def test_run_dry_run_fails_on_mart_sql_binding_error(tmp_path: Path) -> None:
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (tmp_path / "sql" / "clean.sql").write_text('select "x" as value from raw_input', encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text("select missing_col from clean_input", encoding="utf-8")
-
-    config_path = tmp_path / "dataset.yml"
-    root_dir = tmp_path / "out"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "demo_ds"',
-                "  years: [2022]",
-                "raw: {}",
-                "clean:",
-                '  sql: "sql/clean.sql"',
-                "  read:",
-                "    columns:",
-                '      x: "VARCHAR"',
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart/mart_example.sql"',
-            ]
-        ),
-        encoding="utf-8",
+def test_run_dry_run_fails_on_mart_sql_binding_error(tmp_path: Path, runner) -> None:
+    make_standard_sql(tmp_path)
+    (tmp_path / "sql" / "clean.sql").write_text(
+        'select "x" as value from raw_input', encoding="utf-8",
+    )
+    (tmp_path / "sql" / "mart" / "mart_example.sql").write_text(
+        "select missing_col from clean_input", encoding="utf-8",
     )
 
-    runner = CliRunner()
+    config_path = make_dataset_yml(
+        tmp_path / "dataset.yml",
+        mart_tables=[("mart_example", "sql/mart/mart_example.sql")],
+        extra="  read:\n    columns:\n      x: \"VARCHAR\"",
+    )
+
     result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run"])
 
     assert result.exit_code != 0
@@ -137,34 +89,19 @@ def test_run_dry_run_fails_on_mart_sql_binding_error(tmp_path: Path) -> None:
 
 
 @pytest.mark.policy
-def test_run_dry_run_accepts_unquoted_raw_columns_without_read_columns(tmp_path: Path) -> None:
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (tmp_path / "sql" / "clean.sql").write_text("select x as value from raw_input", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
-
-    config_path = tmp_path / "dataset.yml"
-    root_dir = tmp_path / "out"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "demo_ds"',
-                "  years: [2022]",
-                "raw: {}",
-                "clean:",
-                '  sql: "sql/clean.sql"',
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart/mart_example.sql"',
-            ]
-        ),
-        encoding="utf-8",
+def test_run_dry_run_accepts_unquoted_raw_columns_without_read_columns(
+    tmp_path: Path, runner,
+) -> None:
+    make_standard_sql(tmp_path)
+    (tmp_path / "sql" / "clean.sql").write_text(
+        "select x as value from raw_input", encoding="utf-8",
     )
 
-    runner = CliRunner()
+    config_path = make_dataset_yml(
+        tmp_path / "dataset.yml",
+        mart_tables=[("mart_example", "sql/mart/mart_example.sql")],
+    )
+
     result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run"])
 
     assert result.exit_code == 0
@@ -172,43 +109,81 @@ def test_run_dry_run_accepts_unquoted_raw_columns_without_read_columns(tmp_path:
 
 
 @pytest.mark.policy
-def test_run_dry_run_accepts_mart_sql_with_root_posix_placeholder(tmp_path: Path) -> None:
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
+def test_run_dry_run_accepts_mart_sql_with_root_posix_placeholder(
+    tmp_path: Path, runner,
+) -> None:
+    make_standard_sql(tmp_path)
     root_dir = tmp_path / "out"
     lookup_path = root_dir / "lookup" / "mart_lookup_2022.parquet"
     lookup_path.parent.mkdir(parents=True, exist_ok=True)
     duckdb.execute(
         f"COPY (SELECT 1 AS lookup_value) TO '{lookup_path.as_posix()}' (FORMAT PARQUET)"
     )
-
-    (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text(
+    (tmp_path / "sql" / "mart" / "mart_example.sql").write_text(
         "select * from read_parquet('{root_posix}/lookup/mart_lookup_2022.parquet')",
         encoding="utf-8",
     )
 
-    config_path = tmp_path / "dataset.yml"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "demo_ds"',
-                "  years: [2022]",
-                "raw: {}",
-                "clean:",
-                '  sql: "sql/clean.sql"',
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart/mart_example.sql"',
-            ]
-        ),
-        encoding="utf-8",
+    config_path = make_dataset_yml(
+        tmp_path / "dataset.yml", root=root_dir,
+        mart_tables=[("mart_example", "sql/mart/mart_example.sql")],
     )
 
-    runner = CliRunner()
+    result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "sql_validation: OK" in result.output
+
+
+# ── Support datasets ────────────────────────────────────────────────────────
+
+
+def _make_support_config(support_root: Path, support_config: Path,
+                          tables: list[tuple[str, str]]) -> Path:
+    """Write a support dataset.yml and return its path."""
+    make_dataset_yml(
+        support_config, root=support_root, name="lookup_ds", years=[2024],
+        clean_sql="sql/clean.sql",
+        mart_tables=tables,
+    )
+    return support_config
+
+
+@pytest.mark.policy
+def test_run_dry_run_accepts_mart_sql_with_support_placeholder(
+    tmp_path: Path, runner,
+) -> None:
+    make_standard_sql(tmp_path)
+    root_dir = tmp_path / "out"
+    support_root = tmp_path / "support_out"
+
+    support_output = (support_root / "data" / "mart" / "lookup_ds"
+                      / "2024" / "lookup_table.parquet")
+    support_output.parent.mkdir(parents=True, exist_ok=True)
+    duckdb.execute(
+        f"COPY (SELECT 7 AS lookup_value) TO '{support_output.as_posix()}' (FORMAT PARQUET)"
+    )
+
+    support_config = _make_support_config(
+        support_root, tmp_path / "support_dataset.yml",
+        [("lookup_table", "sql/lookup.sql")],
+    )
+
+    (tmp_path / "sql" / "mart" / "mart_example.sql").write_text(
+        "select * from read_parquet('{support.lookup.mart}')", encoding="utf-8",
+    )
+
+    config_path = make_dataset_yml(
+        tmp_path / "dataset.yml", root=root_dir,
+        mart_tables=[("mart_example", "sql/mart/mart_example.sql")],
+        extra=(
+            "support:\n"
+            '  - name: "lookup"\n'
+            f'    config: "{support_config.as_posix()}"\n'
+            "    years: [2024]"
+        ),
+    )
+
     result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run"])
 
     assert result.exit_code == 0
@@ -216,131 +191,33 @@ def test_run_dry_run_accepts_mart_sql_with_root_posix_placeholder(tmp_path: Path
 
 
 @pytest.mark.policy
-def test_run_dry_run_accepts_mart_sql_with_support_placeholder(tmp_path: Path) -> None:
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
+def test_run_dry_run_fails_when_support_output_is_missing(
+    tmp_path: Path, runner,
+) -> None:
+    make_standard_sql(tmp_path)
     root_dir = tmp_path / "out"
-
     support_root = tmp_path / "support_out"
-    support_output = support_root / "data" / "mart" / "lookup_ds" / "2024" / "lookup_table.parquet"
-    support_output.parent.mkdir(parents=True, exist_ok=True)
-    duckdb.execute(
-        f"COPY (SELECT 7 AS lookup_value) TO '{support_output.as_posix()}' (FORMAT PARQUET)"
+
+    support_config = _make_support_config(
+        support_root, tmp_path / "support_dataset.yml",
+        [("lookup_table", "sql/lookup.sql")],
     )
 
-    support_config = tmp_path / "support_dataset.yml"
-    support_config.write_text(
-        "\n".join(
-            [
-                f'root: "{support_root.as_posix()}"',
-                "dataset:",
-                '  name: "lookup_ds"',
-                "  years: [2024]",
-                "raw: {}",
-                "clean: {}",
-                "mart:",
-                "  tables:",
-                '    - name: "lookup_table"',
-                '      sql: "sql/lookup.sql"',
-            ]
+    (tmp_path / "sql" / "mart" / "mart_example.sql").write_text(
+        "select * from read_parquet('{support.lookup.mart}')", encoding="utf-8",
+    )
+
+    config_path = make_dataset_yml(
+        tmp_path / "dataset.yml", root=root_dir,
+        mart_tables=[("mart_example", "sql/mart/mart_example.sql")],
+        extra=(
+            "support:\n"
+            '  - name: "lookup"\n'
+            f'    config: "{support_config.as_posix()}"\n'
+            "    years: [2024]"
         ),
-        encoding="utf-8",
     )
 
-    (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text(
-        "select * from read_parquet('{support.lookup.mart}')",
-        encoding="utf-8",
-    )
-
-    config_path = tmp_path / "dataset.yml"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "demo_ds"',
-                "  years: [2022]",
-                "raw: {}",
-                "clean:",
-                '  sql: "sql/clean.sql"',
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart/mart_example.sql"',
-                "support:",
-                '  - name: "lookup"',
-                f'    config: "{support_config.as_posix()}"',
-                "    years: [2024]",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    runner = CliRunner()
-    result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run"])
-
-    assert result.exit_code == 0
-    assert "sql_validation: OK" in result.output
-
-
-@pytest.mark.policy
-def test_run_dry_run_fails_when_support_output_is_missing(tmp_path: Path) -> None:
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    root_dir = tmp_path / "out"
-
-    support_root = tmp_path / "support_out"
-    support_config = tmp_path / "support_dataset.yml"
-    support_config.write_text(
-        "\n".join(
-            [
-                f'root: "{support_root.as_posix()}"',
-                "dataset:",
-                '  name: "lookup_ds"',
-                "  years: [2024]",
-                "raw: {}",
-                "clean: {}",
-                "mart:",
-                "  tables:",
-                '    - name: "lookup_table"',
-                '      sql: "sql/lookup.sql"',
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text(
-        "select * from read_parquet('{support.lookup.mart}')",
-        encoding="utf-8",
-    )
-
-    config_path = tmp_path / "dataset.yml"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "demo_ds"',
-                "  years: [2022]",
-                "raw: {}",
-                "clean:",
-                '  sql: "sql/clean.sql"',
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart/mart_example.sql"',
-                "support:",
-                '  - name: "lookup"',
-                f'    config: "{support_config.as_posix()}"',
-                "    years: [2024]",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    runner = CliRunner()
     result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run"])
 
     assert result.exit_code == 0, result.output
@@ -348,103 +225,57 @@ def test_run_dry_run_fails_when_support_output_is_missing(tmp_path: Path) -> Non
 
 
 @pytest.mark.policy
-def test_run_dry_run_fails_when_support_outputs_are_only_partially_present(tmp_path: Path) -> None:
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
+def test_run_dry_run_fails_when_support_outputs_are_only_partially_present(
+    tmp_path: Path, runner,
+) -> None:
+    make_standard_sql(tmp_path)
     root_dir = tmp_path / "out"
-
     support_root = tmp_path / "support_out"
-    support_output = support_root / "data" / "mart" / "lookup_ds" / "2024" / "lookup_a.parquet"
+
+    support_output = (support_root / "data" / "mart" / "lookup_ds"
+                      / "2024" / "lookup_a.parquet")
     support_output.parent.mkdir(parents=True, exist_ok=True)
     duckdb.execute(
         f"COPY (SELECT 7 AS lookup_value) TO '{support_output.as_posix()}' (FORMAT PARQUET)"
     )
 
-    support_config = tmp_path / "support_dataset.yml"
-    support_config.write_text(
-        "\n".join(
-            [
-                f'root: "{support_root.as_posix()}"',
-                "dataset:",
-                '  name: "lookup_ds"',
-                "  years: [2024]",
-                "raw: {}",
-                "clean: {}",
-                "mart:",
-                "  tables:",
-                '    - name: "lookup_a"',
-                '      sql: "sql/lookup_a.sql"',
-                '    - name: "lookup_b"',
-                '      sql: "sql/lookup_b.sql"',
-            ]
+    support_config = _make_support_config(
+        support_root, tmp_path / "support_dataset.yml",
+        [("lookup_a", "sql/lookup_a.sql"), ("lookup_b", "sql/lookup_b.sql")],
+    )
+
+    (tmp_path / "sql" / "mart" / "mart_example.sql").write_text(
+        "select * from read_parquet('{support.lookup.mart}')", encoding="utf-8",
+    )
+
+    config_path = make_dataset_yml(
+        tmp_path / "dataset.yml", root=root_dir,
+        mart_tables=[("mart_example", "sql/mart/mart_example.sql")],
+        extra=(
+            "support:\n"
+            '  - name: "lookup"\n'
+            f'    config: "{support_config.as_posix()}"\n'
+            "    years: [2024]"
         ),
-        encoding="utf-8",
     )
 
-    (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text(
-        "select * from read_parquet('{support.lookup.mart}')",
-        encoding="utf-8",
-    )
-
-    config_path = tmp_path / "dataset.yml"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "demo_ds"',
-                "  years: [2022]",
-                "raw: {}",
-                "clean:",
-                '  sql: "sql/clean.sql"',
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart/mart_example.sql"',
-                "support:",
-                '  - name: "lookup"',
-                f'    config: "{support_config.as_posix()}"',
-                "    years: [2024]",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    runner = CliRunner()
     result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run"])
 
     assert result.exit_code == 0, result.output
     assert "DRY_RUN" in result.output
+
+
+# ── Logger context ──────────────────────────────────────────────────────────
 
 
 @pytest.mark.policy
 def test_run_year_logs_effective_root_context(tmp_path: Path, caplog) -> None:
-    sql_dir = tmp_path / "sql" / "mart"
-    sql_dir.mkdir(parents=True, exist_ok=True)
-    (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
-    (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
-
-    config_path = tmp_path / "dataset.yml"
-    root_dir = tmp_path / "out"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "demo_ds"',
-                "  years: [2022]",
-                "raw: {}",
-                "clean:",
-                '  sql: "sql/clean.sql"',
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart/mart_example.sql"',
-            ]
-        ),
-        encoding="utf-8",
+    make_standard_sql(tmp_path)
+    config_path = make_dataset_yml(
+        tmp_path / "dataset.yml",
+        mart_tables=[("mart_example", "sql/mart/mart_example.sql")],
     )
+    root_dir = tmp_path / "out"
 
     cfg = load_config(config_path)
     logger = logging.getLogger("test.run_dry_run")
@@ -461,41 +292,25 @@ def test_run_year_logs_effective_root_context(tmp_path: Path, caplog) -> None:
     assert "root_source=yml" in caplog.text
 
 
+# ── Mart-only / compose ─────────────────────────────────────────────────────
+
+
 @pytest.mark.policy
-def test_run_dry_run_accepts_mart_only_config(tmp_path: Path) -> None:
+def test_run_dry_run_accepts_mart_only_config(tmp_path: Path, runner) -> None:
     mart_sql = tmp_path / "compose" / "sql"
     mart_sql.mkdir(parents=True, exist_ok=True)
     source_path = tmp_path / "external_source.parquet"
-
-    con = duckdb.connect()
-    con.execute("COPY (SELECT 1 AS value) TO ? (FORMAT PARQUET)", [str(source_path)])
-    con.close()
-
+    duckdb.execute("COPY (SELECT 1 AS value) TO ? (FORMAT PARQUET)", [str(source_path)])
     (mart_sql / "mart_example.sql").write_text(
-        f"select * from read_parquet('{source_path.as_posix()}')",
-        encoding="utf-8",
+        f"select * from read_parquet('{source_path.as_posix()}')", encoding="utf-8",
     )
 
-    config_path = tmp_path / "compose" / "dataset.yml"
-    root_dir = tmp_path / "out"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "compose_demo"',
-                "  years: [2022]",
-                "raw: {}",
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart_example.sql"',
-            ]
-        ),
-        encoding="utf-8",
+    config_path = make_dataset_yml(
+        tmp_path / "compose" / "dataset.yml",
+        name="compose_demo", clean_sql=None,
+        mart_tables=[("mart_example", "sql/mart_example.sql")],
     )
 
-    runner = CliRunner()
     result = runner.invoke(app, ["run", "mart", "--config", str(config_path), "--dry-run"])
 
     assert result.exit_code == 0
@@ -505,31 +320,19 @@ def test_run_dry_run_accepts_mart_only_config(tmp_path: Path) -> None:
 
 
 @pytest.mark.policy
-def test_run_dry_run_all_fails_readably_on_mart_only_config(tmp_path: Path) -> None:
+def test_run_dry_run_all_fails_readably_on_mart_only_config(
+    tmp_path: Path, runner,
+) -> None:
     mart_sql = tmp_path / "compose" / "sql"
     mart_sql.mkdir(parents=True, exist_ok=True)
     (mart_sql / "mart_example.sql").write_text("select 1 as value", encoding="utf-8")
 
-    config_path = tmp_path / "compose" / "dataset.yml"
-    root_dir = tmp_path / "out"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "compose_demo"',
-                "  years: [2022]",
-                "raw: {}",
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart_example.sql"',
-            ]
-        ),
-        encoding="utf-8",
+    config_path = make_dataset_yml(
+        tmp_path / "compose" / "dataset.yml",
+        name="compose_demo", clean_sql=None,
+        mart_tables=[("mart_example", "sql/mart_example.sql")],
     )
 
-    runner = CliRunner()
     result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run"])
 
     assert result.exit_code != 0
@@ -537,40 +340,22 @@ def test_run_dry_run_all_fails_readably_on_mart_only_config(tmp_path: Path) -> N
 
 
 @pytest.mark.policy
-def test_run_mart_executes_mart_only_config(tmp_path: Path) -> None:
+def test_run_mart_executes_mart_only_config(tmp_path: Path, runner) -> None:
     mart_sql = tmp_path / "compose" / "sql"
     mart_sql.mkdir(parents=True, exist_ok=True)
     source_path = tmp_path / "external_source.parquet"
-
-    con = duckdb.connect()
-    con.execute("COPY (SELECT 1 AS value) TO ? (FORMAT PARQUET)", [str(source_path)])
-    con.close()
-
+    duckdb.execute("COPY (SELECT 1 AS value) TO ? (FORMAT PARQUET)", [str(source_path)])
     (mart_sql / "mart_example.sql").write_text(
-        f"select * from read_parquet('{source_path.as_posix()}')",
-        encoding="utf-8",
+        f"select * from read_parquet('{source_path.as_posix()}')", encoding="utf-8",
     )
 
-    config_path = tmp_path / "compose" / "dataset.yml"
     root_dir = tmp_path / "out"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "compose_demo"',
-                "  years: [2022]",
-                "raw: {}",
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart_example.sql"',
-            ]
-        ),
-        encoding="utf-8",
+    config_path = make_dataset_yml(
+        tmp_path / "compose" / "dataset.yml",
+        name="compose_demo", root=root_dir, clean_sql=None,
+        mart_tables=[("mart_example", "sql/mart_example.sql")],
     )
 
-    runner = CliRunner()
     result = runner.invoke(app, ["run", "mart", "--config", str(config_path)])
 
     assert result.exit_code == 0
@@ -581,114 +366,75 @@ def test_run_mart_executes_mart_only_config(tmp_path: Path) -> None:
 
 
 @pytest.mark.policy
-def test_run_mart_mart_only_ignores_stale_clean_dir(tmp_path: Path) -> None:
+def test_run_mart_mart_only_ignores_stale_clean_dir(tmp_path: Path, runner) -> None:
     mart_sql = tmp_path / "compose" / "sql"
     mart_sql.mkdir(parents=True, exist_ok=True)
-
-    config_path = tmp_path / "compose" / "dataset.yml"
     root_dir = tmp_path / "out"
-    stale_clean_dir = root_dir / "data" / "clean" / "compose_demo" / "2022"
-    stale_clean_dir.mkdir(parents=True, exist_ok=True)
-    stale_clean_path = stale_clean_dir / "compose_demo_2022_clean.parquet"
+    stale_clean = root_dir / "data" / "clean" / "compose_demo" / "2022"
+    stale_clean.mkdir(parents=True, exist_ok=True)
+    stale_parquet = stale_clean / "compose_demo_2022_clean.parquet"
     duckdb.execute(
-        f"COPY (SELECT 1 AS stale_value) TO '{stale_clean_path.as_posix()}' (FORMAT PARQUET)"
+        f"COPY (SELECT 1 AS stale_value) TO '{stale_parquet.as_posix()}' (FORMAT PARQUET)"
     )
-
     (mart_sql / "mart_example.sql").write_text(
-        "select stale_value from clean_input",
-        encoding="utf-8",
+        "select stale_value from clean_input", encoding="utf-8",
     )
 
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "compose_demo"',
-                "  years: [2022]",
-                "raw: {}",
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart_example.sql"',
-            ]
-        ),
-        encoding="utf-8",
+    config_path = make_dataset_yml(
+        tmp_path / "compose" / "dataset.yml",
+        name="compose_demo", clean_sql=None,
+        mart_tables=[("mart_example", "sql/mart_example.sql")],
     )
 
-    runner = CliRunner()
     result = runner.invoke(app, ["run", "mart", "--config", str(config_path)])
 
     assert result.exit_code != 0
     assert "clean_input" in str(result.exception)
-    mart_output = root_dir / "data" / "mart" / "compose_demo" / "2022" / "mart_example.parquet"
-    assert not mart_output.exists()
+    assert not (root_dir / "data" / "mart" / "compose_demo" / "2022" / "mart_example.parquet").exists()
 
 
 @pytest.mark.policy
-def test_run_all_fails_readably_on_mart_only_config(tmp_path: Path) -> None:
+def test_run_all_fails_readably_on_mart_only_config(tmp_path: Path, runner) -> None:
     mart_sql = tmp_path / "compose" / "sql"
     mart_sql.mkdir(parents=True, exist_ok=True)
     (mart_sql / "mart_example.sql").write_text("select 1 as value", encoding="utf-8")
 
-    config_path = tmp_path / "compose" / "dataset.yml"
-    root_dir = tmp_path / "out"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                '  name: "compose_demo"',
-                "  years: [2022]",
-                "raw: {}",
-                "mart:",
-                "  tables:",
-                '    - name: "mart_example"',
-                '      sql: "sql/mart_example.sql"',
-            ]
-        ),
-        encoding="utf-8",
+    config_path = make_dataset_yml(
+        tmp_path / "compose" / "dataset.yml",
+        name="compose_demo", clean_sql=None,
+        mart_tables=[("mart_example", "sql/mart_example.sql")],
     )
 
-    runner = CliRunner()
     result = runner.invoke(app, ["run", "all", "--config", str(config_path)])
 
     assert result.exit_code != 0
     assert "run all is not supported for mart-only / compose-only configs" in str(result.exception)
 
 
+# ── Raw sources ─────────────────────────────────────────────────────────────
+
+
 @pytest.mark.policy
-def test_run_all_fails_with_bootstrap_hint_when_clean_sql_missing(tmp_path: Path) -> None:
-    """When clean.sql does not exist, run all fails with a clear message pointing to init."""
-    # No clean.sql created — only raw dir (which exists but has no profile).
-    # Config has clean.sql declared but file does not exist.
+def test_run_all_fails_with_bootstrap_hint_when_clean_sql_missing(
+    tmp_path: Path, runner,
+) -> None:
     raw_dir = tmp_path / "data" / "raw" / "demo_ds" / "2022"
     raw_dir.mkdir(parents=True, exist_ok=True)
     (raw_dir / "demo_ds_2022.csv").write_text("col1;col2\nval1;val2\n", encoding="utf-8")
 
-    config_path = tmp_path / "dataset.yml"
-    root_dir = tmp_path / "out"
-    config_path.write_text(
-        "\n".join(
-            [
-                f'root: "{root_dir.as_posix()}"',
-                "dataset:",
-                "  name: demo_ds",
-                "  years: [2022]",
-                "raw:",
-                "  sources:",
-                "    - type: local_file",
-                "      args:",
-                "        path: data/raw/demo_ds/2022/demo_ds_2022.csv",
-                "clean:",
-                "  sql: sql/clean.sql",  # file does not exist
-            ]
+    config_path = make_dataset_yml(
+        tmp_path / "dataset.yml",
+        name="demo_ds",
+        extra=(
+            "raw:\n"
+            "  sources:\n"
+            "    - type: local_file\n"
+            "      args:\n"
+            "        path: data/raw/demo_ds/2022/demo_ds_2022.csv\n"
         ),
-        encoding="utf-8",
+        clean_sql="sql/clean.sql",  # file does not exist
     )
 
-    # Profiling is NOT pre-created; clean.sql does NOT exist.
-    runner = CliRunner()
     result = runner.invoke(app, ["run", "all", "--config", str(config_path)])
 
     assert result.exit_code != 0


### PR DESCRIPTION
## Cosa

Introduce infrastruttura di test condivisa e riduce il boilerplate:

### Nuovo
- **`tests/conftest.py`** — fixture `runner` (CliRunner), `project_example`, `chdir_tmp`
- **`tests/helpers.py`** — `make_dataset_yml()`, `make_standard_sql()`, `write_text()`

### Riduzione
- **`test_run_dry_run.py`**: 697 → 443 righe (-254, -36%). I 18 blocchi YAML inline sono stati sostituiti da chiamate a `make_dataset_yml()`.
- **`test_http_file_plugin.py`**: migrato da `monkeypatch.setattr(HttpClient, "get", ...)` a `FakeHttpClient` da `lab_connectors.testing`. Rimossa classe `_FakeResponse` inline (-12 righe).

### Dipendenza
- `pyproject.toml` aggiornato a `lab-connectors@feat/testing-module` (richiede il modulo `testing` non ancora rilasciato)

## Perché

Ridurre codice duplicato a parità di copertura. Le fixture in conftest sono pronte per essere usate gradualmente dagli altri file di test (altri ~200 righe eliminabili).

## Test
`pytest tests/ -q` → 666 passed, 0 failed
