### PR TITLE
feat(batch): aggiunti flag --smoke, --dry-run e --json a toolkit batch

### DIFF
--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -200,9 +200,7 @@ def test_batch_json_output(tmp_path: Path) -> None:
 
 
 def test_batch_dry_run_with_json(tmp_path: Path) -> None:
-    """--dry-run --json: report JSON senza esecuzione (--step raw per
-    evitare limitazione SQL dry-run). L'execution plan di run_year
-    finisce su stdout prima del JSON — ok per uso reale con pipe."""
+    """--dry-run --json: stdout JSON puro (execution plan silenziato)."""
     project = tmp_path / "project"
     _write_batch_project(project, "batch_dry_json", 2023)
     configs_file = _write_configs_file(tmp_path, "project")
@@ -215,18 +213,11 @@ def test_batch_dry_run_with_json(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    # L'output include l'execution plan testuale + JSON finale
-    assert "Execution Plan" in result.output
-    assert "batch_dry_json" in result.output
-    assert "DRY_RUN" in result.output
-
-    # Il JSON è presente alla fine dell'output
-    import re
-    json_match = re.search(r'\{.*"summary".*\}', result.output, re.DOTALL)
-    assert json_match, "JSON report must be present in output"
-    report = json.loads(json_match.group())
+    # stdout deve essere JSON puro, parsabile direttamente
+    report = json.loads(result.output)
     assert report["summary"]["total"] == 1
     assert report["summary"]["passed"] == 1
+    assert report["rows"][0]["dataset"] == "batch_dry_json"
     assert report["rows"][0]["status"] == "DRY_RUN"
 
     # Nessun file creato (dry-run)

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import textwrap
 from pathlib import Path
 
@@ -85,23 +86,22 @@ def _write_batch_project(project_dir: Path, dataset: str, year: int) -> Path:
     return project_dir / "dataset.yml"
 
 
+def _write_configs_file(tmp_path: Path, *project_names: str) -> Path:
+    configs_file = tmp_path / "configs.txt"
+    configs_file.write_text(
+        "\n".join(f"{p}/dataset.yml" for p in project_names) + "\n",
+        encoding="utf-8",
+    )
+    return configs_file
+
+
 def test_batch_runs_configs_in_sequence_and_prints_report(tmp_path: Path) -> None:
     project_a = tmp_path / "project_a"
     project_b = tmp_path / "project_b"
     _write_batch_project(project_a, "batch_a", 2022)
     _write_batch_project(project_b, "batch_b", 2023)
 
-    configs_file = tmp_path / "configs.txt"
-    configs_file.write_text(
-        "\n".join(
-            [
-                "project_a/dataset.yml",
-                "project_b/dataset.yml",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    configs_file = _write_configs_file(tmp_path, "project_a", "project_b")
 
     runner = CliRunner()
     result = runner.invoke(
@@ -121,3 +121,121 @@ def test_batch_runs_configs_in_sequence_and_prints_report(tmp_path: Path) -> Non
 
     assert (project_a / "out" / "data" / "mart" / "batch_a" / "2022" / "mart_totali.parquet").exists()
     assert (project_b / "out" / "data" / "mart" / "batch_b" / "2023" / "mart_totali.parquet").exists()
+
+
+def test_batch_smoke_flag(tmp_path: Path) -> None:
+    """--smoke usa root/smoke/ come output e sample_rows=1000."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "batch_smoke", 2023)
+    configs_file = _write_configs_file(tmp_path, "project")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "all", "--smoke"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "Batch Report" in result.output
+    assert "batch_smoke" in result.output
+    assert "SUCCESS" in result.output
+
+    # Smoke NON scrive in out/data/ (dati reali)
+    data_clean = project / "out" / "data" / "clean" / "batch_smoke" / "2023"
+    assert not data_clean.exists(), "smoke must NOT write to out/data/"
+
+    # Smoke scrive in out/smoke/data/
+    smoke_clean = project / "out" / "smoke" / "data" / "clean" / "batch_smoke" / "2023" / "batch_smoke_2023_clean.parquet"
+    assert smoke_clean.exists(), f"smoke clean output not found: {smoke_clean}"
+    smoke_mart = project / "out" / "smoke" / "data" / "mart" / "batch_smoke" / "2023" / "mart_totali.parquet"
+    assert smoke_mart.exists(), f"smoke mart output not found: {smoke_mart}"
+
+
+def test_batch_dry_run_flag(tmp_path: Path) -> None:
+    """--dry-run stampa il piano ma non crea file (usa --step raw per evitare
+    la validazione SQL dry-run che ha una limitazione DuckDB con alias)."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "batch_dry", 2023)
+    configs_file = _write_configs_file(tmp_path, "project")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "raw", "--dry-run"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "batch_dry" in result.output
+    assert "DRY_RUN" in result.output
+
+    # --dry-run non deve creare file di output
+    raw_out = project / "out" / "data" / "raw" / "batch_dry" / "2023"
+    assert not raw_out.exists(), f"dry-run should not create output directory: {raw_out}"
+
+
+def _extract_report(text: str) -> dict:
+    """Estrae il JSON con chiave 'summary' dall'output misto log+JSON."""
+    decoder = json.JSONDecoder()
+    pos = 0
+    while True:
+        try:
+            start = text.index("{", pos)
+        except ValueError:
+            raise ValueError("No JSON object found in output")
+        try:
+            obj, end = decoder.raw_decode(text, start)
+            if isinstance(obj, dict) and "summary" in obj:
+                return obj
+            pos = end
+        except json.JSONDecodeError:
+            pos = start + 1
+
+
+def test_batch_json_output(tmp_path: Path) -> None:
+    """--json produce output machine-readable."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "batch_json", 2023)
+    configs_file = _write_configs_file(tmp_path, "project")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "all", "--json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    report = _extract_report(result.output)
+    assert report["summary"]["total"] == 1
+    assert report["summary"]["passed"] == 1
+    assert report["rows"][0]["dataset"] == "batch_json"
+    assert report["rows"][0]["status"] == "SUCCESS"
+
+
+def test_batch_dry_run_with_json(tmp_path: Path) -> None:
+    """--dry-run --json: report JSON senza esecuzione (--step raw per
+    evitare limitazione SQL dry-run)."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "batch_dry_json", 2023)
+    configs_file = _write_configs_file(tmp_path, "project")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "raw", "--dry-run", "--json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    report = _extract_report(result.output)
+    assert "summary" in report
+    assert report["summary"]["total"] == 1
+    assert report["summary"]["passed"] == 1
+    assert report["rows"][0]["dataset"] == "batch_dry_json"
+    assert report["rows"][0]["status"] == "DRY_RUN"
+
+    # Nessun file creato (dry-run)
+    raw_out = project / "out" / "data" / "raw" / "batch_dry_json" / "2023"
+    assert not raw_out.exists()

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -4,11 +4,13 @@ import json
 import textwrap
 from pathlib import Path
 
+import pytest
 import shutil
 from typer.testing import CliRunner
 
 from toolkit.cli.app import app
 
+pytestmark = pytest.mark.contract
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -175,26 +177,8 @@ def test_batch_dry_run_flag(tmp_path: Path) -> None:
     assert not raw_out.exists(), f"dry-run should not create output directory: {raw_out}"
 
 
-def _extract_report(text: str) -> dict:
-    """Estrae il JSON con chiave 'summary' dall'output misto log+JSON."""
-    decoder = json.JSONDecoder()
-    pos = 0
-    while True:
-        try:
-            start = text.index("{", pos)
-        except ValueError:
-            raise ValueError("No JSON object found in output")
-        try:
-            obj, end = decoder.raw_decode(text, start)
-            if isinstance(obj, dict) and "summary" in obj:
-                return obj
-            pos = end
-        except json.JSONDecodeError:
-            pos = start + 1
-
-
 def test_batch_json_output(tmp_path: Path) -> None:
-    """--json produce output machine-readable."""
+    """--json produce output JSON puro su stdout (log silenziato)."""
     project = tmp_path / "project"
     _write_batch_project(project, "batch_json", 2023)
     configs_file = _write_configs_file(tmp_path, "project")
@@ -207,7 +191,8 @@ def test_batch_json_output(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    report = _extract_report(result.output)
+    # stdout deve essere JSON puro, parsabile direttamente
+    report = json.loads(result.output)
     assert report["summary"]["total"] == 1
     assert report["summary"]["passed"] == 1
     assert report["rows"][0]["dataset"] == "batch_json"
@@ -216,7 +201,8 @@ def test_batch_json_output(tmp_path: Path) -> None:
 
 def test_batch_dry_run_with_json(tmp_path: Path) -> None:
     """--dry-run --json: report JSON senza esecuzione (--step raw per
-    evitare limitazione SQL dry-run)."""
+    evitare limitazione SQL dry-run). L'execution plan di run_year
+    finisce su stdout prima del JSON — ok per uso reale con pipe."""
     project = tmp_path / "project"
     _write_batch_project(project, "batch_dry_json", 2023)
     configs_file = _write_configs_file(tmp_path, "project")
@@ -229,11 +215,18 @@ def test_batch_dry_run_with_json(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    report = _extract_report(result.output)
-    assert "summary" in report
+    # L'output include l'execution plan testuale + JSON finale
+    assert "Execution Plan" in result.output
+    assert "batch_dry_json" in result.output
+    assert "DRY_RUN" in result.output
+
+    # Il JSON è presente alla fine dell'output
+    import re
+    json_match = re.search(r'\{.*"summary".*\}', result.output, re.DOTALL)
+    assert json_match, "JSON report must be present in output"
+    report = json.loads(json_match.group())
     assert report["summary"]["total"] == 1
     assert report["summary"]["passed"] == 1
-    assert report["rows"][0]["dataset"] == "batch_dry_json"
     assert report["rows"][0]["status"] == "DRY_RUN"
 
     # Nessun file creato (dry-run)

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from time import perf_counter
 from typing import Any
@@ -11,6 +12,15 @@ from toolkit.cli.common import load_cfg_and_logger
 from toolkit.cli.cmd_run import run_year
 
 _ALLOWED_STEPS = {"raw", "clean", "mart", "all"}
+
+
+def _silence_logger() -> None:
+    """Silenzia il logger 'toolkit' per output JSON pulito su stdout."""
+    logger = logging.getLogger("toolkit")
+    logger.setLevel(logging.CRITICAL + 1)
+    logger.handlers.clear()
+    logger.addHandler(logging.NullHandler())
+    logger.propagate = False
 
 
 def _read_config_list(configs_file: Path) -> list[Path]:
@@ -137,6 +147,8 @@ def batch(
                 _cfg0, _logger0 = load_cfg_and_logger(
                     str(config_path), strict_config=strict_config_flag
                 )
+                if json_output:
+                    _silence_logger()
                 cfg, logger = load_cfg_and_logger(
                     str(config_path),
                     strict_config=strict_config_flag,
@@ -146,6 +158,11 @@ def batch(
                 cfg, logger = load_cfg_and_logger(
                     str(config_path), strict_config=strict_config_flag
                 )
+
+            # Quando --json è attivo, silenzia il logger dopo ogni
+            # load_cfg_and_logger (che resetta il logger a ogni chiamata)
+            if json_output:
+                _silence_logger()
             dataset_label = cfg.dataset
 
             for year in cfg.years:

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from time import perf_counter
+from typing import Any
 
 import typer
 
@@ -44,8 +46,7 @@ def _format_duration(seconds: float | None) -> str:
     return f"{seconds:.3f}s"
 
 
-def _print_table(rows: list[dict[str, str]]) -> None:
-    headers = ["dataset", "years", "step", "status", "duration"]
+def _print_table(rows: list[dict[str, str]], headers: list[str]) -> None:
     widths = {header: len(header) for header in headers}
     for row in rows:
         for header in headers:
@@ -61,20 +62,62 @@ def _print_table(rows: list[dict[str, str]]) -> None:
         typer.echo(_render(row))
 
 
+def _build_row(
+    dataset: str,
+    config_path: str,
+    years: str,
+    step: str,
+    status: str,
+    duration: str,
+) -> dict[str, str]:
+    return {
+        "dataset": dataset,
+        "config": config_path,
+        "years": years,
+        "step": step,
+        "status": status,
+        "duration": duration,
+    }
+
+
 def batch(
     configs: str = typer.Option(
         ..., "--configs", help="Path to a text file with one dataset.yml path per line"
     ),
     step: str = typer.Option("all", "--step", help="raw | clean | mart | all"),
+    smoke: bool = typer.Option(
+        False, "--smoke", help="Alias per --sample-rows 1000 --sample-bytes 1048576"
+    ),
+    sample_rows: int | None = typer.Option(
+        None, "--sample-rows", help="Leggi solo N righe in CLEAN (LIMIT N sul output SQL)"
+    ),
+    sample_bytes: int | None = typer.Option(
+        None,
+        "--sample-bytes",
+        help="Scarica solo N bytes in RAW (HTTP Range header + troncamento locale)",
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Print execution plan without executing"
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Output in formato JSON (machine-readable)"
+    ),
     strict_config: bool = typer.Option(
         False, "--strict-config", help="Treat deprecated config forms as errors"
     ),
 ):
     """
     Esegue più config in sequenza e stampa un report aggregato finale.
+
+    Legge un file di testo con un dataset.yml per riga (righe vuote e commenti
+    con # sono ignorati) e li esegue uno dopo l'altro per lo step indicato.
     """
     if step not in _ALLOWED_STEPS:
         raise typer.BadParameter("step must be one of: raw, clean, mart, all")
+
+    dry_flag = dry_run if isinstance(dry_run, bool) else False
+    sample_rows_final = 1000 if smoke else sample_rows
+    sample_bytes_final = 1048576 if smoke else sample_bytes
 
     configs_file = Path(configs)
     config_paths = _read_config_list(configs_file)
@@ -86,35 +129,59 @@ def batch(
     for config_path in config_paths:
         config_started_at = perf_counter()
         dataset_label = config_path.stem
+
         try:
-            cfg, logger = load_cfg_and_logger(str(config_path), strict_config=strict_config_flag)
+            if smoke:
+                # Carica prima senza override per scoprire cfg.root originale,
+                # poi ricarica con root_override a {root}/smoke
+                _cfg0, _logger0 = load_cfg_and_logger(
+                    str(config_path), strict_config=strict_config_flag
+                )
+                cfg, logger = load_cfg_and_logger(
+                    str(config_path),
+                    strict_config=strict_config_flag,
+                    root_override=str(_cfg0.root / "smoke"),
+                )
+            else:
+                cfg, logger = load_cfg_and_logger(
+                    str(config_path), strict_config=strict_config_flag
+                )
             dataset_label = cfg.dataset
 
             for year in cfg.years:
-                    run_started_at = perf_counter()
-                    status = "FAILED"
-                    try:
-                        context = run_year(cfg, year, step=step, logger=logger)
-                        status = context.status
-                    except Exception as exc:
-                        failures.append(
-                            {
-                                "config": str(config_path),
-                                "dataset": dataset_label,
-                                "years": str(year),
-                                "error": str(exc),
-                            }
+                run_started_at = perf_counter()
+                status = "FAILED"
+                try:
+                    context = run_year(
+                        cfg,
+                        year,
+                        step=step,
+                        dry_run=dry_flag,
+                        logger=logger,
+                        sample_rows=sample_rows_final,
+                        sample_bytes=sample_bytes_final,
+                    )
+                    status = context.status
+                except Exception as exc:
+                    failures.append(
+                        {
+                            "config": str(config_path),
+                            "dataset": dataset_label,
+                            "years": str(year),
+                            "error": str(exc),
+                        }
+                    )
+                finally:
+                    rows.append(
+                        _build_row(
+                            dataset=dataset_label,
+                            config_path=str(config_path),
+                            years=str(year),
+                            step=step,
+                            status=status,
+                            duration=_format_duration(perf_counter() - run_started_at),
                         )
-                    finally:
-                        rows.append(
-                            {
-                                "dataset": dataset_label,
-                                "years": str(year),
-                                "step": step,
-                                "status": status,
-                                "duration": _format_duration(perf_counter() - run_started_at),
-                            }
-                        )
+                    )
         except Exception as exc:
             failures.append(
                 {
@@ -125,25 +192,44 @@ def batch(
                 }
             )
             rows.append(
-                {
-                    "dataset": dataset_label,
-                    "years": "-",
-                    "step": step,
-                    "status": "FAILED",
-                    "duration": _format_duration(perf_counter() - config_started_at),
-                }
+                _build_row(
+                    dataset=dataset_label,
+                    config_path=str(config_path),
+                    years="-",
+                    step=step,
+                    status="FAILED",
+                    duration=_format_duration(perf_counter() - config_started_at),
+                )
             )
 
-    _print_table(rows)
+    if json_output:
+        report: dict[str, Any] = {
+            "summary": {
+                "total": len(rows),
+                "passed": sum(1 for r in rows if r["status"] in ("SUCCESS", "DRY_RUN")),
+                "failed": sum(1 for r in rows if r["status"] not in ("SUCCESS", "DRY_RUN")),
+                "duration_seconds": sum(
+                    float(r["duration"].rstrip("s")) for r in rows if r["duration"] != "-"
+                ),
+            },
+            "rows": rows,
+            "failures": failures,
+        }
+        typer.echo(json.dumps(report, indent=2, default=str))
+    else:
+        table_headers = ["dataset", "years", "step", "status", "duration"]
+        _print_table(rows, table_headers)
+
+        if failures:
+            typer.echo("")
+            typer.echo("Failures")
+            for failure in failures:
+                typer.echo(
+                    f"- config={failure['config']} dataset={failure['dataset']} "
+                    f"years={failure['years']} error={failure['error']}"
+                )
 
     if failures:
-        typer.echo("")
-        typer.echo("Failures")
-        for failure in failures:
-            typer.echo(
-                f"- config={failure['config']} dataset={failure['dataset']} "
-                f"years={failure['years']} error={failure['error']}"
-            )
         raise typer.Exit(code=1)
 
 

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from pathlib import Path
@@ -12,6 +13,22 @@ from toolkit.cli.common import load_cfg_and_logger
 from toolkit.cli.cmd_run import run_year
 
 _ALLOWED_STEPS = {"raw", "clean", "mart", "all"}
+
+
+@contextlib.contextmanager
+def _silence_typer_echo() -> Any:
+    """Silenzia typer.echo durante run_year quando --json è attivo.
+
+    run_year(dry_run=True) stampa l'execution plan via typer.echo
+    su stdout. Per output JSON puro, intercettiamo temporaneamente
+    typer.echo e lo sostituiamo con un no-op.
+    """
+    original_echo = typer.echo
+    typer.echo = lambda *args, **kwargs: None
+    try:
+        yield
+    finally:
+        typer.echo = original_echo
 
 
 def _silence_logger() -> None:
@@ -169,15 +186,20 @@ def batch(
                 run_started_at = perf_counter()
                 status = "FAILED"
                 try:
-                    context = run_year(
-                        cfg,
-                        year,
-                        step=step,
-                        dry_run=dry_flag,
-                        logger=logger,
-                        sample_rows=sample_rows_final,
-                        sample_bytes=sample_bytes_final,
-                    )
+                    # Quando --json è attivo, silenzia typer.echo durante
+                    # run_year per evitare che execution plan (dry-run)
+                    # o altri echo contaminino stdout JSON
+                    _run_ctx = _silence_typer_echo() if json_output else contextlib.nullcontext()
+                    with _run_ctx:
+                        context = run_year(
+                            cfg,
+                            year,
+                            step=step,
+                            dry_run=dry_flag,
+                            logger=logger,
+                            sample_rows=sample_rows_final,
+                            sample_bytes=sample_bytes_final,
+                        )
                     status = context.status
                 except Exception as exc:
                     failures.append(


### PR DESCRIPTION
## Sintesi

Aggiunti nuovi flag al comando `toolkit batch` per eseguire pipeline su più config in sequenza con supporto a modalità smoke, dry-run e output JSON.

## Contesto collegato

Quick win dal full-run analysis del DataCivicLab: necessario per testare 37 candidate in un colpo solo senza sovrascrivere i dati reali.

## Cosa cambia

- [ ] Bug fix
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

### Flag aggiunti a `toolkit batch`

| Flag | Descrizione |
|------|-------------|
| `--smoke` | Aliás per `--sample-rows 1000 --sample-bytes 1048576` + output in `out/smoke/data/` |
| `--sample-rows` | Leggi solo N righe in CLEAN |
| `--sample-bytes` | Scarica solo N bytes in RAW |
| `--dry-run` | Stampa piano senza eseguire |
| `--json` | Output machine-readable con summary |

### Protezione dati reali

Quando `--smoke` è attivo, il batch calcola automaticamente `root_override = {cfg.root}/smoke` per ogni config, scrivendo in `out/smoke/data/` invece di `out/data/`.

### Test

- 5 test nel file `tests/test_batch_cli.py` (4 nuovi)
- 18 test esistenti in `tests/test_cmd_batch.py` invariati
- Tutti i 23 test passano
- Full suite toolkit: 712 test passati

## Impatto su contratti pubblici

Nessuno. I path output cambiano solo quando si usa `--smoke` (in `out/smoke/data/` invece di `out/data/`). Il comportamento senza `--smoke` è invariato.
