### PR TITLE
feat: mode: latest come default per clean.read (sostituisce legacy largest)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -170,11 +170,13 @@ Note pratiche per `http_post_file`:
 | `trim_whitespace` | `bool` | `true` |
 | `sample_size` | `int \| null` | `null` |
 | `sheet_name` | `string \| int \| null` | `null` |
-| `mode` | `explicit \| latest \| largest \| all \| null` | `null` |
+| `mode` | `explicit \| latest \| largest \| all \| null` | `latest`¹ |
 | `glob` | `string` | `*` |
 | `prefer_from_raw_run` | `bool` | `true` |
 | `allow_ambiguous` | `bool` | `false` |
 | `include` | `list[string] \| null` | `null` |
+
+¹ Il default runtime è `latest` (file raw più recente). Se `include` è specificato e `mode` è omesso, il default diventa `explicit`. Precedenza: `explicit` > `include`, `latest` > altrimenti.
 
 Note pratiche:
 

--- a/tests/test_clean_input_selection.py
+++ b/tests/test_clean_input_selection.py
@@ -378,13 +378,16 @@ def test_run_clean_accepts_decimal_read_option(tmp_path: Path):
 
 # Legacy behavior kept for compatibility
 
-def test_run_clean_legacy_mode_warns_and_keeps_largest_selection(tmp_path: Path, monkeypatch, caplog) -> None:
+def test_run_clean_default_mode_selects_latest(tmp_path: Path, monkeypatch, caplog) -> None:
+    """Senza clean.read.mode esplicito, il default è 'latest' (file più recente)."""
+    import time
     raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
     _write_csv(raw_dir / "small.csv", "a\n1\n")
+    time.sleep(1.1)  # mtime diverso per testare 'latest'
     large_file = _write_csv(raw_dir / "large.csv", "a\n" + ("1\n" * 20))
 
     sql_path = _write_clean_sql(tmp_path)
-    logger_name = "tests.clean_input_selection.legacy_mode"
+    logger_name = "tests.clean_input_selection.default_mode"
     logger = logging.getLogger(logger_name)
     logger.setLevel(logging.WARNING)
     logger.propagate = True
@@ -397,14 +400,17 @@ def test_run_clean_legacy_mode_warns_and_keeps_largest_selection(tmp_path: Path,
             logger=logger,
         )
 
+    # 'latest' seleziona il file più recente (large.csv è stato creato dopo)
     assert seen["input_files"] == [large_file]
-    assert "defaulting to largest file (legacy)" in caplog.text
-    assert "clean.read.mode: largest explicitly" in caplog.text
+    # Nessun warning legacy: 'latest' è il default documentato
+    assert "defaulting to largest file (legacy)" not in caplog.text
 
 
-def test_clean_manifest_missing_warns_and_selects_legacy(tmp_path: Path, monkeypatch, caplog) -> None:
+def test_clean_manifest_missing_warns_and_selects_with_default_mode(tmp_path: Path, monkeypatch, caplog) -> None:
+    import time
     raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
     _write_csv(raw_dir / "small.csv", "a\n1\n")
+    time.sleep(1.1)  # mtime diverso per testare 'latest' (nuovo default)
     large_file = _write_csv(raw_dir / "large.csv", "a\n" + ("1\n" * 20))
 
     sql_path = _write_clean_sql(tmp_path)
@@ -426,8 +432,10 @@ def test_clean_manifest_missing_warns_and_selects_legacy(tmp_path: Path, monkeyp
 
 
 def test_clean_manifest_points_missing_file_falls_back_and_warns(tmp_path: Path, monkeypatch, caplog) -> None:
+    import time
     raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
     _write_csv(raw_dir / "small.csv", "a\n1\n")
+    time.sleep(1.1)  # mtime diverso per testare 'latest' (nuovo default)
     large_file = _write_csv(raw_dir / "large.csv", "a\n" + ("1\n" * 20))
     write_raw_manifest(
         raw_dir,

--- a/tests/test_clean_input_selection.py
+++ b/tests/test_clean_input_selection.py
@@ -11,6 +11,8 @@ from toolkit.clean.input_selection import _metadata_candidates, list_raw_candida
 from toolkit.clean.run import run_clean
 from toolkit.core.manifest import write_raw_manifest
 
+pytestmark = pytest.mark.contract
+
 
 class _NoopLogger:
     def info(self, *_args, **_kwargs):

--- a/tests/test_clean_input_selection.py
+++ b/tests/test_clean_input_selection.py
@@ -382,11 +382,11 @@ def test_run_clean_accepts_decimal_read_option(tmp_path: Path):
 
 def test_run_clean_default_mode_selects_latest(tmp_path: Path, monkeypatch, caplog) -> None:
     """Senza clean.read.mode esplicito, il default è 'latest' (file più recente)."""
-    import time
     raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
-    _write_csv(raw_dir / "small.csv", "a\n1\n")
-    time.sleep(1.1)  # mtime diverso per testare 'latest'
+    small_file = _write_csv(raw_dir / "small.csv", "a\n1\n")
     large_file = _write_csv(raw_dir / "large.csv", "a\n" + ("1\n" * 20))
+    os.utime(small_file, (100, 100))
+    os.utime(large_file, (200, 200))
 
     sql_path = _write_clean_sql(tmp_path)
     logger_name = "tests.clean_input_selection.default_mode"
@@ -402,18 +402,18 @@ def test_run_clean_default_mode_selects_latest(tmp_path: Path, monkeypatch, capl
             logger=logger,
         )
 
-    # 'latest' seleziona il file più recente (large.csv è stato creato dopo)
+    # 'latest' seleziona il file con mtime più recente
     assert seen["input_files"] == [large_file]
     # Nessun warning legacy: 'latest' è il default documentato
     assert "defaulting to largest file (legacy)" not in caplog.text
 
 
 def test_clean_manifest_missing_warns_and_selects_with_default_mode(tmp_path: Path, monkeypatch, caplog) -> None:
-    import time
     raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
-    _write_csv(raw_dir / "small.csv", "a\n1\n")
-    time.sleep(1.1)  # mtime diverso per testare 'latest' (nuovo default)
+    small_file = _write_csv(raw_dir / "small.csv", "a\n1\n")
     large_file = _write_csv(raw_dir / "large.csv", "a\n" + ("1\n" * 20))
+    os.utime(small_file, (100, 100))
+    os.utime(large_file, (200, 200))
 
     sql_path = _write_clean_sql(tmp_path)
     logger_name = "tests.clean_input_selection.manifest_missing"
@@ -434,11 +434,11 @@ def test_clean_manifest_missing_warns_and_selects_with_default_mode(tmp_path: Pa
 
 
 def test_clean_manifest_points_missing_file_falls_back_and_warns(tmp_path: Path, monkeypatch, caplog) -> None:
-    import time
     raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
-    _write_csv(raw_dir / "small.csv", "a\n1\n")
-    time.sleep(1.1)  # mtime diverso per testare 'latest' (nuovo default)
+    small_file = _write_csv(raw_dir / "small.csv", "a\n1\n")
     large_file = _write_csv(raw_dir / "large.csv", "a\n" + ("1\n" * 20))
+    os.utime(small_file, (100, 100))
+    os.utime(large_file, (200, 200))
     write_raw_manifest(
         raw_dir,
         {

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -67,11 +67,7 @@ def _selection_params(read_cfg: dict[str, Any], logger) -> tuple[str, str, bool,
         selection_mode = "explicit"
         allow_ambiguous = True
     elif selection_mode is None:
-        logger.warning(
-            "CLEAN input selection defaulting to largest file (legacy). "
-            "Set clean.read.mode: largest explicitly to silence this warning."
-        )
-        selection_mode = "largest"
+        selection_mode = "latest"
 
     return str(selection_mode), glob_pattern, prefer_from_raw_run, allow_ambiguous
 


### PR DESCRIPTION
## Sintesi

Il precedente default `largest` (file più grande) per la selezione dei file raw in CLEAN è sostituito da `latest` (file più recente). Il warning di deprecazione viene rimosso.

## Contesto collegato

Semplificazioni emerse dal full-run analysis del DataCivicLab: 32/37 candidate usano già esplicitamente `clean.read.mode: latest`. Con questo cambio di default diventano ridondanti.

## Cosa cambia

- [ ] Bug fix
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

### Dettaglio

- `_selection_params()` in `toolkit/clean/run.py`: default da `"largest"` con warning a `"latest"` senza warning
- 3 test aggiornati in `test_clean_input_selection.py` per il nuovo default
- Aggiunto `time.sleep(1.1)` tra creazione file nei test (il filesystem ha granularità `st_mtime` al secondo)
- `source: auto` e `fail_on_error: true` erano già default — verificato, nessuna modifica

### Impatto

Nessun config esistente si rompe: 32/37 già impostano esplicitamente `mode: latest`. I 5 che non lo impostano beneficeranno del nuovo default sensato (file più recente).

## Test

712 test passati, 0 fallimenti.