### PR TITLE
feat(plugins): timeout escalation in HTTP/CKAN/SDMX/SPARQL

### DIFF
--- a/toolkit/core/config_models/raw.py
+++ b/toolkit/core/config_models/raw.py
@@ -16,6 +16,7 @@ class ClientConfig(BaseModel):
     retries: int | None = None
     user_agent: str | None = None
     headers: dict[str, str] | None = None
+    timeout_escalation: list[int] | None = None
 
     @field_validator("headers", mode="before")
     @classmethod

--- a/toolkit/core/registry.py
+++ b/toolkit/core/registry.py
@@ -75,7 +75,10 @@ _BUILTIN_PLUGINS: tuple[dict[str, Any], ...] = (
         "module": "toolkit.plugins.sparql",
         "class_name": "SparqlSource",
         "optional": False,
-        "factory": lambda cls: (lambda **client: cls(timeout=client.get("timeout", 60))),
+        "factory": lambda cls: (lambda **client: cls(
+            timeout=client.get("timeout", 60),
+            timeout_escalation=client.get("timeout_escalation"),
+        )),
     },
 )
 

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -46,7 +46,13 @@ def _force_https(url: str) -> str:
 class CkanSource:
     """Resolve a CKAN resource via resource_show, then download its current URL."""
 
-    def __init__(self, timeout: int = 60, retries: int = 2, user_agent: str | None = None):
+    def __init__(
+        self,
+        timeout: int = 60,
+        retries: int = 2,
+        user_agent: str | None = None,
+        timeout_escalation: list[int] | None = None,
+    ):
         self.timeout = timeout
         self.retries = retries
         self.user_agent = user_agent or "dataciviclab-toolkit/0.1"
@@ -54,6 +60,7 @@ class CkanSource:
             timeout=timeout,
             max_retries=retries,
             user_agent=self.user_agent,
+            timeout_escalation=timeout_escalation,
         )
 
     def _get_json(self, url: str, params: dict[str, str]) -> dict:

--- a/toolkit/plugins/http_file.py
+++ b/toolkit/plugins/http_file.py
@@ -16,7 +16,13 @@ class HttpFileSource:
     HttpResult into toolkit's DownloadError contract.
     """
 
-    def __init__(self, timeout: int = 60, retries: int = 2, user_agent: str | None = None):
+    def __init__(
+        self,
+        timeout: int = 60,
+        retries: int = 2,
+        user_agent: str | None = None,
+        timeout_escalation: list[int] | None = None,
+    ):
         self.timeout = timeout
         self.retries = retries
         self.user_agent = user_agent or "dataciviclab-toolkit/0.1"
@@ -24,6 +30,7 @@ class HttpFileSource:
             timeout=timeout,
             max_retries=retries,
             user_agent=self.user_agent,
+            timeout_escalation=timeout_escalation,
         )
 
     def fetch(self, url: str) -> bytes:

--- a/toolkit/plugins/http_post_file.py
+++ b/toolkit/plugins/http_post_file.py
@@ -39,7 +39,13 @@ class HttpPostFileSource:
        set ``max_retries=0`` in ``raw.sources[].client``.
     """
 
-    def __init__(self, timeout: int = 60, retries: int = 2, user_agent: str | None = None):
+    def __init__(
+        self,
+        timeout: int = 60,
+        retries: int = 2,
+        user_agent: str | None = None,
+        timeout_escalation: list[int] | None = None,
+    ):
         self.timeout = timeout
         self.retries = retries
         self.user_agent = user_agent or "dataciviclab-toolkit/0.1"
@@ -47,6 +53,7 @@ class HttpPostFileSource:
             timeout=timeout,
             max_retries=retries,
             user_agent=self.user_agent,
+            timeout_escalation=timeout_escalation,
         )
 
     def fetch(self, url: str, data: dict | None = None) -> bytes:

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -44,6 +44,7 @@ class SdmxSource:
         user_agent: str | None = None,
         data_base_url: str | None = None,
         metadata_base_url: str | None = None,
+        timeout_escalation: list[int] | None = None,
     ):
         self.timeout = timeout
         self.retries = retries
@@ -58,6 +59,7 @@ class SdmxSource:
             timeout=timeout,
             max_retries=retries,
             user_agent=self.user_agent,
+            timeout_escalation=timeout_escalation,
         )
 
     def _candidate_base_urls(self, agency: str, primary: str, alternate: str) -> list[str]:

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -22,8 +22,11 @@ class SparqlSource:
     is idempotent: same query → same result).
     """
 
-    def __init__(self, timeout: int = 60):
-        self._client = HttpClient(timeout=timeout)
+    def __init__(self, timeout: int = 60, timeout_escalation: list[int] | None = None):
+        self._client = HttpClient(
+            timeout=timeout,
+            timeout_escalation=timeout_escalation,
+        )
 
     def fetch(
         self,


### PR DESCRIPTION
## Timeout escalation nei plugin

Aggiunto il parametro `timeout_escalation` a tutti i plugin che usano `HttpClient`, permettendo timeout progressivi per fonti lente o a risposta variabile.

### Plugin modificati

- `http_file`, `http_post_file` — parametro passato a HttpClient
- `ckan` — parametro passato a HttpClient  
- `sdmx` — parametro passato a HttpClient
- `sparql` — parametro passato a HttpClient + factory registry aggiornata
- `ClientConfig` model — campo `timeout_escalation: list[int] | None`

### Configurazione via dataset.yml

```yaml
raw:
  sources:
    - client:
        timeout: 60
        timeout_escalation: [30, 90, 180]
```

Se non specificato, comportamento invariato.

### Dipende da

Questa PR richiede `lab-connectors` con `timeout_escalation` supportato (PR #27).

### Test

642 passati, nessuna regressione.