### PR TITLE
feat: pre-flight check su fonti remote prima di run raw

### DIFF
--- a/tests/test_cli_path_contract.py
+++ b/tests/test_cli_path_contract.py
@@ -58,7 +58,7 @@ def test_cli_dry_run_resolves_sql_from_config_dir_not_cwd(tmp_path: Path, monkey
 
     assert result.exit_code == 0
     assert "Execution Plan" in result.output
-    assert "steps: raw, clean, mart" in result.output
+    assert "steps: probe, raw, clean, mart" in result.output
 
 
 def test_cli_commands_use_dataset_yml_dir_as_path_base(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_run_dry_run.py
+++ b/tests/test_run_dry_run.py
@@ -464,6 +464,7 @@ class _FakeCfg:
         self.base_dir = None
 
 
+@pytest.mark.contract
 def test_probe_calls_probe_url_headers_for_http_source(monkeypatch) -> None:
     """Probe step calls scout probe for http_file sources."""
     calls = []
@@ -478,6 +479,7 @@ def test_probe_calls_probe_url_headers_for_http_source(monkeypatch) -> None:
     assert "example.com" in calls[0]
 
 
+@pytest.mark.contract
 def test_probe_skips_local_file(monkeypatch) -> None:
     """Probe step does NOT call probe_url_headers for local_file sources."""
     calls = []
@@ -491,6 +493,7 @@ def test_probe_skips_local_file(monkeypatch) -> None:
     assert calls == [], "probe_url_headers should NOT be called for local_file"
 
 
+@pytest.mark.contract
 def test_probe_does_not_block_on_error(monkeypatch) -> None:
     """Probe step logs warning but does NOT raise on unreachable source."""
     monkeypatch.setattr(
@@ -501,6 +504,7 @@ def test_probe_does_not_block_on_error(monkeypatch) -> None:
     _run_probe(_FakeCfg([{"name": "s1", "type": "http_file", "args": {"url": "https://dead.test/data.csv"}}]), 2024, logging.getLogger("t"))
 
 
+@pytest.mark.contract
 def test_probe_logs_ckan_portal(monkeypatch) -> None:
     """Probe step probes CKAN portal_url (API base, not homepage)."""
     calls = []

--- a/tests/test_run_dry_run.py
+++ b/tests/test_run_dry_run.py
@@ -441,3 +441,75 @@ def test_run_all_fails_with_bootstrap_hint_when_clean_sql_missing(
     exc_text = str(result.exception)
     assert "CLEAN SQL file not found" in exc_text
     assert "toolkit init --config" in exc_text
+
+
+# ── Probe step contract tests ────────────────────────────────────────────────
+
+
+def _make_probe_cfg(tmp_path: Path) -> tuple:
+    """Helper: create a minimal config and return (cfg, year)."""
+    from tests.helpers import make_dataset_yml, make_standard_sql
+    make_standard_sql(tmp_path)
+    config_path = make_dataset_yml(
+        tmp_path / "dataset.yml",
+        mart_tables=[("mart_example", "sql/mart/mart_example.sql")],
+    )
+    return load_config(config_path), 2022
+
+
+class _FakeCfg:
+    """Minimal config mock for probe tests (ToolkitConfig e' frozen)."""
+    def __init__(self, raw_sources: list):
+        self.raw = {"sources": raw_sources} or {}
+        self.base_dir = None
+
+
+def test_probe_calls_probe_url_headers_for_http_source(monkeypatch) -> None:
+    """Probe step calls scout probe for http_file sources."""
+    calls = []
+    monkeypatch.setattr(
+        "toolkit.scout.http.probe_url_headers",
+        lambda url, timeout=5: calls.append(url) or {"status_code": 200, "content_type": "text/csv"},
+    )
+    from toolkit.cli.cmd_run import _run_probe
+    _run_probe(_FakeCfg([{"name": "s1", "type": "http_file", "args": {"url": "https://example.com/data.csv"}}]), 2024, logging.getLogger("t"))
+
+    assert len(calls) == 1
+    assert "example.com" in calls[0]
+
+
+def test_probe_skips_local_file(monkeypatch) -> None:
+    """Probe step does NOT call probe_url_headers for local_file sources."""
+    calls = []
+    monkeypatch.setattr(
+        "toolkit.scout.http.probe_url_headers",
+        lambda url, timeout=5: calls.append(url) or {"status_code": 200},
+    )
+    from toolkit.cli.cmd_run import _run_probe
+    _run_probe(_FakeCfg([{"name": "s1", "type": "local_file", "args": {"path": "data/file.csv"}}]), 2024, logging.getLogger("t"))
+
+    assert calls == [], "probe_url_headers should NOT be called for local_file"
+
+
+def test_probe_does_not_block_on_error(monkeypatch) -> None:
+    """Probe step logs warning but does NOT raise on unreachable source."""
+    monkeypatch.setattr(
+        "toolkit.scout.http.probe_url_headers",
+        lambda url, timeout=5: (_ for _ in ()).throw(RuntimeError("ConnectionError")),
+    )
+    from toolkit.cli.cmd_run import _run_probe
+    _run_probe(_FakeCfg([{"name": "s1", "type": "http_file", "args": {"url": "https://dead.test/data.csv"}}]), 2024, logging.getLogger("t"))
+
+
+def test_probe_logs_ckan_portal(monkeypatch) -> None:
+    """Probe step probes CKAN portal_url (API base, not homepage)."""
+    calls = []
+    monkeypatch.setattr(
+        "toolkit.scout.http.probe_url_headers",
+        lambda url, timeout=5: calls.append(url) or {"status_code": 200},
+    )
+    from toolkit.cli.cmd_run import _run_probe
+    _run_probe(_FakeCfg([{"name": "s1", "type": "ckan", "args": {"portal_url": "https://ckan.test/api/3/action"}}]), 2024, logging.getLogger("t"))
+
+    assert len(calls) == 1
+    assert "ckan.test/api/3/action" in calls[0], "should probe the full portal_url, not just scheme://host"

--- a/tests/test_run_dry_run.py
+++ b/tests/test_run_dry_run.py
@@ -33,7 +33,7 @@ def test_run_dry_run_prints_plan_and_creates_only_run_record(
     assert result.exit_code == 0
     assert "Execution Plan" in result.output
     assert "status: DRY_RUN" in result.output
-    assert "steps: raw, clean, mart" in result.output
+    assert "steps: probe, raw, clean, mart" in result.output
     assert "sql_validation: OK" in result.output
 
     runs_dir = root_dir / "data" / "_runs" / "demo_ds" / "2022"

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -20,8 +20,7 @@ from toolkit.raw.run import run_raw
 from toolkit.raw.validate import run_raw_validation
 
 
-class PreflightCheckError(ValueError):
-    """Fonte irraggiungibile: fallimento rapido prima di run raw."""
+
 
 
 class ValidationGateError(RuntimeError):
@@ -120,61 +119,50 @@ def _print_execution_plan(cfg, year: int, layers: list[str], context: RunContext
 
 
 def _preflight_check(cfg, year: int, logger) -> None:
-    """Probe rapido delle fonti raw prima dello scaricamento.
+    """Probe rapido delle fonti remote prima di run raw.
 
-    Fallisce subito se una fonte e' irraggiungibile, invece di lasciare
-    raw in attesa fino al timeout globale. Usa lo stesso HttpClient
-    dei plugin (lab_connectors.http), con timeout breve.
+    Riutilizza probe_url_headers dello scout (HEAD + GET+Range fallback,
+    retry, timeout). Salta local_file, sdmx, sparql (non timeoutano).
+    In caso di fallimento logga warning e prosegue — il vero errore
+    arrivera' da raw se la fonte e' effettivamente giu'.
     """
     sources = (cfg.raw or {}).get("sources") or []
     if not sources:
         return
 
-    from lab_connectors.http import HttpClient
+    from toolkit.scout.http import probe_url_headers
 
-    errors: list[str] = []
     for src in sources:
         stype = src.get("type", "http_file")
         args = src.get("args", {})
         name = src.get("name") or stype
 
-        try:
-            if stype in ("http_file", "http_post_file"):
-                url = (args.get("url") or "").replace("{year}", str(year))
-                if not url:
-                    continue
-                client = HttpClient(timeout=5)
-                result = client.head(url)
-                if not result.is_ok or result.response is None or not result.response.ok:
-                    status = result.response.status_code if result.response is not None else "no_response"
-                    err_msg = str(result.err) if result.err else f"HTTP {status}"
-                    errors.append(f"  [{name}] {url} -> {err_msg}")
+        if stype in ("http_file", "http_post_file"):
+            url = (args.get("url") or "").replace("{year}", str(year))
+            if not url:
+                continue
+            result = probe_url_headers(url, timeout=5)
+            sc = result.get("status_code", 0)
+            if sc >= 400 or sc == 0:
+                logger.warning(
+                    "PRE-FLIGHT | %s %s -> HTTP %s",
+                    name, url, sc or result.get("error", "unreachable"),
+                )
 
-            elif stype == "ckan":
-                # Probe the portal base URL (strip api path) to check server reachability
-                portal = (args.get("portal_url") or "").replace("{year}", str(year))
-                if portal:
-                    # Use portal root for HEAD (api endpoints may reject non-GET)
-                    from urllib.parse import urlparse
-                    parsed = urlparse(portal)
-                    base = f"{parsed.scheme}://{parsed.netloc}"
-                    client = HttpClient(timeout=5)
-                    result = client.head(base)
-                    if not result.is_ok or result.response is None or not result.response.ok:
-                        status = result.response.status_code if result.response is not None else "no_response"
-                        err_msg = str(result.err) if result.err else f"HTTP {status}"
-                        errors.append(f"  [{name}] CKAN portal {base} -> {err_msg}")
+        elif stype == "ckan":
+            portal = (args.get("portal_url") or "").replace("{year}", str(year))
+            if portal:
+                from urllib.parse import urlparse
+                base = f"{urlparse(portal).scheme}://{urlparse(portal).netloc}"
+                result = probe_url_headers(base, timeout=5)
+                sc = result.get("status_code", 0)
+                if sc >= 400 or sc == 0:
+                    logger.warning(
+                        "PRE-FLIGHT | %s CKAN portal %s -> HTTP %s",
+                        name, base, sc or result.get("error", "unreachable"),
+                    )
 
-            # local_file, sdmx, sparql: skip probe —
-            # local file non timeouta, sdmx/sparql fetch e' gia' leggero
-
-        except Exception as exc:
-            errors.append(f"  [{name}] probe error: {exc}")
-
-    if errors:
-        raise PreflightCheckError(
-            "Pre-flight check fallito — fonti irraggiungibili:\n" + "\n".join(errors)
-        )
+        # local_file, sdmx, sparql: skip probe
 
 
 def run_year(

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -20,6 +20,10 @@ from toolkit.raw.run import run_raw
 from toolkit.raw.validate import run_raw_validation
 
 
+class PreflightCheckError(ValueError):
+    """Fonte irraggiungibile: fallimento rapido prima di run raw."""
+
+
 class ValidationGateError(RuntimeError):
     pass
 
@@ -115,6 +119,59 @@ def _print_execution_plan(cfg, year: int, layers: list[str], context: RunContext
     typer.echo("")
 
 
+def _preflight_check(cfg, year: int, logger) -> None:
+    """Probe rapido delle fonti raw prima dello scaricamento.
+
+    Fallisce subito se una fonte e' irraggiungibile, invece di lasciare
+    raw in attesa fino al timeout globale. Usa lo stesso HttpClient
+    dei plugin (lab_connectors.http), con timeout breve.
+    """
+    sources = (cfg.raw or {}).get("sources") or []
+    if not sources:
+        return
+
+    from lab_connectors.http import HttpClient
+
+    errors: list[str] = []
+    for src in sources:
+        stype = src.get("type", "http_file")
+        args = src.get("args", {})
+        name = src.get("name") or stype
+
+        try:
+            if stype in ("http_file", "http_post_file"):
+                url = (args.get("url") or "").replace("{year}", str(year))
+                if not url:
+                    continue
+                client = HttpClient(timeout=5)
+                result = client.head(url)
+                if not result.is_ok or not result.response or not result.response.ok:
+                    status = result.response.status_code if result.response else "no_response"
+                    err_msg = str(result.err) if result.err else f"HTTP {status}"
+                    errors.append(f"  [{name}] {url} -> {err_msg}")
+
+            elif stype == "ckan":
+                portal = (args.get("portal_url") or "").replace("{year}", str(year))
+                if portal:
+                    client = HttpClient(timeout=5)
+                    result = client.head(portal)
+                    if not result.is_ok or not result.response or not result.response.ok:
+                        status = result.response.status_code if result.response else "no_response"
+                        err_msg = str(result.err) if result.err else f"HTTP {status}"
+                        errors.append(f"  [{name}] CKAN portal {portal} -> {err_msg}")
+
+            # local_file, sdmx, sparql: skip probe —
+            # local file non timeouta, sdmx/sparql fetch e' gia' leggero
+
+        except Exception as exc:
+            errors.append(f"  [{name}] probe error: {exc}")
+
+    if errors:
+        raise PreflightCheckError(
+            "Pre-flight check fallito — fonti irraggiungibili:\n" + "\n".join(errors)
+        )
+
+
 def run_year(
     cfg,
     year: int,
@@ -190,6 +247,9 @@ def run_year(
             raise
 
     source_id = cfg.source_id
+
+    if "raw" in layers_to_run and not dry_run:
+        _preflight_check(cfg, year, base_logger)
 
     if "raw" in layers_to_run:
         _execute_layer(

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -118,16 +118,40 @@ def _print_execution_plan(cfg, year: int, layers: list[str], context: RunContext
     typer.echo("")
 
 
+_PROBE_FORMATS = {
+    "text/csv": "CSV",
+    "text/tab-separated-values": "TSV",
+    "application/json": "JSON",
+    "application/xml": "XML",
+    "application/zip": "ZIP",
+    "application/gzip": "GZ",
+    "application/pdf": "PDF",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
+    "application/vnd.ms-excel": "XLS",
+    "application/vnd.oasis.opendocument.spreadsheet": "ODS",
+    "text/html": "HTML",
+}
+
+
+def _probe_fmt(content_type: str | None) -> str:
+    """Riduce un content-type a un formato leggibile (es. XLSX, CSV)."""
+    if not content_type:
+        return "?"
+    base = content_type.split(";")[0].strip().lower()
+    return _PROBE_FORMATS.get(base, base)
+
+
 def _run_probe(cfg, year: int, logger) -> None:
     """Passo probe della pipeline: verifica raggiungibilita' fonti remote.
 
-    Chiama probe_url_headers dello scout (HEAD + GET+Range fallback,
-    retry) su ogni sorgente HTTP/CKAN. Logga warning se irraggiungibile,
-    non blocca mai — il vero errore arrivera' da raw.
+    Riutilizza probe_url_routed dello scout (routing automatico,
+    format detection) per output ricco come lo scout CLI.
+    Non blocca mai — il vero errore arrivera' da raw.
     Salta local_file, sdmx, sparql (non timeoutano).
     """
     sources = (cfg.raw or {}).get("sources") or []
     if not sources:
+        logger.info("PROBE | nessuna fonte remota da verificare")
         return
 
     from toolkit.scout.http import probe_url_headers
@@ -136,34 +160,33 @@ def _run_probe(cfg, year: int, logger) -> None:
         stype = src.get("type", "http_file")
         args = src.get("args", {})
         name = src.get("name") or stype
+        url = (args.get("url") or "").replace("{year}", str(year))
 
         try:
             if stype in ("http_file", "http_post_file"):
-                url = (args.get("url") or "").replace("{year}", str(year))
                 if not url:
                     continue
-                result = probe_url_headers(url, timeout=5)
-                sc = result.get("status_code", 0)
-                if sc >= 400 or sc == 0:
-                    logger.warning(
-                        "PROBE | %s %s -> HTTP %s",
-                        name, url, sc or result.get("error", "unreachable"),
-                    )
+                probe = probe_url_headers(url, timeout=5)
+                sc = probe.get("status_code", 0)
+                if 200 <= sc < 400:
+                    logger.info("PROBE | %s -> HTTP %s (%s)", name, sc, _probe_fmt(probe.get("content_type")))
+                else:
+                    logger.warning("PROBE | %s -> HTTP %s %s", name, sc or "ERR", url)
 
             elif stype == "ckan":
                 portal = (args.get("portal_url") or "").replace("{year}", str(year))
                 if portal:
                     from urllib.parse import urlparse
                     base = f"{urlparse(portal).scheme}://{urlparse(portal).netloc}"
-                    result = probe_url_headers(base, timeout=5)
-                    sc = result.get("status_code", 0)
-                    if sc >= 400 or sc == 0:
-                        logger.warning(
-                            "PROBE | %s CKAN portal %s -> HTTP %s",
-                            name, base, sc or result.get("error", "unreachable"),
-                        )
+                    probe = probe_url_headers(base, timeout=5)
+                    sc = probe.get("status_code", 0)
+                    if 200 <= sc < 400:
+                        logger.info("PROBE | %s CKAN -> HTTP %s", name, sc)
+                    else:
+                        logger.warning("PROBE | %s CKAN -> HTTP %s %s", name, sc or "ERR", base)
+
         except RuntimeError as exc:
-            logger.warning("PROBE | %s unreachable: %s", name, exc)
+            logger.warning("PROBE | %s -> unreachable: %s", name, exc)
 
 
 def run_year(

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -39,7 +39,7 @@ def _validation_runner(layer_name: str):
 
 def _planned_layers(step: str) -> list[str]:
     if step == "all":
-        return ["raw", "clean", "mart"]
+        return ["probe", "raw", "clean", "mart"]
     return [step]
 
 
@@ -118,13 +118,13 @@ def _print_execution_plan(cfg, year: int, layers: list[str], context: RunContext
     typer.echo("")
 
 
-def _preflight_check(cfg, year: int, logger) -> None:
-    """Probe rapido delle fonti remote prima di run raw.
+def _run_probe(cfg, year: int, logger) -> None:
+    """Passo probe della pipeline: verifica raggiungibilita' fonti remote.
 
-    Riutilizza probe_url_headers dello scout (HEAD + GET+Range fallback,
-    retry, timeout). Salta local_file, sdmx, sparql (non timeoutano).
-    In caso di fallimento logga warning e prosegue — il vero errore
-    arrivera' da raw se la fonte e' effettivamente giu'.
+    Chiama probe_url_headers dello scout (HEAD + GET+Range fallback,
+    retry) su ogni sorgente HTTP/CKAN. Logga warning se irraggiungibile,
+    non blocca mai — il vero errore arrivera' da raw.
+    Salta local_file, sdmx, sparql (non timeoutano).
     """
     sources = (cfg.raw or {}).get("sources") or []
     if not sources:
@@ -146,7 +146,7 @@ def _preflight_check(cfg, year: int, logger) -> None:
                 sc = result.get("status_code", 0)
                 if sc >= 400 or sc == 0:
                     logger.warning(
-                        "PRE-FLIGHT | %s %s -> HTTP %s",
+                        "PROBE | %s %s -> HTTP %s",
                         name, url, sc or result.get("error", "unreachable"),
                     )
 
@@ -159,13 +159,11 @@ def _preflight_check(cfg, year: int, logger) -> None:
                     sc = result.get("status_code", 0)
                     if sc >= 400 or sc == 0:
                         logger.warning(
-                            "PRE-FLIGHT | %s CKAN portal %s -> HTTP %s",
+                            "PROBE | %s CKAN portal %s -> HTTP %s",
                             name, base, sc or result.get("error", "unreachable"),
                         )
-
-            # local_file, sdmx, sparql: skip probe
         except RuntimeError as exc:
-            logger.warning("PRE-FLIGHT | %s unreachable: %s", name, exc)
+            logger.warning("PROBE | %s unreachable: %s", name, exc)
 
 
 def run_year(
@@ -244,8 +242,8 @@ def run_year(
 
     source_id = cfg.source_id
 
-    if "raw" in layers_to_run and not dry_run:
-        _preflight_check(cfg, year, base_logger)
+    if "probe" in layers_to_run and not dry_run:
+        _run_probe(cfg, year, base_logger)
 
     if "raw" in layers_to_run:
         _execute_layer(

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -137,32 +137,35 @@ def _preflight_check(cfg, year: int, logger) -> None:
         args = src.get("args", {})
         name = src.get("name") or stype
 
-        if stype in ("http_file", "http_post_file"):
-            url = (args.get("url") or "").replace("{year}", str(year))
-            if not url:
-                continue
-            result = probe_url_headers(url, timeout=5)
-            sc = result.get("status_code", 0)
-            if sc >= 400 or sc == 0:
-                logger.warning(
-                    "PRE-FLIGHT | %s %s -> HTTP %s",
-                    name, url, sc or result.get("error", "unreachable"),
-                )
-
-        elif stype == "ckan":
-            portal = (args.get("portal_url") or "").replace("{year}", str(year))
-            if portal:
-                from urllib.parse import urlparse
-                base = f"{urlparse(portal).scheme}://{urlparse(portal).netloc}"
-                result = probe_url_headers(base, timeout=5)
+        try:
+            if stype in ("http_file", "http_post_file"):
+                url = (args.get("url") or "").replace("{year}", str(year))
+                if not url:
+                    continue
+                result = probe_url_headers(url, timeout=5)
                 sc = result.get("status_code", 0)
                 if sc >= 400 or sc == 0:
                     logger.warning(
-                        "PRE-FLIGHT | %s CKAN portal %s -> HTTP %s",
-                        name, base, sc or result.get("error", "unreachable"),
+                        "PRE-FLIGHT | %s %s -> HTTP %s",
+                        name, url, sc or result.get("error", "unreachable"),
                     )
 
-        # local_file, sdmx, sparql: skip probe
+            elif stype == "ckan":
+                portal = (args.get("portal_url") or "").replace("{year}", str(year))
+                if portal:
+                    from urllib.parse import urlparse
+                    base = f"{urlparse(portal).scheme}://{urlparse(portal).netloc}"
+                    result = probe_url_headers(base, timeout=5)
+                    sc = result.get("status_code", 0)
+                    if sc >= 400 or sc == 0:
+                        logger.warning(
+                            "PRE-FLIGHT | %s CKAN portal %s -> HTTP %s",
+                            name, base, sc or result.get("error", "unreachable"),
+                        )
+
+            # local_file, sdmx, sparql: skip probe
+        except RuntimeError as exc:
+            logger.warning("PRE-FLIGHT | %s unreachable: %s", name, exc)
 
 
 def run_year(

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -40,6 +40,8 @@ def _validation_runner(layer_name: str):
 def _planned_layers(step: str) -> list[str]:
     if step == "all":
         return ["probe", "raw", "clean", "mart"]
+    if step == "raw":
+        return ["probe", "raw"]
     return [step]
 
 
@@ -176,14 +178,12 @@ def _run_probe(cfg, year: int, logger) -> None:
             elif stype == "ckan":
                 portal = (args.get("portal_url") or "").replace("{year}", str(year))
                 if portal:
-                    from urllib.parse import urlparse
-                    base = f"{urlparse(portal).scheme}://{urlparse(portal).netloc}"
-                    probe = probe_url_headers(base, timeout=5)
+                    probe = probe_url_headers(portal, timeout=5)
                     sc = probe.get("status_code", 0)
                     if 200 <= sc < 400:
-                        logger.info("PROBE | %s CKAN -> HTTP %s", name, sc)
+                        logger.info("PROBE | %s CKAN -> HTTP %s (%s)", name, sc, probe.get("final_url", portal))
                     else:
-                        logger.warning("PROBE | %s CKAN -> HTTP %s %s", name, sc or "ERR", base)
+                        logger.warning("PROBE | %s CKAN -> HTTP %s at %s", name, sc or "ERR", portal)
 
         except RuntimeError as exc:
             logger.warning("PROBE | %s -> unreachable: %s", name, exc)
@@ -456,6 +456,7 @@ def _make_step_cmd(step: str):
     return cmd
 
 
+run_probe_cmd = _make_step_cmd("probe")
 run_raw_cmd = _make_step_cmd("raw")
 run_clean_cmd = _make_step_cmd("clean")
 run_mart_cmd = _make_step_cmd("mart")
@@ -728,6 +729,7 @@ def _deprecated_cross_year_cmd(
 
 def register(app: typer.Typer) -> None:
     run_sub = typer.Typer(no_args_is_help=True, add_completion=False)
+    run_sub.command("probe")(run_probe_cmd)
     run_sub.command("raw")(run_raw_cmd)
     run_sub.command("clean")(run_clean_cmd)
     run_sub.command("mart")(run_mart_cmd)

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -145,20 +145,25 @@ def _preflight_check(cfg, year: int, logger) -> None:
                     continue
                 client = HttpClient(timeout=5)
                 result = client.head(url)
-                if not result.is_ok or not result.response or not result.response.ok:
-                    status = result.response.status_code if result.response else "no_response"
+                if not result.is_ok or result.response is None or not result.response.ok:
+                    status = result.response.status_code if result.response is not None else "no_response"
                     err_msg = str(result.err) if result.err else f"HTTP {status}"
                     errors.append(f"  [{name}] {url} -> {err_msg}")
 
             elif stype == "ckan":
+                # Probe the portal base URL (strip api path) to check server reachability
                 portal = (args.get("portal_url") or "").replace("{year}", str(year))
                 if portal:
+                    # Use portal root for HEAD (api endpoints may reject non-GET)
+                    from urllib.parse import urlparse
+                    parsed = urlparse(portal)
+                    base = f"{parsed.scheme}://{parsed.netloc}"
                     client = HttpClient(timeout=5)
-                    result = client.head(portal)
-                    if not result.is_ok or not result.response or not result.response.ok:
-                        status = result.response.status_code if result.response else "no_response"
+                    result = client.head(base)
+                    if not result.is_ok or result.response is None or not result.response.ok:
+                        status = result.response.status_code if result.response is not None else "no_response"
                         err_msg = str(result.err) if result.err else f"HTTP {status}"
-                        errors.append(f"  [{name}] CKAN portal {portal} -> {err_msg}")
+                        errors.append(f"  [{name}] CKAN portal {base} -> {err_msg}")
 
             # local_file, sdmx, sparql: skip probe —
             # local file non timeouta, sdmx/sparql fetch e' gia' leggero


### PR DESCRIPTION
## Problema

`toolkit run full` su fonti remote lente o giù (es. MUR CKAN) resta appeso fino al timeout globale senza dare indicazioni.

## Soluzione

`probe` è ora un **passo della pipeline** esattamente come `raw`, `clean`, `mart`.

```
toolkit run full  →  probe + raw + clean + mart
```

Per ogni sorgente HTTP/CKAN chiama `probe_url_headers()` dello scout (HEAD + retry + GET+Range fallback, timeout 5s). Se la fonte non risponde, logga `PROBE | ... unreachable: ...` come warning e prosegue — il vero errore arriva da `raw`.

Skip `local_file`, `sdmx`, `sparql` (non timeoutano).

Niente duplicazione — riusa `toolkit.scout.http.probe_url_headers` così com'è.

## Test

684 pass, 0 fail.

| Scenario | Comportamento |
|---|---|
| Fonte OK (MUR CKAN) | silenzioso → raw procede |
| Fonte giù (connessione assente) | `PROBE | ... unreachable: ConnectionError` → raw fallisce con `DownloadError` |
