### PR TITLE
fix: SPARQL fetch — fallback text/plain a CSV/JSON

### DIFF
--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -9,6 +9,8 @@ from lab_connectors.http import HttpResult
 from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.sparql import SparqlSource, _sparql_json_to_csv
 
+pytestmark = pytest.mark.contract
+
 
 def _http_ok(status=200, text="", headers=None):
     """Build success HttpResult for sparql responses."""

--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -128,7 +128,7 @@ def test_sparql_fetch_invalid_json():
 
 
 def test_sparql_fetch_unsupported_content_type_raises():
-    """Unsupported Content-Type raises DownloadError."""
+    """Unsupported Content-Type (es. application/xml) raise DownloadError."""
     with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
         mock_cls.return_value.post.return_value = _http_ok(
             status=200,
@@ -142,6 +142,45 @@ def test_sparql_fetch_unsupported_content_type_raises():
                 "SELECT * WHERE { }",
                 accept_format="csv",
             )
+
+
+def test_sparql_fetch_text_plain_csv_fallback():
+    """text/plain con corpo CSV non deve fallire (fallback)."""
+    csv_body = "col1,col2\na,1\nb,2\n"
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=200,
+            text=csv_body,
+            headers={"Content-Type": "text/plain"},
+        )
+        source = SparqlSource()
+        result, endpoint = source.fetch(
+            "https://example.test/sparql",
+            "SELECT * WHERE { }",
+            accept_format="csv",
+        )
+        assert result == csv_body.encode("utf-8")
+        assert endpoint == "https://example.test/sparql"
+
+
+def test_sparql_fetch_text_plain_json_fallback():
+    """text/plain con corpo SPARQL JSON deve convertirsi in CSV."""
+    json_body = '{"head": {"vars": ["s","p"]}, "results": {"bindings": [{"s": {"value": "x"}, "p": {"value": "y"}}]}}'
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=200,
+            text=json_body,
+            headers={"Content-Type": "text/plain"},
+        )
+        source = SparqlSource()
+        result, endpoint = source.fetch(
+            "https://example.test/sparql",
+            "SELECT * WHERE { }",
+            accept_format="csv",
+        )
+        assert result  # non vuoto
+        assert b"s,p" in result
+        assert b"x,y" in result
 
 
 def test_sparql_fetch_unsupported_accept_format_raises():

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import csv
 import io
+import json
 from typing import Any
 
 from lab_connectors.http import HttpClient
@@ -86,6 +87,21 @@ class SparqlSource:
             csv_bytes = _sparql_json_to_csv(r.text)
             return csv_bytes, endpoint
 
+        # Fallback per Content-Type text/plain: alcuni endpoint SPARQL
+        # (es. dati.camera.it) rispondono con Content-Type sbagliato
+        # ma corpo CSV o JSON valido. Altri Content-Type (es. application/xml)
+        # rimangono errore.
+        if "text/plain" in content_type:
+            stripped = r.text.strip()
+            if stripped.startswith("{"):
+                try:
+                    return _sparql_json_to_csv(r.text), endpoint
+                except (DownloadError, json.JSONDecodeError):
+                    pass
+            else:
+                # Assume CSV — se non è CSV, fallirà in CLEAN con errore chiaro
+                return r.content, endpoint
+
         raise DownloadError(
             f"Unsupported Content-Type '{content_type}' for SPARQL fetch. "
             "Expected 'text/csv' or 'application/sparql-results+json'."
@@ -111,7 +127,6 @@ class SparqlSource:
             dict with keys: variables, row_count, null_counts, distinct_counts,
             sample_rows, warnings, query_time_ms, endpoint.
         """
-        import json
         import time
 
         if not endpoint:
@@ -221,8 +236,6 @@ def _sparql_json_to_csv(json_text: str) -> bytes:
     Assumes all bindings share the same set of variables (homogeneous schema).
     Extra keys in later bindings or missing keys produce empty values silently.
     """
-    import json
-
     try:
         payload = json.loads(json_text)
     except json.JSONDecodeError as e:


### PR DESCRIPTION
## Sintesi

Alcuni endpoint SPARQL (es. dati.camera.it) rispondono con `Content-Type: text/plain` invece di `text/csv`, pur avendo il corpo CSV valido. Il plugin ora tenta il fallback quando `Content-Type` è `text/plain`.

## Cosa cambia

- [x] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

### Dettaglio

- `toolkit/plugins/sparql.py`: quando Content-Type è `text/plain`:
  - Se il corpo inizia con `{` → tenta parsing SPARQL JSON → CSV
  - Altrimenti → assume CSV, restituisce direttamente
- Altri Content-Type inattesi (es. `application/xml`) restano errore
- `json` spostato da import locale (in 2 funzioni) a import di modulo
- 2 nuovi test: `test_text_plain_csv_fallback`, `test_text_plain_json_fallback`

## Test

- 19 test SPARQL: 17 originali + 2 nuovi ✅
- 714 test suite toolkit ✅