### PR TITLE
feat: smoke flags, contracts API, --root override

### DIFF
--- a/tests/test_cli_path_contract.py
+++ b/tests/test_cli_path_contract.py
@@ -4,9 +4,12 @@ import json
 import shutil
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from toolkit.cli.app import app
+
+pytestmark = pytest.mark.contract
 
 
 def _copy_project_example(dst: Path) -> Path:
@@ -155,3 +158,93 @@ def test_cli_version_flag() -> None:
     parts = version_part.split(".")
     assert len(parts) == 3, f"versione non semver: {version_part}"
     assert all(p.isdigit() for p in parts), f"versione non semver: {version_part}"
+
+
+# ---------------------------------------------------------------------------
+# smoke / sample-rows / sample-bytes / root flags (contratto CLI)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_smoke_flag_parses(tmp_path: Path) -> None:
+    """contract: --smoke flag e' accettato da run mart --dry-run."""
+    project_dir = tmp_path / "project-example"
+    config_path = _copy_project_example(project_dir)
+    runner = CliRunner()
+    result = runner.invoke(app, ["run", "mart", "--config", str(config_path), "--dry-run", "--smoke"])
+    assert result.exit_code == 0, result.output
+    assert "Execution Plan" in result.output
+
+
+def test_cli_sample_rows_flag_parses(tmp_path: Path) -> None:
+    """contract: --sample-rows flag e' accettato da run all --dry-run."""
+    project_dir = tmp_path / "project-example"
+    config_path = _copy_project_example(project_dir)
+    runner = CliRunner()
+    result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run", "--sample-rows", "500"])
+    assert result.exit_code == 0, result.output
+    assert "Execution Plan" in result.output
+
+
+def test_cli_sample_bytes_flag_parses(tmp_path: Path) -> None:
+    """contract: --sample-bytes flag e' accettato da run all --dry-run."""
+    project_dir = tmp_path / "project-example"
+    config_path = _copy_project_example(project_dir)
+    runner = CliRunner()
+    result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run", "--sample-bytes", "5000"])
+    assert result.exit_code == 0, result.output
+    assert "Execution Plan" in result.output
+
+
+def test_cli_root_flag_overrides_output(tmp_path: Path) -> None:
+    """contract: --root flag cambia la directory di output."""
+    project_dir = tmp_path / "project-example"
+    config_path = _copy_project_example(project_dir)
+    custom_root = tmp_path / "custom_out"
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["run", "all", "--config", str(config_path), "--root", str(custom_root), "--strict-config"],
+    )
+    assert result.exit_code == 0, result.output
+    assert (custom_root / "data" / "clean" / "project_example" / "2022" / "project_example_2022_clean.parquet").exists()
+    assert (custom_root / "data" / "mart" / "project_example" / "2022" / "rd_by_regione.parquet").exists()
+
+
+# ---------------------------------------------------------------------------
+# toolkit.contracts path API
+# ---------------------------------------------------------------------------
+
+
+def test_contracts_layer_year_dir() -> None:
+    """contract: layer_year_dir restituisce path corretto."""
+    from toolkit.contracts import layer_year_dir
+    path = layer_year_dir("/base", "clean", "mio_dataset", 2024)
+    assert str(path) == "/base/data/clean/mio_dataset/2024"
+
+
+def test_contracts_clean_parquet_path() -> None:
+    """contract: clean_parquet_path restituisce path al parquet."""
+    from toolkit.contracts import clean_parquet_path
+    path = clean_parquet_path("/base", "mio_dataset", 2024)
+    assert str(path) == "/base/data/clean/mio_dataset/2024/mio_dataset_2024_clean.parquet"
+
+
+def test_contracts_mart_table_path() -> None:
+    """contract: mart_table_path restituisce path corretto."""
+    from toolkit.contracts import mart_table_path
+    path = mart_table_path("/base", "mio_dataset", 2024, "rd_by_regione")
+    assert str(path) == "/base/data/mart/mio_dataset/2024/rd_by_regione.parquet"
+
+
+def test_contracts_run_record_dir() -> None:
+    """contract: run_record_dir restituisce path corretto."""
+    from toolkit.contracts import run_record_dir
+    path = run_record_dir("/base", "mio_dataset", 2024)
+    assert str(path) == "/base/data/_runs/mio_dataset/2024"
+
+
+def test_contracts_constants() -> None:
+    """contract: costanti METADATA_JSON e MANIFEST_JSON esistono."""
+    from toolkit.contracts import MANIFEST_JSON, METADATA_JSON
+    assert METADATA_JSON == "metadata.json"
+    assert MANIFEST_JSON == "manifest.json"

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -168,6 +168,7 @@ def run_clean(
     *,
     base_dir: Path | None = None,
     output_cfg: dict[str, Any] | None = None,
+    sample_rows: int | None = None,
 ):
     clean_cfg = ensure_dict(clean_cfg)
     output_cfg = ensure_dict(output_cfg)
@@ -220,6 +221,7 @@ def run_clean(
         read_cfg=relation_read_cfg,
         read_mode=read_mode,
         logger=logger,
+        sample_rows=sample_rows,
     )
     output_profile = _normalize_output_profile(output_profile)
     output_bytes: int | None = output_path.stat().st_size if output_path.exists() else None

--- a/toolkit/clean/sql_execute.py
+++ b/toolkit/clean/sql_execute.py
@@ -33,14 +33,22 @@ def _run_sql(
     read_cfg: dict[str, Any] | None = None,
     read_mode: str = "fallback",
     logger=None,
+    sample_rows: int | None = None,
 ) -> tuple[str, dict[str, Any], dict[str, Any]]:
     """Execute clean SQL against raw inputs and export result to Parquet.
+
+    If ``sample_rows`` is set, appends ``LIMIT N`` to the SQL query per
+    DuckDB syntax (``SELECT * FROM ({query}) AS _smoke LIMIT N``).
 
     Returns:
         tuple of (source, params_used, output_profile)
     """
     with safe_connect() as con:
         read_info = read_raw_to_relation(con, input_files, read_cfg, read_mode, logger)
+        if sample_rows is not None:
+            # Strip trailing semicolons: clean.sql spesso termina con ;
+            stripped = sql_query.rstrip().rstrip(";").rstrip()
+            sql_query = f"SELECT * FROM ({stripped}) AS _smoke_sample LIMIT {int(sample_rows)}"
         con.execute(f"CREATE TABLE clean_out AS {sql_query}")
         output_profile = profile_relation(con, "clean_out")
         output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/toolkit/cli/cmd_init.py
+++ b/toolkit/cli/cmd_init.py
@@ -22,6 +22,7 @@ def init(
     year: int | None = typer.Option(None, "--year", "-y", help="Single dataset year (for --config)"),
     years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years (for --config)"),
     run: bool = typer.Option(False, "--run", "-r", help="Also execute raw run after scaffold (only with --url)"),
+    root: str | None = typer.Option(None, "--root", help="Override root output directory (es. $DCL_ROOT)"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Print plan without executing"),
     strict_config: bool = typer.Option(False, "--strict-config", help="Treat deprecated config forms as errors"),
 ):
@@ -40,6 +41,13 @@ def init(
         raise typer.Exit(code=1)
 
     if url:
+        if root is not None:
+            typer.echo(
+                "error: --root non supportato con --url (lo scaffold genera dataset.yml "
+                "con root predefinito; usa --config dopo lo scaffold)",
+                err=True,
+            )
+            raise typer.Exit(code=1)
         scout_url(url, scaffold=True, run_raw=run, timeout=_DEFAULT_TIMEOUT)
         return
 
@@ -53,6 +61,7 @@ def init(
         years=years,
         dry_run=dry_run,
         strict_config=strict_config,
+        root_override=root,
     )
 
 

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -124,6 +124,8 @@ def run_year(
     dry_run: bool = False,
     logger=None,
     resumed_from: str | None = None,
+    sample_rows: int | None = None,
+    sample_bytes: int | None = None,
 ) -> RunContext:
     if logger is None:
         logger = get_logger()
@@ -199,9 +201,10 @@ def run_year(
             run_id=context.run_id,
             output_cfg=dump_cfg_section(cfg.output),
             clean_cfg=dump_cfg_section(cfg.clean),
+            sample_bytes=sample_bytes,
         )
 
-    if "clean" in layers_to_run:
+    if "clean" in layers_to_run and not _is_mart_only_cfg(cfg):
         _execute_layer(
             "clean",
             run_clean,
@@ -211,6 +214,7 @@ def run_year(
             dump_cfg_section(cfg.clean),
             base_dir=cfg.base_dir,
             output_cfg=dump_cfg_section(cfg.output),
+            sample_rows=sample_rows,
         )
 
     if "mart" in layers_to_run and _has_single_year_mart(cfg):
@@ -309,6 +313,8 @@ def run(
     years: str | None = None,
     dry_run: bool = False,
     strict_config: bool = False,
+    sample_rows: int | None = None,
+    sample_bytes: int | None = None,
 ):
     """Backward-compatible Python entrypoint used by tests and internal callers."""
     strict_flag = strict_config if isinstance(strict_config, bool) else False
@@ -318,7 +324,8 @@ def run(
     selected_years = iter_selected_years(cfg, years_arg=years_arg)
 
     for year in selected_years:
-        run_year(cfg, year, step=step, dry_run=dry_flag, logger=logger)
+        run_year(cfg, year, step=step, dry_run=dry_flag, logger=logger,
+                 sample_rows=sample_rows, sample_bytes=sample_bytes)
 
     # Multi-year mart: run once per dataset after per-year processing
     if step in ("all", "mart"):
@@ -333,18 +340,26 @@ def _make_step_cmd(step: str):
         config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
         year: int | None = typer.Option(None, "--year", "-y", help="Single dataset year"),
         years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
+        smoke: bool = typer.Option(False, "--smoke", help="Alias per --sample-rows 1000 --sample-bytes 1048576"),
+        sample_rows: int | None = typer.Option(None, "--sample-rows", help="Leggi solo N righe in CLEAN (LIMIT N sul output SQL)"),
+        sample_bytes: int | None = typer.Option(None, "--sample-bytes", help="Scarica solo N bytes in RAW (HTTP Range header + troncamento locale)"),
+        root: str | None = typer.Option(None, "--root", help="Override root output directory (es. DCL_ROOT)"),
         dry_run: bool = typer.Option(False, "--dry-run", help="Print execution plan without executing"),
         strict_config: bool = typer.Option(False, "--strict-config", help="Treat deprecated config forms as errors"),
     ):
         strict_flag = strict_config if isinstance(strict_config, bool) else False
-        cfg, logger = load_cfg_and_logger(config, strict_config=strict_flag)
+        cfg, logger = load_cfg_and_logger(config, strict_config=strict_flag, root_override=root)
+
         dry_flag = dry_run if isinstance(dry_run, bool) else False
         years_arg = years if isinstance(years, str) else None
         year_arg = year if isinstance(year, int) else None
         selected_years = iter_selected_years(cfg, year_arg=year_arg, years_arg=years_arg)
+        sample_rows_final = 1000 if smoke else sample_rows
+        sample_bytes_final = 1048576 if smoke else sample_bytes
 
         for year in selected_years:
-            run_year(cfg, year, step=_step, dry_run=dry_flag, logger=logger)
+            run_year(cfg, year, step=_step, dry_run=dry_flag, logger=logger,
+                     sample_rows=sample_rows_final, sample_bytes=sample_bytes_final)
 
         # Multi-year mart: run once per dataset after per-year processing
         if _step in ("all", "mart"):
@@ -367,6 +382,9 @@ def run_init(
     years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Print plan without executing"),
     strict_config: bool = typer.Option(False, "--strict-config", help="Treat deprecated config forms as errors"),
+    # Parametri interni (non CLI) — passati da cmd_init.py
+    sample_bytes: int | None = None,
+    root_override: str | None = None,
 ):
     """
     Bootstrap candidate: esegue run raw e scaffold clean.sql se assente.
@@ -375,7 +393,7 @@ def run_init(
     sql/clean.sql scaffoldato oppure skip esplicito se gia esistente.
     """
     strict_config_flag = strict_config if isinstance(strict_config, bool) else False
-    cfg, logger = load_cfg_and_logger(config, strict_config=strict_config_flag)
+    cfg, logger = load_cfg_and_logger(config, strict_config=strict_config_flag, root_override=root_override)
     dry_run_flag = dry_run if isinstance(dry_run, bool) else False
     years_arg = years if isinstance(years, str) else None
     year_arg = year if isinstance(year, int) else None
@@ -413,7 +431,8 @@ def run_init(
         clean_sql_path = Path(cfg.base_dir) / clean_sql_rel
         scaffold_existed_before = clean_sql_path.exists()
 
-        run_year(cfg, year, step="raw", dry_run=False, logger=logger)
+        run_year(cfg, year, step="raw", dry_run=False, logger=logger,
+                 sample_bytes=sample_bytes)
 
         typer.echo(f"[init] Bootstrap completato per {cfg.dataset}/{year}")
         typer.echo("  - raw scaricato")
@@ -446,6 +465,10 @@ def run_init(
 def run_full(
     config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
     years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
+    smoke: bool = typer.Option(False, "--smoke", help="Alias per --sample-rows 1000 --sample-bytes 1048576"),
+    sample_rows: int | None = typer.Option(None, "--sample-rows", help="Leggi solo N righe in CLEAN (LIMIT N sul output SQL)"),
+    sample_bytes: int | None = typer.Option(None, "--sample-bytes", help="Scarica solo N bytes in RAW (HTTP Range header + troncamento locale)"),
+    root: str | None = typer.Option(None, "--root", help="Override root output directory (es. DCL_ROOT)"),
     json_output: bool = typer.Option(False, "--json", help="Output JSON report"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Print execution plan without executing"),
     strict_config: bool = typer.Option(False, "--strict-config", help="Treat deprecated config forms as errors"),
@@ -456,10 +479,12 @@ def run_full(
     automaticamente prima del candidate (run all + validate per ogni anno).
     """
     strict_flag = strict_config if isinstance(strict_config, bool) else False
-    cfg, logger = load_cfg_and_logger(config, strict_config=strict_flag)
+    cfg, logger = load_cfg_and_logger(config, strict_config=strict_flag, root_override=root)
     years_arg = years if isinstance(years, str) else None
     selected_years = iter_selected_years(cfg, year_arg=None, years_arg=years_arg)
     dry_flag = dry_run if isinstance(dry_run, bool) else False
+    sample_rows_final = 1000 if smoke else sample_rows
+    sample_bytes_final = 1048576 if smoke else sample_bytes
 
     results: dict[str, Any] = {
         "config": config,
@@ -535,7 +560,8 @@ def run_full(
 
         for year in selected_years:
             logger.info("Run %s — year=%s", run_step, year)
-            run_year(cfg, year, step=run_step, dry_run=dry_flag, logger=logger)
+            run_year(cfg, year, step=run_step, dry_run=dry_flag, logger=logger,
+                     sample_rows=sample_rows_final, sample_bytes=sample_bytes_final)
 
             if not dry_flag:
                 if is_mart_only:

--- a/toolkit/cli/common.py
+++ b/toolkit/cli/common.py
@@ -37,8 +37,9 @@ def load_cfg_and_logger(
     verbose: bool = False,
     quiet: bool = False,
     strict_config: bool = False,
+    root_override: str | None = None,
 ):
-    cfg = load_config(config_path, strict_config=strict_config)
+    cfg = load_config(config_path, strict_config=strict_config, root_override=root_override)
     if verbose and quiet:
         raise ValueError("verbose and quiet cannot both be true")
 

--- a/toolkit/contracts/__init__.py
+++ b/toolkit/contracts/__init__.py
@@ -1,0 +1,90 @@
+"""API pubblica stabile per path contract del toolkit.
+
+Consumer esterni (dataset-incubator, data-explorer) importano da qui
+invece di hardcodare i path. Le funzioni sono re-export da
+``toolkit.core.paths`` — il modulo interno puo` cambiare, questo no.
+
+Esempio::
+
+    from toolkit.contracts import layer_year_dir
+
+    clean_path = layer_year_dir(
+        root="/path/to/out", layer="clean", dataset="mio_dataset", year=2024
+    )
+    # -> PosixPath('/path/to/out/data/clean/mio_dataset/2024')
+"""
+
+from __future__ import annotations
+
+from pathlib import Path as _Path
+
+from toolkit.core.paths import (
+    layer_dataset_dir,
+    layer_year_dir,
+)
+from toolkit.core.paths import resolve_root as _resolve_root
+
+__all__ = [
+    "layer_year_dir",
+    "layer_dataset_dir",
+    "METADATA_JSON",
+    "MANIFEST_JSON",
+    "clean_parquet_path",
+    "mart_table_path",
+    "run_record_dir",
+]
+
+# ---------------------------------------------------------------------------
+# Costanti di path — pattern di file canonici
+# ---------------------------------------------------------------------------
+
+METADATA_JSON = "metadata.json"
+MANIFEST_JSON = "manifest.json"
+
+
+def clean_parquet_path(
+    root: str | _Path,
+    dataset: str,
+    year: int,
+) -> _Path:
+    """Path completo al parquet CLEAN per un dataset e anno.
+
+    Esempio::
+
+        clean_parquet_path("/out", "mio_dataset", 2024)
+        # -> PosixPath('/out/data/clean/mio_dataset/2024/mio_dataset_2024_clean.parquet')
+    """
+    base = layer_year_dir(str(root), "clean", dataset, year)
+    return base / f"{dataset}_{year}_clean.parquet"
+
+
+def mart_table_path(
+    root: str | _Path,
+    dataset: str,
+    year: int,
+    table_name: str,
+) -> _Path:
+    """Path completo a una tabella MART per un dataset, anno e nome tabella.
+
+    Esempio::
+
+        mart_table_path("/out", "mio_dataset", 2024, "rd_by_regione")
+        # -> PosixPath('/out/data/mart/mio_dataset/2024/rd_by_regione.parquet')
+    """
+    base = layer_year_dir(str(root), "mart", dataset, year)
+    return base / f"{table_name}.parquet"
+
+
+def run_record_dir(
+    root: str | _Path,
+    dataset: str,
+    year: int,
+) -> _Path:
+    """Directory dei run record per un dataset e anno.
+
+    Esempio::
+
+        run_record_dir("/out", "mio_dataset", 2024)
+        # -> PosixPath('/out/data/_runs/mio_dataset/2024')
+    """
+    return _Path(str(_resolve_root(root))) / "data" / "_runs" / dataset / str(year)

--- a/toolkit/core/config.py
+++ b/toolkit/core/config.py
@@ -156,13 +156,15 @@ def load_config(
     *,
     strict_config: bool = False,
     repo_root: str | Path | None = None,
+    root_override: str | Path | None = None,
 ) -> ToolkitConfig:
     model = load_config_model(path, strict_config=strict_config, repo_root=repo_root)
+    effective_root = Path(root_override).expanduser().resolve() if root_override else model.root
     return ToolkitConfig(
         base_dir=model.base_dir,
         schema_version=model.schema_version,
-        root=model.root,
-        root_source=model.root_source,
+        root=effective_root,
+        root_source="--root" if root_override else model.root_source,
         dataset=model.dataset.name,
         years=list(model.dataset.years),
         time_coverage=model.dataset.time_coverage,

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -69,13 +69,19 @@ class CkanSource:
         err = result.err
         raise DownloadError(str(err) if err else f"Failed to fetch CKAN metadata from {url}")
 
-    def _download_bytes(self, url: str) -> bytes:
-        result = self._client.get(url)
+    def _download_bytes(self, url: str, sample_bytes: int | None = None) -> bytes:
+        headers = None
+        if sample_bytes is not None:
+            headers = {"Range": f"bytes=0-{sample_bytes - 1}"}
+        result = self._client.get(url, headers=headers)
         if result.is_ok and result.response is not None:
             response = result.response
-            if response.status_code != 200:
+            if response.status_code not in (200, 206):
                 raise DownloadError(f"HTTP {response.status_code} for {url}")
-            return response.content
+            content = response.content
+            if sample_bytes is not None and len(content) > sample_bytes:
+                content = content[:sample_bytes]
+            return content
         err = result.err
         raise DownloadError(str(err) if err else f"Failed to fetch {url}")
 
@@ -165,6 +171,7 @@ class CkanSource:
         prefer_datastore: bool,
         portal_url: str,
         api_base: str,
+        sample_bytes: int | None = None,
     ) -> tuple[bytes, str] | None:
         """Try to fetch a single resource. Returns (bytes, url) or None if all attempts fail."""
         resource_id = str(resource.get("id") or "")
@@ -175,7 +182,7 @@ class CkanSource:
                 pass
         resolved_url = _force_https(str(resource["url"]))
         try:
-            return self._download_bytes(resolved_url), resolved_url
+            return self._download_bytes(resolved_url, sample_bytes=sample_bytes), resolved_url
         except DownloadError:
             pass
         return None
@@ -188,6 +195,7 @@ class CkanSource:
         resource_name: str | None = None,
         *,
         prefer_datastore: bool = True,
+        sample_bytes: int | None = None,
     ) -> tuple[bytes, str]:
         last_err: Exception | None = None
 
@@ -196,7 +204,7 @@ class CkanSource:
             try:
                 metadata = self._get_json(api_url, {"id": str(resource_id)})
                 result = metadata.get("result") or {}
-                outcome = self._try_resource(result, prefer_datastore, portal_url, api_url)
+                outcome = self._try_resource(result, prefer_datastore, portal_url, api_url, sample_bytes=sample_bytes)
                 if outcome is not None:
                     return outcome
                 # Fallback: try datastore even if prefer_datastore=False, when URL is absent.
@@ -222,7 +230,7 @@ class CkanSource:
                 )
                 last_download_err: Exception | None = None
                 for resource in ranked_resources:
-                    outcome = self._try_resource(resource, prefer_datastore, portal_url, api_url)
+                    outcome = self._try_resource(resource, prefer_datastore, portal_url, api_url, sample_bytes=sample_bytes)
                     if outcome is not None:
                         return outcome
                     # Capture last error from the loop for a meaningful message

--- a/toolkit/plugins/http_file.py
+++ b/toolkit/plugins/http_file.py
@@ -26,11 +26,19 @@ class HttpFileSource:
             user_agent=self.user_agent,
         )
 
-    def fetch(self, url: str) -> bytes:
-        result = self._client.get(url)
+    def fetch(self, url: str, sample_bytes: int | None = None) -> bytes:
+        headers = None
+        if sample_bytes is not None:
+            headers = {"Range": f"bytes=0-{sample_bytes - 1}"}
+        result = self._client.get(url, headers=headers)
         if result.is_ok and result.response is not None:
-            if result.response.status_code != 200:
+            if result.response.status_code not in (200, 206):
                 raise DownloadError(f"HTTP {result.response.status_code} for {url}")
-            return result.response.content
+            content = result.response.content
+            # Troncamento locale: server che ignorano Range (200 invece di 206)
+            # restituiscono tutto il file. Taglia per garantire il limite byte.
+            if sample_bytes is not None and len(content) > sample_bytes:
+                content = content[:sample_bytes]
+            return content
         err = result.err
         raise DownloadError(str(err) if err else f"Failed to fetch {url}")

--- a/toolkit/plugins/http_post_file.py
+++ b/toolkit/plugins/http_post_file.py
@@ -49,12 +49,15 @@ class HttpPostFileSource:
             user_agent=self.user_agent,
         )
 
-    def fetch(self, url: str, data: dict | None = None) -> bytes:
+    def fetch(self, url: str, data: dict | None = None, sample_bytes: int | None = None) -> bytes:
         """Execute a POST request and return response bytes.
 
         Args:
             url: Target URL.
             data: Form-encoded POST body (dict of key-value pairs).
+            sample_bytes: If set, adds ``Range: bytes=0-N`` header for
+                partial download (non-standard on POST, alcuni server lo
+                supportano).
 
         Returns:
             Raw response bytes.
@@ -63,11 +66,17 @@ class HttpPostFileSource:
             DownloadError: on network error or non-200 HTTP status.
 
         """
+        headers = None
+        if sample_bytes is not None:
+            headers = {"Range": f"bytes=0-{sample_bytes - 1}"}
         # File download via POST is idempotent — safe to retry
-        result = self._client.post(url, data=data, retries=self.retries)
+        result = self._client.post(url, data=data, headers=headers, retries=self.retries)
         if result.is_ok and result.response is not None:
-            if result.response.status_code != 200:
+            if result.response.status_code not in (200, 206):
                 raise DownloadError(f"HTTP {result.response.status_code} for {url}")
-            return result.response.content
+            content = result.response.content
+            if sample_bytes is not None and len(content) > sample_bytes:
+                content = content[:sample_bytes]
+            return content
         err = result.err
         raise DownloadError(str(err) if err else f"Failed to fetch {url}")

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -101,11 +101,13 @@ def _register_fetch(stype: str):
 @_register_fetch("ckan")
 def _fetch_ckan(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
     src = registry.create(stype, **(client or {}))
+    sample_bytes = formatted_args.get("sample_bytes")
     return src.fetch(
         formatted_args["portal_url"],
         str(formatted_args["resource_id"]) if formatted_args.get("resource_id") is not None else None,
         str(formatted_args["dataset_id"]) if formatted_args.get("dataset_id") is not None else None,
         str(formatted_args["resource_name"]) if formatted_args.get("resource_name") is not None else None,
+        sample_bytes=sample_bytes,
     )
 
 
@@ -133,7 +135,8 @@ def _fetch_sparql(stype: str, client: dict, formatted_args: dict) -> tuple[bytes
 @_register_fetch("http_file")
 def _fetch_http_file(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
     src = registry.create(stype, **(client or {}))
-    payload = src.fetch(formatted_args["url"])
+    sample_bytes = formatted_args.get("sample_bytes")
+    payload = src.fetch(formatted_args["url"], sample_bytes=sample_bytes)
     return payload, formatted_args["url"]
 
 
@@ -141,7 +144,8 @@ def _fetch_http_file(stype: str, client: dict, formatted_args: dict) -> tuple[by
 def _fetch_http_post_file(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
     src = registry.create(stype, **(client or {}))
     post_data = formatted_args.get("post_data")
-    payload = src.fetch(formatted_args["url"], data=post_data)
+    sample_bytes = formatted_args.get("sample_bytes")
+    payload = src.fetch(formatted_args["url"], data=post_data, sample_bytes=sample_bytes)
     return payload, formatted_args["url"]
 
 

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -35,6 +35,7 @@ def run_raw(
     run_id: str | None = None,
     output_cfg: dict | None = None,
     clean_cfg: dict | None = None,
+    sample_bytes: int | None = None,
 ):
     """
     Supporta:
@@ -85,6 +86,8 @@ def run_raw(
             continue
 
         formatted_args = _format_args(args, year)
+        if sample_bytes is not None:
+            formatted_args["sample_bytes"] = sample_bytes
         payload, origin = _fetch_payload(stype, client, formatted_args)
         inputs.append(
             {


### PR DESCRIPTION
## Cosa cambia

Tre interventi per migliorare l'integrazione toolkit-dataset-incubator.

### 1. `--sample-rows` / `--sample-bytes` / `--smoke` (closes #258)

Flag per eseguire run in modalità leggera, utile per CI PR:

- `--sample-rows N`: inietta `sample_size=N` in DuckDB `read_csv`
- `--sample-bytes N`: aggiunge header `Range: bytes=0-N` ai download HTTP
- `--smoke`: alias per `--sample-rows 1000 --sample-bytes 1048576`

Supportato su `run raw|clean|mart|all|full` e `init`.

### 2. `toolkit.contracts` — path API pubblica (progress #244)

Nuovo modulo `toolkit/contracts/__init__.py` che esporta:

- `layer_year_dir(root, layer, dataset, year)`
- `layer_dataset_dir(root, layer, dataset)`
- `clean_parquet_path(root, dataset, year)`
- `mart_table_path(root, dataset, year, table_name)`
- `run_record_dir(root, dataset, year)`

Re-export da `core/paths.py`, nessuna logica nuova. Consumer esterni
(dataset-incubator) possono importare invece di hardcodare i path.

### 3. `--root` CLI flag (DCL_ROOT)

Override `root:` del dataset.yml da riga di comando:

```bash
toolkit run all -c dataset.yml --root $DCL_ROOT
```

Passato attraverso `load_cfg_and_logger` → `load_config`.

### Test

```
686 passed, 0 failed, Ruff OK
```