### PR TITLE
feat(hierarchy): exclude_metrics per escludere colonne numeriche non metriche

### DIFF
--- a/tests/test_mart_hierarchy.py
+++ b/tests/test_mart_hierarchy.py
@@ -104,6 +104,54 @@ def test_hierarchy_count_fallback(tmp_path: Path) -> None:
     con.close()
 
 
+def test_hierarchy_exclude_metrics(tmp_path: Path) -> None:
+    """exclude_metrics rimuove colonne numeriche dalla lista metriche."""
+    con = duckdb.connect()
+    con.execute(
+        "CREATE VIEW clean_input AS SELECT * FROM (VALUES "
+        "  ('Lazio', 2023, 100, 50.5), "
+        "  ('Lombardia', 2023, 200, 75.2), "
+        "  ('Lazio', 2024, 150, 60.0) "
+        ") AS t(regione, anno, valore, costo)"
+    )
+    mart_dir = tmp_path / "m"
+    mart_dir.mkdir()
+
+    # exclude_metrics=['anno'] — anno è numerico ma non deve essere sommato
+    written, executed, _ = _run_hierarchy_levels(
+        con, {
+            "hierarchy": {
+                "axis": "territoriale",
+                "levels": [
+                    {"level": "regione", "table": "h_reg", "grain": ["regione"],
+                     "exclude_metrics": ["anno"]},
+                ],
+            }
+        },
+        "test", 2024, mart_dir, logger=_null_logger,
+    )
+    assert len(written) == 1
+
+    # 'anno' non deve apparire come metrica (solo valore e costo)
+    cols = con.execute(
+        f"DESCRIBE SELECT * FROM read_parquet('{mart_dir / 'h_reg.parquet'}')"
+    ).fetchall()
+    col_names = [c[0].lower() for c in cols]
+
+    assert "regione" in col_names
+    assert "valore" in col_names     # SUM(valore) — metrica
+    assert "costo" in col_names      # SUM(costo) — metrica
+    assert "anno" not in col_names, f"anno should be excluded but found in: {col_names}"
+
+    # Verify the SUM values are correct (compare as floats due to DuckDB Decimal)
+    rows = con.execute(
+        f"SELECT regione, CAST(valore AS DOUBLE), CAST(costo AS DOUBLE) FROM read_parquet('{mart_dir / 'h_reg.parquet'}') ORDER BY regione"
+    ).fetchall()
+    assert ("Lazio", 250.0, 110.5) in rows  # 100+150, 50.5+60.0
+    assert ("Lombardia", 200.0, 75.2) in rows
+    con.close()
+
+
 def test_hierarchy_edge_cases(tmp_path: Path) -> None:
     """Empty config returns empty; numeric grain not treated as metric."""
     con = duckdb.connect()

--- a/toolkit/core/config_models/mart.py
+++ b/toolkit/core/config_models/mart.py
@@ -92,6 +92,7 @@ class HierarchyLevel(BaseModel):
     table: str
     grain: list[str]
     source_table: str | None = None
+    exclude_metrics: list[str] = Field(default_factory=list)
 
     @field_validator("level")
     @classmethod
@@ -133,6 +134,17 @@ class HierarchyLevel(BaseModel):
             if not re.fullmatch(_SAFE_SQL_IDENTIFIER_RE, g.strip()):
                 raise ValueError(
                     f"mart.hierarchy.levels[].grain element '{g}' must be a safe SQL identifier "
+                    "(letters, numbers, underscore; cannot start with a number)"
+                )
+        return value
+
+    @field_validator("exclude_metrics")
+    @classmethod
+    def _validate_exclude_metrics(cls, value: list[str]) -> list[str]:
+        for m in value:
+            if not re.fullmatch(_SAFE_SQL_IDENTIFIER_RE, m.strip()):
+                raise ValueError(
+                    f"mart.hierarchy.levels[].exclude_metrics element '{m}' must be a safe SQL identifier "
                     "(letters, numbers, underscore; cannot start with a number)"
                 )
         return value

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -229,6 +229,13 @@ def _run_hierarchy_levels(
             and c["name"].lower() not in grain_lower
         ]
 
+        # Remove excluded columns from metrics (e.g. year, codes — numeric
+        # columns that are dimensions rather than additive metrics)
+        exclude_metrics = level_cfg.get("exclude_metrics") or []
+        if exclude_metrics:
+            excluded_lower = [e.lower() for e in exclude_metrics]
+            metric_cols = [c for c in metric_cols if c.lower() not in excluded_lower]
+
         # Build grain expression (safe quoting via double-quote)
         grain_expr = ", ".join(f'"{g}"' for g in grain)
 


### PR DESCRIPTION
## Tipo

Root fix

## Problema reale

`_run_hierarchy_levels` scopre come metriche tutte le colonne numeriche non-grain, ma colonne dimensionali numeriche (anno, codici, ecc.) vengono sommante con SUM producendo valori senza senso. Manca un contratto per escluderle.

## Soluzione

- **Core contract**: aggiunto campo `exclude_metrics: list[str]` a `HierarchyLevel` con validatore safe SQL identifier
- **Runtime**: `_run_hierarchy_levels` filtra `metric_cols` rimuovendo quelle presenti in `exclude_metrics`
- **Test**: `test_hierarchy_exclude_metrics` — verifica che la colonna esclusa non appaia come metrica e che le SUM siano corrette

## Files modificati

| File | Modifica |
|---|---|
| `toolkit/core/config_models/mart.py` | +11 righe: exclude_metrics + validatore |
| `toolkit/mart/run.py` | +7 righe: filtro metric_cols dopo discovery |
| `tests/test_mart_hierarchy.py` | +48 righe: test |

## Test

- 6/6 test passano (5 esistenti + 1 nuovo)
- Smoke test su irpef-comunale e dipendenti-pubblici con exclude_metrics

## Rischio residuo

Nessuno. Campo opzionale (default lista vuota), backward-compatible.

## Follow-up

Nessuno.