### PR TITLE
chore: Python 3.12 uniforme — CI matrix + requires-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install Build Tooling
         run: python -m pip install build twine
       - name: Build Distributions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dataciviclab-toolkit"
 dynamic = ["version"]
 description = "DataCivicLab Toolkit: RAW -> CLEAN -> MART with DuckDB"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = "MIT"
 authors = [
   { name = "DataCivicLab" }


### PR DESCRIPTION
- CI: matrix `["3.10", "3.11", "3.12"]` → `["3.12"]` (-67% build time)
- pyproject.toml: `requires-python >= 3.10` → `>= 3.12`
- Allineato a tutti gli altri repo del Lab