### PR TITLE
fix: `run --smoke` isola output in {root}/smoke/ e marca run record

### DIFF
--- a/tests/test_cli_path_contract.py
+++ b/tests/test_cli_path_contract.py
@@ -211,6 +211,85 @@ def test_cli_root_flag_overrides_output(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# smoke flag — output isolation + run record marker
+# ---------------------------------------------------------------------------
+
+
+def test_cli_run_smoke_isolates_output(tmp_path: Path) -> None:
+    """contract: --smoke in 'run all' scrive in {root}/smoke/ non in {root}/data/."""
+    project_dir = tmp_path / "project-example"
+    config_path = _copy_project_example(project_dir)
+    root_dir = project_dir / "_smoke_out"
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        ["run", "all", "--config", str(config_path), "--smoke", "--strict-config"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    # Smoke output DEVE essere in _smoke_out/smoke/data/
+    smoke_clean = root_dir / "smoke" / "data" / "clean" / "project_example" / "2022" / "project_example_2022_clean.parquet"
+    assert smoke_clean.exists(), f"smoke clean not found: {smoke_clean}"
+    smoke_mart = root_dir / "smoke" / "data" / "mart" / "project_example" / "2022" / "rd_by_regione.parquet"
+    assert smoke_mart.exists(), f"smoke mart not found: {smoke_mart}"
+
+    # NO output in _smoke_out/data/ (root normale non contaminata)
+    clean_out = root_dir / "data" / "clean" / "project_example" / "2022"
+    assert not clean_out.exists(), "smoke must NOT write to root/data/"
+
+
+def test_cli_run_full_smoke_isolates_output(tmp_path: Path) -> None:
+    """contract: --smoke in 'run full' scrive in {root}/smoke/ non in {root}/data/."""
+    project_dir = tmp_path / "project-example"
+    config_path = _copy_project_example(project_dir)
+    root_dir = project_dir / "_smoke_out"
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        ["run", "full", "--config", str(config_path), "--smoke", "--strict-config"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    # Smoke output in _smoke_out/smoke/data/
+    smoke_clean = root_dir / "smoke" / "data" / "clean" / "project_example" / "2022" / "project_example_2022_clean.parquet"
+    assert smoke_clean.exists(), f"smoke clean not found: {smoke_clean}"
+    smoke_mart = root_dir / "smoke" / "data" / "mart" / "project_example" / "2022" / "rd_by_regione.parquet"
+    assert smoke_mart.exists(), f"smoke mart not found: {smoke_mart}"
+
+    # NO output in _smoke_out/data/
+    clean_out = root_dir / "data" / "clean" / "project_example" / "2022"
+    assert not clean_out.exists(), "run full --smoke must NOT write to root/data/"
+
+
+def test_cli_run_smoke_run_record_marked(tmp_path: Path) -> None:
+    """contract: run record da 'run all --smoke' contiene smoke: true."""
+    project_dir = tmp_path / "project-example"
+    config_path = _copy_project_example(project_dir)
+    root_dir = project_dir / "_smoke_out"
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        ["run", "all", "--config", str(config_path), "--smoke", "--strict-config"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    # Trova il run record più recente in _smoke_out/smoke/data/_runs/project_example/2022/
+    runs_dir = root_dir / "smoke" / "data" / "_runs" / "project_example" / "2022"
+    assert runs_dir.exists(), f"runs dir not found: {runs_dir}"
+    records = sorted(runs_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    assert len(records) >= 1, "no run record found"
+
+    latest = json.loads(records[0].read_text(encoding="utf-8"))
+    assert latest.get("smoke") is True, f"expected smoke=True in run record, got: {latest.get('smoke')}"
+
+
+# ---------------------------------------------------------------------------
 # toolkit.contracts path API
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cli_path_contract.py
+++ b/tests/test_cli_path_contract.py
@@ -289,6 +289,86 @@ def test_cli_run_smoke_run_record_marked(tmp_path: Path) -> None:
     assert latest.get("smoke") is True, f"expected smoke=True in run record, got: {latest.get('smoke')}"
 
 
+def test_cli_run_full_smoke_isolates_support_output(tmp_path: Path) -> None:
+    """contract: 'run full --smoke' isola output di candidate E support in {root}/smoke/."""
+    project_dir = tmp_path / "project"
+    config_path = _copy_project_example(project_dir)
+    root_dir = project_dir / "_smoke_out"
+
+    # Crea un support dataset minimale
+    support_dir = tmp_path / "support_ds"
+    (support_dir / "data").mkdir(parents=True)
+    (support_dir / "sql").mkdir(parents=True)
+    (support_dir / "sql" / "clean.sql").write_text(
+        "SELECT 1 AS ok FROM raw_input\n", encoding="utf-8"
+    )
+    (support_dir / "data" / "dummy.csv").write_text("a;b\n1;2\n", encoding="utf-8")
+    (support_dir / "sql" / "mart.sql").write_text(
+        "SELECT * FROM clean_input\n", encoding="utf-8"
+    )
+    (support_dir / "dataset.yml").write_text(
+        """schema_version: 1
+root: out
+dataset:
+  name: support_ds
+  years: [2022]
+raw:
+  sources:
+    - name: csv
+      type: local_file
+      args:
+        path: data/dummy.csv
+        filename: support_ds_2022.csv
+clean:
+  sql: sql/clean.sql
+mart:
+  tables:
+    - name: support_mart
+      sql: sql/mart.sql
+""",
+        encoding="utf-8",
+    )
+
+    # Aggiunge il support al candidate dataset.yml
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8")
+        + f"""
+support:
+  - name: "sup"
+    config: "{support_dir / 'dataset.yml'}"
+    years: [2022]
+""",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["run", "full", "--config", str(config_path), "--smoke", "--years", "2022"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    # Candidate output in _smoke_out/smoke/data/
+    smoke_clean = root_dir / "smoke" / "data" / "clean" / "project_example" / "2022" / "project_example_2022_clean.parquet"
+    assert smoke_clean.exists(), f"candidate smoke clean not found: {smoke_clean}"
+    smoke_mart = root_dir / "smoke" / "data" / "mart" / "project_example" / "2022" / "rd_by_regione.parquet"
+    assert smoke_mart.exists(), f"candidate smoke mart not found: {smoke_mart}"
+
+    # Niente candidate in _smoke_out/data/
+    clean_out = root_dir / "data" / "clean" / "project_example" / "2022"
+    assert not clean_out.exists(), "candidate smoke must NOT write to root/data/"
+
+    # Support output in support_ds/out/smoke/data/
+    sup_root = support_dir / "out"
+    sup_clean = sup_root / "smoke" / "data" / "clean" / "support_ds" / "2022" / "support_ds_2022_clean.parquet"
+    assert sup_clean.exists(), f"support smoke clean not found: {sup_clean}"
+
+    # Niente support in support_ds/out/data/
+    sup_clean_out = sup_root / "data" / "clean" / "support_ds" / "2022"
+    assert not sup_clean_out.exists(), "support smoke must NOT write to support root/data/"
+
+
 # ---------------------------------------------------------------------------
 # toolkit.contracts path API
 # ---------------------------------------------------------------------------

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -333,6 +333,7 @@ def run_year(
             output_cfg=dump_cfg_section(cfg.output),
             support_cfg=dump_cfg_section(cfg.support),
             source_id=source_id,
+            smoke=smoke,
         )
 
     context.complete_run(success_with_warnings=run_has_validation_warnings)
@@ -370,6 +371,7 @@ def _maybe_run_multi_year_mart(
     *,
     dry_run: bool = False,
     logger=None,
+    smoke: bool = False,
 ) -> None:
     """Run multi-year MART tables if any table has explicit ``years``.
 
@@ -405,6 +407,7 @@ def _maybe_run_multi_year_mart(
             output_cfg=dump_cfg_section(cfg.output),
             support_cfg=dump_cfg_section(cfg.support),
             source_id=cfg.source_id,
+            smoke=smoke,
         )
     except Exception as exc:
         if fail_on_error:
@@ -480,7 +483,7 @@ def _make_step_cmd(step: str):
 
         # Multi-year mart: run once per dataset after per-year processing
         if _step in ("all", "mart"):
-            _maybe_run_multi_year_mart(cfg, selected_years, dry_run=dry_flag, logger=logger)
+            _maybe_run_multi_year_mart(cfg, selected_years, dry_run=dry_flag, logger=logger, smoke=smoke)
 
     cmd.__name__ = f"run_{_step}_cmd"
     cmd.__doc__ = f"Esegue lo step {_step} della pipeline."
@@ -639,9 +642,17 @@ def run_full(
                 continue
 
             try:
-                support_cfg, support_logger = load_cfg_and_logger(
-                    str(entry.config), strict_config=strict_flag
-                )
+                # Smoke mode: isola output del support in {root}/smoke (come il candidate)
+                if smoke:
+                    _sup0, _ = load_cfg_and_logger(str(entry.config), strict_config=strict_flag)
+                    support_cfg, support_logger = load_cfg_and_logger(
+                        str(entry.config), strict_config=strict_flag,
+                        root_override=str(_sup0.root / "smoke"),
+                    )
+                else:
+                    support_cfg, support_logger = load_cfg_and_logger(
+                        str(entry.config), strict_config=strict_flag
+                    )
             except Exception as exc:
                 logger.error("Support: cannot load config %s: %s", entry.config, exc)
                 results["status"] = "failed"
@@ -650,7 +661,9 @@ def run_full(
             for sy in entry.years:
                 logger.info("Support: running %s year=%s", entry.name, sy)
                 try:
-                    run_year(support_cfg, sy, step="all", logger=support_logger)
+                    run_year(support_cfg, sy, step="all", logger=support_logger,
+                             sample_rows=sample_rows_final, sample_bytes=sample_bytes_final,
+                             smoke=smoke)
                 except Exception as exc:
                     logger.error("Support run failed: %s year=%s — %s", entry.name, sy, exc)
                     results["status"] = "failed"
@@ -725,7 +738,7 @@ def run_full(
         # Multi-year mart: run once per dataset after per-year processing
         if not dry_flag and _has_multi_year_mart(cfg):
             try:
-                _maybe_run_multi_year_mart(cfg, selected_years, dry_run=False, logger=logger)
+                _maybe_run_multi_year_mart(cfg, selected_years, dry_run=False, logger=logger, smoke=smoke)
                 results["multi_year_mart"] = "ok"
             except Exception as exc:
                 results["multi_year_mart"] = f"failed: {exc}"

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -199,6 +199,7 @@ def run_year(
     resumed_from: str | None = None,
     sample_rows: int | None = None,
     sample_bytes: int | None = None,
+    smoke: bool = False,
 ) -> RunContext:
     if logger is None:
         logger = get_logger()
@@ -207,7 +208,7 @@ def run_year(
     planned_layers = _validate_execution_plan(cfg, step)
     layers_to_run = _layers_from_start(planned_layers, start_from_layer)
 
-    context = RunContext(cfg.dataset, year, root=cfg.root, resumed_from=resumed_from)
+    context = RunContext(cfg.dataset, year, root=cfg.root, resumed_from=resumed_from, smoke=smoke)
     base_logger = bind_logger(
         logger,
         dataset=cfg.dataset,
@@ -455,18 +456,27 @@ def _make_step_cmd(step: str):
         strict_config: bool = typer.Option(False, "--strict-config", help="Treat deprecated config forms as errors"),
     ):
         strict_flag = strict_config if isinstance(strict_config, bool) else False
-        cfg, logger = load_cfg_and_logger(config, strict_config=strict_flag, root_override=root)
-
         dry_flag = dry_run if isinstance(dry_run, bool) else False
-        years_arg = years if isinstance(years, str) else None
-        year_arg = year if isinstance(year, int) else None
-        selected_years = iter_selected_years(cfg, year_arg=year_arg, years_arg=years_arg)
+
         sample_rows_final = 1000 if smoke else sample_rows
         sample_bytes_final = 1048576 if smoke else sample_bytes
 
+        # Smoke mode: isola output in {root}/smoke (come batch --smoke)
+        root_override_final = root
+        if smoke and not root:
+            _cfg0, _ = load_cfg_and_logger(config, strict_config=strict_flag)
+            root_override_final = str(_cfg0.root / "smoke")
+
+        cfg, logger = load_cfg_and_logger(config, strict_config=strict_flag, root_override=root_override_final)
+
+        years_arg = years if isinstance(years, str) else None
+        year_arg = year if isinstance(year, int) else None
+        selected_years = iter_selected_years(cfg, year_arg=year_arg, years_arg=years_arg)
+
         for year in selected_years:
             run_year(cfg, year, step=_step, dry_run=dry_flag, logger=logger,
-                     sample_rows=sample_rows_final, sample_bytes=sample_bytes_final)
+                     sample_rows=sample_rows_final, sample_bytes=sample_bytes_final,
+                     smoke=smoke)
 
         # Multi-year mart: run once per dataset after per-year processing
         if _step in ("all", "mart"):
@@ -587,13 +597,21 @@ def run_full(
     automaticamente prima del candidate (run all + validate per ogni anno).
     """
     strict_flag = strict_config if isinstance(strict_config, bool) else False
-    cfg, logger = load_cfg_and_logger(config, strict_config=strict_flag, root_override=root)
-    years_arg = years if isinstance(years, str) else None
-    selected_years = iter_selected_years(cfg, year_arg=None, years_arg=years_arg)
     dry_flag = dry_run if isinstance(dry_run, bool) else False
+
     sample_rows_final = 1000 if smoke else sample_rows
     sample_bytes_final = 1048576 if smoke else sample_bytes
     sample_mode = sample_rows_final is not None or sample_bytes_final is not None
+
+    # Smoke mode: isola output in {root}/smoke (come batch --smoke)
+    root_override_final = root
+    if smoke and not root:
+        _cfg0, _ = load_cfg_and_logger(config, strict_config=strict_flag)
+        root_override_final = str(_cfg0.root / "smoke")
+
+    cfg, logger = load_cfg_and_logger(config, strict_config=strict_flag, root_override=root_override_final)
+    years_arg = years if isinstance(years, str) else None
+    selected_years = iter_selected_years(cfg, year_arg=None, years_arg=years_arg)
 
     results: dict[str, Any] = {
         "config": config,
@@ -672,7 +690,8 @@ def run_full(
         for year in selected_years:
             logger.info("Run %s — year=%s", run_step, year)
             run_year(cfg, year, step=run_step, dry_run=dry_flag, logger=logger,
-                     sample_rows=sample_rows_final, sample_bytes=sample_bytes_final)
+                     sample_rows=sample_rows_final, sample_bytes=sample_bytes_final,
+                     smoke=smoke)
 
             if not dry_flag:
                 if is_mart_only:

--- a/toolkit/core/run_context.py
+++ b/toolkit/core/run_context.py
@@ -62,11 +62,13 @@ class RunContext:
         *,
         root: Path | str,
         resumed_from: str | None = None,
+        smoke: bool = False,
     ) -> None:
         self.dataset = dataset
         self.year = year
         self.root = Path(root)
         self.resumed_from = resumed_from
+        self.smoke = smoke
         self.run_id = f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}_{uuid.uuid4().hex[:8]}"
         self.started_at = _now_iso()
         self.finished_at: str | None = None
@@ -109,6 +111,7 @@ class RunContext:
             "validations": self.validations,
             "source_urls": self.source_urls,
             "resumed_from": self.resumed_from,
+            "smoke": self.smoke,
             "error": self.error,
         }
 

--- a/toolkit/core/support.py
+++ b/toolkit/core/support.py
@@ -28,13 +28,19 @@ def resolve_support_payloads(
     support_entries: list[dict[str, Any]] | None,
     *,
     require_exists: bool,
+    smoke: bool = False,
 ) -> list[dict[str, Any]]:
     resolved: list[dict[str, Any]] = []
     for entry in support_entries or []:
         name = str(entry["name"])
         config_path = Path(entry["config"])
         years = [int(year) for year in entry.get("years") or []]
-        support_cfg = load_config(config_path)
+        # Smoke mode: output del support e' in {root}/smoke/data/... (root override eseguito in run_full)
+        if smoke:
+            _sup0 = load_config(config_path)
+            support_cfg = load_config(config_path, root_override=_sup0.root / "smoke")
+        else:
+            support_cfg = load_config(config_path)
 
         year_payloads: list[dict[str, Any]] = []
         all_outputs: list[str] = []

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -35,6 +35,7 @@ def run_mart_multi_year(
     output_cfg: dict[str, Any] | None = None,
     support_cfg: list[dict[str, Any]] | None = None,
     source_id: str | None = None,
+    smoke: bool = False,
 ) -> dict[str, Any]:
     """Run multi-year MART tables (tables with explicit ``years`` in config).
 
@@ -60,7 +61,7 @@ def run_mart_multi_year(
     if not multi_year_tables:
         return {"output_rows": 0, "output_bytes": 0, "tables_count": 0, "col_count": None}
 
-    support_payloads = resolve_support_payloads(support_cfg, require_exists=True)
+    support_payloads = resolve_support_payloads(support_cfg, require_exists=True, smoke=smoke)
     base_ctx = build_runtime_template_ctx(
         dataset=dataset,
         year=dataset_years[0] if dataset_years else 0,
@@ -303,6 +304,7 @@ def run_mart(
     output_cfg: dict[str, Any] | None = None,
     support_cfg: list[dict[str, Any]] | None = None,
     source_id: str | None = None,
+    smoke: bool = False,
 ):
     mart_cfg = ensure_dict(mart_cfg)
     clean_cfg = ensure_dict(clean_cfg)
@@ -346,7 +348,7 @@ def run_mart(
                 "(add explicit tables or a hierarchy section)"
             )
 
-        support_payloads = resolve_support_payloads(support_cfg, require_exists=True)
+        support_payloads = resolve_support_payloads(support_cfg, require_exists=True, smoke=smoke)
         template_ctx = build_runtime_template_ctx(
             dataset=dataset,
             year=year,


### PR DESCRIPTION
## Bugfix: smoke output isolation + run record marker

### Problema
`toolkit run raw/clean/mart/all --smoke` e `toolkit run full --smoke` scrivevano dati campionati nella **root normale** (`{root}/data/...`), rischiando di contaminare dati reali. `toolkit batch --smoke` invece isolava correttamente in `{root}/smoke/`. Inoltre i run record non permettevano di distinguere run smoke da run reali.

### Causa
`_make_step_cmd` e `run_full` in `cmd_run.py` applicavano `sample_rows`/`sample_bytes` ma **non facevano root override**, a differenza di `batch` che lo faceva. `RunContext` non registrava la modalità smoke.

### Verifica
- Eseguito `toolkit run all --smoke` su project-example → output in `_smoke_out/smoke/data/`, non in `_smoke_out/data/`
- Eseguito `toolkit run full --smoke` → stesso isolamento
- Run record letto → `smoke: true`

### Fix applicato
1. **`toolkit/cli/cmd_run.py`**: `_make_step_cmd` e `run_full` ora applicano root override `{root}/smoke` quando `--smoke` è attivo e nessun `--root` esplicito. Stesso pattern di `batch --smoke`.
2. **`toolkit/cli/cmd_run.py`**: `run_year` accetta e propaga parametro `smoke`.
3. **`toolkit/core/run_context.py`**: `RunContext` accetta `smoke=False` in `__init__` e lo include in `to_dict()`.

### Test
- 3 nuovi test contract in `test_cli_path_contract.py`:
  - `test_cli_run_smoke_isolates_output` — output in `root/smoke/`, non in `root/data/`
  - `test_cli_run_full_smoke_isolates_output` — idem per `run full`
  - `test_cli_run_smoke_run_record_marked` — run record contiene `smoke: true`
- 20 test esistenti in `test_batch_cli.py`, `test_smoke_tiny_e2e.py`, `test_cli_path_contract.py`, `test_cli_smoke_e2e.py`, `test_mart_hierarchy.py` — tutti verdi

### Impatto downstream
Nessuno. Comportamento backward compatible per run senza `--smoke`. Per `--smoke` l'output cambia directory (da `root/data/` a `root/smoke/data/`) — è il comportamento atteso e corretto.

### Files toccati
- `toolkit/cli/cmd_run.py` — root override in `_make_step_cmd` e `run_full`, parametro `smoke` in `run_year`
- `toolkit/core/run_context.py` — campo `smoke` in `__init__` e `to_dict()`
- `tests/test_cli_path_contract.py` — 3 nuovi test contract