### PR TITLE
fix: template comment placeholder, trim fallback per Excel — stress test risultati

### DIFF
--- a/tests/test_cmd_scout.py
+++ b/tests/test_cmd_scout.py
@@ -145,55 +145,55 @@ def test_scout_json_output() -> None:
 
 
 @pytest.mark.policy
-def test_scout_scaffold_generates_dataset_yml(tmp_path: Path) -> None:
+def test_scout_scaffold_generates_dataset_yml(tmp_path: Path, monkeypatch) -> None:
     """toolkit scout --scaffold genera dataset.yml valido (YAML parsabile)."""
     server, base_url = _serve()
     runner = CliRunner()
+    monkeypatch.chdir(tmp_path)
     try:
-        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
-            result = runner.invoke(app, ["scout", "--scaffold", f"{base_url}/files/multi_col.csv"])
-            assert result.exit_code == 0, f"scout --scaffold failed: {result.output}"
+        result = runner.invoke(app, ["scout", "--scaffold", f"{base_url}/files/multi_col.csv"])
+        assert result.exit_code == 0, f"scout --scaffold failed: {result.output}"
 
-            # Trova la directory generata
-            dirs = [d for d in Path(td).iterdir() if d.is_dir()]
-            assert len(dirs) >= 1, f"no directories created in {td}"
-            slug_dir = dirs[0]
+        # Trova la directory generata
+        dirs = [d for d in tmp_path.iterdir() if d.is_dir()]
+        assert len(dirs) >= 1, f"no directories created in {tmp_path}"
+        slug_dir = dirs[0]
 
-            # dataset.yml valido
-            yml_path = slug_dir / "dataset.yml"
-            assert yml_path.exists(), f"dataset.yml not found at {yml_path}"
-            data = yaml.safe_load(yml_path.read_text(encoding="utf-8"))
-            assert data["dataset"]["name"].startswith("multi_col")
-            assert data["raw"]["sources"][0]["type"] == "http_file"
-            assert "clean" in data
-            assert "mart" in data
+        # dataset.yml valido
+        yml_path = slug_dir / "dataset.yml"
+        assert yml_path.exists(), f"dataset.yml not found at {yml_path}"
+        data = yaml.safe_load(yml_path.read_text(encoding="utf-8"))
+        assert data["dataset"]["name"].startswith("multi_col")
+        assert data["raw"]["sources"][0]["type"] == "http_file"
+        assert "clean" in data
+        assert "mart" in data
 
-            # SQL files
-            assert (slug_dir / "sql" / "clean.sql").exists()
-            assert (slug_dir / "sql" / "mart.sql").exists()
+        # SQL files
+        assert (slug_dir / "sql" / "clean.sql").exists()
+        assert (slug_dir / "sql" / "mart.sql").exists()
     finally:
         server.shutdown()
         server.server_close()
 
 
 @pytest.mark.policy
-def test_scout_scaffold_has_type_casts_in_clean_sql(tmp_path: Path) -> None:
+def test_scout_scaffold_has_type_casts_in_clean_sql(tmp_path: Path, monkeypatch) -> None:
     """clean.sql generato da scout --scaffold ha TRY_CAST per colonne numeriche."""
     server, base_url = _serve()
     runner = CliRunner()
+    monkeypatch.chdir(tmp_path)
     try:
-        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
-            result = runner.invoke(app, ["scout", "--scaffold", f"{base_url}/files/multi_col.csv"])
-            assert result.exit_code == 0
+        result = runner.invoke(app, ["scout", "--scaffold", f"{base_url}/files/multi_col.csv"])
+        assert result.exit_code == 0
 
-            dirs = [d for d in Path(td).iterdir() if d.is_dir()]
-            slug_dir = dirs[0]
-            clean_sql = (slug_dir / "sql" / "clean.sql").read_text()
-            mart_sql = (slug_dir / "sql" / "mart.sql").read_text()
+        dirs = [d for d in tmp_path.iterdir() if d.is_dir()]
+        slug_dir = dirs[0]
+        clean_sql = (slug_dir / "sql" / "clean.sql").read_text()
+        mart_sql = (slug_dir / "sql" / "mart.sql").read_text()
 
-            # Verifica cast
-            assert clean_sql, "clean.sql is empty"
-            assert mart_sql, "mart.sql is empty"
+        # Verifica cast
+        assert clean_sql, "clean.sql is empty"
+        assert mart_sql, "mart.sql is empty"
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/test_scaffold_clean.py
+++ b/tests/test_scaffold_clean.py
@@ -171,14 +171,14 @@ class TestColumnsSpec:
 
     @pytest.mark.pure_unit
     def test_no_mapping_fallback(self) -> None:
-        """Senza mapping: TRIM per tutte le colonne raw."""
+        """Senza mapping: CAST(... AS VARCHAR) + TRIM per safety su tipi misti."""
         profile: dict[str, Any] = {
             "mapping_suggestions": {},
             "columns_raw": ["Col1", "Col2"],
         }
         exprs, spec = _columns_spec(profile, 2024)
-        assert 'trim("Col1") AS col1' in exprs
-        assert 'trim("Col2") AS col2' in exprs
+        assert 'trim(CAST("Col1" AS VARCHAR)) AS col1' in exprs
+        assert 'trim(CAST("Col2" AS VARCHAR)) AS col2' in exprs
         assert spec == {"Col1": "VARCHAR", "Col2": "VARCHAR"}
 
     @pytest.mark.pure_unit

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,6 +1,6 @@
 import pytest
 
-from toolkit.core.template import render_template
+from toolkit.core.template import render_template, _strip_sql_comments
 
 
 def test_render_template_raises_clear_error_for_unresolved_placeholder():
@@ -14,3 +14,43 @@ def test_render_template_raises_clear_error_for_unresolved_dotted_placeholder():
             "select * from read_parquet('{support.lookup.mart}')",
             {"year": 2024},
         )
+
+
+def test_comment_placeholder_does_not_raise():
+    """Placeholders inside SQL comments (-- ...) are ignored."""
+    sql = (
+        "-- Template contains {n} inside a comment from DuckDB error\n"
+        "SELECT {year}::INTEGER AS anno\n"
+        "FROM raw_input\n"
+    )
+    result = render_template(sql, {"year": 2024})
+    assert "2024" in result
+    assert "{n}" in result  # comment preserved as-is
+
+
+def test_unresolved_in_code_still_raises():
+    """Unresolved placeholders outside comments still raise."""
+    sql = (
+        "-- comment with {n}\n"
+        "SELECT * FROM {unknown_placeholder}\n"
+    )
+    with pytest.raises(ValueError, match=r"\{unknown_placeholder\}"):
+        render_template(sql, {"year": 2024})
+
+
+def test_strip_sql_comments_empty():
+    assert _strip_sql_comments("") == ""
+
+
+def test_strip_sql_comments_only_comments():
+    # A single comment line -- the regex removes the text but the newline
+    # is not part of the match (multiline $), so we get empty string.
+    assert _strip_sql_comments("-- just a comment") == ""
+
+
+def test_strip_sql_comments_mixed():
+    text = "SELECT 1\n-- comment\nFROM raw\n"
+    result = _strip_sql_comments(text)
+    assert "comment" not in result
+    assert "SELECT 1" in result
+    assert "FROM raw" in result

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2,6 +2,8 @@ import pytest
 
 from toolkit.core.template import render_template, _strip_sql_comments
 
+pytestmark = pytest.mark.pure_unit
+
 
 def test_render_template_raises_clear_error_for_unresolved_placeholder():
     with pytest.raises(ValueError, match=r"unresolved placeholders.*\{root_posix\}"):

--- a/toolkit/core/template.py
+++ b/toolkit/core/template.py
@@ -5,6 +5,17 @@ from pathlib import Path
 from typing import Any
 
 _UNRESOLVED_PLACEHOLDER_RE = re.compile(r"\{[A-Za-z_][A-Za-z0-9_.]*\}")
+_SQL_COMMENT_LINE_RE = re.compile(r"^\s*--.*$", re.MULTILINE)
+
+
+def _strip_sql_comments(sql: str) -> str:
+    """Remove SQL single-line comments (-- ...) from the text.
+
+    Used to avoid false positives when checking for unresolved template
+    placeholders — DuckDB error messages embedded in SQL comments can
+    contain ``{n}`` or similar patterns that are not actual placeholders.
+    """
+    return _SQL_COMMENT_LINE_RE.sub("", sql)
 
 
 def render_template(text: str, ctx: dict[str, Any]) -> str:
@@ -13,11 +24,18 @@ def render_template(text: str, ctx: dict[str, Any]) -> str:
 
     Supports only plain placeholders such as `{year}` and `{dataset}`.
     This is intentionally not a general templating engine.
+
+    SQL comments (``-- ...``) are excluded from the unresolved-placeholder
+    check so that DuckDB error messages embedded in comments do not trigger
+    false positives.
     """
     out = text
     for k, v in sorted(ctx.items(), key=lambda item: len(item[0]), reverse=True):
         out = out.replace("{" + k + "}", str(v))
-    unresolved = sorted(set(_UNRESOLVED_PLACEHOLDER_RE.findall(out)))
+    # Strip comments before checking for unresolved placeholders, so
+    # that {n} or other patterns in DuckDB error messages don't break.
+    code_only = _strip_sql_comments(out)
+    unresolved = sorted(set(_UNRESOLVED_PLACEHOLDER_RE.findall(code_only)))
     if unresolved:
         raise ValueError(
             "Template contains unresolved placeholders after render: "

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -97,10 +97,12 @@ def _columns_spec(
     """Build SELECT expressions and read_csv columns spec from mapping_suggestions."""
     mapping = profile.get("mapping_suggestions", {})
     if not mapping:
-        # Fallback to columns_raw if mapping is empty
+        # Fallback to columns_raw if mapping is empty (e.g. Excel profiling,
+        # or profiling that failed to infer types). Use trim(CAST(... AS VARCHAR))
+        # to safely handle both text and numeric columns.
         columns_raw = profile.get("columns_raw", [])
         if columns_raw:
-            select_exprs = [f'trim("{c}") AS {_snake_case(c)}' for c in columns_raw]
+            select_exprs = [f'trim(CAST("{c}" AS VARCHAR)) AS {_snake_case(c)}' for c in columns_raw]
             columns_spec = {c: "VARCHAR" for c in columns_raw}
             return select_exprs, columns_spec
         return ["*"], {}


### PR DESCRIPTION
## Sintesi

Fix emersi da stress test su 6 candidati reali (terna, openga, aifa, consip, mur, irpef).

## Cosa cambia

- [ ] Bug fix
- [ ] Refactor / performance

## Dettaglio

### template.py: `{n}` in commenti SQL non rompe più
- DuckDB errori con `skip={n}` finivano nei commenti di clean.sql
- `render_template()` crashava: "unresolved placeholders: {n}"
- Fix: `_strip_sql_comments()` esclude le righe `--` dal controllo placeholder
- Il commento viene preservato nell'output, ma ignorato nel check

### scaffold/clean.py: `trim(DOUBLE)` non fallisce più
- Fallback mapping vuoto (Excel profiling, profiling fallito) usava `trim("col")`
- Su colonne numeriche: `Binder Error: no function trim(DOUBLE)`
- Fix: `trim(CAST(col AS VARCHAR))` per gestire tipi misti
- Colpiva: **terna** (XLSX), **mef-partecipazioni** (trim su colonna DECIMAL)

## Verifica

```
pytest tests/ -q  →  741 passed
```

- [x] Test aggiunti: 5 template (comment placeholder, strip comments)
- [x] Test aggiornati: 1 scaffold (fallback mapping trim)
- [x] Stress test reale: terna, openga, aifa full run OK

## Note

Assorbe parzialmente il branch DI `feat/fix-candidate-pipeline`:
- `mef: trim numeric` → assorbito (trim(CAST...) fix)
- `consip: escape quote` → assorbito solo template crash ({n})
  Il dato sporco (unterminated quote) serve ancora il workaround DI
