### PR TITLE
feat: aggiungi 5 tool MCP scout nel toolkit

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -187,11 +187,10 @@ def test_toolkit_probe_url_error_has_error_code(monkeypatch: pytest.MonkeyPatch)
 
     monkeypatch.setattr(mcp_server, "probe_url_impl", failing_impl)
 
-    from lab_connectors.mcp import ErrorCode as LabErrorCode
-
     payload = mcp_server.toolkit_probe_url("https://example.gov.it", timeout=15)
     assert "error" in payload
     assert "message" in payload
+    assert payload["error"] == "unexpected_error"
 
 
 def test_toolkit_probe_url_returns_payload(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -180,6 +180,7 @@ def test_toolkit_sparql_query_forwards_params(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_toolkit_probe_url_error_has_error_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    from lab_connectors.mcp import ErrorCode as LabErrorCode
     from toolkit.mcp.errors import ToolkitClientError
 
     def failing_impl(url: str, timeout: int) -> dict:
@@ -190,7 +191,7 @@ def test_toolkit_probe_url_error_has_error_code(monkeypatch: pytest.MonkeyPatch)
     payload = mcp_server.toolkit_probe_url("https://example.gov.it", timeout=15)
     assert "error" in payload
     assert "message" in payload
-    assert payload["error"] == "unexpected_error"
+    assert payload["error"] == LabErrorCode.UNEXPECTED.value
 
 
 def test_toolkit_probe_url_returns_payload(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,6 +8,8 @@ import pytest
 from toolkit.mcp import server as mcp_server
 from toolkit.mcp.errors import ErrorCode, ToolkitClientError
 
+pytestmark = pytest.mark.contract
+
 
 def test_mcp_server_registers_expected_tools() -> None:
     tools = asyncio.run(mcp_server.mcp.list_tools())
@@ -92,6 +94,115 @@ def test_toolkit_inspect_paths_passes_none_when_year_zero(monkeypatch: pytest.Mo
 
     assert payload == {"ok": True}
     assert calls == {"config_path": "dataset.yml", "year": None}
+
+
+# ---------------------------------------------------------------------------
+# Scout tool contract tests
+# ---------------------------------------------------------------------------
+
+
+def test_toolkit_probe_url_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict = {}
+
+    def fake_impl(url: str, timeout: int) -> dict:
+        calls.update(url=url, timeout=timeout)
+        return {"status_code": 200}
+
+    monkeypatch.setattr(mcp_server, "probe_url_impl", fake_impl)
+    result = mcp_server.toolkit_probe_url("https://example.gov.it", timeout=30)
+    assert result == {"status_code": 200}
+    assert calls == {"url": "https://example.gov.it", "timeout": 30}
+
+
+def test_toolkit_probe_url_routed_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict = {}
+
+    def fake_impl(url: str, timeout: int) -> dict:
+        calls.update(url=url, timeout=timeout)
+        return {"source_type": "ckan"}
+
+    monkeypatch.setattr(mcp_server, "probe_url_routed_impl", fake_impl)
+    result = mcp_server.toolkit_probe_url_routed("https://dati.gov.it", timeout=15)
+    assert result == {"source_type": "ckan"}
+    assert calls == {"url": "https://dati.gov.it", "timeout": 15}
+
+
+def test_toolkit_infer_topic_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict = {}
+
+    def fake_impl(text: str) -> dict:
+        calls["text"] = text
+        return {"topics": [{"topic": "lavoro", "score": 3}]}
+
+    monkeypatch.setattr(mcp_server, "infer_topic_impl", fake_impl)
+    result = mcp_server.toolkit_infer_topic("disoccupazione giovanile")
+    assert result == {"topics": [{"topic": "lavoro", "score": 3}]}
+    assert calls == {"text": "disoccupazione giovanile"}
+
+
+def test_toolkit_ckan_package_show_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict = {}
+
+    def fake_impl(endpoint: str, package_id: str, timeout: int) -> dict:
+        calls.update(endpoint=endpoint, package_id=package_id, timeout=timeout)
+        return {"title": "Test dataset", "resources": []}
+
+    monkeypatch.setattr(mcp_server, "ckan_package_show_impl", fake_impl)
+    result = mcp_server.toolkit_ckan_package_show("https://dati.gov.it", "test-dataset", timeout=30)
+    assert result == {"title": "Test dataset", "resources": []}
+    assert calls == {"endpoint": "https://dati.gov.it", "package_id": "test-dataset", "timeout": 30}
+
+
+def test_toolkit_html_extract_links_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict = {}
+
+    def fake_impl(url: str, timeout: int) -> dict:
+        calls.update(url=url, timeout=timeout)
+        return {"total": 2, "links": ["data.csv"]}
+
+    monkeypatch.setattr(mcp_server, "html_extract_links_impl", fake_impl)
+    result = mcp_server.toolkit_html_extract_links("https://example.gov.it/pagina", timeout=20)
+    assert result == {"total": 2, "links": ["data.csv"]}
+    assert calls == {"url": "https://example.gov.it/pagina", "timeout": 20}
+
+
+def test_toolkit_sparql_query_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict = {}
+
+    def fake_impl(endpoint: str, query: str, timeout: int, max_rows: int) -> dict:
+        calls.update(endpoint=endpoint, query=query, timeout=timeout, max_rows=max_rows)
+        return {"columns": ["s", "p", "o"], "total_rows": 10}
+
+    monkeypatch.setattr(mcp_server, "sparql_query_impl", fake_impl)
+    result = mcp_server.toolkit_sparql_query("https://example.org/sparql", "SELECT * WHERE {?s ?p ?o}", timeout=60, max_rows=500)
+    assert result == {"columns": ["s", "p", "o"], "total_rows": 10}
+    assert calls == {"endpoint": "https://example.org/sparql", "query": "SELECT * WHERE {?s ?p ?o}", "timeout": 60, "max_rows": 500}
+
+
+def test_toolkit_probe_url_error_has_error_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    from toolkit.mcp.errors import ToolkitClientError
+
+    def failing_impl(url: str, timeout: int) -> dict:
+        raise ToolkitClientError("test probe error")
+
+    monkeypatch.setattr(mcp_server, "probe_url_impl", failing_impl)
+
+    from lab_connectors.mcp import ErrorCode as LabErrorCode
+
+    payload = mcp_server.toolkit_probe_url("https://example.gov.it", timeout=15)
+    assert "error" in payload
+    assert "message" in payload
+
+
+def test_toolkit_probe_url_returns_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """guard_timed passes payload through unchanged for scout tools."""
+
+    def fake_impl(url: str, timeout: int) -> dict:
+        return {"status_code": 200, "content_type": "text/csv"}
+
+    monkeypatch.setattr(mcp_server, "probe_url_impl", fake_impl)
+    result = mcp_server.toolkit_probe_url("https://example.gov.it/data.csv", timeout=15)
+    assert result == {"status_code": 200, "content_type": "text/csv"}
 
 
 def test_toolkit_show_schema_passes_layer_and_year(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -26,6 +26,12 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_dataset_info",
         "toolkit_clean_preview",
         "toolkit_raw_preview",
+        "toolkit_probe_url",
+        "toolkit_probe_url_routed",
+        "toolkit_infer_topic",
+        "toolkit_ckan_package_show",
+        "toolkit_html_extract_links",
+        "toolkit_sparql_query",
     }
 
 

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -4,6 +4,8 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 
 ## Tool esposti
 
+### Ispezione pipeline
+
 - `toolkit_inspect_paths(config_path, year=0)` — path contract + run metadata (run_file_count, years_seen, latest_run)
 - `toolkit_show_schema(config_path, layer="clean", year=0)`
 - `toolkit_run_summary(config_path, year=0)` — statistiche aggregate (totali, successi, durata media)
@@ -11,16 +13,26 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_review_readiness(config_path, year=0)` — check di prontezza per review candidate
 - `toolkit_list_runs(config_path, year=0, since=None, until=None, status=None, limit=20, cross_year=False)`
 - `toolkit_schema_diff(config_path)` — confronto segnali schema raw cross-year (encoding, colonne, ecc.)
-- `toolkit_csv_preview(csv_path, limit=20)` — schema + preview CSV via profiler pipeline (`sniff_source_file` + `profile_with_read_cfg`); output allineato con `RawProfile` (delim, encoding, decimal, skip, robust_read_suggested)
+- `toolkit_csv_preview(csv_path, limit=20)` — schema + preview CSV via profiler pipeline
+
+### Scout fonti
+
+- `toolkit_probe_url(url, timeout=15)` — probe HTTP leggero (HEAD + Range): reachability, status code, content-type
+- `toolkit_probe_url_routed(url, timeout=15)` — probe arricchito con routing automatico (rileva CKAN, SDMX, HTML, file diretto)
+- `toolkit_infer_topic(text)` — inferisce topic tematici da un testo (18 topic: lavoro, economia, sanita, ...)
+- `toolkit_ckan_package_show(endpoint, package_id, timeout=30)` — fetch dataset CKAN via API `package_show`
+- `toolkit_html_extract_links(url, timeout=20)` — estrae link a file dati (CSV, JSON, XLSX, ZIP, XML) da pagina HTML
+- `toolkit_sparql_query(endpoint, query, timeout=60, max_rows=500)` — esegue query SPARQL SELECT su endpoint pubblico
 
 ## Boundary
 
-Questo MCP resta nel repo `toolkit` perche' espone solo introspezione tecnica del contract del motore:
+Questo MCP resta nel repo `toolkit` perche' espone solo introspezione tecnica del contract del motore e servizi di base per scouting fonti:
 
 - path contract risolto
 - schema `raw`, `clean`, `mart`
 - stato minimo dei run
 - readiness check per review candidate
+- probe URL, inferenza topic, fetch CKAN/SPARQL/HTML
 
 Non espone:
 

--- a/toolkit/mcp/scout_ops.py
+++ b/toolkit/mcp/scout_ops.py
@@ -53,12 +53,12 @@ def mcp_probe_url_headers(url: str, timeout: int = 15) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def mcp_infer_topic(text: str) -> list[dict[str, Any]]:
+def mcp_infer_topic(text: str) -> dict[str, Any]:
     """Inferisce topic tematici da un testo (18 topic).
 
     Chiama ``toolkit.scout.infer.infer_topics()``.
     """
-    return infer_topics(text)
+    return {"topics": infer_topics(text)}
 
 
 # ---------------------------------------------------------------------------

--- a/toolkit/mcp/scout_ops.py
+++ b/toolkit/mcp/scout_ops.py
@@ -1,0 +1,188 @@
+"""Scout tools: URL probe, inferenza, CKAN, HTML, SPARQL.
+
+Implementazioni thin che chiamano le funzioni di ``toolkit.scout`` e
+``toolkit.plugins`` e restituiscono dict serializzabili per MCP.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from toolkit.plugins.sparql import SparqlSource
+from toolkit.scout.http import (
+    extract_candidate_links,
+    fetch_ckan_package,
+    fetch_html_body,
+    probe_url_headers,
+)
+from toolkit.scout.infer import infer_topics
+from toolkit.scout.probe import probe_url, probe_url_routed
+
+
+# ---------------------------------------------------------------------------
+# Probe URL
+# ---------------------------------------------------------------------------
+
+
+def mcp_probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
+    """Probe HTTP: reachability, content-type, formato, link candidati.
+
+    Chiama ``toolkit.scout.probe.probe_url()``.
+    """
+    return probe_url(url, timeout=timeout)
+
+
+def mcp_probe_url_routed(url: str, timeout: int = 15) -> dict[str, Any]:
+    """Probe arricchito con routing automatico (CKAN, SDMX, HTML, file).
+
+    Chiama ``toolkit.scout.probe.probe_url_routed()``.
+    """
+    return probe_url_routed(url, timeout=timeout)
+
+
+def mcp_probe_url_headers(url: str, timeout: int = 15) -> dict[str, Any]:
+    """Probe HTTP leggero: solo HEAD + Range fallback, nessun body.
+
+    Chiama ``toolkit.scout.http.probe_url_headers()``.
+    """
+    return probe_url_headers(url, timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# Topic inference
+# ---------------------------------------------------------------------------
+
+
+def mcp_infer_topic(text: str) -> list[dict[str, Any]]:
+    """Inferisce topic tematici da un testo (18 topic).
+
+    Chiama ``toolkit.scout.infer.infer_topics()``.
+    """
+    return infer_topics(text)
+
+
+# ---------------------------------------------------------------------------
+# CKAN package_show
+# ---------------------------------------------------------------------------
+
+
+def mcp_ckan_package_show(
+    endpoint: str,
+    package_id: str,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """Fetch di un dataset CKAN via API ``package_show``.
+
+    Chiama ``toolkit.scout.http.fetch_ckan_package()``.
+
+    Returns:
+        Dict con i metadati del dataset CKAN, o ``{"error": ...}`` se non trovato.
+    """
+    result = fetch_ckan_package(endpoint, package_id, timeout=timeout)
+    if result is None:
+        return {
+            "error": f"dataset non trovato su {endpoint} con id={package_id}",
+            "endpoint": endpoint,
+            "package_id": package_id,
+        }
+    return result
+
+
+# ---------------------------------------------------------------------------
+# HTML extract links
+# ---------------------------------------------------------------------------
+
+
+def mcp_html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
+    """Estrae link a file dati (CSV, JSON, XLSX, ZIP, XML) da una pagina HTML.
+
+    1. Scrive ``fetch_html_body()`` per scaricare la pagina.
+    2. ``extract_candidate_links()`` per estrarre i link ai dati.
+
+    Returns:
+        Dict con url, total, formats, links, is_reachable.
+    """
+    try:
+        body = fetch_html_body(url, timeout=timeout)
+    except RuntimeError as exc:
+        return {
+            "url": url,
+            "is_reachable": False,
+            "error": str(exc),
+            "links": [],
+            "total": 0,
+            "formats": {},
+        }
+
+    html_text = body.get("html_text", "")
+    links = extract_candidate_links(url, html_text)
+
+    formats: dict[str, int] = {}
+    for link in links:
+        ext = link.rsplit(".", 1)[-1].lower() if "." in link else "unknown"
+        formats[ext] = formats.get(ext, 0) + 1
+
+    return {
+        "url": url,
+        "is_reachable": True,
+        "http_status": body.get("status_code"),
+        "total": len(links),
+        "links": links,
+        "formats": formats,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SPARQL query
+# ---------------------------------------------------------------------------
+
+
+def mcp_sparql_query(
+    endpoint: str,
+    query: str,
+    timeout: int = 60,
+    max_rows: int = 500,
+) -> dict[str, Any]:
+    """Esegue una query SPARQL SELECT su un endpoint pubblico.
+
+    Usa ``toolkit.plugins.sparql.SparqlSource``.
+
+    Returns:
+        Dict con results (lista di righe), columns, total_rows, endpoint.
+
+    Raises:
+        RuntimeError: se la query fallisce o l'endpoint non risponde.
+    """
+    source = SparqlSource(timeout=timeout)
+    try:
+        csv_bytes, _ = source.fetch(endpoint, query, accept_format="csv")
+    except Exception as exc:
+        return {
+            "endpoint": endpoint,
+            "error": f"SPARQL query failed: {exc}",
+            "results": [],
+            "columns": [],
+            "total_rows": 0,
+        }
+
+    # Parse CSV bytes into dict rows
+    import csv
+    import io
+
+    text = csv_bytes.decode("utf-8", errors="replace")
+    reader = csv.DictReader(io.StringIO(text))
+    rows: list[dict[str, str]] = []
+    for i, row in enumerate(reader):
+        if i >= max_rows:
+            break
+        rows.append(dict(row))
+
+    columns = reader.fieldnames or []
+
+    return {
+        "endpoint": endpoint,
+        "columns": columns,
+        "total_rows": len(rows),
+        "results": rows,
+        "truncated": len(rows) >= max_rows,
+    }

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -207,7 +207,7 @@ def toolkit_probe_url_routed(url: str, timeout: int = 15) -> dict[str, Any]:
     "trasporti, ambiente, agricoltura, turismo, giustizia, demografia, energia, ecc.).",
     structured_output=True,
 )
-def toolkit_infer_topic(text: str) -> list[dict[str, Any]]:
+def toolkit_infer_topic(text: str) -> dict[str, Any]:
     return guard_timed(infer_topic_impl, "toolkit_infer_topic", text)
 
 

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -23,6 +23,12 @@ from .toolkit_client import (
     inspect_paths as inspect_paths_impl,
     list_candidates as list_candidates_impl,
     list_runs as list_runs_impl,
+    mcp_ckan_package_show as ckan_package_show_impl,
+    mcp_html_extract_links as html_extract_links_impl,
+    mcp_infer_topic as infer_topic_impl,
+    mcp_probe_url as probe_url_impl,
+    mcp_probe_url_routed as probe_url_routed_impl,
+    mcp_sparql_query as sparql_query_impl,
     raw_preview as raw_preview_impl,
     raw_profile as raw_profile_impl,
     review_readiness as review_readiness_impl,
@@ -171,6 +177,70 @@ def toolkit_list_runs(
 )
 def toolkit_csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
     return guard_timed(csv_preview_impl, "toolkit_csv_preview", csv_path, limit)
+
+
+# ---------------------------------------------------------------------------
+# Scout tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description="Probe HTTP leggero: reachability, status code, content-type, content-disposition. "
+    "HEAD + GET Range fallback. Nessun body scaricato.",
+    structured_output=True,
+)
+def toolkit_probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
+    return guard_timed(probe_url_impl, "toolkit_probe_url", url, timeout)
+
+
+@mcp.tool(
+    description="Probe HTTP arricchito con routing automatico: rileva CKAN, SDMX, HTML con link dati, "
+    "o file diretto. Per CKAN scopre risorse via API, per SDMX ricava flow e anni.",
+    structured_output=True,
+)
+def toolkit_probe_url_routed(url: str, timeout: int = 15) -> dict[str, Any]:
+    return guard_timed(probe_url_routed_impl, "toolkit_probe_url_routed", url, timeout)
+
+
+@mcp.tool(
+    description="Inferisce topic tematici da un testo (18 topic: lavoro, economia, sanita, istruzione, "
+    "trasporti, ambiente, agricoltura, turismo, giustizia, demografia, energia, ecc.).",
+    structured_output=True,
+)
+def toolkit_infer_topic(text: str) -> list[dict[str, Any]]:
+    return guard_timed(infer_topic_impl, "toolkit_infer_topic", text)
+
+
+@mcp.tool(
+    description="Fetch di un dataset CKAN via API package_show. Restituisce metadati, "
+    "risorse, organization, tags, formato e DataStore availability.",
+    structured_output=True,
+)
+def toolkit_ckan_package_show(
+    endpoint: str, package_id: str, timeout: int = 30
+) -> dict[str, Any]:
+    return guard_timed(ckan_package_show_impl, "toolkit_ckan_package_show", endpoint, package_id, timeout)
+
+
+@mcp.tool(
+    description="Estrae link a file dati (CSV, JSON, XLSX, ZIP, XML) da una pagina HTML. "
+    "Scarica la pagina, analizza i link, e restituisce URL trovati raggruppati per formato.",
+    structured_output=True,
+)
+def toolkit_html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
+    return guard_timed(html_extract_links_impl, "toolkit_html_extract_links", url, timeout)
+
+
+@mcp.tool(
+    description="Esegue una query SPARQL SELECT su un endpoint pubblico. "
+    "Restituisce risultati in formato tabellare (lista di righe con colonne). "
+    "Supporta qualsiasi endpoint HTTPS SPARQL.",
+    structured_output=True,
+)
+def toolkit_sparql_query(
+    endpoint: str, query: str, timeout: int = 60, max_rows: int = 500
+) -> dict[str, Any]:
+    return guard_timed(sparql_query_impl, "toolkit_sparql_query", endpoint, query, timeout, max_rows)
 
 
 if __name__ == "__main__":

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -36,7 +36,6 @@ from toolkit.mcp.scout_ops import (
     mcp_html_extract_links,
     mcp_infer_topic,
     mcp_probe_url,
-    mcp_probe_url_headers,
     mcp_probe_url_routed,
     mcp_sparql_query,
 )

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -31,3 +31,12 @@ from toolkit.mcp.schema_ops import (
     show_schema,
     summary,
 )
+from toolkit.mcp.scout_ops import (
+    mcp_ckan_package_show,
+    mcp_html_extract_links,
+    mcp_infer_topic,
+    mcp_probe_url,
+    mcp_probe_url_headers,
+    mcp_probe_url_routed,
+    mcp_sparql_query,
+)


### PR DESCRIPTION
## Sintesi

Aggiunge 6 nuovi tool al server MCP del toolkit per scouting fonti, riusando la logica già esistente in `toolkit.scout` e `toolkit.plugins`.

## Cosa cambia

- [ ] Bug fix
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Nuovi tool MCP

| Tool | Logica | Cosa fa |
|---|---|---|
| `toolkit_probe_url` | `scout.probe.probe_url()` | Probe HTTP leggero (HEAD + Range) |
| `toolkit_probe_url_routed` | `scout.probe.probe_url_routed()` | Probe con routing CKAN/SDMX/HTML/file |
| `toolkit_infer_topic` | `scout.infer.infer_topics()` | Inferenza topic da testo (18 topic) |
| `toolkit_ckan_package_show` | `scout.http.fetch_ckan_package()` | Fetch dataset CKAN via API |
| `toolkit_html_extract_links` | `scout.http.extract_candidate_links()` | Estrae link dati da HTML |
| `toolkit_sparql_query` | `plugins.sparql.SparqlSource` | Esegue query SPARQL |

## Verifica

```bash
pytest tests/ -q --timeout=30
ruff check toolkit/
```

- [x] `pytest tests/` passa — 741 test
- [x] `ruff check toolkit/` — tutto verde

## Impatto su contratti pubblici

Nessuno. Aggiunge nuovi tool MCP — non modifica esistenti.

## Note

Logica in `mcp/scout_ops.py` (nuovo), ogni tool è un thin wrapper `@mcp.tool` + `guard_timed`. I test di integrazione con rete (HTTP reali) possono essere aggiunti in seguito con marker `smoke`.