### PR TITLE
fix: `--sample-rows`/`--sample-bytes` isolano output in `{root}/smoke` come `--smoke`

### DIFF
--- a/tests/test_cli_path_contract.py
+++ b/tests/test_cli_path_contract.py
@@ -394,6 +394,86 @@ support:
     assert not sup_clean_out.exists(), "support smoke must NOT write to support root/data/"
 
 
+def test_cli_run_full_sample_rows_isolates_support_output(tmp_path: Path) -> None:
+    """contract: 'run full --sample-rows' isola output di candidate E support in {root}/smoke/."""
+    project_dir = tmp_path / "project"
+    config_path = _copy_project_example(project_dir)
+    root_dir = project_dir / "_smoke_out"
+
+    # Crea un support dataset minimale
+    support_dir = tmp_path / "support_ds"
+    (support_dir / "data").mkdir(parents=True)
+    (support_dir / "sql").mkdir(parents=True)
+    (support_dir / "sql" / "clean.sql").write_text(
+        "SELECT 1 AS ok FROM raw_input\n", encoding="utf-8"
+    )
+    (support_dir / "data" / "dummy.csv").write_text("a;b\n1;2\n", encoding="utf-8")
+    (support_dir / "sql" / "mart.sql").write_text(
+        "SELECT * FROM clean_input\n", encoding="utf-8"
+    )
+    (support_dir / "dataset.yml").write_text(
+        """schema_version: 1
+root: out
+dataset:
+  name: support_ds
+  years: [2022]
+raw:
+  sources:
+    - name: csv
+      type: local_file
+      args:
+        path: data/dummy.csv
+        filename: support_ds_2022.csv
+clean:
+  sql: sql/clean.sql
+mart:
+  tables:
+    - name: support_mart
+      sql: sql/mart.sql
+""",
+        encoding="utf-8",
+    )
+
+    # Aggiunge il support al candidate dataset.yml
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8")
+        + f"""
+support:
+  - name: "sup"
+    config: "{support_dir / 'dataset.yml'}"
+    years: [2022]
+""",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["run", "full", "--config", str(config_path), "--sample-rows", "500", "--years", "2022"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    # Candidate output in _smoke_out/smoke/data/
+    smoke_clean = root_dir / "smoke" / "data" / "clean" / "project_example" / "2022" / "project_example_2022_clean.parquet"
+    assert smoke_clean.exists(), f"candidate sampled clean not found: {smoke_clean}"
+    smoke_mart = root_dir / "smoke" / "data" / "mart" / "project_example" / "2022" / "rd_by_regione.parquet"
+    assert smoke_mart.exists(), f"candidate sampled mart not found: {smoke_mart}"
+
+    # Niente candidate in _smoke_out/data/
+    clean_out = root_dir / "data" / "clean" / "project_example" / "2022"
+    assert not clean_out.exists(), "candidate --sample-rows must NOT write to root/data/"
+
+    # Support output in support_ds/out/smoke/data/
+    sup_root = support_dir / "out"
+    sup_clean = sup_root / "smoke" / "data" / "clean" / "support_ds" / "2022" / "support_ds_2022_clean.parquet"
+    assert sup_clean.exists(), f"support sampled clean not found: {sup_clean}"
+
+    # Niente support in support_ds/out/data/
+    sup_clean_out = sup_root / "data" / "clean" / "support_ds" / "2022"
+    assert not sup_clean_out.exists(), "support --sample-rows must NOT write to support root/data/"
+
+
 # ---------------------------------------------------------------------------
 # toolkit.contracts path API
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_path_contract.py
+++ b/tests/test_cli_path_contract.py
@@ -240,6 +240,31 @@ def test_cli_run_smoke_isolates_output(tmp_path: Path) -> None:
     assert not clean_out.exists(), "smoke must NOT write to root/data/"
 
 
+def test_cli_run_sample_rows_isolates_output(tmp_path: Path) -> None:
+    """contract: --sample-rows (senza --smoke) isola output in {root}/smoke/."""
+    project_dir = tmp_path / "project-example"
+    config_path = _copy_project_example(project_dir)
+    root_dir = project_dir / "_smoke_out"
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        ["run", "all", "--config", str(config_path), "--sample-rows", "500", "--strict-config"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    # Output in _smoke_out/smoke/data/ (come --smoke)
+    smoke_clean = root_dir / "smoke" / "data" / "clean" / "project_example" / "2022" / "project_example_2022_clean.parquet"
+    assert smoke_clean.exists(), f"sampled clean not found: {smoke_clean}"
+    smoke_mart = root_dir / "smoke" / "data" / "mart" / "project_example" / "2022" / "rd_by_regione.parquet"
+    assert smoke_mart.exists(), f"sampled mart not found: {smoke_mart}"
+
+    # NO output in _smoke_out/data/
+    clean_out = root_dir / "data" / "clean" / "project_example" / "2022"
+    assert not clean_out.exists(), "--sample-rows must NOT write to root/data/"
+
+
 def test_cli_run_full_smoke_isolates_output(tmp_path: Path) -> None:
     """contract: --smoke in 'run full' scrive in {root}/smoke/ non in {root}/data/."""
     project_dir = tmp_path / "project-example"

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -321,6 +321,9 @@ def run_year(
             layers_to_run = [layer for layer in layers_to_run if layer != "mart"]
 
     if "mart" in layers_to_run and _has_single_year_mart(cfg):
+        # Il resolver dei support deve sapere se il campionamento e' attivo
+        # (root override in {root}/smoke), non solo se --smoke e' stato usato
+        sampling_active = smoke or sample_rows is not None or sample_bytes is not None
         _execute_layer(
             "mart",
             run_mart,
@@ -333,7 +336,7 @@ def run_year(
             output_cfg=dump_cfg_section(cfg.output),
             support_cfg=dump_cfg_section(cfg.support),
             source_id=source_id,
-            smoke=smoke,
+            smoke=sampling_active,
         )
 
     context.complete_run(success_with_warnings=run_has_validation_warnings)
@@ -371,12 +374,15 @@ def _maybe_run_multi_year_mart(
     *,
     dry_run: bool = False,
     logger=None,
-    smoke: bool = False,
+    sampling_active: bool = False,
 ) -> None:
     """Run multi-year MART tables if any table has explicit ``years``.
 
     Da chiamare una volta per dataset (non per anno), dopo il processing
     dei singoli anni. Sostituisce l'ex comando ``run cross_year``.
+
+    ``sampling_active`` indica che il root e' stato spostato in ``{root}/smoke``
+    per via di ``--smoke``, ``--sample-rows`` o ``--sample-bytes``.
     """
     if not _has_multi_year_mart(cfg):
         return
@@ -407,7 +413,7 @@ def _maybe_run_multi_year_mart(
             output_cfg=dump_cfg_section(cfg.output),
             support_cfg=dump_cfg_section(cfg.support),
             source_id=cfg.source_id,
-            smoke=smoke,
+            smoke=sampling_active,
         )
     except Exception as exc:
         if fail_on_error:
@@ -485,7 +491,8 @@ def _make_step_cmd(step: str):
 
         # Multi-year mart: run once per dataset after per-year processing
         if _step in ("all", "mart"):
-            _maybe_run_multi_year_mart(cfg, selected_years, dry_run=dry_flag, logger=logger, smoke=smoke)
+            _sampling = sample_rows_final is not None or sample_bytes_final is not None
+            _maybe_run_multi_year_mart(cfg, selected_years, dry_run=dry_flag, logger=logger, sampling_active=_sampling)
 
     cmd.__name__ = f"run_{_step}_cmd"
     cmd.__doc__ = f"Esegue lo step {_step} della pipeline."
@@ -741,7 +748,7 @@ def run_full(
         # Multi-year mart: run once per dataset after per-year processing
         if not dry_flag and _has_multi_year_mart(cfg):
             try:
-                _maybe_run_multi_year_mart(cfg, selected_years, dry_run=False, logger=logger, smoke=smoke)
+                _maybe_run_multi_year_mart(cfg, selected_years, dry_run=False, logger=logger, sampling_active=sample_mode)
                 results["multi_year_mart"] = "ok"
             except Exception as exc:
                 results["multi_year_mart"] = f"failed: {exc}"

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -464,9 +464,11 @@ def _make_step_cmd(step: str):
         sample_rows_final = 1000 if smoke else sample_rows
         sample_bytes_final = 1048576 if smoke else sample_bytes
 
-        # Smoke mode: isola output in {root}/smoke (come batch --smoke)
+        # Qualsiasi forma di campionamento (--smoke, --sample-rows, --sample-bytes)
+        # isola l'output in {root}/smoke per evitare contaminazione dei dati reali
+        sampling_active = sample_rows_final is not None or sample_bytes_final is not None
         root_override_final = root
-        if smoke and not root:
+        if sampling_active and not root:
             _cfg0, _ = load_cfg_and_logger(config, strict_config=strict_flag)
             root_override_final = str(_cfg0.root / "smoke")
 
@@ -606,9 +608,10 @@ def run_full(
     sample_bytes_final = 1048576 if smoke else sample_bytes
     sample_mode = sample_rows_final is not None or sample_bytes_final is not None
 
-    # Smoke mode: isola output in {root}/smoke (come batch --smoke)
+    # Qualsiasi forma di campionamento isola l'output in {root}/smoke
+    sampling_active = sample_rows_final is not None or sample_bytes_final is not None
     root_override_final = root
-    if smoke and not root:
+    if sampling_active and not root:
         _cfg0, _ = load_cfg_and_logger(config, strict_config=strict_flag)
         root_override_final = str(_cfg0.root / "smoke")
 
@@ -642,8 +645,8 @@ def run_full(
                 continue
 
             try:
-                # Smoke mode: isola output del support in {root}/smoke (come il candidate)
-                if smoke:
+                # Campionamento attivo: isola output del support in {root}/smoke (come il candidate)
+                if sample_mode:
                     _sup0, _ = load_cfg_and_logger(str(entry.config), strict_config=strict_flag)
                     support_cfg, support_logger = load_cfg_and_logger(
                         str(entry.config), strict_config=strict_flag,


### PR DESCRIPTION
## Bugfix: --sample-rows/--sample-bytes contaminano la root dati

### Problema
`--sample-rows 500` e `--sample-bytes 5000` (senza `--smoke`) scrivevano dati campionati nella root normale, stesso problema per cui era stato fixato `--smoke` in #289. `--smoke` è documentato come "alias per --sample-rows 1000 --sample-bytes 1048576" ma si comportava diversamente (root override aggiunto in #289).

### Causa
La condizione per il root override era `if smoke and not root`, escludendo i casi in cui l'utente usa `--sample-rows` o `--sample-bytes` direttamente.

### Fix
`_make_step_cmd` e `run_full` in `cmd_run.py`: condizione cambiata da `if smoke` a `if sampling_active` dove `sampling_active = sample_rows_final is not None or sample_bytes_final is not None`. Stessa logica per il caricamento dei support dataset.

### Test
- Nuovo test `test_cli_run_sample_rows_isolates_output`: `--sample-rows 500` scrive in `{root}/smoke/` e non in `{root}/data/`
- 71 test totali: tutti verdi

### Files toccati
- `toolkit/cli/cmd_run.py` — condizione root override
- `tests/test_cli_path_contract.py` — nuovo test contract