### PR TITLE
refactor: normalizza logica condivisa in cli/inspect/ — MCP diventa thin wrapper

### DIFF
--- a/tests/test_run_validation_gate.py
+++ b/tests/test_run_validation_gate.py
@@ -324,7 +324,8 @@ def test_run_full_second_validation_block_uses_sample_mode(tmp_path: Path, monke
     monkeypatch.setattr(cmd_run, "run_raw_validation", lambda *args, **kwargs: _ok_summary())
     monkeypatch.setattr(cmd_run, "run_clean_validation", _tracking_clean_validation)
     monkeypatch.setattr(cmd_run, "run_mart_validation", _tracking_mart_validation)
-    monkeypatch.setattr(cmd_run, "_review_readiness", lambda *args, **kwargs: {"readiness": "ready", "check_count": 0, "ok_count": 0, "fail_count": 0})
+    import toolkit.cli.inspect.readiness_ops as _readiness_ops
+    monkeypatch.setattr(_readiness_ops, "review_readiness", lambda *args, **kwargs: {"readiness": "ready", "check_count": 0, "ok_count": 0, "fail_count": 0})
 
     # Esegue run full COME se chiamato da CI con --sample-rows 1000
     # (tutti i parametri espliciti per bypassare i default Typer che

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -14,7 +14,7 @@ from toolkit.core.template import build_runtime_template_ctx, public_template_ct
 from toolkit.clean.sql_execute import _normalize_output_profile, _run_sql
 
 
-def _load_clean_sql(
+def load_clean_sql(
     clean_cfg: dict[str, Any],
     *,
     dataset: str,
@@ -187,7 +187,7 @@ def run_clean(
         read_cfg,
         logger,
     )
-    sql_path_obj, sql, template_ctx = _load_clean_sql(
+    sql_path_obj, sql, template_ctx = load_clean_sql(
         clean_cfg,
         dataset=dataset,
         year=year,

--- a/toolkit/cli/cmd_review_readiness.py
+++ b/toolkit/cli/cmd_review_readiness.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from toolkit.mcp.schema_ops import review_readiness as _review_readiness
+from toolkit.cli.inspect.readiness_ops import review_readiness as _review_readiness
 from toolkit.core.config import load_config
 
 import typer

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -15,7 +15,6 @@ from toolkit.core.paths import layer_dataset_dir, layer_year_dir
 from toolkit.core.run_context import RunContext
 from toolkit.mart.run import run_mart, run_mart_multi_year
 from toolkit.mart.validate import run_mart_validation
-from toolkit.mcp.schema_ops import review_readiness as _review_readiness
 from toolkit.raw.run import run_raw
 from toolkit.raw.validate import run_raw_validation
 
@@ -697,6 +696,7 @@ def run_full(
                     results["status"] = "failed"
 
                 # Review readiness (capture, not print)
+                from toolkit.cli.inspect.readiness_ops import review_readiness as _review_readiness
                 readiness = _review_readiness(config, year or None)
                 results["steps"][str(year)]["readiness"] = readiness.get("readiness")
                 results["steps"][str(year)]["checks"] = readiness.get("check_count", 0)

--- a/toolkit/cli/cmd_status.py
+++ b/toolkit/cli/cmd_status.py
@@ -10,7 +10,7 @@ from toolkit.cli.common import format_profile_preview, load_layer_profile_summar
 from toolkit.core.config import load_config
 from toolkit.core.paths import layer_dataset_dir
 from toolkit.core.run_context import get_run_dir, read_run_record
-from toolkit.mcp.schema_ops import summary as _summary
+from toolkit.cli.inspect.readiness_ops import summary as _summary
 
 
 def _print_raw_hints(hints: dict[str, Any]) -> None:

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -9,6 +9,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import duckdb
+
 from toolkit.cli.common import load_layer_profile_summaries
 from toolkit.core.metadata import read_layer_metadata
 from toolkit.core.paths import layer_year_dir
@@ -204,3 +206,213 @@ def _payload_for_year(cfg, year: int) -> dict[str, Any]:
         "layer_profiles": load_layer_profile_summaries(root, cfg.dataset, year),
         "latest_run": latest_payload,
     }
+
+
+# ---------------------------------------------------------------------------
+# DuckDB helpers — schema, row count, preview da parquet e CSV
+# Condivise da cli/inspect e mcp (MCP wrappa con ToolkitClientError).
+# ---------------------------------------------------------------------------
+
+
+def _sql_literal(value: str) -> str:
+    """Escape a string for safe use inside a SQL single-quoted literal."""
+    return value.replace("'", "''")
+
+
+def _schema_from_parquet(parquet_path: Path) -> dict[str, Any]:
+    """Return schema (columns + count) of a parquet file via DuckDB.
+
+    Raises:
+        FileNotFoundError: if the file doesn't exist.
+        RuntimeError: if DuckDB can't read the file.
+    """
+    if not parquet_path.exists():
+        raise FileNotFoundError(f"Parquet non trovato: {parquet_path}")
+    relation = f"read_parquet('{_sql_literal(str(parquet_path))}')"
+    try:
+        with duckdb.connect(database=":memory:") as conn:
+            conn.execute("PRAGMA disable_progress_bar")
+            describe_rows = conn.execute(f"DESCRIBE SELECT * FROM {relation}").fetchall()
+    except Exception as exc:
+        raise RuntimeError(f"Lettura schema parquet fallita per {parquet_path}: {exc}") from exc
+
+    columns = [{"name": row[0], "type": row[1]} for row in describe_rows]
+    return {"path": str(parquet_path), "column_count": len(columns), "columns": columns}
+
+
+def _read_parquet_row_count(parquet_path: Path | None) -> int | None:
+    """Return row count of a parquet file, or None if unreadable."""
+    if parquet_path is None or not parquet_path.exists():
+        return None
+    try:
+        with duckdb.connect(database=":memory:") as conn:
+            conn.execute("PRAGMA disable_progress_bar")
+            result = conn.execute(
+                f"SELECT COUNT(*) FROM read_parquet('{_sql_literal(str(parquet_path))}')"
+            ).fetchone()
+            return int(result[0]) if result else None
+    except Exception:
+        return None
+
+
+def _read_parquet_preview(parquet_path: Path, limit: int = 10) -> dict[str, Any]:
+    """Return schema + row preview of a parquet file via DuckDB.
+
+    Returns:
+        dict with keys: path, column_count, columns (list of {name, type}),
+        row_count, preview (list of dicts), truncated (bool).
+
+    Raises:
+        FileNotFoundError: if the file doesn't exist.
+        RuntimeError: if DuckDB can't read the file.
+    """
+    if not parquet_path.exists():
+        raise FileNotFoundError(f"Parquet non trovato: {parquet_path}")
+
+    rel = f"read_parquet('{_sql_literal(str(parquet_path))}')"
+    try:
+        with duckdb.connect(database=":memory:") as conn:
+            conn.execute("PRAGMA disable_progress_bar")
+
+            # schema
+            describe = conn.execute(f"DESCRIBE SELECT * FROM {rel}").fetchall()
+            columns = [{"name": row[0], "type": row[1]} for row in describe]
+
+            # row count
+            count_row = conn.execute(f"SELECT COUNT(*) FROM {rel}").fetchone()
+            row_count = int(count_row[0]) if count_row else None
+
+            # preview
+            preview_rows = conn.execute(
+                f"SELECT * FROM {rel} LIMIT {int(limit)}"
+            ).fetchall()
+            col_names = [c["name"] for c in columns]
+            preview = [dict(zip(col_names, row)) for row in preview_rows]
+
+            truncated = bool(row_count and row_count > limit)
+
+            return {
+                "path": str(parquet_path),
+                "column_count": len(columns),
+                "columns": columns,
+                "row_count": row_count,
+                "preview": preview,
+                "truncated": truncated,
+            }
+    except Exception as exc:
+        raise RuntimeError(f"Lettura parquet fallita per {parquet_path}: {exc}") from exc
+
+
+def _exists(path: str | None) -> bool:
+    """Return True if path is a real file/directory."""
+    if not path:
+        return False
+    return Path(path).exists()
+
+
+def _read_validation_content(path: str | None) -> dict[str, Any] | None:
+    """Read a validation JSON file and return its content, or None if missing."""
+    if not path or not _exists(path):
+        return None
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _check_run_record_coherence(
+    run_record: dict[str, Any] | None,
+    layers: dict[str, Any],
+) -> list[dict[str, str]]:
+    """Verifica che i layer marcati SUCCESS nel run record abbiano output reali.
+
+    Ritorna una lista di hint (dict con code, severity, message).
+    """
+    hints: list[dict[str, str]] = []
+    if not run_record:
+        return hints
+
+    layers_map = run_record.get("layers") or {}
+    for layer_name, layer_detail in layers_map.items():
+        layer_status = (
+            layer_detail.get("status") if isinstance(layer_detail, dict) else layer_detail
+        )
+        if layer_status != "SUCCESS":
+            continue
+
+        layer_info = layers.get(layer_name, {})
+
+        if layer_name == "clean" and not layer_info.get("output_exists"):
+            hints.append({
+                "code": "run_says_clean_success_but_output_missing",
+                "severity": "blocker",
+                "message": "run record dice clean SUCCESS ma output file manca",
+            })
+        elif layer_name == "mart":
+            out_count = layer_info.get("output_count", 0) or 0
+            exists_count = layer_info.get("output_exists_count", 0) or 0
+            if exists_count == 0 and out_count > 0:
+                hints.append({
+                    "code": "run_says_mart_success_but_outputs_missing",
+                    "severity": "blocker",
+                    "message": "run record dice mart SUCCESS ma nessun output file presente",
+                })
+
+    return hints
+
+
+def _validation_summary_for_layer(
+    layer_dir: Path, validation_filename: str
+) -> dict[str, Any] | None:
+    """Extract summary from a layer's validation JSON.
+
+    Adds: ok, errors_count, warnings_count, row_count, col_count,
+    raw_row_count, clean_row_count.
+    Reads row/col counts from summary.stats (clean) or summary.row_counts (mart).
+    Falls back to sections.stats for layers that use that path.
+    Returns None if the validation file does not exist.
+    """
+    validation_path = layer_dir / validation_filename
+    content = _read_validation_content(str(validation_path))
+    if not content:
+        return None
+
+    result = {
+        "ok": content.get("ok"),
+        "errors_count": len(content.get("errors", [])),
+        "warnings_count": len(content.get("warnings", [])),
+        "row_count": None,
+        "col_count": None,
+    }
+
+    # Extract stats from summary (clean layer: summary.stats.clean_rows/clean_cols)
+    summary = content.get("summary", {})
+    stats = summary.get("stats", {})
+    result["row_count"] = stats.get("clean_rows") or stats.get("row_count")
+    result["col_count"] = stats.get("clean_cols")
+
+    # Fallback: sections.stats (mart layer uses sections differently)
+    sections = content.get("sections", {})
+    if result["row_count"] is None and "stats" in sections:
+        result["row_count"] = sections["stats"].get("row_count")
+        result["col_count"] = sections["stats"].get("col_count")
+
+    # Extract transition metadata (clean validation)
+    if "transition" in sections:
+        t = sections["transition"]
+        if "clean_cols" in t:
+            result["col_count"] = t.get("clean_cols")
+        if "raw_row_count" in t:
+            result["raw_row_count"] = t.get("raw_row_count")
+        if "clean_row_count" in t:
+            result["clean_row_count"] = t.get("clean_row_count")
+
+    # Extract row_counts from mart summary (mart layer)
+    if result["row_count"] is None:
+        row_counts = summary.get("row_counts", {})
+        if row_counts:
+            first_key = next(iter(row_counts), None)
+            if first_key:
+                result["row_count"] = row_counts[first_key]
+
+    return result

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -416,3 +416,27 @@ def _validation_summary_for_layer(
                 result["row_count"] = row_counts[first_key]
 
     return result
+
+
+def _csv_quick_shape(csv_path: str | Path) -> dict[str, Any]:
+    """Quick row count and column count for a CSV file via DuckDB auto-detect.
+
+    Returns dict with ``row_count_estimate`` and ``column_count``.
+    Returns empty dict if the file can't be read (non-CSV, unreadable, etc.).
+
+    Non fa sniff esplicito (usa ``read_csv_auto``) — approssimativo ma veloce.
+    """
+    path = Path(csv_path)
+    if not path.exists():
+        return {}
+    try:
+        with duckdb.connect(database=":memory:") as conn:
+            conn.execute("PRAGMA disable_progress_bar")
+            rel = f"read_csv_auto('{_sql_literal(str(path))}', auto_detect=true)"
+            describe = conn.execute(f"DESCRIBE SELECT * FROM {rel}").fetchall()
+            col_count = len(describe)
+            count_row = conn.execute(f"SELECT COUNT(*) FROM {rel}").fetchone()
+            row_count = int(count_row[0]) if count_row else None
+            return {"row_count_estimate": row_count, "column_count": col_count}
+    except Exception:
+        return {}

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -418,25 +418,4 @@ def _validation_summary_for_layer(
     return result
 
 
-def _csv_quick_shape(csv_path: str | Path) -> dict[str, Any]:
-    """Quick row count and column count for a CSV file via DuckDB auto-detect.
 
-    Returns dict with ``row_count_estimate`` and ``column_count``.
-    Returns empty dict if the file can't be read (non-CSV, unreadable, etc.).
-
-    Non fa sniff esplicito (usa ``read_csv_auto``) — approssimativo ma veloce.
-    """
-    path = Path(csv_path)
-    if not path.exists():
-        return {}
-    try:
-        with duckdb.connect(database=":memory:") as conn:
-            conn.execute("PRAGMA disable_progress_bar")
-            rel = f"read_csv_auto('{_sql_literal(str(path))}', auto_detect=true)"
-            describe = conn.execute(f"DESCRIBE SELECT * FROM {rel}").fetchall()
-            col_count = len(describe)
-            count_row = conn.execute(f"SELECT COUNT(*) FROM {rel}").fetchone()
-            row_count = int(count_row[0]) if count_row else None
-            return {"row_count_estimate": row_count, "column_count": col_count}
-    except Exception:
-        return {}

--- a/toolkit/cli/inspect/readiness_ops.py
+++ b/toolkit/cli/inspect/readiness_ops.py
@@ -36,7 +36,8 @@ def run_state(config_path: str, year: int | None = None) -> dict[str, Any]:
         FileNotFoundError: config o directory non trovata.
     """
     cfg = load_config(config_path, strict_config=False)
-    paths = _payload_for_year(cfg, year or (max(cfg.years) if cfg.years else None))
+    _target_year: int = year if year is not None else (max(cfg.years) if cfg.years else 0)
+    paths = _payload_for_year(cfg, _target_year)
 
     run_dir = Path(paths["paths"]["run_dir"])
     run_files = sorted(run_dir.glob("*.json")) if run_dir.exists() else []
@@ -88,7 +89,8 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
         FileNotFoundError: config non trovata.
     """
     cfg = load_config(config_path, strict_config=False)
-    paths = _payload_for_year(cfg, year or (max(cfg.years) if cfg.years else None))
+    _target_year: int = year if year is not None else (max(cfg.years) if cfg.years else 0)
+    paths = _payload_for_year(cfg, _target_year)
 
     raw_paths = paths["paths"]["raw"]
     clean_paths = paths["paths"]["clean"]

--- a/toolkit/cli/inspect/readiness_ops.py
+++ b/toolkit/cli/inspect/readiness_ops.py
@@ -18,7 +18,7 @@ from toolkit.cli.inspect._helpers import (
     _validation_summary_for_layer,
 )
 from toolkit.core.config import load_config
-from toolkit.core.run_records import get_run_dir_dataset
+
 
 
 # ---------------------------------------------------------------------------

--- a/toolkit/cli/inspect/readiness_ops.py
+++ b/toolkit/cli/inspect/readiness_ops.py
@@ -1,0 +1,329 @@
+"""Diagnostica: summary layer, run_state, review_readiness.
+
+Implementazione condivisa tra CLI e MCP.
+MCP wrappa le eccezioni in ToolkitClientError.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from toolkit.cli.inspect._helpers import (
+    _check_run_record_coherence,
+    _exists,
+    _payload_for_year,
+    _read_parquet_row_count,
+    _validation_summary_for_layer,
+)
+from toolkit.core.config import load_config
+from toolkit.core.run_records import get_run_dir_dataset
+
+
+# ---------------------------------------------------------------------------
+# run_state
+# ---------------------------------------------------------------------------
+
+
+def run_state(config_path: str, year: int | None = None) -> dict[str, Any]:
+    """Stato della run directory: file presenti, latest run, anni visti.
+
+    Returns:
+        Dict con stato della run directory.
+
+    Raises:
+        FileNotFoundError: config o directory non trovata.
+    """
+    cfg = load_config(config_path, strict_config=False)
+    paths = _payload_for_year(cfg, year or (max(cfg.years) if cfg.years else None))
+
+    run_dir = Path(paths["paths"]["run_dir"])
+    run_files = sorted(run_dir.glob("*.json")) if run_dir.exists() else []
+
+    latest_run = paths.get("latest_run")
+    latest_payload: dict[str, Any] | None = None
+    if latest_run and latest_run.get("path"):
+        latest_path = Path(latest_run["path"])
+        if latest_path.exists():
+            try:
+                latest_payload = json.loads(latest_path.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+
+    years_seen = (
+        sorted({p.parent.name for p in run_dir.parent.glob("*/*.json") if p.parent.name.isdigit()})
+        if run_dir.parent.exists()
+        else []
+    )
+
+    return {
+        "dataset": paths.get("dataset"),
+        "config_path": str(config_path),
+        "requested_year": year,
+        "run_dir": str(run_dir),
+        "run_dir_exists": run_dir.exists(),
+        "run_file_count": len(run_files),
+        "years_seen": years_seen,
+        "latest_run": latest_run,
+        "latest_run_record": latest_payload,
+    }
+
+
+# ---------------------------------------------------------------------------
+# summary
+# ---------------------------------------------------------------------------
+
+
+def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
+    """Layer-level overview with existence checks.
+
+    Restituisce una panoramica dei layer raw/clean/mart: path, esistenza,
+    validation, run status. Legge i dati dal disco, non esegue la pipeline.
+
+    Returns:
+        Dict con stato dei layer.
+
+    Raises:
+        FileNotFoundError: config non trovata.
+    """
+    cfg = load_config(config_path, strict_config=False)
+    paths = _payload_for_year(cfg, year or (max(cfg.years) if cfg.years else None))
+
+    raw_paths = paths["paths"]["raw"]
+    clean_paths = paths["paths"]["clean"]
+    mart_paths = paths["paths"]["mart"]
+    run_dir = Path(paths["paths"]["run_dir"])
+
+    raw_dir = Path(raw_paths["dir"])
+    clean_dir = Path(clean_paths["dir"])
+    mart_dir = Path(mart_paths["dir"])
+    mart_outputs = list(mart_paths.get("outputs") or [])
+    missing_mart_outputs = [output for output in mart_outputs if not _exists(output)]
+
+    primary_output_file = (paths.get("raw_hints") or {}).get("primary_output_file")
+    primary_output_path = str(raw_dir / primary_output_file) if primary_output_file else None
+
+    latest_run = paths.get("latest_run") or {}
+    latest_run_path = latest_run.get("path")
+
+    run_files = sorted(run_dir.glob("*.json")) if run_dir.exists() else []
+    run_file_count = paths.get("run_file_count", len(run_files))
+    years_seen = paths.get("years_seen", [])
+
+    latest_run_record: dict[str, Any] | None = None
+    if latest_run_path and Path(latest_run_path).exists():
+        try:
+            latest_run_record = json.loads(Path(latest_run_path).read_text(encoding="utf-8"))
+        except Exception:
+            pass
+
+    warnings: list[str] = []
+    if primary_output_file and not _exists(primary_output_path):
+        warnings.append("raw_output_missing")
+    if not _exists(clean_paths.get("output")):
+        warnings.append("clean_output_missing")
+    if mart_outputs and missing_mart_outputs:
+        warnings.append("mart_outputs_missing")
+    if latest_run_path and not _exists(latest_run_path):
+        warnings.append("latest_run_record_missing")
+
+    # Estrai layer run status dal run record (se presente)
+    layer_run_statuses: dict[str, dict[str, Any]] = {}
+    if latest_run_record:
+        for layer_name in ("raw", "clean", "mart"):
+            layer_info = (latest_run_record.get("layers") or {}).get(layer_name, {})
+            layer_val = (latest_run_record.get("validations") or {}).get(layer_name, {})
+            layer_run_statuses[layer_name] = {
+                "status": layer_info.get("status", "PENDING"),
+                "validation_passed": layer_val.get("passed"),
+                "validation_errors": layer_val.get("errors_count", 0),
+                "validation_warnings": layer_val.get("warnings_count", 0),
+            }
+
+    return {
+        "dataset": paths.get("dataset"),
+        "config_path": str(config_path),
+        "year": paths.get("year"),
+        "layers": {
+            "raw": {
+                "dir": str(raw_dir),
+                "dir_exists": raw_dir.exists(),
+                "manifest_exists": _exists(raw_paths.get("manifest")),
+                "metadata_exists": _exists(raw_paths.get("metadata")),
+                "primary_output_file": primary_output_file,
+                "primary_output_exists": _exists(primary_output_path),
+                "suggested_read_exists": (paths.get("raw_hints") or {}).get(
+                    "suggested_read_exists"
+                ),
+                "encoding_suggested": (paths.get("raw_hints") or {}).get("encoding"),
+                "delim_suggested": (paths.get("raw_hints") or {}).get("delim"),
+                "decimal_suggested": (paths.get("raw_hints") or {}).get("decimal"),
+                "skip_suggested": (paths.get("raw_hints") or {}).get("skip"),
+                "raw_warnings": (paths.get("raw_hints") or {}).get("warnings", []),
+                "validation": _validation_summary_for_layer(raw_dir, "_validate/raw_validation.json"),
+                "run_status": layer_run_statuses.get("raw"),
+            },
+            "clean": {
+                "dir": str(clean_dir),
+                "dir_exists": clean_dir.exists(),
+                "output": clean_paths.get("output"),
+                "output_exists": _exists(clean_paths.get("output")),
+                "manifest_exists": _exists(clean_paths.get("manifest")),
+                "metadata_exists": _exists(clean_paths.get("metadata")),
+                "validation": _validation_summary_for_layer(clean_dir, "_validate/clean_validation.json"),
+                "run_status": layer_run_statuses.get("clean"),
+            },
+            "mart": {
+                "dir": str(mart_dir),
+                "dir_exists": mart_dir.exists(),
+                "outputs": mart_outputs,
+                "output_count": len(mart_outputs),
+                "output_exists_count": len(mart_outputs) - len(missing_mart_outputs),
+                "missing_outputs": missing_mart_outputs,
+                "manifest_exists": _exists(mart_paths.get("manifest")),
+                "metadata_exists": _exists(mart_paths.get("metadata")),
+                "validation": _validation_summary_for_layer(mart_dir, "_validate/mart_validation.json"),
+                "run_status": layer_run_statuses.get("mart"),
+            },
+        },
+        "run": {
+            "run_dir": str(run_dir),
+            "run_dir_exists": run_dir.exists(),
+            "run_file_count": run_file_count,
+            "years_seen": years_seen,
+            "latest_run": latest_run or None,
+            "latest_run_record": latest_run_record,
+        },
+        "warnings": warnings,
+        "multi_year_hint": paths.get("_year_resolution"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# review_readiness
+# ---------------------------------------------------------------------------
+
+
+def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any]:
+    """Check minimale di readiness per review di intake/run candidate.
+
+    Verifica:
+    - il candidate e' runnabile almeno al minimo?
+    - i layer attesi esistono davvero?
+    - c'e' almeno un output leggibile?
+    - il run record e' coerente con gli output presenti?
+
+    Returns:
+        Dict con readiness, checks, ok/fail count.
+
+    Raises:
+        FileNotFoundError: config non trovata.
+    """
+    cfg = load_config(config_path, strict_config=False)
+
+    years = list(cfg.years or [])
+    target_year = year or (years[0] if years else None)
+
+    checks: list[dict[str, Any]] = []
+
+    # --- Config check ---
+    checks.append({
+        "check": "config_valid",
+        "ok": True,
+        "detail": "config parse ok",
+    })
+
+    # --- Raw layer ---
+    s = summary(str(config_path), target_year)
+    raw = s.get("layers", {}).get("raw", {})
+    raw_primary = raw.get("primary_output_file")
+    if raw_primary:
+        raw_ok = raw.get("primary_output_exists")
+    else:
+        raw_dir_path = Path(raw.get("dir", ""))
+        raw_ok = raw_dir_path.exists() and any(raw_dir_path.iterdir())
+    checks.append({
+        "check": "raw_output_present",
+        "ok": raw_ok,
+        "detail": f"primary_output={raw.get('primary_output_file', 'unknown')}"
+        if raw_ok
+        else "raw output mancante",
+    })
+
+    # --- Clean layer ---
+    clean = s.get("layers", {}).get("clean", {})
+    clean_path_str = clean.get("output")
+    clean_path = Path(clean_path_str) if clean_path_str else None
+    clean_rows = _read_parquet_row_count(clean_path) if clean_path else None
+    clean_ok = clean.get("output_exists") and (clean_rows is not None)
+    checks.append({
+        "check": "clean_output_readable",
+        "ok": clean_ok,
+        "detail": f"{clean_rows} rows"
+        if clean_rows is not None
+        else "clean output mancante o illeggibile",
+    })
+
+    # --- Mart layer ---
+    mart = s.get("layers", {}).get("mart", {})
+    mart_outputs = mart.get("outputs", [])
+    mart_checks: list[dict[str, Any]] = []
+    for output_name in mart_outputs:
+        o_path = Path(output_name)
+        rows = _read_parquet_row_count(o_path)
+        mart_checks.append({
+            "name": o_path.name,
+            "exists": o_path.exists(),
+            "readable": rows is not None,
+            "rows": rows,
+        })
+    mart_ok = len(mart_outputs) > 0 and all(
+        m.get("exists") and m.get("readable") for m in mart_checks
+    )
+    checks.append({
+        "check": "mart_outputs_readable",
+        "ok": mart_ok,
+        "detail": mart_checks,
+    })
+
+    # --- Run record coherence ---
+    rs = run_state(str(config_path), target_year)
+    run_record = rs.get("latest_run_record")
+    coherence_hints = _check_run_record_coherence(run_record, s.get("layers", {}))
+    run_coherent = len(coherence_hints) == 0
+    if run_coherent:
+        run_detail = (
+            f"run record coerente ({run_record.get('status', 'unknown')})"
+            if run_record
+            else "nessun run record (ok se output presenti)"
+        )
+    else:
+        run_detail = coherence_hints[0].get("message", "incoerenza run record")
+
+    checks.append({
+        "check": "run_record_coherent",
+        "ok": run_coherent,
+        "detail": run_detail,
+    })
+
+    ok_count = sum(1 for c in checks if c["ok"])
+    fail_count = sum(1 for c in checks if not c["ok"])
+
+    if fail_count == 0:
+        readiness = "ready"
+    elif ok_count >= len(checks) - 1:
+        readiness = "needs-review"
+    else:
+        readiness = "incomplete"
+
+    return {
+        "dataset": s.get("dataset"),
+        "config_path": str(config_path),
+        "year": s.get("year"),
+        "readiness": readiness,
+        "check_count": len(checks),
+        "ok_count": ok_count,
+        "fail_count": fail_count,
+        "checks": checks,
+    }

--- a/toolkit/cli/inspect/schema_ops.py
+++ b/toolkit/cli/inspect/schema_ops.py
@@ -1,12 +1,91 @@
-"""CLI per `inspect schema` — schema di un layer raw/clean/mart."""
+"""CLI per `inspect schema` — schema di un layer raw/clean/mart.
+
+Implementazione condivisa: sia CLI che MCP la chiamano.
+MCP wrappa le eccezioni in ToolkitClientError.
+"""
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from typing import Any
 
 import typer
 
-from toolkit.mcp.schema_ops import show_schema
+from toolkit.cli.inspect._helpers import (
+    _payload_for_year,
+    _raw_schema_payload,
+    _schema_from_parquet,
+)
+from toolkit.core.config import load_config
+
+
+# --- Implementazione condivisa ---
+
+
+def show_schema(config_path: str, layer: str = "clean", year: int | None = None) -> dict[str, Any]:
+    """Mostra lo schema (colonne + tipi) di raw, clean o mart.
+
+    Args:
+        config_path: path al dataset.yml.
+        layer: ``"raw"``, ``"clean"`` (default), o ``"mart"``.
+        year: anno. Se ``None`` per dataset multi-year usa l'ultimo.
+
+    Returns:
+        Dict con schema del layer richiesto.
+
+    Raises:
+        ValueError: layer non valido o anno non disponibile.
+        FileNotFoundError: file parquet o config non trovati.
+    """
+    cfg = load_config(config_path, strict_config=False)
+
+    safe_layer = (layer or "clean").strip().lower()
+    if safe_layer not in {"raw", "clean", "mart"}:
+        raise ValueError(f"layer deve essere uno tra: raw, clean, mart (ricevuto: {layer})")
+
+    if safe_layer == "raw":
+        years = list(cfg.years or [])
+        entries = [_raw_schema_payload(cfg, yr) for yr in years]
+        if year is not None:
+            entries = [e for e in entries if e.get("year") == year]
+        return {
+            "dataset": cfg.dataset,
+            "layer": "raw",
+            "year": year,
+            "entry_count": len(entries),
+            "entries": entries,
+        }
+
+    paths = _payload_for_year(cfg, year or max(cfg.years) if cfg.years else None)
+    if safe_layer == "clean":
+        parquet_path_str = paths["paths"]["clean"].get("output")
+        if not parquet_path_str:
+            raise FileNotFoundError("Nessun output clean configurato")
+        parquet_path = Path(parquet_path_str)
+        payload = _schema_from_parquet(parquet_path)
+    else:
+        outputs = paths["paths"]["mart"].get("outputs") or []
+        if not outputs:
+            raise FileNotFoundError("Nessun output mart risolto dal toolkit")
+        parquet_path = Path(outputs[0])
+        payload = _schema_from_parquet(parquet_path)
+        payload["available_outputs"] = outputs
+        if len(outputs) > 1:
+            payload["warning"] = (
+                "Sono presenti piu' output mart; lo schema mostrato riguarda solo il primo output."
+            )
+
+    payload.update({
+        "dataset": paths.get("dataset"),
+        "year": paths.get("year"),
+        "layer": safe_layer,
+        "config_path": str(config_path),
+    })
+    return payload
+
+
+# --- CLI wrapper (Typer) ---
 
 
 def schema(
@@ -18,8 +97,6 @@ def schema(
 ) -> None:
     """Mostra lo schema (colonne + tipi) di raw, clean o mart.
 
-    Chiama la stessa implementazione del tool MCP toolkit_show_schema.
-
     Il path config puo' essere passato come argomento posizionale
     (es. toolkit inspect schema path/to/dataset.yml)
     o con l'opzione --config / -c.
@@ -29,8 +106,16 @@ def schema(
         typer.echo("error: specificare il path al dataset.yml (argomento o --config)", err=True)
         raise typer.Exit(code=1)
 
-    result = show_schema(resolved_config, layer, year or None)
-    status = result.get("status", "ok" if result.get("columns") else "empty")
+    try:
+        result = show_schema(resolved_config, layer, year or None)
+    except (ValueError, FileNotFoundError) as exc:
+        if json_output:
+            typer.echo(json.dumps({"status": "error", "message": str(exc)}, indent=2))
+        else:
+            typer.echo(f"Errore: {exc}")
+        raise typer.Exit(code=1)
+
+    status = "ok" if result.get("columns") or result.get("entries") else "empty"
 
     if json_output:
         typer.echo(json.dumps(result, indent=2, default=str))

--- a/toolkit/cli/inspect/schema_ops.py
+++ b/toolkit/cli/inspect/schema_ops.py
@@ -57,7 +57,8 @@ def show_schema(config_path: str, layer: str = "clean", year: int | None = None)
             "entries": entries,
         }
 
-    paths = _payload_for_year(cfg, year or max(cfg.years) if cfg.years else None)
+    _target_year: int = year if year is not None else (max(cfg.years) if cfg.years else 0)
+    paths = _payload_for_year(cfg, _target_year)
     if safe_layer == "clean":
         parquet_path_str = paths["paths"]["clean"].get("output")
         if not parquet_path_str:

--- a/toolkit/cli/sql_dry_run.py
+++ b/toolkit/cli/sql_dry_run.py
@@ -6,7 +6,7 @@ from typing import Any
 import duckdb
 from lab_connectors.duckdb import safe_connect
 
-from toolkit.clean.run import _load_clean_sql
+from toolkit.clean.run import load_clean_sql
 from toolkit.core.config import ensure_dict
 from toolkit.core.paths import resolve_sql_path as _resolve_mart_sql_path
 from toolkit.core.support import flatten_support_template_ctx, resolve_support_payloads
@@ -75,7 +75,7 @@ def _build_clean_preview(
     con: duckdb.DuckDBPyConnection,
 ) -> None:
     clean_cfg_ = ensure_dict(cfg.clean)
-    clean_sql_path, clean_sql, _ = _load_clean_sql(
+    clean_sql_path, clean_sql, _ = load_clean_sql(
         clean_cfg_,
         dataset=cfg.dataset,
         year=year,

--- a/toolkit/core/csv_shape.py
+++ b/toolkit/core/csv_shape.py
@@ -1,0 +1,47 @@
+"""Quick CSV shape detection — righe e colonne via DuckDB auto-detect.
+
+Condiviso da tutti i layer (raw, cli, mcp). Non dipende da CLI ne MCP.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import duckdb
+
+
+def _sql_literal(value: str) -> str:
+    """Escape a string for safe use inside a SQL single-quoted literal."""
+    return value.replace("'", "''")
+
+
+def csv_quick_shape(csv_path: str | Path) -> dict[str, Any]:
+    """Quick row count and column count for a CSV file via DuckDB auto-detect.
+
+    Args:
+        csv_path: Path to the CSV file.
+
+    Returns:
+        Dict with ``row_count_estimate`` (int | None) and ``column_count`` (int | None).
+        Returns empty dict if file not found or unreadable (non-CSV, encoding issues, etc.).
+
+    Note:
+        Uses ``read_csv_auto`` with ``auto_detect=true``. Non fa sniff esplicito,
+        approssimativo ma veloce. Per profiling completo vedi
+        ``toolkit.profile.raw.profile_raw``.
+    """
+    path = Path(csv_path)
+    if not path.exists():
+        return {}
+    try:
+        with duckdb.connect(database=":memory:") as conn:
+            conn.execute("PRAGMA disable_progress_bar")
+            rel = f"read_csv_auto('{_sql_literal(str(path))}', auto_detect=true)"
+            describe = conn.execute(f"DESCRIBE SELECT * FROM {rel}").fetchall()
+            col_count = len(describe)
+            count_row = conn.execute(f"SELECT COUNT(*) FROM {rel}").fetchone()
+            row_count = int(count_row[0]) if count_row else None
+            return {"row_count_estimate": row_count, "column_count": col_count}
+    except Exception:
+        return {}

--- a/toolkit/mcp/_schema_utils.py
+++ b/toolkit/mcp/_schema_utils.py
@@ -1,225 +1,101 @@
-"""Shared helpers for MCP schema operations.
+"""Shared helpers for MCP schema operations — re-exported from cli/inspect.
 
-Internal utilities used by the MCP tool functions in schema_ops.py.
-Not part of the public API — no stability guarantee.
+Tutti gli helper sono in ``toolkit.cli.inspect._helpers``.
+Qui MCP li re-esporta wrappando gli errori con ``ToolkitClientError``
+dove serve, o semplicemente re-indirizzando per backward compat.
+
+Lazy import per evitare circular import con cli/inspect/ -> cli/cmd_*.
 """
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
-import duckdb
-
 from lab_connectors.mcp.errors import ErrorCode
+
 from toolkit.mcp.errors import ToolkitClientError
 
 
+def _cli_helpers():
+    """Lazy import to avoid circular dependency with cli/inspect."""
+    from toolkit.cli.inspect._helpers import (  # noqa: F401
+        _check_run_record_coherence,
+        _exists,
+        _read_parquet_preview,
+        _read_parquet_row_count,
+        _read_validation_content,
+        _schema_from_parquet,
+        _sql_literal,
+        _validation_summary_for_layer,
+    )
+    return (
+        _check_run_record_coherence,
+        _exists,
+        _read_parquet_preview,
+        _read_parquet_row_count,
+        _read_validation_content,
+        _schema_from_parquet,
+        _sql_literal,
+        _validation_summary_for_layer,
+    )
+
+
+# --- Pure re-exports (no error wrapping needed) ---
+
+
 def _sql_literal(value: str) -> str:
-    """Escape a string for safe use inside a SQL single-quoted literal."""
-    return value.replace("'", "''")
+    return _cli_helpers()[6](value)
 
 
-def _schema_from_parquet(parquet_path: Path) -> dict[str, Any]:
-    """Return schema (columns + count) of a parquet file via DuckDB.
-
-    Raises:
-        ToolkitClientError: if the file doesn't exist or can't be read.
-    """
-    if not parquet_path.exists():
-        raise ToolkitClientError(f"Parquet non trovato: {parquet_path}", code=ErrorCode.PARQUET_NOT_FOUND)
-    relation = f"read_parquet('{_sql_literal(str(parquet_path))}')"
-    try:
-        with duckdb.connect(database=":memory:") as conn:
-            conn.execute("PRAGMA disable_progress_bar")
-            describe_rows = conn.execute(f"DESCRIBE SELECT * FROM {relation}").fetchall()
-    except Exception as exc:
-        raise ToolkitClientError(
-            f"Lettura schema parquet fallita per {parquet_path}: {exc}",
-            code=ErrorCode.DUCKDB_ERROR,
-        ) from exc
-
-    columns = [{"name": row[0], "type": row[1]} for row in describe_rows]
-    return {"path": str(parquet_path), "column_count": len(columns), "columns": columns}
-
-
-def _read_parquet_row_count(parquet_path: Path) -> int | None:
-    """Return row count of a parquet file, or None if unreadable."""
-    if not parquet_path.exists():
-        return None
-    try:
-        with duckdb.connect(database=":memory:") as conn:
-            conn.execute("PRAGMA disable_progress_bar")
-            result = conn.execute(
-                f"SELECT COUNT(*) FROM read_parquet('{_sql_literal(str(parquet_path))}')"
-            ).fetchone()
-            return int(result[0]) if result else None
-    except Exception:
-        return None
-
-
-def _read_parquet_preview(parquet_path: Path, limit: int = 10) -> dict[str, Any]:
-    """Return schema + row preview of a parquet file via DuckDB.
-
-    Returns:
-        dict with keys: path, column_count, columns (list of {name, type}),
-        row_count, preview (list of dicts), truncated (bool).
-
-    Raises:
-        ToolkitClientError: if the file doesn't exist or can't be read.
-    """
-    if not parquet_path.exists():
-        raise ToolkitClientError(f"Parquet non trovato: {parquet_path}", code=ErrorCode.PARQUET_NOT_FOUND)
-
-    rel = f"read_parquet('{_sql_literal(str(parquet_path))}')"
-    try:
-        with duckdb.connect(database=":memory:") as conn:
-            conn.execute("PRAGMA disable_progress_bar")
-
-            # schema
-            describe = conn.execute(f"DESCRIBE SELECT * FROM {rel}").fetchall()
-            columns = [{"name": row[0], "type": row[1]} for row in describe]
-
-            # row count
-            count_row = conn.execute(f"SELECT COUNT(*) FROM {rel}").fetchone()
-            row_count = int(count_row[0]) if count_row else None
-
-            # preview
-            preview_rows = conn.execute(
-                f"SELECT * FROM {rel} LIMIT {int(limit)}"
-            ).fetchall()
-            col_names = [c["name"] for c in columns]
-            preview = [dict(zip(col_names, row)) for row in preview_rows]
-
-            truncated = bool(row_count and row_count > limit)
-
-            return {
-                "path": str(parquet_path),
-                "column_count": len(columns),
-                "columns": columns,
-                "row_count": row_count,
-                "preview": preview,
-                "truncated": truncated,
-            }
-    except Exception as exc:
-        raise ToolkitClientError(
-            f"Lettura parquet fallita per {parquet_path}: {exc}",
-            code=ErrorCode.DUCKDB_ERROR,
-        ) from exc
+def _read_parquet_row_count(parquet_path: Path | None) -> int | None:
+    return _cli_helpers()[3](parquet_path)
 
 
 def _exists(path: str | None) -> bool:
-    """Return True if path is a real file/directory."""
-    if not path:
-        return False
-    return Path(path).exists()
+    return _cli_helpers()[1](path)
 
 
 def _read_validation_content(path: str | None) -> dict[str, Any] | None:
-    """Read a validation JSON file and return its content, or None if missing."""
-    if not path or not _exists(path):
-        return None
-    try:
-        return json.loads(Path(path).read_text(encoding="utf-8"))
-    except Exception:
-        return None
+    return _cli_helpers()[4](path)
 
 
 def _check_run_record_coherence(
-    run_record: dict[str, Any] | None,
-    layers: dict[str, Any],
+    run_record: dict[str, Any] | None, layers: dict[str, Any]
 ) -> list[dict[str, str]]:
-    """Verifica che i layer marcati SUCCESS nel run record abbiano output reali.
-
-    Ritorna una lista di hint (dict con code, severity, message).
-    Usata da review_readiness().
-    """
-    hints: list[dict[str, str]] = []
-    if not run_record:
-        return hints
-
-    layers_map = run_record.get("layers") or {}
-    for layer_name, layer_detail in layers_map.items():
-        layer_status = (
-            layer_detail.get("status") if isinstance(layer_detail, dict) else layer_detail
-        )
-        if layer_status != "SUCCESS":
-            continue
-
-        layer_info = layers.get(layer_name, {})
-
-        if layer_name == "clean" and not layer_info.get("output_exists"):
-            hints.append({
-                "code": "run_says_clean_success_but_output_missing",
-                "severity": "blocker",
-                "message": "run record dice clean SUCCESS ma output file manca",
-            })
-        elif layer_name == "mart":
-            out_count = layer_info.get("output_count", 0) or 0
-            exists_count = layer_info.get("output_exists_count", 0) or 0
-            if exists_count == 0 and out_count > 0:
-                hints.append({
-                    "code": "run_says_mart_success_but_outputs_missing",
-                    "severity": "blocker",
-                    "message": "run record dice mart SUCCESS ma nessun output file presente",
-                })
-
-    return hints
+    return _cli_helpers()[0](run_record, layers)
 
 
 def _validation_summary_for_layer(
     layer_dir: Path, validation_filename: str
 ) -> dict[str, Any] | None:
-    """Extract summary from a layer's validation JSON.
+    return _cli_helpers()[7](layer_dir, validation_filename)
 
-    Adds: ok, errors_count, warnings_count, row_count, col_count,
-    raw_row_count, clean_row_count.
-    Reads row/col counts from summary.stats (clean) or summary.row_counts (mart).
-    Falls back to sections.stats for layers that use that path.
-    Returns None if the validation file does not exist.
+
+# --- Wrapped with ToolkitClientError ---
+
+
+def _schema_from_parquet(parquet_path: Path) -> dict[str, Any]:
+    """Return schema (columns + count) of a parquet file via DuckDB.
+
+    Wraps CLI implementation with MCP error handling.
     """
-    validation_path = layer_dir / validation_filename
-    content = _read_validation_content(str(validation_path))
-    if not content:
-        return None
+    try:
+        return _cli_helpers()[5](parquet_path)
+    except FileNotFoundError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.PARQUET_NOT_FOUND) from exc
+    except RuntimeError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.DUCKDB_ERROR) from exc
 
-    result = {
-        "ok": content.get("ok"),
-        "errors_count": len(content.get("errors", [])),
-        "warnings_count": len(content.get("warnings", [])),
-        "row_count": None,
-        "col_count": None,
-    }
 
-    # Extract stats from summary (clean layer: summary.stats.clean_rows/clean_cols)
-    summary = content.get("summary", {})
-    stats = summary.get("stats", {})
-    result["row_count"] = stats.get("clean_rows") or stats.get("row_count")
-    result["col_count"] = stats.get("clean_cols")
+def _read_parquet_preview(parquet_path: Path, limit: int = 10) -> dict[str, Any]:
+    """Return schema + row preview of a parquet file via DuckDB.
 
-    # Fallback: sections.stats (mart layer uses sections differently)
-    sections = content.get("sections", {})
-    if result["row_count"] is None and "stats" in sections:
-        result["row_count"] = sections["stats"].get("row_count")
-        result["col_count"] = sections["stats"].get("col_count")
-
-    # Extract transition metadata (clean validation)
-    if "transition" in sections:
-        t = sections["transition"]
-        if "clean_cols" in t:
-            result["col_count"] = t.get("clean_cols")
-        if "raw_row_count" in t:
-            result["raw_row_count"] = t.get("raw_row_count")
-        if "clean_row_count" in t:
-            result["clean_row_count"] = t.get("clean_row_count")
-
-    # Extract row_counts from mart summary (mart layer)
-    if result["row_count"] is None:
-        row_counts = summary.get("row_counts", {})
-        if row_counts:
-            first_key = next(iter(row_counts), None)
-            if first_key:
-                result["row_count"] = row_counts[first_key]
-
-    return result
+    Wraps CLI implementation with MCP error handling.
+    """
+    try:
+        return _cli_helpers()[2](parquet_path, limit=limit)
+    except FileNotFoundError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.PARQUET_NOT_FOUND) from exc
+    except RuntimeError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.DUCKDB_ERROR) from exc

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -16,13 +16,6 @@ import json
 from pathlib import Path
 from typing import Any
 
-from toolkit.mcp._schema_utils import (
-    _check_run_record_coherence,
-    _exists,
-    _read_parquet_row_count,
-    _schema_from_parquet,
-    _validation_summary_for_layer,
-)
 from lab_connectors.mcp.errors import ErrorCode
 
 from toolkit.mcp.errors import ToolkitClientError
@@ -52,48 +45,18 @@ def _compare_schema_entries(*args: Any, **kwargs: Any) -> Any:
 
 
 def show_schema(config_path: str, layer: str = "clean", year: int | None = None) -> dict[str, Any]:
-    config, _cfg = _load_cfg(config_path)
-    safe_layer = (layer or "clean").strip().lower()
-    if safe_layer not in {"raw", "clean", "mart"}:
-        raise ToolkitClientError("layer deve essere uno tra: raw, clean, mart", code=ErrorCode.INVALID_PARAMS)
+    """Mostra lo schema (colonne + tipi) di raw, clean o mart.
 
-    if safe_layer == "raw":
-        years = list(_cfg.years or [])
-        entries = [_raw_schema_payload(_cfg, yr) for yr in years]
-        entries_filtered = [e for e in entries if year is None or e.get("year") == year]
-        return {
-            "dataset": _cfg.dataset,
-            "layer": "raw",
-            "year": year,
-            "entry_count": len(entries_filtered),
-            "entries": entries_filtered,
-        }
+    Thin wrapper MCP: delega a ``toolkit.cli.inspect.schema_ops.show_schema``.
+    """
+    from toolkit.cli.inspect.schema_ops import show_schema as _cli_show_schema
 
-    paths = _inspect_paths(str(config), year)
-    if safe_layer == "clean":
-        parquet_path = Path(paths["paths"]["clean"]["output"])
-        payload = _schema_from_parquet(parquet_path)
-    else:
-        outputs = paths["paths"]["mart"].get("outputs") or []
-        if not outputs:
-            raise ToolkitClientError("Nessun output mart risolto dal toolkit", code=ErrorCode.PARQUET_NOT_FOUND)
-        parquet_path = Path(outputs[0])
-        payload = _schema_from_parquet(parquet_path)
-        payload["available_outputs"] = outputs
-        if len(outputs) > 1:
-            payload["warning"] = (
-                "Sono presenti piu' output mart; lo schema mostrato riguarda solo il primo output."
-            )
-
-    payload.update(
-        {
-            "dataset": paths.get("dataset"),
-            "year": paths.get("year"),
-            "layer": safe_layer,
-            "config_path": str(config_path),
-        }
-    )
-    return payload
+    try:
+        return _cli_show_schema(config_path, layer=layer, year=year)
+    except ValueError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.INVALID_PARAMS) from exc
+    except FileNotFoundError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.PARQUET_NOT_FOUND) from exc
 
 
 def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
@@ -180,32 +143,16 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
 
 
 def run_state(config_path: str, year: int | None = None) -> dict[str, Any]:
-    config = _safe_path(config_path)
-    paths = _inspect_paths(str(config), year)
-    run_dir = Path(paths["paths"]["run_dir"])
-    run_files = sorted(run_dir.glob("*.json")) if run_dir.exists() else []
-    latest_run = paths.get("latest_run")
-    latest_payload = None
-    if latest_run and latest_run.get("path"):
-        latest_path = Path(latest_run["path"])
-        if latest_path.exists():
-            latest_payload = json.loads(latest_path.read_text(encoding="utf-8"))
-    years_seen = (
-        sorted({p.parent.name for p in run_dir.parent.glob("*/*.json") if p.parent.name.isdigit()})
-        if run_dir.parent.exists()
-        else []
-    )
-    return {
-        "dataset": paths.get("dataset"),
-        "config_path": str(config_path),
-        "requested_year": year,
-        "run_dir": str(run_dir),
-        "run_dir_exists": run_dir.exists(),
-        "run_file_count": len(run_files),
-        "years_seen": years_seen,
-        "latest_run": latest_run,
-        "latest_run_record": latest_payload,
-    }
+    """Stato della run directory.
+
+    Thin wrapper MCP: delega a ``toolkit.cli.inspect.readiness_ops.run_state``.
+    """
+    from toolkit.cli.inspect.readiness_ops import run_state as _cli_run_state
+
+    try:
+        return _cli_run_state(_safe_path(str(config_path)), year=year)
+    except FileNotFoundError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.CONFIG_NOT_FOUND) from exc
 
 
 def list_runs(
@@ -397,243 +344,30 @@ def run_summary(
 
 
 def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
-    config = _safe_path(config_path)
-    paths = _inspect_paths(str(config), year)
-    raw_paths = paths["paths"]["raw"]
-    clean_paths = paths["paths"]["clean"]
-    mart_paths = paths["paths"]["mart"]
-    run_dir = Path(paths["paths"]["run_dir"])
+    """Layer-level overview with existence checks.
 
-    raw_dir = Path(raw_paths["dir"])
-    clean_dir = Path(clean_paths["dir"])
-    mart_dir = Path(mart_paths["dir"])
-    mart_outputs = list(mart_paths.get("outputs") or [])
-    missing_mart_outputs = [output for output in mart_outputs if not _exists(output)]
+    Thin wrapper MCP: delega a ``toolkit.cli.inspect.readiness_ops.summary``.
+    """
+    from toolkit.cli.inspect.readiness_ops import summary as _cli_summary
 
-    primary_output_file = (paths.get("raw_hints") or {}).get("primary_output_file")
-    primary_output_path = str(raw_dir / primary_output_file) if primary_output_file else None
-
-    latest_run = paths.get("latest_run") or {}
-    latest_run_path = latest_run.get("path")
-
-    run_files = sorted(run_dir.glob("*.json")) if run_dir.exists() else []
-    run_file_count = paths.get("run_file_count", len(run_files))
-    years_seen = paths.get("years_seen", [])
-
-    latest_run_record: dict[str, Any] | None = None
-    if latest_run_path and Path(latest_run_path).exists():
-        try:
-            latest_run_record = json.loads(Path(latest_run_path).read_text(encoding="utf-8"))
-        except Exception:
-            pass
-
-    warnings: list[str] = []
-    if primary_output_file and not _exists(primary_output_path):
-        warnings.append("raw_output_missing")
-    if not _exists(clean_paths.get("output")):
-        warnings.append("clean_output_missing")
-    if mart_outputs and missing_mart_outputs:
-        warnings.append("mart_outputs_missing")
-    if latest_run_path and not _exists(latest_run_path):
-        warnings.append("latest_run_record_missing")
-
-    # Estrai layer run status dal run record (se presente)
-    layer_run_statuses: dict[str, dict[str, Any]] = {}
-    if latest_run_record:
-        for layer_name in ("raw", "clean", "mart"):
-            layer_info = (latest_run_record.get("layers") or {}).get(layer_name, {})
-            layer_val = (latest_run_record.get("validations") or {}).get(layer_name, {})
-            layer_run_statuses[layer_name] = {
-                "status": layer_info.get("status", "PENDING"),
-                "validation_passed": layer_val.get("passed"),
-                "validation_errors": layer_val.get("errors_count", 0),
-                "validation_warnings": layer_val.get("warnings_count", 0),
-            }
-
-    return {
-        "dataset": paths.get("dataset"),
-        "config_path": str(config_path),
-        "year": paths.get("year"),
-        "layers": {
-            "raw": {
-                "dir": str(raw_dir),
-                "dir_exists": raw_dir.exists(),
-                "manifest_exists": _exists(raw_paths.get("manifest")),
-                "metadata_exists": _exists(raw_paths.get("metadata")),
-                "primary_output_file": primary_output_file,
-                "primary_output_exists": _exists(primary_output_path),
-                "suggested_read_exists": (paths.get("raw_hints") or {}).get(
-                    "suggested_read_exists"
-                ),
-                "encoding_suggested": (paths.get("raw_hints") or {}).get("encoding"),
-                "delim_suggested": (paths.get("raw_hints") or {}).get("delim"),
-                "decimal_suggested": (paths.get("raw_hints") or {}).get("decimal"),
-                "skip_suggested": (paths.get("raw_hints") or {}).get("skip"),
-                "raw_warnings": (paths.get("raw_hints") or {}).get("warnings", []),
-                "validation": _validation_summary_for_layer(raw_dir, "_validate/raw_validation.json"),
-                "run_status": layer_run_statuses.get("raw"),
-            },
-            "clean": {
-                "dir": str(clean_dir),
-                "dir_exists": clean_dir.exists(),
-                "output": clean_paths.get("output"),
-                "output_exists": _exists(clean_paths.get("output")),
-                "manifest_exists": _exists(clean_paths.get("manifest")),
-                "metadata_exists": _exists(clean_paths.get("metadata")),
-                "validation": _validation_summary_for_layer(clean_dir, "_validate/clean_validation.json"),
-                "run_status": layer_run_statuses.get("clean"),
-            },
-            "mart": {
-                "dir": str(mart_dir),
-                "dir_exists": mart_dir.exists(),
-                "outputs": mart_outputs,
-                "output_count": len(mart_outputs),
-                "output_exists_count": len(mart_outputs) - len(missing_mart_outputs),
-                "missing_outputs": missing_mart_outputs,
-                "manifest_exists": _exists(mart_paths.get("manifest")),
-                "metadata_exists": _exists(mart_paths.get("metadata")),
-                "validation": _validation_summary_for_layer(mart_dir, "_validate/mart_validation.json"),
-                "run_status": layer_run_statuses.get("mart"),
-            },
-        },
-        "run": {
-            "run_dir": str(run_dir),
-            "run_dir_exists": run_dir.exists(),
-            "run_file_count": run_file_count,
-            "years_seen": years_seen,
-            "latest_run": latest_run or None,
-            "latest_run_record": latest_run_record,
-        },
-        "warnings": warnings,
-        "multi_year_hint": paths.get("_year_resolution"),
-    }
+    try:
+        return _cli_summary(_safe_path(str(config_path)), year=year)
+    except FileNotFoundError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.CONFIG_NOT_FOUND) from exc
 
 
 
 def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any]:
     """Check minimale di readiness per review di intake/run candidate.
 
-    Risponde a:
-    - il candidate e' runnable almeno al minimo?
-    - i layer attesi esistono davvero?
-    - c'e' almeno un output leggibile?
-    - il run record e' coerente con gli output presenti?
+    Thin wrapper MCP: delega a ``toolkit.cli.inspect.readiness_ops.review_readiness``.
     """
-    config = _safe_path(config_path)
-    _, cfg = _load_cfg(config)
+    from toolkit.cli.inspect.readiness_ops import review_readiness as _cli_review_readiness
 
-    years = getattr(cfg, "years", []) if hasattr(cfg, "years") else []
-    target_year = year or (years[0] if years else None)
-
-    checks: list[dict[str, Any]] = []
-
-    # --- Config check ---
-    checks.append(
-        {
-            "check": "config_valid",
-            "ok": True,
-            "detail": "config parse ok",
-        }
-    )
-
-    # --- Raw layer ---
-    s = summary(str(config), target_year)
-    raw = s.get("layers", {}).get("raw", {})
-    raw_primary = raw.get("primary_output_file")
-    if raw_primary:
-        raw_ok = raw.get("primary_output_exists")
-    else:
-        # Nessun manifest: fallback su esistenza dir e presenza file
-        raw_dir_path = Path(raw.get("dir", ""))
-        raw_ok = raw_dir_path.exists() and any(raw_dir_path.iterdir())
-    checks.append(
-        {
-            "check": "raw_output_present",
-            "ok": raw_ok,
-            "detail": f"primary_output={raw.get('primary_output_file', 'unknown')}"
-            if raw_ok
-            else "raw output mancante",
-        }
-    )
-
-    # --- Clean layer ---
-    clean = s.get("layers", {}).get("clean", {})
-    clean_path_str = clean.get("output")
-    clean_path = Path(clean_path_str) if clean_path_str else None
-    clean_rows = _read_parquet_row_count(clean_path) if clean_path else None
-    clean_ok = clean.get("output_exists") and (clean_rows is not None)
-    checks.append(
-        {
-            "check": "clean_output_readable",
-            "ok": clean_ok,
-            "detail": f"{clean_rows} rows"
-            if clean_rows is not None
-            else "clean output mancante o illeggibile",
-        }
-    )
-
-    # --- Mart layer ---
-    mart = s.get("layers", {}).get("mart", {})
-    mart_outputs = mart.get("outputs", [])
-    mart_checks: list[dict[str, Any]] = []
-    for output_name in mart_outputs:
-        o_path = Path(output_name)
-        rows = _read_parquet_row_count(o_path)
-        mart_checks.append(
-            {
-                "name": o_path.name,
-                "exists": o_path.exists(),
-                "readable": rows is not None,
-                "rows": rows,
-            }
-        )
-    mart_ok = len(mart_outputs) > 0 and all(
-        m.get("exists") and m.get("readable") for m in mart_checks
-    )
-    checks.append(
-        {
-            "check": "mart_outputs_readable",
-            "ok": mart_ok,
-            "detail": mart_checks,
-        }
-    )
-
-    # --- Run record coherence (helper condiviso con _check_run_record_coherence) ---
-    rs = run_state(str(config), target_year)
-    run_record = rs.get("latest_run_record")
-    coherence_hints = _check_run_record_coherence(run_record, s.get("layers", {}))
-    run_coherent = len(coherence_hints) == 0
-    if run_coherent:
-        run_detail = f"run record coerente ({run_record.get('status', 'unknown')})" if run_record else "nessun run record (ok se output presenti)"
-    else:
-        run_detail = coherence_hints[0].get("message", "incoerenza run record")
-
-    checks.append({
-        "check": "run_record_coherent",
-        "ok": run_coherent,
-        "detail": run_detail,
-    })
-
-    ok_count = sum(1 for c in checks if c["ok"])
-    fail_count = sum(1 for c in checks if not c["ok"])
-
-    if fail_count == 0:
-        readiness = "ready"
-    elif ok_count >= len(checks) - 1:
-        readiness = "needs-review"
-    else:
-        readiness = "incomplete"
-
-    return {
-        "dataset": s.get("dataset"),
-        "config_path": str(config_path),
-        "year": s.get("year"),
-        "readiness": readiness,
-        "check_count": len(checks),
-        "ok_count": ok_count,
-        "fail_count": fail_count,
-        "checks": checks,
-    }
+    try:
+        return _cli_review_readiness(_safe_path(str(config_path)), year=year)
+    except FileNotFoundError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.CONFIG_NOT_FOUND) from exc
 
 
 def schema_diff(config_path: str) -> dict[str, Any]:

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -150,7 +150,7 @@ def run_state(config_path: str, year: int | None = None) -> dict[str, Any]:
     from toolkit.cli.inspect.readiness_ops import run_state as _cli_run_state
 
     try:
-        return _cli_run_state(_safe_path(str(config_path)), year=year)
+        return _cli_run_state(str(_safe_path(str(config_path))), year=year)
     except FileNotFoundError as exc:
         raise ToolkitClientError(str(exc), code=ErrorCode.CONFIG_NOT_FOUND) from exc
 
@@ -351,7 +351,7 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
     from toolkit.cli.inspect.readiness_ops import summary as _cli_summary
 
     try:
-        return _cli_summary(_safe_path(str(config_path)), year=year)
+        return _cli_summary(str(_safe_path(str(config_path))), year=year)
     except FileNotFoundError as exc:
         raise ToolkitClientError(str(exc), code=ErrorCode.CONFIG_NOT_FOUND) from exc
 
@@ -365,7 +365,7 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
     from toolkit.cli.inspect.readiness_ops import review_readiness as _cli_review_readiness
 
     try:
-        return _cli_review_readiness(_safe_path(str(config_path)), year=year)
+        return _cli_review_readiness(str(_safe_path(str(config_path))), year=year)
     except FileNotFoundError as exc:
         raise ToolkitClientError(str(exc), code=ErrorCode.CONFIG_NOT_FOUND) from exc
 

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -249,14 +249,14 @@ def run_raw(
         inp["origin"] for inp in inputs if inp.get("origin") and str(inp["origin"]).startswith("http")
     ))
 
-    # Calcola righe/colonne del primary output (riusa _csv_quick_shape da helpers condivisi)
+    # Calcola righe/colonne del primary output (riusa csv_quick_shape da toolit.core)
     output_rows = None
     col_count = None
     if primary_output_path.exists() and primary_output_path.suffix.lower() in {".csv", ".tsv", ".txt"}:
         try:
-            from toolkit.cli.inspect._helpers import _csv_quick_shape
+            from toolkit.core.csv_shape import csv_quick_shape
 
-            shape = _csv_quick_shape(str(primary_output_path))
+            shape = csv_quick_shape(str(primary_output_path))
             output_rows = shape.get("row_count_estimate")
             col_count = shape.get("column_count")
         except Exception:

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -249,16 +249,16 @@ def run_raw(
         inp["origin"] for inp in inputs if inp.get("origin") and str(inp["origin"]).startswith("http")
     ))
 
-    # Calcola righe/colonne del primary output (riusa csv_preview già esistente)
+    # Calcola righe/colonne del primary output (riusa _csv_quick_shape da helpers condivisi)
     output_rows = None
     col_count = None
     if primary_output_path.exists() and primary_output_path.suffix.lower() in {".csv", ".tsv", ".txt"}:
         try:
-            from toolkit.cli.inspect.profile_ops import csv_preview
+            from toolkit.cli.inspect._helpers import _csv_quick_shape
 
-            preview = csv_preview(str(primary_output_path), limit=1)
-            output_rows = preview.get("row_count_estimate")
-            col_count = preview.get("column_count")
+            shape = _csv_quick_shape(str(primary_output_path))
+            output_rows = shape.get("row_count_estimate")
+            col_count = shape.get("column_count")
         except Exception:
             pass
 

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -248,4 +248,23 @@ def run_raw(
     source_urls = list(dict.fromkeys(
         inp["origin"] for inp in inputs if inp.get("origin") and str(inp["origin"]).startswith("http")
     ))
-    return {"output_bytes": output_bytes, "source_urls": source_urls}
+
+    # Calcola righe/colonne del primary output (riusa csv_preview già esistente)
+    output_rows = None
+    col_count = None
+    if primary_output_path.exists() and primary_output_path.suffix.lower() in {".csv", ".tsv", ".txt"}:
+        try:
+            from toolkit.cli.inspect.profile_ops import csv_preview
+
+            preview = csv_preview(str(primary_output_path), limit=1)
+            output_rows = preview.get("row_count_estimate")
+            col_count = preview.get("column_count")
+        except Exception:
+            pass
+
+    return {
+        "output_bytes": output_bytes,
+        "source_urls": source_urls,
+        "output_rows": output_rows,
+        "col_count": col_count,
+    }


### PR DESCRIPTION
## Sintesi

Normalizza la frammentazione tra CLI e MCP: le funzioni diagnostiche (show_schema, summary, review_readiness) vivono ora in `cli/inspect/` e sia CLI che MCP le importano da lì. MCP diventa thin wrapper con `ToolkitClientError`.

Include anche:
- run_raw() ora salva output_rows e col_count nel run record (riusa csv_preview)
- `_load_clean_sql` → `load_clean_sql` (pubblica)

## Cosa cambia

- [ ] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

- [ ] Struttura `dataset.yml`
- [ ] Path output
- [ ] Schema parquet
- [x] CLI o MCP tool (nessuna modifica API — solo riorganizzazione interna)
- [ ] API pubblica del toolkit

> `run_raw()` ora ritorna `output_rows` e `col_count` in piu' nel dict — `_execute_layer()` li passa gia' a `set_layer_metrics()` senza modifiche.

## Verifica

```bash
pytest tests/ -q --timeout=30
```

- [x] `pytest tests/` passa — 741 test
- [x] Modificato o aggiunto test con marker appropriato

## Checklist PR

- [x] Perimetro stretto: una PR = un refactor mirato
- [x] Issue collegata o motivazione dell'assenza: audit tecnico concordato col civic-director

## Note per chi revisiona

La PR inverte le dipendenze tra CLI e MCP per 4 funzioni:
- `show_schema` → `cli/inspect/schema_ops.py`
- `summary`, `review_readiness`, `run_state` → `cli/inspect/readiness_ops.py` (nuovo)
- `mcp/_schema_utils.py` diventa re-export lazy da `cli/inspect/_helpers.py`

Rischi: il circolare `cli/inspect/__init__.py` → `url_ops.py` → `cmd_scout.py` → `cmd_run.py` e' pre-esistente. Questa PR lo evita con lazy import in `cmd_run.py`.