### PR TITLE
fix: CKAN URL detection + mart preferisce misure a ID

### DIFF
--- a/toolkit/scaffold/full.py
+++ b/toolkit/scaffold/full.py
@@ -182,7 +182,7 @@ def suggest_mart_sql(columns: list[dict[str, Any]] | list[str], profile: dict[st
     has_numeric = _has_numeric_column(col_names, profile)
     if has_year and has_numeric:
         year_keywords = ["anno", "year", "periodo", "period"]
-        measure_keywords = ["importo", "ammontare", "valore", "costo", "spesa", "gettito", "reddito"]
+        measure_keywords = ["importo", "ammontare", "valore", "costo", "spesa", "gettito", "reddito", "canone", "prezzo", "tariffa"]
         mapping = profile.get("mapping_suggestions") or {}
         numeric_col = None
 

--- a/toolkit/scaffold/full.py
+++ b/toolkit/scaffold/full.py
@@ -182,16 +182,33 @@ def suggest_mart_sql(columns: list[dict[str, Any]] | list[str], profile: dict[st
     has_numeric = _has_numeric_column(col_names, profile)
     if has_year and has_numeric:
         year_keywords = ["anno", "year", "periodo", "period"]
+        measure_keywords = ["importo", "ammontare", "valore", "costo", "spesa", "gettito", "reddito"]
         mapping = profile.get("mapping_suggestions") or {}
         numeric_col = None
+
+        # 1. Cerca colonna con keyword misura (evita ID)
         for name in col_names:
             is_year_col = any(kw in name.lower() for kw in year_keywords)
             spec = mapping.get(name) or {}
             if is_year_col:
                 continue
             if spec.get("type") in ("integer", "float", "double", "bigint", "decimal", "int"):
-                numeric_col = name
-                break
+                if any(kw in name.lower() for kw in measure_keywords):
+                    numeric_col = name
+                    break
+
+        # 2. Fallback: primo numerico non-anno
+        if numeric_col is None:
+            for name in col_names:
+                is_year_col = any(kw in name.lower() for kw in year_keywords)
+                spec = mapping.get(name) or {}
+                if is_year_col:
+                    continue
+                if spec.get("type") in ("integer", "float", "double", "bigint", "decimal", "int"):
+                    numeric_col = name
+                    break
+
+        # 3. Fallback estremo: primo numerico
         if numeric_col is None:
             for name in col_names:
                 spec = mapping.get(name) or {}

--- a/toolkit/scout/probe.py
+++ b/toolkit/scout/probe.py
@@ -160,6 +160,9 @@ def _route_html(
 
     candidate_links = extract_candidate_links(final_url, html_text)
     is_ckan = detect_ckan_in_html(html_bytes)
+    # Se l'URL contiene /dataset/, probabilmente è CKAN anche senza firme HTML
+    if not is_ckan and "/dataset/" in urlparse(final_url).path:
+        is_ckan = True
 
     if is_ckan:
         # Tentativo: se l'URL punta a un dataset specifico, fetcha le risorse


### PR DESCRIPTION
## Quick win

### CKAN: rilevamento anche su temi personalizzati
`_route_html` ora controlla `/dataset/` nel path dell URL, oltre alle firme HTML. Portali come OpenGA (giustizia-amministrativa) ora vengono riconosciuti come CKAN anche senza le firme CKAN standard nell HTML.

### Mart: priorità a colonne misura
`suggest_mart_sql` cerca prima colonne con keyword misura (importo, ammontare, valore, costo, spesa, gettito, reddito, canone, prezzo, tariffa) prima di scegliere il primo numerico disponibile.

Evita `SUM("CODICE_SEDE")` su un ID — preferisce `SUM("IMPORTO_LOTTO")`.
Evita `SUM("X")` su una coordinata — preferisce `SUM("canone")`.

### Test
- `pytest tests/ -x -q` → 683 passati
- Testato con URL reali: OpenGA CKAN, MIT concessioni, Giustizia amministrativa