### PR TITLE
feat: skippa min_rows in sample mode (--sample-rows / --sample-bytes)

### DIFF
--- a/tests/test_run_validation_gate.py
+++ b/tests/test_run_validation_gate.py
@@ -103,3 +103,176 @@ def test_run_continues_after_failed_validation_when_fail_on_error_false(tmp_path
     record = _read_run_record(tmp_path / "out")
     assert record["status"] == "SUCCESS_WITH_WARNINGS"
     assert record["validations"]["clean"]["passed"] is False
+
+
+def _write_config_with_min_rows(path: Path, *, min_rows: int) -> None:
+    """Config con min_rows per clean e mart, pochi dati raw."""
+    sql_dir = path.parent / "sql" / "mart"
+    sql_dir.mkdir(parents=True, exist_ok=True)
+    (path.parent / "sql" / "clean.sql").write_text(
+        "select 42 as value, 'a' as label", encoding="utf-8"
+    )
+    (sql_dir / "mart_example.sql").write_text(
+        "select * from clean_input where label = 'a'", encoding="utf-8"
+    )
+    path.write_text(
+        "\n".join(
+            [
+                f'root: "{(path.parent / "out").as_posix()}"',
+                "dataset:",
+                '  name: "test_dataset"',
+                "  years: [2022]",
+                "raw: {}",
+                "clean:",
+                '  sql: "sql/clean.sql"',
+                "  validate:",
+                f"    min_rows: {min_rows}",
+                "mart:",
+                "  tables:",
+                '    - name: "mart_example"',
+                '      sql: "sql/mart/mart_example.sql"',
+                "  validate:",
+                "    table_rules:",
+                "      mart_example:",
+                f"        min_rows: {min_rows}",
+                "validation:",
+                '  fail_on_error: false',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _render_dummy_clean_dir(clean_dir: Path, rows: int = 5) -> None:
+    """Crea parquet + metadata.json + raw profile per test di validazione."""
+    # Clean parquet
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    parquet = clean_dir / "test_dataset_2022_clean.parquet"
+    import duckdb
+    con = duckdb.connect()
+    con.execute(f"COPY (SELECT 42 as value, 'a' as label FROM range({rows})) TO '{parquet}' (FORMAT PARQUET)")
+    con.close()
+    # metadata.json con output_profile per validate_promotion
+    (clean_dir / "metadata.json").write_text(
+        json.dumps({
+            "dataset": "test_dataset",
+            "year": 2022,
+            "outputs": ["test_dataset_2022_clean.parquet"],
+            "output_profile": {"row_count": rows, "columns": [{"name": "value", "type": "INTEGER"}, {"name": "label", "type": "VARCHAR"}]},
+        }),
+        encoding="utf-8",
+    )
+    # Raw dir con CSV minimo per validate_promotion
+    raw_dir = clean_dir.parent.parent.parent / "raw" / "test_dataset" / "2022"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "test_2022.csv").write_text("value,label\n42,a\n", encoding="utf-8")
+    # Profilo raw per validate_promotion
+    profile_dir = raw_dir / "_profile"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "raw_profile.json").write_text(
+        json.dumps({"row_count": rows, "columns_raw": ["value", "label"]}),
+        encoding="utf-8",
+    )
+
+
+def _make_full_config(tmp_path: Path, root: str | None = None) -> tuple[Path, object]:
+    """Crea un config completo per test (dataset + raw + clean + mart).
+
+    Ritorna (config_path, cfg_object). Il cfg_object ha attributi
+    .dataset, .root, .base_dir, .clean, .mart per run_clean_validation.
+    """
+    config_path = tmp_path / "dataset.yml"
+    _write_config_with_min_rows(config_path, min_rows=1000)
+
+    from toolkit.cli.cmd_run import load_cfg_and_logger
+    cfg, _ = load_cfg_and_logger(str(config_path))
+    return config_path, cfg
+
+
+def test_clean_validation_skips_min_rows_in_sample_mode(tmp_path: Path) -> None:
+    """run_clean_validation con sample_mode=True ignora min_rows."""
+    config_path, cfg = _make_full_config(tmp_path)
+
+    clean_dir = config_path.parent / "out" / "data" / "clean" / "test_dataset" / "2022"
+    _render_dummy_clean_dir(clean_dir, rows=5)
+
+    import logging
+    logger = logging.getLogger("test")
+
+    # sample_mode=True -> min_rows ignorato, passa
+    result = cmd_run.run_clean_validation(cfg, 2022, logger, sample_mode=True)
+    assert result.get("passed") is True, f"Expected passed in sample mode, got: {result}"
+
+    # sample_mode=False -> min_rows attivo, fallisce
+    result = cmd_run.run_clean_validation(cfg, 2022, logger, sample_mode=False)
+    assert result.get("passed") is False, f"Expected failed in normal mode, got: {result}"
+
+
+def test_mart_validation_skips_min_rows_in_sample_mode(tmp_path: Path) -> None:
+    """run_mart_validation con sample_mode=True ignora table_rules.*.min_rows."""
+    config_path, cfg = _make_full_config(tmp_path)
+
+    # Mart dir con parquet e metadata
+    mart_dir = config_path.parent / "out" / "data" / "mart" / "test_dataset" / "2022"
+    mart_dir.mkdir(parents=True, exist_ok=True)
+    import duckdb
+    con = duckdb.connect()
+    con.execute("COPY (SELECT 42 as value, 'a' as label FROM range(5)) TO '" + str(mart_dir / "mart_example.parquet") + "' (FORMAT PARQUET)")
+    con.close()
+    (mart_dir / "metadata.json").write_text(
+        '{"dataset": "test_dataset", "year": 2022, "outputs": ["mart_example.parquet"]}',
+        encoding="utf-8",
+    )
+
+    import logging
+    logger = logging.getLogger("test")
+
+    # sample_mode=True -> min_rows ignorato, passa
+    result = cmd_run.run_mart_validation(cfg, 2022, logger, sample_mode=True)
+    assert result.get("passed") is True, f"Expected passed in sample mode, got: {result}"
+
+    # sample_mode=False -> min_rows attivo, fallisce
+    result = cmd_run.run_mart_validation(cfg, 2022, logger, sample_mode=False)
+    assert result.get("passed") is False, f"Expected failed in normal mode, got: {result}"
+
+
+def test_run_full_second_validation_block_uses_sample_mode(tmp_path: Path, monkeypatch) -> None:
+    """Il blocco di validazione finale in run_full() riceve sample_mode=True con --sample-rows."""
+    config_path = tmp_path / "dataset.yml"
+    _write_config_with_min_rows(config_path, min_rows=1000)
+
+    sample_mode_passed = {"clean": False, "mart": False}
+
+    def _tracking_clean_validation(cfg, year, logger, *, sample_mode=False):
+        sample_mode_passed["clean"] = sample_mode
+        return _ok_summary()
+
+    def _tracking_mart_validation(cfg, year, logger, *, sample_mode=False):
+        sample_mode_passed["mart"] = sample_mode
+        return _ok_summary()
+
+    monkeypatch.setattr(cmd_run, "run_raw", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cmd_run, "run_clean", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cmd_run, "run_mart", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cmd_run, "run_raw_validation", lambda *args, **kwargs: _ok_summary())
+    monkeypatch.setattr(cmd_run, "run_clean_validation", _tracking_clean_validation)
+    monkeypatch.setattr(cmd_run, "run_mart_validation", _tracking_mart_validation)
+    monkeypatch.setattr(cmd_run, "_review_readiness", lambda *args, **kwargs: {"readiness": "ready", "check_count": 0, "ok_count": 0, "fail_count": 0})
+
+    # Esegue run full COME se chiamato da CI con --sample-rows 1000
+    # (tutti i parametri espliciti per bypassare i default Typer che
+    #  altrimenti restituiscono oggetti OptionInfo invece di None)
+    cmd_run.run_full(
+        config=str(config_path),
+        smoke=False,
+        sample_rows=1000,
+        sample_bytes=None,
+        years=None,
+        root=None,
+        json_output=False,
+        dry_run=False,
+        strict_config=False,
+    )
+
+    assert sample_mode_passed["clean"] is True, "run_full deve passare sample_mode=True alla validazione clean"
+    assert sample_mode_passed["mart"] is True, "run_full deve passare sample_mode=True alla validazione mart"

--- a/tests/test_run_validation_gate.py
+++ b/tests/test_run_validation_gate.py
@@ -60,6 +60,7 @@ def _failed_summary() -> dict[str, object]:
     }
 
 
+@pytest.mark.contract
 def test_run_stops_after_failed_validation_when_fail_on_error_true(tmp_path: Path, monkeypatch) -> None:
     config_path = tmp_path / "dataset.yml"
     _write_config(config_path, fail_on_error=True)
@@ -83,6 +84,7 @@ def test_run_stops_after_failed_validation_when_fail_on_error_true(tmp_path: Pat
     assert record["validations"]["clean"]["passed"] is False
 
 
+@pytest.mark.contract
 def test_run_continues_after_failed_validation_when_fail_on_error_false(tmp_path: Path, monkeypatch) -> None:
     config_path = tmp_path / "dataset.yml"
     _write_config(config_path, fail_on_error=False)

--- a/tests/test_run_validation_gate.py
+++ b/tests/test_run_validation_gate.py
@@ -189,6 +189,7 @@ def _make_full_config(tmp_path: Path, root: str | None = None) -> tuple[Path, ob
     return config_path, cfg
 
 
+@pytest.mark.regression
 def test_clean_validation_skips_min_rows_in_sample_mode(tmp_path: Path) -> None:
     """run_clean_validation con sample_mode=True ignora min_rows."""
     config_path, cfg = _make_full_config(tmp_path)
@@ -208,6 +209,7 @@ def test_clean_validation_skips_min_rows_in_sample_mode(tmp_path: Path) -> None:
     assert result.get("passed") is False, f"Expected failed in normal mode, got: {result}"
 
 
+@pytest.mark.regression
 def test_mart_validation_skips_min_rows_in_sample_mode(tmp_path: Path) -> None:
     """run_mart_validation con sample_mode=True ignora table_rules.*.min_rows."""
     config_path, cfg = _make_full_config(tmp_path)
@@ -236,6 +238,7 @@ def test_mart_validation_skips_min_rows_in_sample_mode(tmp_path: Path) -> None:
     assert result.get("passed") is False, f"Expected failed in normal mode, got: {result}"
 
 
+@pytest.mark.regression
 def test_run_full_second_validation_block_uses_sample_mode(tmp_path: Path, monkeypatch) -> None:
     """Il blocco di validazione finale in run_full() riceve sample_mode=True con --sample-rows."""
     config_path = tmp_path / "dataset.yml"

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -251,7 +251,7 @@ def validate_promotion(
     )
 
 
-def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
+def run_clean_validation(cfg, year: int, logger, *, sample_mode: bool = False) -> dict[str, Any]:
     out_dir = layer_year_dir(cfg.root, "clean", cfg.dataset, year)
     parquet = out_dir / f"{cfg.dataset}_{year}_clean.parquet"
 
@@ -262,6 +262,11 @@ def run_clean_validation(cfg, year: int, logger) -> dict[str, Any]:
             "validate": clean_cfg.get("validate") or {},
         }
     )
+
+    # In sample mode (--sample-rows / --sample-bytes), min_rows non e' applicabile:
+    # il campione non e' rappresentativo per validazioni quantitative.
+    if sample_mode:
+        spec.validate.min_rows = None
 
     result = validate_clean(
         parquet,

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -239,6 +239,7 @@ def run_year(
 
     base_logger.info(f"RUN -> step={step} dataset={cfg.dataset} year={year}")
     run_has_validation_warnings = False
+    sample_mode = sample_rows is not None or sample_bytes is not None
 
     def _execute_layer(layer_name: str, target, *args, **kwargs) -> None:
         nonlocal run_has_validation_warnings
@@ -251,7 +252,10 @@ def run_year(
             if isinstance(metrics, dict):
                 context.set_layer_metrics(layer_name, **metrics)
 
-            summary = _validation_runner(layer_name)(cfg, year, layer_logger)
+            validation_kwargs = {}
+            if layer_name in ("clean", "mart"):
+                validation_kwargs["sample_mode"] = sample_mode
+            summary = _validation_runner(layer_name)(cfg, year, layer_logger, **validation_kwargs)
             context.set_validation(layer_name, summary)
             if not summary.get("passed", False):
                 message = f"{layer_name.upper()} validation failed"

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -576,6 +576,7 @@ def run_full(
     dry_flag = dry_run if isinstance(dry_run, bool) else False
     sample_rows_final = 1000 if smoke else sample_rows
     sample_bytes_final = 1048576 if smoke else sample_bytes
+    sample_mode = sample_rows_final is not None or sample_bytes_final is not None
 
     results: dict[str, Any] = {
         "config": config,
@@ -623,8 +624,8 @@ def run_full(
                 # Validate all layers
                 try:
                     sv_raw = run_raw_validation(support_cfg.root, support_cfg.dataset, sy, support_logger)
-                    sv_clean = run_clean_validation(support_cfg, sy, support_logger)
-                    sv_mart = run_mart_validation(support_cfg, sy, support_logger)
+                    sv_clean = run_clean_validation(support_cfg, sy, support_logger, sample_mode=sample_mode)
+                    sv_mart = run_mart_validation(support_cfg, sy, support_logger, sample_mode=sample_mode)
                     all_support_passed = all(
                         r.get("passed") for r in [sv_raw, sv_clean, sv_mart]
                     )
@@ -657,14 +658,14 @@ def run_full(
             if not dry_flag:
                 if is_mart_only:
                     # Validate solo mart (compose non ha raw/clean)
-                    val_mart = run_mart_validation(cfg, year, logger)
+                    val_mart = run_mart_validation(cfg, year, logger, sample_mode=sample_mode)
                     all_passed = bool(val_mart.get("passed"))
                 else:
                     # Validate all layers
                     logger.info("Validate all — year=%s", year)
                     val_raw = run_raw_validation(cfg.root, cfg.dataset, year, logger)
-                    val_clean = run_clean_validation(cfg, year, logger)
-                    val_mart = run_mart_validation(cfg, year, logger)
+                    val_clean = run_clean_validation(cfg, year, logger, sample_mode=sample_mode)
+                    val_mart = run_mart_validation(cfg, year, logger, sample_mode=sample_mode)
                     all_passed = all(
                         r.get("passed") for r in [val_raw, val_clean, val_mart]
                     )

--- a/toolkit/mart/validate.py
+++ b/toolkit/mart/validate.py
@@ -209,7 +209,7 @@ def validate_mart(
     )
 
 
-def run_mart_validation(cfg, year: int, logger) -> dict[str, Any]:
+def run_mart_validation(cfg, year: int, logger, *, sample_mode: bool = False) -> dict[str, Any]:
     mart_dir = layer_year_dir(cfg.root, "mart", cfg.dataset, year)
 
     mart_cfg: dict[str, Any] = cfg.mart or {}
@@ -224,6 +224,11 @@ def run_mart_validation(cfg, year: int, logger) -> dict[str, Any]:
             "validate": mart_cfg.get("validate") or {},
         }
     )
+
+    # In sample mode, min_rows non e' applicabile (campione non rappresentativo).
+    if sample_mode:
+        for rule in spec.validate.table_rules.values():
+            rule.min_rows = None
 
     result = validate_mart(
         mart_dir,


### PR DESCRIPTION
## Problema

Il CI usa `--sample-rows 1000` per smoke test dei candidate. Con dataset che filtrano righe nel passaggio clean→mart (es. bdap-lea: esclusione enti '000'), il mart campionato scendeva sotto `min_rows: 1000` causando `ValidationGateError: MART validation failed`.

## Soluzione

Il toolkit ora riconosce automaticamente quando è in **sample mode** (`sample_rows` o `sample_bytes` attivo) e neutralizza i controlli `min_rows` per clean e mart. Il sample serve per verificare che la pipeline giri, non per validare i dati reali.

## Cambiamenti

### `toolkit/cli/cmd_run.py`
- Calcola `sample_mode` in `run_year()`: `sample_rows is not None or sample_bytes is not None`
- Lo passa ai validation runner di clean e mart via `validation_kwargs`

### `toolkit/clean/validate.py` — `run_clean_validation()`
- Se `sample_mode=True`: `spec.validate.min_rows = None`

### `toolkit/mart/validate.py` — `run_mart_validation()`
- Se `sample_mode=True`: `rule.min_rows = None` per ogni `table_rule`

## Test

- 187 test passati (tutti i test clean/mart)
- Run reale su bdap-lea con `--sample-rows 1000`: **status=passed, checks=5/5**
- Nessun impatto su run senza sample (sample_mode=False = comportamento invariato)

## Note

- Gli altri controlli di validazione (not_null, primary_key, ranges, max_null_pct) continuano a funzionare anche in sample mode — sono validi su qualsiasi campione
- Il fix vale per tutti i candidate, non solo bdap-lea