### PR TITLE
feat: PR template e issue template bug per toolkit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,107 @@
+name: Bug — pipeline o plugin
+description: Segnala un bug nel motore pipeline, in un plugin sorgente, nella CLI o nel server MCP.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Usa questo template per segnalare un problema tecnico nel toolkit.
+
+        Se il dubbio è su un dataset specifico (config errata, run candidate), apri prima in `dataset-incubator`.
+
+  - type: input
+    id: version
+    attributes:
+      label: Versione / commit
+      description: Output di `git describe --tags` o commit SHA.
+      placeholder: es. v0.12.0-5-g3a4b2c1
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problema
+      description: Descrivi in modo chiaro e sintetico il bug.
+      placeholder: Il comando X fallisce con Y quando Z...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Riproduzione
+      description: Comando esatto, dataset.yml o codice per riprodurre.
+      placeholder: |
+        ```
+        python -m toolkit.cli.app run all --config percorso/dataset.yml
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Output / trace
+      description: Incolla l'output completo (log, trace, codice errore).
+      placeholder: Incolla qui l'output del comando.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Comportamento atteso
+      description: Cosa doveva succedere invece?
+      placeholder: Il run doveva completare con successo e produrre il parquet in output/...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area del toolkit
+      description: Dove si manifesta il bug?
+      options:
+        - Pipeline (core / raw / clean / mart)
+        - Plugin sorgente (http_file / ckan / sdmx / sparql / local_file)
+        - CLI
+        - Server MCP
+        - Profiler (raw profile)
+        - Config / validazione dataset.yml
+        - Path / artifact policy
+        - Altro
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severità
+      options:
+        - Bloccante (pipeline non funziona)
+        - Grave (funzionalità principale rotta)
+        - Moderata (funzionalità secondaria)
+        - Minore (estetica, errore non bloccante)
+    validations:
+      required: true
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Workaround (opzionale)
+      description: Se esiste un modo per aggirare il problema.
+      placeholder: Usare --year X invece di run all...
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Note aggiuntive
+      description: Ambiente, frequenza, ipotesi sulla causa.
+      placeholder: Ubuntu 22.04, Python 3.12, succede ogni volta...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussioni e orientamento
+    url: https://github.com/orgs/dataciviclab/discussions
+    about: Per domande, idee e confronto iniziale usa le Discussions dell'organizzazione.
+  - name: Issue dataset specifici
+    url: https://github.com/dataciviclab/dataset-incubator/issues/new/choose
+    about: Per problemi su un candidate o config dataset, apri in dataset-incubator.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,69 @@
+name: Task — attività sul toolkit
+description: Attività operativa sul motore pipeline, plugin, CLI o MCP server.
+title: "[Task] "
+labels: ["task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Usa questo template per tracciare un'attività concreta sul toolkit.
+
+        Per segnalare un bug, usa il template **Bug — pipeline o plugin**.
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Obiettivo
+      description: Cosa deve essere fatto?
+      placeholder: Descrivi il task in modo chiaro e sintetico.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Contesto
+      description: Perché è necessario? Quale problema risolve?
+      placeholder: Spiega il contesto o il bisogno che genera questo task.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area del toolkit
+      description: Dove cade principalmente questo task?
+      options:
+        - Pipeline (core / raw / clean / mart)
+        - Plugin sorgente
+        - CLI
+        - Server MCP
+        - Profiler
+        - Config / validazione
+        - Docs
+        - CI / dipendenze
+        - Altro
+    validations:
+      required: true
+
+  - type: textarea
+    id: completion_criteria
+    attributes:
+      label: Criteri di completamento
+      description: Cosa deve essere vero quando il task è finito?
+      placeholder: |
+        - [ ] pytest -m core passa
+        - [ ] documentazione aggiornata
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Collegamenti
+      description: Issue correlate, Discussion, PR.
+      placeholder: |
+        - Issue correlata: #
+        - Discussion: link
+        - PR: #

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+## Sintesi
+
+Descrivi in poche righe cosa cambia e perché.
+
+## Contesto collegato
+
+Closes #
+
+## Cosa cambia
+
+- [ ] Bug fix
+- [ ] Nuova funzionalità del motore
+- [ ] Nuovo plugin sorgente
+- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
+- [ ] Refactor / performance
+- [ ] Documentazione
+- [ ] Dipendenze o CI
+
+## Impatto su contratti pubblici
+
+Se modifichi un contratto pubblico, segna cosa impatti.
+
+- [ ] Struttura `dataset.yml` (nuovo campo, cambio obbligatorietà)
+- [ ] Path output (nuovo layer, cambio percorso artifact)
+- [ ] Schema parquet (nuova colonna, rename, cambio tipo)
+- [ ] CLI o MCP tool (nuovo comando, cambio parametro)
+- [ ] API pubblica del toolkit (firma funzione, classe, eccezione)
+
+> Se segnato, hai aggiornato downstream? [ ] `dataset-incubator` — [ ] `docs/`
+
+## Verifica
+
+Spiega come hai verificato il cambiamento.
+
+```bash
+# Esempi: comandi usati per testare
+pytest -m core -x --tb=short
+ruff check .
+mypy toolkit/
+```
+
+- [ ] `pytest -m core` passa
+- [ ] `ruff check .` passa
+- [ ] `mypy toolkit/` passa (o motiva le eccezioni)
+- [ ] Modificato o aggiunto test con marker appropriato (`contract` / `policy` / `regression` / `adapter` / `pure_unit` / `smoke`)
+
+## Checklist PR
+
+- [ ] Perimetro stretto: una PR = un layer o un fix mirato
+- [ ] Se nuovo plugin: test + docs inclusi
+- [ ] Issue collegata o motivazione dell'assenza
+
+## Note per chi revisiona
+
+Rischi, limiti, punti da controllare con attenzione.


### PR DESCRIPTION
## Sintesi

Aggiunge PR template e issue template bug a toolkit, che finora usava solo i template generici dell'org `.github`.

## Cosa cambia

| File | Descrizione |
|---|---|
| `.github/PULL_REQUEST_TEMPLATE.md` | PR template con checklist specifica toolkit: contratti pubblici, test tiers (`core`/`ruff`/`mypy`), perimetro stretto "una PR = un layer" |
| `.github/ISSUE_TEMPLATE/bug.yml` | Segnalazione bug strutturata: versione, area dropdown (pipeline/plugin/CLI/MCP/...), riproduzione, severità |
| `.github/ISSUE_TEMPLATE/config.yml` | Link a Discussions e dataset-incubator |

## Perché

- toolkit è il motore del Lab, ha procedure PR specifiche (test tiers, contratti pubblici) che il template org generico non catturava
- Il bug template org (`.github/bug.md`) era troppo generico — 4 campi minimi — per un motore di pipeline

## Verifica

- I template sono solo file statici, nessun codice modificato
- `pytest -m core` ✅ — invariato
- `ruff check .` ✅ — invariato
- `mypy toolkit/` ✅ — invariato
