### PR TITLE
feat: hierarchy runtime generator + source_id nei metadata

### DIFF
--- a/tests/test_mart_hierarchy.py
+++ b/tests/test_mart_hierarchy.py
@@ -91,7 +91,8 @@ def test_hierarchy_count_fallback(tmp_path: Path) -> None:
         "CREATE VIEW clean_input AS SELECT * FROM (VALUES ('Roma','Lazio','X'),('Milano','Lombardia','Y')) "
         "AS t(comune, regione, codice)"
     )
-    mart_dir = tmp_path / "m"; mart_dir.mkdir()
+    mart_dir = tmp_path / "m"
+    mart_dir.mkdir()
     written, _, _ = _run_hierarchy_levels(
         con, {"hierarchy": {"axis": "x", "levels": [{"level": "c", "table": "h_c", "grain": ["comune"]}]}},
         "test", 2024, mart_dir, logger=_null_logger,
@@ -107,7 +108,8 @@ def test_hierarchy_edge_cases(tmp_path: Path) -> None:
     """Empty config returns empty; numeric grain not treated as metric."""
     con = duckdb.connect()
     _setup_clean_view(con)
-    d = tmp_path / "d"; d.mkdir()
+    d = tmp_path / "d"
+    d.mkdir()
 
     # Empty hierarchy → empty result
     w, e, r = _run_hierarchy_levels(con, {}, "t", 2024, d, logger=_null_logger)
@@ -129,7 +131,8 @@ def test_hierarchy_edge_cases(tmp_path: Path) -> None:
 
     # Missing source → ValueError (separate connection without clean_input)
     con2 = duckdb.connect()
-    d2 = tmp_path / "d2"; d2.mkdir()
+    d2 = tmp_path / "d2"
+    d2.mkdir()
     with pytest.raises(ValueError, match="source table.*not found"):
         _run_hierarchy_levels(
             con2, {"hierarchy": {"axis": "x", "levels": [{"level": "x", "table": "x", "grain": ["comune"]}]}},

--- a/tests/test_mart_hierarchy.py
+++ b/tests/test_mart_hierarchy.py
@@ -20,333 +20,159 @@ pytestmark = [pytest.mark.smoke, pytest.mark.core]
 
 
 def _setup_clean_view(con: duckdb.DuckDBPyConnection) -> None:
-    """Create clean_input view with mixed column types for hierarchy testing."""
     con.execute(
         "CREATE OR REPLACE VIEW clean_input AS SELECT * FROM (VALUES "
-        "  ('Roma', 'Lazio', 100, 50.5, 'A'), "
-        "  ('Milano', 'Lombardia', 200, 75.2, 'B'), "
-        "  ('Napoli', 'Campania', 150, 60.0, 'A'), "
-        "  ('Roma', 'Lazio', 120, 55.0, 'A'), "
-        "  ('Milano', 'Lombardia', 180, 70.0, 'B') "
-        ") AS t(comune, regione, valore, costo, categoria)"
+        "  ('Roma', 'Lazio', 100, 50.5), "
+        "  ('Milano', 'Lombardia', 200, 75.2), "
+        "  ('Napoli', 'Campania', 150, 60.0), "
+        "  ('Roma', 'Lazio', 120, 55.0), "
+        "  ('Milano', 'Lombardia', 180, 70.0) "
+        ") AS t(comune, regione, valore, costo)"
     )
     con.execute("CREATE OR REPLACE VIEW clean AS SELECT * FROM clean_input")
 
 
-def _describe_cols(con, table: str) -> list[tuple[str, str]]:
-    """Return (name, type) pairs from DESCRIBE for introspection."""
-    return con.execute(f"DESCRIBE {table}").fetchall()
-
-
-def test_hierarchy_levels_generate_aggregation(tmp_path: Path) -> None:
-    """Hierarchy levels generate correct aggregation SQL."""
+def test_hierarchy_generates_aggregation(tmp_path: Path) -> None:
+    """Two-level hierarchy + source_table override."""
     con = duckdb.connect()
     _setup_clean_view(con)
-
-    # Introspect column naming (DuckDB may upper-case VALUE columns)
-    raw_cols = _describe_cols(con, "clean_input")
-    col_map = {c[0].lower(): c[0] for c in raw_cols}
-    # Find the actual names DuckDB chose for valore and costo
-    v_col = col_map.get("valore", "valore")
-    c_col = col_map.get("costo", "costo")
-
-    mart_cfg = {
-        "hierarchy": {
-            "axis": "territoriale",
-            "levels": [
-                {"level": "comune", "table": "mart_comune", "grain": ["comune", "regione"]},
-                {"level": "regione", "table": "mart_regione", "grain": ["regione"]},
-            ],
-        }
-    }
-
     mart_dir = tmp_path / "mart"
     mart_dir.mkdir()
 
+    # Two hierarchy levels aggregate from clean_input
     written, executed, total_rows = _run_hierarchy_levels(
-        con, mart_cfg, "test", 2024, mart_dir, logger=_null_logger,
+        con, {
+            "hierarchy": {
+                "axis": "territoriale",
+                "levels": [
+                    {"level": "comune", "table": "h_comune", "grain": ["comune", "regione"]},
+                    {"level": "regione", "table": "h_regione", "grain": ["regione"]},
+                ],
+            }
+        },
+        "test", 2024, mart_dir, logger=_null_logger,
     )
+    assert len(written) == 2
+    assert (mart_dir / "h_comune.parquet").exists()
+    assert (mart_dir / "h_regione.parquet").exists()
 
-    # Both levels should produce parquet files
-    assert len(written) == 2, f"expected 2 parquet files, got {len(written)}"
-    assert (mart_dir / "mart_comune.parquet").exists()
-    assert (mart_dir / "mart_regione.parquet").exists()
-
-    # Both levels should be in executed records
-    assert len(executed) == 2
-    level_names = [e["level"] for e in executed]
-    assert "comune" in level_names
-    assert "regione" in level_names
-
-    # Verify aggregations are correct by querying parquet files
-    comune_rows = con.execute(
-        f"SELECT comune, regione, \"{v_col}\", \"{c_col}\" FROM read_parquet('" +
-        str(mart_dir / "mart_comune.parquet") + "') ORDER BY comune"
+    # Verify SUM values: Roma=100+120=220, Milano=200+180=380
+    rows = con.execute(
+        f"SELECT comune, valore FROM read_parquet('{mart_dir / 'h_comune.parquet'}') ORDER BY comune"
     ).fetchall()
-    # Napoli, Milano, Roma → 3 gruppi
-    assert len(comune_rows) == 3, f"expected 3 aggregated rows, got {len(comune_rows)}"
-    # Roma: valore=100+120=220, costo=50.5+55.0=105.5
-    roma = [r for r in comune_rows if r[0] == "Roma"][0]
-    assert roma[2] == 220, f"expected SUM(valore)=220 for Roma, got {roma[2]}"
-    assert abs(float(roma[3]) - 105.5) < 0.01, f"expected SUM(costo)=105.5 for Roma, got {roma[3]}"
-    # Milano: valore=200+180=380, costo=75.2+70.0=145.2
-    milano = [r for r in comune_rows if r[0] == "Milano"][0]
-    assert milano[2] == 380, f"expected SUM(valore)=380 for Milano, got {milano[2]}"
+    assert rows[0] == ("Milano", 380)
+    assert rows[2] == ("Roma", 220)
+    assert total_rows == 6  # 3 comune + 3 regione
 
-    regione_rows = con.execute(
-        f"SELECT regione, \"{v_col}\", \"{c_col}\" FROM read_parquet('" +
-        str(mart_dir / "mart_regione.parquet") + "') ORDER BY regione"
+    # Second pass: source_table override aggregates from a mart table
+    con.execute("CREATE TABLE mart_base AS SELECT * FROM clean_input")
+    w2, _, _ = _run_hierarchy_levels(
+        con, {
+            "hierarchy": {
+                "axis": "x", "levels": [
+                    {"level": "s", "table": "h_sub", "grain": ["regione"], "source_table": "mart_base"},
+                ]
+            }
+        },
+        "test", 2024, mart_dir, logger=_null_logger,
+    )
+    assert len(w2) == 1
+    rows2 = con.execute(
+        f"SELECT regione, valore FROM read_parquet('{mart_dir / 'h_sub.parquet'}') ORDER BY regione"
     ).fetchall()
-    assert len(regione_rows) == 3, f"expected 3 aggregated rows, got {len(regione_rows)}"
-    for r in regione_rows:
-        if r[0] == "Lombardia":
-            assert r[1] == 380  # SUM(valore)
-        elif r[0] == "Lazio":
-            assert r[1] == 220  # SUM(valore)
-        elif r[0] == "Campania":
-            assert r[1] == 150  # SUM(valore)
-
-    assert total_rows == 6  # 3 comune rows + 3 regione rows
+    assert rows2[2] == ("Lombardia", 380)  # SUM(valore) from mart_base
     con.close()
 
 
-def test_hierarchy_source_table_override(tmp_path: Path) -> None:
-    """Hierarchy level can aggregate from a different source table."""
-    con = duckdb.connect()
-    _setup_clean_view(con)
-
-    # Introspect column names
-    raw_cols = _describe_cols(con, "clean_input")
-    col_map = {c[0].lower(): c[0] for c in raw_cols}
-    v_col = col_map.get("valore", "valore")
-
-    # Create a custom mart table to aggregate from
-    con.execute("CREATE OR REPLACE TABLE mart_base AS SELECT * FROM clean_input")
-
-    mart_cfg = {
-        "hierarchy": {
-            "axis": "territoriale",
-            "levels": [
-                {
-                    "level": "regione",
-                    "table": "mart_regione",
-                    "grain": ["regione"],
-                    "source_table": "mart_base",
-                },
-            ],
-        }
-    }
-
-    mart_dir = tmp_path / "mart2"
-    mart_dir.mkdir()
-
-    written, executed, total_rows = _run_hierarchy_levels(
-        con, mart_cfg, "test", 2024, mart_dir, logger=_null_logger,
-    )
-
-    assert len(written) == 1
-    assert (mart_dir / "mart_regione.parquet").exists()
-
-    regione_rows = con.execute(
-        f"SELECT regione, \"{v_col}\" FROM read_parquet('" +
-        str(mart_dir / "mart_regione.parquet") + "') ORDER BY regione"
-    ).fetchall()
-    assert len(regione_rows) == 3, f"expected 3 rows, got {len(regione_rows)}"
-    for r in regione_rows:
-        if r[0] == "Lombardia":
-            assert r[1] == 380  # SUM(valore)
-    con.close()
-
-
-def test_hierarchy_no_metric_columns_count_fallback(tmp_path: Path) -> None:
-    """Without numeric columns, hierarchy falls back to COUNT(*)."""
+def test_hierarchy_count_fallback(tmp_path: Path) -> None:
+    """Without numeric columns, hierarchy uses COUNT(*)."""
     con = duckdb.connect()
     con.execute(
-        "CREATE OR REPLACE VIEW clean_input AS SELECT * FROM (VALUES "
-        "  ('Roma', 'Lazio', 'X'), "
-        "  ('Milano', 'Lombardia', 'Y'), "
-        "  ('Napoli', 'Campania', 'Z') "
-        ") AS t(comune, regione, codice)"
+        "CREATE VIEW clean_input AS SELECT * FROM (VALUES ('Roma','Lazio','X'),('Milano','Lombardia','Y')) "
+        "AS t(comune, regione, codice)"
     )
-
-    mart_cfg = {
-        "hierarchy": {
-            "axis": "territoriale",
-            "levels": [
-                {"level": "comune", "table": "mart_comune", "grain": ["comune", "regione"]},
-            ],
-        }
-    }
-
-    mart_dir = tmp_path / "mart3"
-    mart_dir.mkdir()
-
-    written, executed, total_rows = _run_hierarchy_levels(
-        con, mart_cfg, "test", 2024, mart_dir, logger=_null_logger,
+    mart_dir = tmp_path / "m"; mart_dir.mkdir()
+    written, _, _ = _run_hierarchy_levels(
+        con, {"hierarchy": {"axis": "x", "levels": [{"level": "c", "table": "h_c", "grain": ["comune"]}]}},
+        "test", 2024, mart_dir, logger=_null_logger,
     )
-
-    assert len(written) == 1
     rows = con.execute(
-        "SELECT comune, record_count FROM read_parquet('" +
-        str(mart_dir / "mart_comune.parquet") + "') ORDER BY comune"
+        f"SELECT record_count FROM read_parquet('{mart_dir / 'h_c.parquet'}')"
     ).fetchall()
-    assert len(rows) == 3  # one row per comune
-    # Each comune has exactly 1 record
-    for r in rows:
-        assert r[1] == 1, f"expected COUNT(*)=1 for {r[0]}"
+    assert rows == [(1,), (1,)]  # COUNT(*) per comune
     con.close()
 
 
-def test_hierarchy_empty_config(tmp_path: Path) -> None:
-    """Empty or missing hierarchy returns empty results."""
+def test_hierarchy_edge_cases(tmp_path: Path) -> None:
+    """Empty config returns empty; numeric grain not treated as metric."""
     con = duckdb.connect()
     _setup_clean_view(con)
-    mart_dir = tmp_path / "empty"
-    mart_dir.mkdir()
+    d = tmp_path / "d"; d.mkdir()
 
-    w, e, r = _run_hierarchy_levels(con, {}, "test", 2024, mart_dir, logger=_null_logger)
-    assert w == []
-    assert e == []
-    assert r == 0
+    # Empty hierarchy → empty result
+    w, e, r = _run_hierarchy_levels(con, {}, "t", 2024, d, logger=_null_logger)
+    assert (w, e, r) == ([], [], 0)
 
-    w2, e2, r2 = _run_hierarchy_levels(
-        con, {"hierarchy": {"axis": "x", "levels": []}}, "test", 2024, mart_dir, logger=_null_logger
+    # Numeric grain column (valore=INTEGER) must NOT appear as SUM metric
+    # Grain column must be excluded from metric_cols
+    w2, e2, _ = _run_hierarchy_levels(
+        con, {"hierarchy": {"axis": "x", "levels": [{"level": "x", "table": "h_test", "grain": ["valore"]}]}},
+        "t", 2024, d, logger=_null_logger,
     )
-    assert w2 == []
-    assert e2 == []
-    assert r2 == 0
+    cols = con.execute(f"DESCRIBE SELECT * FROM read_parquet('{d / 'h_test.parquet'}')").fetchall()
+    col_names = [c[0].lower() for c in cols]
+    assert "valore" in col_names
+    # There should NOT be a SUM(valore) AS valore_1 or similar extra metric
+    metric_count = sum(1 for c in col_names if c.startswith("valore"))
+    assert metric_count == 1, f"valore appears {metric_count} times (grain leaking as metric): {col_names}"
     con.close()
 
-
-def test_hierarchy_missing_source_raises(tmp_path: Path) -> None:
-    """Missing source table raises a clear error."""
-    con = duckdb.connect()
-    mart_dir = tmp_path / "missing"
-    mart_dir.mkdir()
-
-    mart_cfg = {
-        "hierarchy": {
-            "axis": "territoriale",
-            "levels": [
-                {"level": "comune", "table": "mart_comune", "grain": ["comune"]},
-            ],
-        }
-    }
-
+    # Missing source → ValueError (separate connection without clean_input)
+    con2 = duckdb.connect()
+    d2 = tmp_path / "d2"; d2.mkdir()
     with pytest.raises(ValueError, match="source table.*not found"):
-        _run_hierarchy_levels(con, mart_cfg, "test", 2024, mart_dir, logger=_null_logger)
-    con.close()
+        _run_hierarchy_levels(
+            con2, {"hierarchy": {"axis": "x", "levels": [{"level": "x", "table": "x", "grain": ["comune"]}]}},
+            "t", 2024, d2, logger=_null_logger,
+        )
+    con2.close()
 
 
 @pytest.mark.smoke
 def test_hierarchy_integration_via_run(project_example: Path) -> None:
-    """End-to-end: hierarchy levels generated correctly through full pipeline."""
-    config_path = project_example / "dataset.yml"
-
-    # Add hierarchy to existing project_example config
-    config_text = config_path.read_text(encoding="utf-8")
-    config_data = yaml.safe_load(config_text)
-    config_data.setdefault("mart", {})["hierarchy"] = {
-        "axis": "territoriale",
-        "levels": [
-            {
-                "level": "provincia",
-                "table": "h_provincia",
-                "grain": ["provincia", "regione"],
-            },
-            {
-                "level": "regione",
-                "table": "h_regione",
-                "grain": ["regione"],
-            },
-        ],
-    }
-    config_path.write_text(
-        yaml.dump(config_data, default_flow_style=False, allow_unicode=True, sort_keys=False),
-        encoding="utf-8",
-    )
-
-    from toolkit.cli.cmd_run import run as run_cmd
-    run_cmd(step="all", config=str(config_path))
-
-    # Hierarchy parquet files should exist alongside normal mart tables
-    mart_dir_2022 = project_example / "_smoke_out" / "data" / "mart" / "project_example" / "2022"
-    assert (mart_dir_2022 / "h_provincia.parquet").exists(), "hierarchy provincia parquet missing"
-    assert (mart_dir_2022 / "h_regione.parquet").exists(), "hierarchy regione parquet missing"
-
-    # Normal mart tables still work
-    assert (mart_dir_2022 / "rd_by_regione.parquet").exists()
-
-    # Hierarchy data should be aggregated
-    con = duckdb.connect()
-    prov_rows = con.execute(
-        f"SELECT * FROM read_parquet('{mart_dir_2022 / 'h_provincia.parquet'}')"
-    ).fetchall()
-    assert len(prov_rows) > 0, "h_provincia should have data"
-    # Fetch column names via duckdb col description
-    prov_desc = con.execute(
-        f"SELECT column_name, column_type FROM (DESCRIBE SELECT * FROM read_parquet('{mart_dir_2022 / 'h_provincia.parquet'}'))"
-    ).fetchall()
-    col_names = [r[0].lower() for r in prov_desc]
-    assert "provincia" in col_names, f"provincia not in columns: {col_names}"
-    con.close()
-
-
-def test_source_id_propagated_to_toolkit_config(tmp_path: Path) -> None:
-    """source_id from dataset.yml is propagated to ToolkitConfig."""
-    yml = tmp_path / "dataset.yml"
-    yml.write_text(
-        "\n".join([
-            "dataset:",
-            "  name: test_sid",
-            "  years: [2024]",
-            "  source_id: my_test_source",
-            "raw: {}",
-            "clean: {}",
-            "mart: {}",
-        ]),
-        encoding="utf-8",
-    )
-    cfg = load_config(yml)
-    assert cfg.source_id == "my_test_source"
-
-    # Without source_id
-    yml2 = tmp_path / "dataset_no_sid.yml"
-    yml2.write_text(
-        "\n".join([
-            "dataset:",
-            "  name: test_no_sid",
-            "  years: [2024]",
-            "raw: {}",
-            "clean: {}",
-            "mart: {}",
-        ]),
-        encoding="utf-8",
-    )
-    cfg2 = load_config(yml2)
-    assert cfg2.source_id is None
-
-
-def test_source_id_in_metadata_after_run(project_example: Path) -> None:
-    """source_id appears in layer metadata after pipeline run."""
+    """End-to-end: hierarchy + source_id in metadata."""
     config_path = project_example / "dataset.yml"
     config_text = config_path.read_text(encoding="utf-8")
     config_data = yaml.safe_load(config_text)
     config_data["dataset"]["source_id"] = "ispra_linked_data"
-    config_path.write_text(
-        yaml.dump(config_data, default_flow_style=False, allow_unicode=True, sort_keys=False),
-        encoding="utf-8",
-    )
+    config_data.setdefault("mart", {})["hierarchy"] = {
+        "axis": "territoriale",
+        "levels": [
+            {"level": "provincia", "table": "h_provincia", "grain": ["provincia", "regione"]},
+            {"level": "regione", "table": "h_regione", "grain": ["regione"]},
+        ],
+    }
+    config_path.write_text(yaml.dump(config_data, default_flow_style=False, allow_unicode=True, sort_keys=False), encoding="utf-8")
 
     from toolkit.cli.cmd_run import run as run_cmd
     run_cmd(step="all", config=str(config_path))
 
-    # Check clean metadata
-    clean_dir = project_example / "_smoke_out" / "data" / "clean" / "project_example" / "2022"
-    clean_meta = json.loads((clean_dir / "metadata.json").read_text(encoding="utf-8"))
-    assert clean_meta.get("source_id") == "ispra_linked_data", f"got {clean_meta.get('source_id')}"
-
-    # Check mart metadata
     mart_dir = project_example / "_smoke_out" / "data" / "mart" / "project_example" / "2022"
-    mart_meta = json.loads((mart_dir / "metadata.json").read_text(encoding="utf-8"))
-    assert mart_meta.get("source_id") == "ispra_linked_data", f"got {mart_meta.get('source_id')}"
+    assert (mart_dir / "h_provincia.parquet").exists()
+    assert (mart_dir / "h_regione.parquet").exists()
+
+    # source_id in metadata
+    for layer in ("clean", "mart"):
+        meta = json.loads((project_example / "_smoke_out" / "data" / layer / "project_example" / "2022" / "metadata.json").read_text())
+        assert meta.get("source_id") == "ispra_linked_data", f"{layer} missing source_id"
+
+
+def test_source_id_propagated(tmp_path: Path) -> None:
+    """source_id from dataset.yml reaches ToolkitConfig."""
+    yml = tmp_path / "d.yml"
+    yml.write_text("dataset:\n  name: t\n  years: [2024]\n  source_id: src1\nraw: {}\nclean: {}\nmart: {}\n")
+    assert load_config(yml).source_id == "src1"
+
+    yml2 = tmp_path / "d2.yml"
+    yml2.write_text("dataset:\n  name: t\n  years: [2024]\nraw: {}\nclean: {}\nmart: {}\n")
+    assert load_config(yml2).source_id is None

--- a/tests/test_mart_hierarchy.py
+++ b/tests/test_mart_hierarchy.py
@@ -1,0 +1,352 @@
+"""Test: hierarchy levels come generatore runtime di tabelle aggregate."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import duckdb
+import pytest
+import yaml
+
+from toolkit.core.config import load_config
+from toolkit.mart.run import _run_hierarchy_levels
+
+_null_logger = logging.getLogger("test_null")
+_null_logger.addHandler(logging.NullHandler())
+
+pytestmark = [pytest.mark.smoke, pytest.mark.core]
+
+
+def _setup_clean_view(con: duckdb.DuckDBPyConnection) -> None:
+    """Create clean_input view with mixed column types for hierarchy testing."""
+    con.execute(
+        "CREATE OR REPLACE VIEW clean_input AS SELECT * FROM (VALUES "
+        "  ('Roma', 'Lazio', 100, 50.5, 'A'), "
+        "  ('Milano', 'Lombardia', 200, 75.2, 'B'), "
+        "  ('Napoli', 'Campania', 150, 60.0, 'A'), "
+        "  ('Roma', 'Lazio', 120, 55.0, 'A'), "
+        "  ('Milano', 'Lombardia', 180, 70.0, 'B') "
+        ") AS t(comune, regione, valore, costo, categoria)"
+    )
+    con.execute("CREATE OR REPLACE VIEW clean AS SELECT * FROM clean_input")
+
+
+def _describe_cols(con, table: str) -> list[tuple[str, str]]:
+    """Return (name, type) pairs from DESCRIBE for introspection."""
+    return con.execute(f"DESCRIBE {table}").fetchall()
+
+
+def test_hierarchy_levels_generate_aggregation(tmp_path: Path) -> None:
+    """Hierarchy levels generate correct aggregation SQL."""
+    con = duckdb.connect()
+    _setup_clean_view(con)
+
+    # Introspect column naming (DuckDB may upper-case VALUE columns)
+    raw_cols = _describe_cols(con, "clean_input")
+    col_map = {c[0].lower(): c[0] for c in raw_cols}
+    # Find the actual names DuckDB chose for valore and costo
+    v_col = col_map.get("valore", "valore")
+    c_col = col_map.get("costo", "costo")
+
+    mart_cfg = {
+        "hierarchy": {
+            "axis": "territoriale",
+            "levels": [
+                {"level": "comune", "table": "mart_comune", "grain": ["comune", "regione"]},
+                {"level": "regione", "table": "mart_regione", "grain": ["regione"]},
+            ],
+        }
+    }
+
+    mart_dir = tmp_path / "mart"
+    mart_dir.mkdir()
+
+    written, executed, total_rows = _run_hierarchy_levels(
+        con, mart_cfg, "test", 2024, mart_dir, logger=_null_logger,
+    )
+
+    # Both levels should produce parquet files
+    assert len(written) == 2, f"expected 2 parquet files, got {len(written)}"
+    assert (mart_dir / "mart_comune.parquet").exists()
+    assert (mart_dir / "mart_regione.parquet").exists()
+
+    # Both levels should be in executed records
+    assert len(executed) == 2
+    level_names = [e["level"] for e in executed]
+    assert "comune" in level_names
+    assert "regione" in level_names
+
+    # Verify aggregations are correct by querying parquet files
+    comune_rows = con.execute(
+        f"SELECT comune, regione, \"{v_col}\", \"{c_col}\" FROM read_parquet('" +
+        str(mart_dir / "mart_comune.parquet") + "') ORDER BY comune"
+    ).fetchall()
+    # Napoli, Milano, Roma → 3 gruppi
+    assert len(comune_rows) == 3, f"expected 3 aggregated rows, got {len(comune_rows)}"
+    # Roma: valore=100+120=220, costo=50.5+55.0=105.5
+    roma = [r for r in comune_rows if r[0] == "Roma"][0]
+    assert roma[2] == 220, f"expected SUM(valore)=220 for Roma, got {roma[2]}"
+    assert abs(float(roma[3]) - 105.5) < 0.01, f"expected SUM(costo)=105.5 for Roma, got {roma[3]}"
+    # Milano: valore=200+180=380, costo=75.2+70.0=145.2
+    milano = [r for r in comune_rows if r[0] == "Milano"][0]
+    assert milano[2] == 380, f"expected SUM(valore)=380 for Milano, got {milano[2]}"
+
+    regione_rows = con.execute(
+        f"SELECT regione, \"{v_col}\", \"{c_col}\" FROM read_parquet('" +
+        str(mart_dir / "mart_regione.parquet") + "') ORDER BY regione"
+    ).fetchall()
+    assert len(regione_rows) == 3, f"expected 3 aggregated rows, got {len(regione_rows)}"
+    for r in regione_rows:
+        if r[0] == "Lombardia":
+            assert r[1] == 380  # SUM(valore)
+        elif r[0] == "Lazio":
+            assert r[1] == 220  # SUM(valore)
+        elif r[0] == "Campania":
+            assert r[1] == 150  # SUM(valore)
+
+    assert total_rows == 6  # 3 comune rows + 3 regione rows
+    con.close()
+
+
+def test_hierarchy_source_table_override(tmp_path: Path) -> None:
+    """Hierarchy level can aggregate from a different source table."""
+    con = duckdb.connect()
+    _setup_clean_view(con)
+
+    # Introspect column names
+    raw_cols = _describe_cols(con, "clean_input")
+    col_map = {c[0].lower(): c[0] for c in raw_cols}
+    v_col = col_map.get("valore", "valore")
+
+    # Create a custom mart table to aggregate from
+    con.execute("CREATE OR REPLACE TABLE mart_base AS SELECT * FROM clean_input")
+
+    mart_cfg = {
+        "hierarchy": {
+            "axis": "territoriale",
+            "levels": [
+                {
+                    "level": "regione",
+                    "table": "mart_regione",
+                    "grain": ["regione"],
+                    "source_table": "mart_base",
+                },
+            ],
+        }
+    }
+
+    mart_dir = tmp_path / "mart2"
+    mart_dir.mkdir()
+
+    written, executed, total_rows = _run_hierarchy_levels(
+        con, mart_cfg, "test", 2024, mart_dir, logger=_null_logger,
+    )
+
+    assert len(written) == 1
+    assert (mart_dir / "mart_regione.parquet").exists()
+
+    regione_rows = con.execute(
+        f"SELECT regione, \"{v_col}\" FROM read_parquet('" +
+        str(mart_dir / "mart_regione.parquet") + "') ORDER BY regione"
+    ).fetchall()
+    assert len(regione_rows) == 3, f"expected 3 rows, got {len(regione_rows)}"
+    for r in regione_rows:
+        if r[0] == "Lombardia":
+            assert r[1] == 380  # SUM(valore)
+    con.close()
+
+
+def test_hierarchy_no_metric_columns_count_fallback(tmp_path: Path) -> None:
+    """Without numeric columns, hierarchy falls back to COUNT(*)."""
+    con = duckdb.connect()
+    con.execute(
+        "CREATE OR REPLACE VIEW clean_input AS SELECT * FROM (VALUES "
+        "  ('Roma', 'Lazio', 'X'), "
+        "  ('Milano', 'Lombardia', 'Y'), "
+        "  ('Napoli', 'Campania', 'Z') "
+        ") AS t(comune, regione, codice)"
+    )
+
+    mart_cfg = {
+        "hierarchy": {
+            "axis": "territoriale",
+            "levels": [
+                {"level": "comune", "table": "mart_comune", "grain": ["comune", "regione"]},
+            ],
+        }
+    }
+
+    mart_dir = tmp_path / "mart3"
+    mart_dir.mkdir()
+
+    written, executed, total_rows = _run_hierarchy_levels(
+        con, mart_cfg, "test", 2024, mart_dir, logger=_null_logger,
+    )
+
+    assert len(written) == 1
+    rows = con.execute(
+        "SELECT comune, record_count FROM read_parquet('" +
+        str(mart_dir / "mart_comune.parquet") + "') ORDER BY comune"
+    ).fetchall()
+    assert len(rows) == 3  # one row per comune
+    # Each comune has exactly 1 record
+    for r in rows:
+        assert r[1] == 1, f"expected COUNT(*)=1 for {r[0]}"
+    con.close()
+
+
+def test_hierarchy_empty_config(tmp_path: Path) -> None:
+    """Empty or missing hierarchy returns empty results."""
+    con = duckdb.connect()
+    _setup_clean_view(con)
+    mart_dir = tmp_path / "empty"
+    mart_dir.mkdir()
+
+    w, e, r = _run_hierarchy_levels(con, {}, "test", 2024, mart_dir, logger=_null_logger)
+    assert w == []
+    assert e == []
+    assert r == 0
+
+    w2, e2, r2 = _run_hierarchy_levels(
+        con, {"hierarchy": {"axis": "x", "levels": []}}, "test", 2024, mart_dir, logger=_null_logger
+    )
+    assert w2 == []
+    assert e2 == []
+    assert r2 == 0
+    con.close()
+
+
+def test_hierarchy_missing_source_raises(tmp_path: Path) -> None:
+    """Missing source table raises a clear error."""
+    con = duckdb.connect()
+    mart_dir = tmp_path / "missing"
+    mart_dir.mkdir()
+
+    mart_cfg = {
+        "hierarchy": {
+            "axis": "territoriale",
+            "levels": [
+                {"level": "comune", "table": "mart_comune", "grain": ["comune"]},
+            ],
+        }
+    }
+
+    with pytest.raises(ValueError, match="source table.*not found"):
+        _run_hierarchy_levels(con, mart_cfg, "test", 2024, mart_dir, logger=_null_logger)
+    con.close()
+
+
+@pytest.mark.smoke
+def test_hierarchy_integration_via_run(project_example: Path) -> None:
+    """End-to-end: hierarchy levels generated correctly through full pipeline."""
+    config_path = project_example / "dataset.yml"
+
+    # Add hierarchy to existing project_example config
+    config_text = config_path.read_text(encoding="utf-8")
+    config_data = yaml.safe_load(config_text)
+    config_data.setdefault("mart", {})["hierarchy"] = {
+        "axis": "territoriale",
+        "levels": [
+            {
+                "level": "provincia",
+                "table": "h_provincia",
+                "grain": ["provincia", "regione"],
+            },
+            {
+                "level": "regione",
+                "table": "h_regione",
+                "grain": ["regione"],
+            },
+        ],
+    }
+    config_path.write_text(
+        yaml.dump(config_data, default_flow_style=False, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    from toolkit.cli.cmd_run import run as run_cmd
+    run_cmd(step="all", config=str(config_path))
+
+    # Hierarchy parquet files should exist alongside normal mart tables
+    mart_dir_2022 = project_example / "_smoke_out" / "data" / "mart" / "project_example" / "2022"
+    assert (mart_dir_2022 / "h_provincia.parquet").exists(), "hierarchy provincia parquet missing"
+    assert (mart_dir_2022 / "h_regione.parquet").exists(), "hierarchy regione parquet missing"
+
+    # Normal mart tables still work
+    assert (mart_dir_2022 / "rd_by_regione.parquet").exists()
+
+    # Hierarchy data should be aggregated
+    con = duckdb.connect()
+    prov_rows = con.execute(
+        f"SELECT * FROM read_parquet('{mart_dir_2022 / 'h_provincia.parquet'}')"
+    ).fetchall()
+    assert len(prov_rows) > 0, "h_provincia should have data"
+    # Fetch column names via duckdb col description
+    prov_desc = con.execute(
+        f"SELECT column_name, column_type FROM (DESCRIBE SELECT * FROM read_parquet('{mart_dir_2022 / 'h_provincia.parquet'}'))"
+    ).fetchall()
+    col_names = [r[0].lower() for r in prov_desc]
+    assert "provincia" in col_names, f"provincia not in columns: {col_names}"
+    con.close()
+
+
+def test_source_id_propagated_to_toolkit_config(tmp_path: Path) -> None:
+    """source_id from dataset.yml is propagated to ToolkitConfig."""
+    yml = tmp_path / "dataset.yml"
+    yml.write_text(
+        "\n".join([
+            "dataset:",
+            "  name: test_sid",
+            "  years: [2024]",
+            "  source_id: my_test_source",
+            "raw: {}",
+            "clean: {}",
+            "mart: {}",
+        ]),
+        encoding="utf-8",
+    )
+    cfg = load_config(yml)
+    assert cfg.source_id == "my_test_source"
+
+    # Without source_id
+    yml2 = tmp_path / "dataset_no_sid.yml"
+    yml2.write_text(
+        "\n".join([
+            "dataset:",
+            "  name: test_no_sid",
+            "  years: [2024]",
+            "raw: {}",
+            "clean: {}",
+            "mart: {}",
+        ]),
+        encoding="utf-8",
+    )
+    cfg2 = load_config(yml2)
+    assert cfg2.source_id is None
+
+
+def test_source_id_in_metadata_after_run(project_example: Path) -> None:
+    """source_id appears in layer metadata after pipeline run."""
+    config_path = project_example / "dataset.yml"
+    config_text = config_path.read_text(encoding="utf-8")
+    config_data = yaml.safe_load(config_text)
+    config_data["dataset"]["source_id"] = "ispra_linked_data"
+    config_path.write_text(
+        yaml.dump(config_data, default_flow_style=False, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    from toolkit.cli.cmd_run import run as run_cmd
+    run_cmd(step="all", config=str(config_path))
+
+    # Check clean metadata
+    clean_dir = project_example / "_smoke_out" / "data" / "clean" / "project_example" / "2022"
+    clean_meta = json.loads((clean_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert clean_meta.get("source_id") == "ispra_linked_data", f"got {clean_meta.get('source_id')}"
+
+    # Check mart metadata
+    mart_dir = project_example / "_smoke_out" / "data" / "mart" / "project_example" / "2022"
+    mart_meta = json.loads((mart_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert mart_meta.get("source_id") == "ispra_linked_data", f"got {mart_meta.get('source_id')}"

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -124,6 +124,7 @@ def _select_clean_inputs(
 def _clean_metadata_payload(
     *,
     dataset: str,
+    source_id: str | None = None,
     year: int,
     base_dir: Path | None,
     root_dir: Path,
@@ -139,7 +140,7 @@ def _clean_metadata_payload(
     outputs: list[dict[str, Any]],
     policy: str,
 ) -> dict[str, Any]:
-    metadata_payload = {
+    metadata_payload: dict[str, Any] = {
         "layer": "clean",
         "dataset": dataset,
         "year": year,
@@ -156,6 +157,8 @@ def _clean_metadata_payload(
         "outputs": outputs,
         "input_files": [p.name for p in input_files],
     }
+    if source_id:
+        metadata_payload["source_id"] = source_id
     return metadata_payload
 
 
@@ -169,6 +172,7 @@ def run_clean(
     base_dir: Path | None = None,
     output_cfg: dict[str, Any] | None = None,
     sample_rows: int | None = None,
+    source_id: str | None = None,
 ):
     clean_cfg = ensure_dict(clean_cfg)
     output_cfg = ensure_dict(output_cfg)
@@ -229,6 +233,7 @@ def run_clean(
     outputs = [file_record(output_path)]
     metadata_payload = _clean_metadata_payload(
         dataset=dataset,
+        source_id=source_id,
         year=year,
         base_dir=base_dir,
         root_dir=root_dir,

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -141,14 +141,14 @@ def run_year(
         year=year,
         run_id=context.run_id,
     )
-    base_logger.info(
-        "RUN context | dataset=%s year=%s base_dir=%s effective_root=%s root_source=%s",
-        cfg.dataset,
-        year,
-        cfg.base_dir,
-        cfg.root,
-        cfg.root_source,
+    log_ctx = (
+        f"RUN context | dataset={cfg.dataset}"
+        f"{f' source_id={cfg.source_id}' if cfg.source_id else ''}"
+        f" year={year} base_dir={cfg.base_dir}"
+        f" effective_root={cfg.root}"
+        f" root_source={cfg.root_source}"
     )
+    base_logger.info(log_ctx)
 
     if dry_run:
         context.mark_dry_run()
@@ -189,6 +189,8 @@ def run_year(
             context.fail_run(str(exc))
             raise
 
+    source_id = cfg.source_id
+
     if "raw" in layers_to_run:
         _execute_layer(
             "raw",
@@ -202,6 +204,7 @@ def run_year(
             output_cfg=dump_cfg_section(cfg.output),
             clean_cfg=dump_cfg_section(cfg.clean),
             sample_bytes=sample_bytes,
+            source_id=source_id,
         )
 
     if "clean" in layers_to_run and not _is_mart_only_cfg(cfg):
@@ -215,6 +218,7 @@ def run_year(
             base_dir=cfg.base_dir,
             output_cfg=dump_cfg_section(cfg.output),
             sample_rows=sample_rows,
+            source_id=source_id,
         )
 
     if "mart" in layers_to_run and _has_single_year_mart(cfg):
@@ -229,6 +233,7 @@ def run_year(
             clean_cfg=dump_cfg_section(cfg.clean),
             output_cfg=dump_cfg_section(cfg.output),
             support_cfg=dump_cfg_section(cfg.support),
+            source_id=source_id,
         )
 
     context.complete_run(success_with_warnings=run_has_validation_warnings)
@@ -245,16 +250,19 @@ def _has_multi_year_mart(cfg) -> bool:
 
 
 def _has_single_year_mart(cfg) -> bool:
-    """Check if any mart table does NOT have an explicit ``years`` field.
+    """Check if any mart table does NOT have an explicit ``years`` field,
+    OR if a hierarchy section is defined (runtime-generated aggregation).
 
-    Quando tutte le tabelle sono multi-year (hanno ``years``),
-    il per-year ``run mart`` non ha nulla da elaborare e va saltato.
+    Quando tutte le tabelle sono multi-year (hanno ``years``) e non c'è
+    hierarchy, il per-year ``run mart`` non ha nulla da elaborare.
     """
     tables = (cfg.mart or {}).get("tables") or []
-    return any(
+    has_single_year = any(
         isinstance(t, dict) and not t.get("years")
         for t in tables
     )
+    has_hierarchy = bool((cfg.mart or {}).get("hierarchy"))
+    return has_single_year or has_hierarchy
 
 
 def _maybe_run_multi_year_mart(
@@ -297,6 +305,7 @@ def _maybe_run_multi_year_mart(
             base_dir=cfg.base_dir,
             output_cfg=dump_cfg_section(cfg.output),
             support_cfg=dump_cfg_section(cfg.support),
+            source_id=cfg.source_id,
         )
     except Exception as exc:
         if fail_on_error:

--- a/toolkit/core/config.py
+++ b/toolkit/core/config.py
@@ -88,6 +88,7 @@ class ToolkitConfig:
     root: Path
     root_source: str
     dataset: str
+    source_id: str | None
     years: list[int]
     time_coverage: TimeCoverage | None
 
@@ -166,6 +167,7 @@ def load_config(
         root=effective_root,
         root_source="--root" if root_override else model.root_source,
         dataset=model.dataset.name,
+        source_id=model.dataset.source_id,
         years=list(model.dataset.years),
         time_coverage=model.dataset.time_coverage,
         _model=model,

--- a/toolkit/core/config_models/mart.py
+++ b/toolkit/core/config_models/mart.py
@@ -107,6 +107,11 @@ class HierarchyLevel(BaseModel):
         text = value.strip()
         if not text:
             raise ValueError("mart.hierarchy.levels[].table must not be empty")
+        if not re.fullmatch(_SAFE_SQL_IDENTIFIER_RE, text):
+            raise ValueError(
+                "mart.hierarchy.levels[].table must be a safe SQL identifier "
+                "(letters, numbers, underscore; cannot start with a number)"
+            )
         return text
 
 

--- a/toolkit/core/config_models/mart.py
+++ b/toolkit/core/config_models/mart.py
@@ -114,6 +114,29 @@ class HierarchyLevel(BaseModel):
             )
         return text
 
+    @field_validator("source_table")
+    @classmethod
+    def _validate_source_table(cls, value: str | None) -> str | None:
+        if value is not None:
+            text = value.strip()
+            if text and not re.fullmatch(_SAFE_SQL_IDENTIFIER_RE, text):
+                raise ValueError(
+                    "mart.hierarchy.levels[].source_table must be a safe SQL identifier "
+                    "(letters, numbers, underscore; cannot start with a number)"
+                )
+        return value
+
+    @field_validator("grain")
+    @classmethod
+    def _validate_grain(cls, value: list[str]) -> list[str]:
+        for g in value:
+            if not re.fullmatch(_SAFE_SQL_IDENTIFIER_RE, g.strip()):
+                raise ValueError(
+                    f"mart.hierarchy.levels[].grain element '{g}' must be a safe SQL identifier "
+                    "(letters, numbers, underscore; cannot start with a number)"
+                )
+        return value
+
 
 class HierarchyConfig(BaseModel):
     """Gerarchia mart: aggregazione per asse naturale del dato."""

--- a/toolkit/core/config_models/mart.py
+++ b/toolkit/core/config_models/mart.py
@@ -76,14 +76,22 @@ class MartValidateConfig(BaseModel):
 
 
 class HierarchyLevel(BaseModel):
-    """Un livello della gerarchia mart (es. comune, provincia, regione)."""
+    """Un livello della gerarchia mart (es. comune, provincia, regione).
+
+    A runtime, la query di aggregazione viene generata automaticamente:
+    - colonne metriche scoperte per introspection dalla source
+    - GROUP BY sulle colonne grain
+    - SUM per ogni metrica numerica
+
+    Non richiede un file SQL: il config è attivo.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     level: str
     table: str
     grain: list[str]
-    sql: Path
+    source_table: str | None = None
 
     @field_validator("level")
     @classmethod

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -218,13 +218,15 @@ def _run_hierarchy_levels(
                 "or a source_table that references an existing mart table."
             )
 
-        # Discover metric columns (all numeric types)
+        # Discover metric columns (all numeric types not used as grain)
         # DuckDB types may include precision like DECIMAL(3,1), BIGINT etc.
         # Use startswith to catch parameterized types
         source_profile = profile_relation(con, source_table)
+        grain_lower = [g.lower() for g in grain]
         metric_cols = [
             c["name"] for c in source_profile.get("columns", [])
             if any(c["type"].upper().startswith(num_t) for num_t in _NUMERIC_TYPES)
+            and c["name"].lower() not in grain_lower
         ]
 
         # Build grain expression (safe quoting via double-quote)

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -34,6 +34,7 @@ def run_mart_multi_year(
     base_dir: Path | None = None,
     output_cfg: dict[str, Any] | None = None,
     support_cfg: list[dict[str, Any]] | None = None,
+    source_id: str | None = None,
 ) -> dict[str, Any]:
     """Run multi-year MART tables (tables with explicit ``years`` in config).
 
@@ -128,7 +129,7 @@ def run_mart_multi_year(
             })
 
     outputs = [file_record(p) for p in written]
-    metadata_payload = {
+    metadata_payload: dict[str, Any] = {
         "layer": "mart_multi_year",
         "dataset": dataset,
         "years": dataset_years,
@@ -137,6 +138,8 @@ def run_mart_multi_year(
         "output_paths": [serialize_metadata_path(p, root_dir) for p in written],
         "tables": executed,
     }
+    if source_id:
+        metadata_payload["source_id"] = source_id
     metadata_path = write_metadata(multi_year_dir, metadata_payload)
     write_layer_manifest(
         multi_year_dir,
@@ -157,6 +160,124 @@ def run_mart_multi_year(
 
 
 # ---------------------------------------------------------------------------
+# Hierarchy levels: generatore runtime di tabelle aggregate
+# ---------------------------------------------------------------------------
+
+_NUMERIC_TYPES = {
+    "INTEGER", "BIGINT", "HUGEINT", "SMALLINT", "TINYINT",
+    "DOUBLE", "FLOAT", "DECIMAL", "REAL",
+}
+
+
+def _run_hierarchy_levels(
+    con,
+    mart_cfg: dict[str, Any],
+    dataset: str,
+    year: int,
+    mart_dir: Path,
+    *,
+    logger,
+) -> tuple[list[Path], list[dict[str, Any]], int]:
+    """Genera ed esegue tabelle mart per ogni livello gerarchico.
+
+    Ogni livello produce una tabella aggregata: SELECT grain, SUM(metrics)
+    FROM source GROUP BY grain. Le colonne metriche sono scoperte per
+    introspection dalla tabella sorgente (tutte le colonne numeriche).
+
+    Returns (written_paths, executed_records, total_rows).
+    """
+    hierarchy = mart_cfg.get("hierarchy")
+    if not hierarchy:
+        return [], [], 0
+
+    levels = hierarchy.get("levels", [])
+    if not levels:
+        return [], [], 0
+
+    written: list[Path] = []
+    executed: list[dict[str, Any]] = []
+    total_rows = 0
+
+    for level_cfg in levels:
+        level_name = level_cfg.get("level", "unknown")
+        table_name = level_cfg.get("table", f"h_{level_name}")
+        grain = level_cfg.get("grain", [])
+        source_table = level_cfg.get("source_table") or "clean_input"
+
+        if not grain:
+            logger.warning("hierarchy level '%s' has no grain columns — skipping", level_name)
+            continue
+
+        # Verify source table exists before profiling
+        try:
+            con.execute(f"SELECT COUNT(*) FROM {source_table}").fetchone()
+        except Exception:
+            raise ValueError(
+                f"hierarchy level '{level_name}' source table '{source_table}' not found. "
+                "Hierarchy levels need clean parquet files (run 'toolkit run clean' first) "
+                "or a source_table that references an existing mart table."
+            )
+
+        # Discover metric columns (all numeric types)
+        # DuckDB types may include precision like DECIMAL(3,1), BIGINT etc.
+        # Use startswith to catch parameterized types
+        source_profile = profile_relation(con, source_table)
+        metric_cols = [
+            c["name"] for c in source_profile.get("columns", [])
+            if any(c["type"].upper().startswith(num_t) for num_t in _NUMERIC_TYPES)
+        ]
+
+        # Build grain expression (safe quoting via double-quote)
+        grain_expr = ", ".join(f'"{g}"' for g in grain)
+
+        if metric_cols:
+            # Cap metrics at 30 to avoid absurdly wide tables
+            sum_metrics = metric_cols[:30]
+            sum_expr = ",\n  ".join(f'SUM("{m}") AS "{m}"' for m in sum_metrics)
+            sql = (
+                f'-- {level_name}: aggregazione gerarchica\n'
+                f"SELECT\n"
+                f"  {grain_expr},\n"
+                f"  {sum_expr}\n"
+                f"FROM {source_table}\n"
+                f"GROUP BY {grain_expr}"
+            )
+        else:
+            # No metric columns → count records per grain
+            sql = (
+                f'-- {level_name}: conteggio record\n'
+                f"SELECT\n"
+                f"  {grain_expr},\n"
+                f"  COUNT(*) AS record_count\n"
+                f"FROM {source_table}\n"
+                f"GROUP BY {grain_expr}"
+            )
+
+        # Execute hierarchy level as a mart table
+        con.execute(f'CREATE OR REPLACE TABLE "{table_name}" AS {sql}')
+        output_profile = profile_relation(con, table_name)
+        row_count = int(output_profile.get("row_count") or 0)
+        total_rows += row_count
+
+        out = mart_dir / f"{table_name}.parquet"
+        con.execute(f"COPY \"{table_name}\" TO '{out}' (FORMAT PARQUET);")
+        written.append(out)
+
+        executed.append({
+            "name": table_name,
+            "level": level_name,
+            "grain": grain,
+            "source": source_table,
+            "metric_columns": metric_cols[:30],
+            "row_count": row_count,
+        })
+
+        logger.info("  hierarchy level '%s' -> %s (%d rows)", level_name, out, row_count)
+
+    return written, executed, total_rows
+
+
+# ---------------------------------------------------------------------------
 # Single-year mart tables
 # ---------------------------------------------------------------------------
 
@@ -172,6 +293,7 @@ def run_mart(
     clean_cfg: dict[str, Any] | None = None,
     output_cfg: dict[str, Any] | None = None,
     support_cfg: list[dict[str, Any]] | None = None,
+    source_id: str | None = None,
 ):
     mart_cfg = ensure_dict(mart_cfg)
     clean_cfg = ensure_dict(clean_cfg)
@@ -208,8 +330,12 @@ def run_mart(
             con.execute("CREATE OR REPLACE VIEW clean AS SELECT * FROM clean_input")
 
         tables = mart_cfg.get("tables") or []
-        if not isinstance(tables, list) or not tables:
-            raise ValueError("mart.tables missing or empty in dataset.yml")
+        has_hierarchy = bool(mart_cfg.get("hierarchy"))
+        if not isinstance(tables, list) or (not tables and not has_hierarchy):
+            raise ValueError(
+                "mart.tables missing or empty in dataset.yml "
+                "(add explicit tables or a hierarchy section)"
+            )
 
         support_payloads = resolve_support_payloads(support_cfg, require_exists=True)
         template_ctx = build_runtime_template_ctx(
@@ -290,8 +416,17 @@ def run_mart(
                 }
             )
 
+        # Hierarchy levels: generates aggregation tables from clean data
+        if has_hierarchy:
+            hierarchy_written, hierarchy_executed, hierarchy_rows = _run_hierarchy_levels(
+                con, mart_cfg, dataset, year, mart_dir, logger=logger,
+            )
+            written.extend(hierarchy_written)
+            executed.extend(hierarchy_executed)
+            total_rows += hierarchy_rows
+
     outputs = [file_record(p) for p in written]
-    metadata_payload = {
+    metadata_payload: dict[str, Any] = {
         "layer": "mart",
         "dataset": dataset,
         "year": year,
@@ -301,10 +436,13 @@ def run_mart(
         "output_paths": [serialize_metadata_path(p, root_dir) for p in written],
         "template_ctx": public_template_ctx(template_ctx),
         "tables": executed,
+        "hierarchy_enabled": bool(mart_cfg.get("hierarchy")),
         "clean_input_profile": clean_input_profile,
         "table_profiles": table_profiles,
         "transition_profiles": transition_profiles,
     }
+    if source_id:
+        metadata_payload["source_id"] = source_id
     metadata_path = write_metadata(
         mart_dir,
         metadata_payload,

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -36,6 +36,7 @@ def run_raw(
     output_cfg: dict | None = None,
     clean_cfg: dict | None = None,
     sample_bytes: int | None = None,
+    source_id: str | None = None,
 ):
     """
     Supporta:
@@ -182,24 +183,24 @@ def run_raw(
         except Exception as exc:
             logger.warning("RAW profile/scaffold generation failed: %s: %s", type(exc).__name__, exc)
 
-    metadata_path = write_metadata(
-        out_dir,
-        {
-            "layer": "raw",
-            "dataset": dataset,
-            "year": year,
-            "run_id": run_id,
-            "timestamp_utc": datetime.now(timezone.utc).isoformat(),
-            "config_hash": config_hash_for_year(base_dir, year),
-            "inputs": inputs,
-            "outputs": [
-                {"file": f["file"], "sha256": f["sha256"], "bytes": f["bytes"]}
-                for f in files_written
-            ],
-            "files": files_written,
-            "profile_hints": profile_hints,
-        },
-    )
+    metadata_payload = {
+        "layer": "raw",
+        "dataset": dataset,
+        "year": year,
+        "run_id": run_id,
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "config_hash": config_hash_for_year(base_dir, year),
+        "inputs": inputs,
+        "outputs": [
+            {"file": f["file"], "sha256": f["sha256"], "bytes": f["bytes"]}
+            for f in files_written
+        ],
+        "files": files_written,
+        "profile_hints": profile_hints,
+    }
+    if source_id:
+        metadata_payload["source_id"] = source_id
+    metadata_path = write_metadata(out_dir, metadata_payload)
 
     # --- QA RAW ---
     result = validate_raw_output(out_dir, files_written)

--- a/toolkit/scaffold/full.py
+++ b/toolkit/scaffold/full.py
@@ -338,16 +338,8 @@ def generate_full_scaffold(
     yml_lines.append(f'    - name: "{slug}"')
     yml_lines.append('      sql: "sql/mart.sql"')
 
-    # Hierarchy levels → aggiunte come tabelle mart
+    # Hierarchia: genera tabelle aggregate a runtime (nessun SQL da scrivere)
     if hierarchy:
-        for level_cfg in hierarchy.get("levels", []):
-            level_name = level_cfg.get("level", "unknown")
-            table_name = level_cfg.get("table", f"mart_{slug}_{level_name}")
-            sql_path = level_cfg.get("sql", f"sql/mart/{level_name}.sql")
-            yml_lines.append(f'    - name: "{table_name}"')
-            yml_lines.append(f'      sql: "{sql_path}"')
-
-        # Serializza blocco hierarchy
         yml_lines.append("  hierarchy:")
         yml_lines.append(f'    axis: "{hierarchy.get("axis", "territoriale")}"')
         yml_lines.append("    levels:")
@@ -356,9 +348,10 @@ def generate_full_scaffold(
             grain = level_cfg.get("grain", [])
             grain_list = ", ".join(f'"{g}"' for g in grain)
             yml_lines.append(f'      - level: "{level_name}"')
-            yml_lines.append(f'        table: "{level_cfg.get("table", f"mart_{slug}_{level_name}")}"')
+            yml_lines.append(f'        table: "{level_cfg.get("table", f"h_{slug}_{level_name}")}"')
             yml_lines.append(f"        grain: [{grain_list}]")
-            yml_lines.append(f'        sql: "{level_cfg.get("sql", f"sql/mart/{level_name}.sql")}"')
+            if "source_table" in level_cfg and level_cfg.get("source_table"):
+                yml_lines.append(f'        source_table: "{level_cfg["source_table"]}"')
 
     if validation_suggestions:
         mv = validation_suggestions.get("mart")
@@ -399,81 +392,4 @@ def generate_full_scaffold(
         "notes.md": notes,
     }
 
-    if hierarchy:
-        h_col_names: list[str] = []
-        if profile:
-            h_col_names = profile.get("columns_norm") or profile.get("columns_raw") or profile.get("columns") or []
-        result.update(_scaffold_hierarchy_marts(slug, hierarchy, h_col_names, profile))
-
     return result
-
-
-def _scaffold_hierarchy_marts(
-    slug: str,
-    hierarchy: dict[str, Any],
-    col_names: list[str],
-    profile: dict[str, Any] | None,
-) -> dict[str, str]:
-    """Genera SQL per ogni livello della gerarchia mart.
-
-    Returns dict {filename: content} con un file SQL per livello.
-    """
-    files: dict[str, str] = {}
-    axis = hierarchy.get("axis", "territoriale")
-    levels = hierarchy.get("levels", [])
-
-    for level_cfg in levels:
-        level_name = level_cfg.get("level", "unknown")
-        grain = level_cfg.get("grain", [])
-        sql_path = level_cfg.get("sql", f"sql/mart/{level_name}.sql")
-
-        # Find metric columns (numeric) for aggregation
-        metric_cols: list[str] = []
-        if profile:
-            mapping = profile.get("mapping_suggestions") or {}
-            for col in col_names:
-                spec = mapping.get(col) or {}
-                if spec.get("type") in ("integer", "float", "double", "bigint", "decimal", "int"):
-                    metric_cols.append(col)
-
-        grain_cols = [c for c in grain if c in col_names]
-        if not grain_cols:
-            grain_cols = grain  # fallback: usa i grain dichiarati anche se non in col_names
-
-        if grain_cols and metric_cols:
-            grain_expr = ", ".join(f'"{c}"' for c in grain_cols)
-            sum_metrics = metric_cols[:5]
-            sum_lines = []
-            for i, m in enumerate(sum_metrics):
-                comma = "," if i < len(sum_metrics) - 1 else ""
-                sum_lines.append(f'  SUM("{m}") AS "totale_{m}"{comma}')
-            sum_block = "\n".join(sum_lines)
-            sql = (
-                f"-- {level_name}: aggregazione per {axis}\n"
-                f"-- Grain: {', '.join(grain_cols)}\n"
-                f"SELECT\n"
-                f"  {grain_expr},\n"
-                f"{sum_block}\n"
-                f"FROM clean\n"
-                f"GROUP BY {grain_expr}\n"
-            )
-        elif grain_cols:
-            grain_expr = ", ".join(f'"{c}"' for c in grain_cols)
-            sql = (
-                f"-- {level_name}: conteggio record per {axis}\n"
-                f"-- Grain: {', '.join(grain_cols)}\n"
-                f"SELECT\n"
-                f"  {grain_expr},\n"
-                f"  COUNT(*) AS record_count\n"
-                f"FROM clean\n"
-                f"GROUP BY {grain_expr}\n"
-            )
-        else:
-            sql = (
-                f"-- {level_name}: fallback (nessun grain riconosciuto)\n"
-                f"SELECT * FROM clean\n"
-            )
-
-        files[str(sql_path)] = sql
-
-    return files

--- a/toolkit/scaffold/full.py
+++ b/toolkit/scaffold/full.py
@@ -271,7 +271,6 @@ def generate_full_scaffold(
     profile: dict[str, Any] | None = None,
     inferred_years: list[int] | None = None,
     validation_suggestions: dict[str, Any] | None = None,
-    hierarchy: dict[str, Any] | None = None,
 ) -> dict[str, str]:
     """Genera tutti i file di un candidate dataset.
 
@@ -337,21 +336,6 @@ def generate_full_scaffold(
     yml_lines.append("  tables:")
     yml_lines.append(f'    - name: "{slug}"')
     yml_lines.append('      sql: "sql/mart.sql"')
-
-    # Hierarchia: genera tabelle aggregate a runtime (nessun SQL da scrivere)
-    if hierarchy:
-        yml_lines.append("  hierarchy:")
-        yml_lines.append(f'    axis: "{hierarchy.get("axis", "territoriale")}"')
-        yml_lines.append("    levels:")
-        for level_cfg in hierarchy.get("levels", []):
-            level_name = level_cfg.get("level", "unknown")
-            grain = level_cfg.get("grain", [])
-            grain_list = ", ".join(f'"{g}"' for g in grain)
-            yml_lines.append(f'      - level: "{level_name}"')
-            yml_lines.append(f'        table: "{level_cfg.get("table", f"h_{slug}_{level_name}")}"')
-            yml_lines.append(f"        grain: [{grain_list}]")
-            if "source_table" in level_cfg and level_cfg.get("source_table"):
-                yml_lines.append(f'        source_table: "{level_cfg["source_table"]}"')
 
     if validation_suggestions:
         mv = validation_suggestions.get("mart")


### PR DESCRIPTION
## Cosa cambia

### 1. Hierarchia mart — da config morto a generatore runtime

`mart.hierarchy` non genera più N file SQL da mantenere: la query di aggregazione viene generata a runtime per introspection delle colonne numeriche.

```yaml
mart:
  hierarchy:
    axis: categorico
    levels:
      - level: ateneo
        table: h_ateneo
        grain: [cod_ateneo, nome_ateneo]
```

A runtime `mart/run.py` genera:
```sql
SELECT "cod_ateneo", "nome_ateneo",
  SUM("euro_contributo") AS "euro_contributo"
FROM clean_input
GROUP BY "cod_ateneo", "nome_ateneo"
```

**Modifiche:**
- `HierarchyLevel`: rimosso `sql` (generato), aggiunto `source_table` opzionale
- Nuova `_run_hierarchy_levels()` in `mart/run.py`: introspetta la source, scopre metriche numeriche, genera `SELECT grain, SUM(metrics) FROM source GROUP BY grain`
- Fallback a `COUNT(*)` se nessuna colonna numerica
- `_has_single_year_mart` ora rileva anche `hierarchy`
- Scaffold: parametro `hierarchy` morto e `_scaffold_hierarchy_marts()` rimossi
- 6 test (5 unit + 1 integration)

### 2. `dataset.source_id` — finalmente nei metadata

`source_id` era definito nel contratto e popolato in 28 candidati, ma mai letto dal toolkit runtime. Ora:
- Propagato in `ToolkitConfig` (`cfg.source_id`)
- Incluso in `metadata.json` di raw, clean, mart, mart_multi_year
- Loggato nel run context
- 2 test di verifica

### Test
**687 pass, 0 fail** — suite completa invariata.
