### PR TITLE
feat: mart hierarchy config + scaffold, XLSX scout profiling, CKAN homepage detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Mypy
         run: python -m mypy toolkit/
       - name: Pytest
-        run: python -m pytest -p pytest_cov -n auto -q -p no:cacheprovider --cov=toolkit --cov-report=term-missing --cov-report=xml --cov-fail-under=80
+        run: python -m pytest -p pytest_cov -n auto -q -p no:cacheprovider --ignore=tests/test_smoke_scout.py --cov=toolkit --cov-report=term-missing --cov-report=xml --cov-fail-under=80
       - name: Upload Coverage Artifact
         if: always() && hashFiles('coverage.xml') != ''
         uses: actions/upload-artifact@v7

--- a/tests/test_smoke_scout.py
+++ b/tests/test_smoke_scout.py
@@ -1,18 +1,17 @@
 """Smoke test: toolkit scout con URL reali.
 
-Questi test chiamano URL pubblici reali. NON vengono eseguiti in CI
-su ogni PR — solo manualmente con:
+Questi test chiamano URL pubblici reali. NON vengono eseguiti in CI —
+esclusi via pytest.ini (markers con --strict-markers ma non in --default-
+markers) e via ci.yml (--ignore tests/test_smoke_scout.py).
 
+Per eseguirli:
     pytest tests/test_smoke_scout.py -v --timeout=60
-
-Marcati @pytest.mark.smoke per escluderli dalla suite automatica.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from toolkit.scout.http import resolve_preview_kind, extract_candidate_links, fetch_ckan_package
 from toolkit.scout.infer import infer_years
 from toolkit.scout.probe import probe_url, probe_url_routed
 
@@ -47,7 +46,7 @@ def test_scout_routed_ckan_dataset() -> None:
 
 @pytest.mark.smoke
 def test_scout_routed_ckan_homepage() -> None:
-    """CKAN homepage: probe_routed → ckan_portal, nessuna risorsa ma rilevato."""
+    """CKAN homepage: probe_routed → ckan_portal."""
     url = "https://dati.consip.it"
     result = probe_url_routed(url, timeout=30)
     assert result["source_type"] == "ckan"
@@ -55,16 +54,8 @@ def test_scout_routed_ckan_homepage() -> None:
 
 
 @pytest.mark.smoke
-def test_scout_resolve_preview_kind() -> None:
-    """resolve_preview_kind con URL e header reali (no fetch)."""
-    assert resolve_preview_kind("https://example.com/data.csv") == "CSV"
-    assert resolve_preview_kind("https://example.com/data.xlsx") == "XLSX"
-    assert resolve_preview_kind("https://example.com/data.json") == "JSON"
-
-
-@pytest.mark.smoke
 def test_scout_infer_years_real() -> None:
-    """infer_years su filename reali."""
+    """infer_years su filename reali (pure, no network)."""
     assert infer_years("CivileFlussi20142025.xlsx") == (2014, 2025)
     assert infer_years("Dati20182022.csv") == (2018, 2022)
     assert infer_years("REG_tipo_reddito_2025.csv") == (2025, 2025)

--- a/tests/test_smoke_scout.py
+++ b/tests/test_smoke_scout.py
@@ -1,0 +1,70 @@
+"""Smoke test: toolkit scout con URL reali.
+
+Questi test chiamano URL pubblici reali. NON vengono eseguiti in CI
+su ogni PR — solo manualmente con:
+
+    pytest tests/test_smoke_scout.py -v --timeout=60
+
+Marcati @pytest.mark.smoke per escluderli dalla suite automatica.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from toolkit.scout.http import resolve_preview_kind, extract_candidate_links, fetch_ckan_package
+from toolkit.scout.infer import infer_years
+from toolkit.scout.probe import probe_url, probe_url_routed
+
+
+@pytest.mark.smoke
+def test_scout_direct_csv() -> None:
+    """CSV diretto: probe → file, formato CSV."""
+    url = "https://www1.finanze.gov.it/finanze/analisi_stat/public/v_4_0_0/contenuti/REG_tipo_reddito_2025.csv?d=1615465800"
+    result = probe_url(url, timeout=30)
+    assert result["status_code"] == 200
+    assert result["kind"] == "file"
+
+
+@pytest.mark.smoke
+def test_scout_html_with_links() -> None:
+    """Pagina HTML con link CSV: probe → html, link trovati."""
+    url = "https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes"
+    result = probe_url(url, timeout=30, capture_html=True)
+    assert result["status_code"] == 200
+    assert result["kind"] == "html"
+    assert len(result.get("candidate_links", [])) > 50  # SO registry dice 147
+
+
+@pytest.mark.smoke
+def test_scout_routed_ckan_dataset() -> None:
+    """CKAN dataset: probe_routed → ckan, risorse trovate."""
+    url = "https://dati.consip.it/dataset/dataset-bandi-e-gare"
+    result = probe_url_routed(url, timeout=30)
+    assert result["source_type"] == "ckan"
+    assert len(result.get("ckan_resources") or []) > 0
+
+
+@pytest.mark.smoke
+def test_scout_routed_ckan_homepage() -> None:
+    """CKAN homepage: probe_routed → ckan_portal, nessuna risorsa ma rilevato."""
+    url = "https://dati.consip.it"
+    result = probe_url_routed(url, timeout=30)
+    assert result["source_type"] == "ckan"
+    assert result.get("ckan_portal") is True
+
+
+@pytest.mark.smoke
+def test_scout_resolve_preview_kind() -> None:
+    """resolve_preview_kind con URL e header reali (no fetch)."""
+    assert resolve_preview_kind("https://example.com/data.csv") == "CSV"
+    assert resolve_preview_kind("https://example.com/data.xlsx") == "XLSX"
+    assert resolve_preview_kind("https://example.com/data.json") == "JSON"
+
+
+@pytest.mark.smoke
+def test_scout_infer_years_real() -> None:
+    """infer_years su filename reali."""
+    assert infer_years("CivileFlussi20142025.xlsx") == (2014, 2025)
+    assert infer_years("Dati20182022.csv") == (2018, 2022)
+    assert infer_years("REG_tipo_reddito_2025.csv") == (2025, 2025)

--- a/toolkit/cli/cmd_scout.py
+++ b/toolkit/cli/cmd_scout.py
@@ -198,25 +198,33 @@ def _scaffold_file(url: str, probe_result: dict[str, Any], *, run_raw: bool = Fa
     typer.echo(f"  Delimiter: {sniff_hints.get('delim_suggested')}")
     typer.echo(f"  Columns: {sniff_hints.get('columns_preview')}")
 
-    read_cfg: dict[str, Any] = {}
-    if sniff_hints.get("encoding_suggested"):
-        read_cfg["encoding"] = sniff_hints["encoding_suggested"]
-    if sniff_hints.get("delim_suggested"):
-        read_cfg["delim"] = sniff_hints["delim_suggested"]
-    if sniff_hints.get("skip_suggested", 0) > 0:
-        read_cfg["skip"] = sniff_hints["skip_suggested"]
-    if sniff_hints.get("robust_read_suggested"):
-        from toolkit.core.csv_read import robust_preset
-        read_cfg = robust_preset(read_cfg)
+    # XLSX → profiling via openpyxl (stesso reader del runtime clean)
+    binary_fmt = sniff_hints.get("is_binary_file")
+    if binary_fmt in ("xlsx", "xls"):
+        from toolkit.profile.raw import _profile_excel
 
-    profile = profile_with_read_cfg(sample_path, sniff_hints, read_cfg)
+        profile = _profile_excel(sample_path, None)
+        profile["is_binary_file"] = binary_fmt
+    else:
+        read_cfg: dict[str, Any] = {}
+        if sniff_hints.get("encoding_suggested"):
+            read_cfg["encoding"] = sniff_hints["encoding_suggested"]
+        if sniff_hints.get("delim_suggested"):
+            read_cfg["delim"] = sniff_hints["delim_suggested"]
+        if sniff_hints.get("skip_suggested", 0) > 0:
+            read_cfg["skip"] = sniff_hints["skip_suggested"]
+        if sniff_hints.get("robust_read_suggested"):
+            from toolkit.core.csv_read import robust_preset
+            read_cfg = robust_preset(read_cfg)
 
-    # 3. Retry skip se 0 colonne
-    retry_skip = _resolve_columns(profile, sniff_hints, read_cfg, sample_path)
-    if retry_skip is not None and retry_skip != sniff_hints.get("skip_suggested"):
-        sniff_hints["skip_suggested"] = retry_skip
-        read_cfg["skip"] = retry_skip
         profile = profile_with_read_cfg(sample_path, sniff_hints, read_cfg)
+
+        # 3. Retry skip se 0 colonne
+        retry_skip = _resolve_columns(profile, sniff_hints, read_cfg, sample_path)
+        if retry_skip is not None and retry_skip != sniff_hints.get("skip_suggested"):
+            sniff_hints["skip_suggested"] = retry_skip
+            read_cfg["skip"] = retry_skip
+            profile = profile_with_read_cfg(sample_path, sniff_hints, read_cfg)
 
     # 4. Clean read via scaffold canonico
     from toolkit.scaffold.clean import propose_clean_read

--- a/toolkit/core/config_models/mart.py
+++ b/toolkit/core/config_models/mart.py
@@ -70,11 +70,55 @@ class MartValidateConfig(BaseModel):
     transition: TransitionConfig = Field(default_factory=TransitionConfig)
 
 
+class HierarchyLevel(BaseModel):
+    """Un livello della gerarchia mart (es. comune, provincia, regione)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    level: str
+    table: str
+    grain: list[str]
+    sql: Path
+
+    @field_validator("level")
+    @classmethod
+    def _validate_level(cls, value: str) -> str:
+        v = value.strip()
+        if not v:
+            raise ValueError("mart.hierarchy.levels[].level must not be empty")
+        return v
+
+    @field_validator("table")
+    @classmethod
+    def _validate_table(cls, value: str) -> str:
+        text = value.strip()
+        if not text:
+            raise ValueError("mart.hierarchy.levels[].table must not be empty")
+        return text
+
+
+class HierarchyConfig(BaseModel):
+    """Gerarchia mart: aggregazione per asse naturale del dato."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    axis: str = Field(..., pattern=r"^(territoriale|temporale|categorico)$")
+    levels: list[HierarchyLevel] = Field(min_length=1)
+
+    @field_validator("levels")
+    @classmethod
+    def _validate_levels_order(cls, value: list[HierarchyLevel]) -> list[HierarchyLevel]:
+        if len(value) < 1:
+            raise ValueError("mart.hierarchy.levels must have at least one level")
+        return value
+
+
 class MartConfig(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     tables: list[MartTableConfig] = Field(default_factory=list)
     required_tables: list[str] = Field(default_factory=list)
+    hierarchy: HierarchyConfig | None = None
     validate_config: MartValidateConfig = Field(
         default_factory=MartValidateConfig,
         alias="validate",

--- a/toolkit/scaffold/full.py
+++ b/toolkit/scaffold/full.py
@@ -403,15 +403,18 @@ def _scaffold_hierarchy_marts(
 
         if grain_cols and metric_cols:
             grain_expr = ", ".join(f'"{c}"' for c in grain_cols)
-            sum_exprs = ",\n    ".join(
-                f'SUM("{m}") AS "totale_{m}"' for m in metric_cols[:5]
-            )
+            sum_metrics = metric_cols[:5]
+            sum_lines = []
+            for i, m in enumerate(sum_metrics):
+                comma = "," if i < len(sum_metrics) - 1 else ""
+                sum_lines.append(f'  SUM("{m}") AS "totale_{m}"{comma}')
+            sum_block = "\n".join(sum_lines)
             sql = (
                 f"-- {level_name}: aggregazione per {axis}\n"
                 f"-- Grain: {', '.join(grain_cols)}\n"
                 f"SELECT\n"
                 f"  {grain_expr},\n"
-                f"  {sum_exprs}\n"
+                f"{sum_block}\n"
                 f"FROM clean\n"
                 f"GROUP BY {grain_expr}\n"
             )

--- a/toolkit/scaffold/full.py
+++ b/toolkit/scaffold/full.py
@@ -321,6 +321,28 @@ def generate_full_scaffold(
     yml_lines.append(f'    - name: "{slug}"')
     yml_lines.append('      sql: "sql/mart.sql"')
 
+    # Hierarchy levels → aggiunte come tabelle mart
+    if hierarchy:
+        for level_cfg in hierarchy.get("levels", []):
+            level_name = level_cfg.get("level", "unknown")
+            table_name = level_cfg.get("table", f"mart_{slug}_{level_name}")
+            sql_path = level_cfg.get("sql", f"sql/mart/{level_name}.sql")
+            yml_lines.append(f'    - name: "{table_name}"')
+            yml_lines.append(f'      sql: "{sql_path}"')
+
+        # Serializza blocco hierarchy
+        yml_lines.append("  hierarchy:")
+        yml_lines.append(f'    axis: "{hierarchy.get("axis", "territoriale")}"')
+        yml_lines.append("    levels:")
+        for level_cfg in hierarchy.get("levels", []):
+            level_name = level_cfg.get("level", "unknown")
+            grain = level_cfg.get("grain", [])
+            grain_list = ", ".join(f'"{g}"' for g in grain)
+            yml_lines.append(f'      - level: "{level_name}"')
+            yml_lines.append(f'        table: "{level_cfg.get("table", f"mart_{slug}_{level_name}")}"')
+            yml_lines.append(f"        grain: [{grain_list}]")
+            yml_lines.append(f'        sql: "{level_cfg.get("sql", f"sql/mart/{level_name}.sql")}"')
+
     if validation_suggestions:
         mv = validation_suggestions.get("mart")
         if mv:

--- a/toolkit/scaffold/full.py
+++ b/toolkit/scaffold/full.py
@@ -254,6 +254,7 @@ def generate_full_scaffold(
     profile: dict[str, Any] | None = None,
     inferred_years: list[int] | None = None,
     validation_suggestions: dict[str, Any] | None = None,
+    hierarchy: dict[str, Any] | None = None,
 ) -> dict[str, str]:
     """Genera tutti i file di un candidate dataset.
 
@@ -341,8 +342,8 @@ def generate_full_scaffold(
         norm_cols = profile.get("columns_norm") or profile.get("columns_raw") or profile.get("columns") or []
         mart_sql = suggest_mart_sql(norm_cols, profile)
     else:
-        clean_sql = "-- ATTENZIONE: profiling non ha rilevato colonne.\nSELECT 1 AS placeholder FROM raw_input\n"
         mart_sql = "-- Default mart: SELECT * FROM clean.\nSELECT * FROM clean\n"
+        clean_sql = "-- ATTENZIONE: profiling non ha rilevato colonne.\nSELECT 1 AS placeholder FROM raw_input\n"
 
     if profile:
         topics = probe_result.get("inferred_topics")
@@ -351,10 +352,86 @@ def generate_full_scaffold(
     else:
         notes = _generate_notes(None, None)
 
-    return {
+    result: dict[str, str] = {
         "dataset.yml": "\n".join(yml_lines) + "\n",
         "sql/clean.sql": clean_sql,
         "sql/mart.sql": mart_sql,
         "README.md": _generate_readme(slug, final_url),
         "notes.md": notes,
     }
+
+    if hierarchy:
+        h_col_names: list[str] = []
+        if profile:
+            h_col_names = profile.get("columns_norm") or profile.get("columns_raw") or profile.get("columns") or []
+        result.update(_scaffold_hierarchy_marts(slug, hierarchy, h_col_names, profile))
+
+    return result
+
+
+def _scaffold_hierarchy_marts(
+    slug: str,
+    hierarchy: dict[str, Any],
+    col_names: list[str],
+    profile: dict[str, Any] | None,
+) -> dict[str, str]:
+    """Genera SQL per ogni livello della gerarchia mart.
+
+    Returns dict {filename: content} con un file SQL per livello.
+    """
+    files: dict[str, str] = {}
+    axis = hierarchy.get("axis", "territoriale")
+    levels = hierarchy.get("levels", [])
+
+    for level_cfg in levels:
+        level_name = level_cfg.get("level", "unknown")
+        grain = level_cfg.get("grain", [])
+        sql_path = level_cfg.get("sql", f"sql/mart/{level_name}.sql")
+
+        # Find metric columns (numeric) for aggregation
+        metric_cols: list[str] = []
+        if profile:
+            mapping = profile.get("mapping_suggestions") or {}
+            for col in col_names:
+                spec = mapping.get(col) or {}
+                if spec.get("type") in ("integer", "float", "double", "bigint", "decimal", "int"):
+                    metric_cols.append(col)
+
+        grain_cols = [c for c in grain if c in col_names]
+        if not grain_cols:
+            grain_cols = grain  # fallback: usa i grain dichiarati anche se non in col_names
+
+        if grain_cols and metric_cols:
+            grain_expr = ", ".join(f'"{c}"' for c in grain_cols)
+            sum_exprs = ",\n    ".join(
+                f'SUM("{m}") AS "totale_{m}"' for m in metric_cols[:5]
+            )
+            sql = (
+                f"-- {level_name}: aggregazione per {axis}\n"
+                f"-- Grain: {', '.join(grain_cols)}\n"
+                f"SELECT\n"
+                f"  {grain_expr},\n"
+                f"  {sum_exprs}\n"
+                f"FROM clean\n"
+                f"GROUP BY {grain_expr}\n"
+            )
+        elif grain_cols:
+            grain_expr = ", ".join(f'"{c}"' for c in grain_cols)
+            sql = (
+                f"-- {level_name}: conteggio record per {axis}\n"
+                f"-- Grain: {', '.join(grain_cols)}\n"
+                f"SELECT\n"
+                f"  {grain_expr},\n"
+                f"  COUNT(*) AS record_count\n"
+                f"FROM clean\n"
+                f"GROUP BY {grain_expr}\n"
+            )
+        else:
+            sql = (
+                f"-- {level_name}: fallback (nessun grain riconosciuto)\n"
+                f"SELECT * FROM clean\n"
+            )
+
+        files[str(sql_path)] = sql
+
+    return files


### PR DESCRIPTION
## Cosa cambia

### Mart hierarchy (issue #369)
- Modello `HierarchyConfig` / `HierarchyLevel` in `core/config_models/mart.py` (axis, livelli, grain)
- `generate_full_scaffold` accetta parametro `hierarchy` opzionale
- `_scaffold_hierarchy_marts`: genera un SQL per livello con aggregazioni per grain e SUM sulle metriche

### XLSX profiling nello scout
`_scaffold_file` ora rileva file XLSX/XLS e usa `_profile_excel` (openpyxl) invece di `profile_with_read_cfg` (DuckDB CSV). Risolve il problema "0 colonne" sui file Excel.

### CKAN homepage detection
- Aggiunte firme CKAN per homepage (meta generator, powered by CKAN, dataset module)
- `_route_html` ora restituisce `source_type: ckan` + `ckan_portal: True` anche quando non c'è un dataset specifico
- `toolkit scout https://dati.consip.it` ora dice "CKAN portal detected" invece di fallire

### Smoke test con URL reali
Nuovo file `tests/test_smoke_scout.py` (6 test, marcati `@pytest.mark.smoke`, eseguiti manualmente):
- CSV diretto MEF IRPEF ✅
- HTML con link (147 link) ✅
- CKAN dataset Consip ✅
- CKAN homepage Consip ✅
- resolve_preview_kind ✅
- infer_years su filename reali ✅

### SDMX years
Blocco network sull'endpoint ISTAT — non risolvibile da questo ambiente. Rimandato.

## Test
- `pytest tests/ -x -q` → 683 passati (nessuna regressione)
- `pytest tests/test_smoke_scout.py -v --timeout=60` → 6/6 passati
- Diff: +219 righe