### PR TITLE
feat: passa support_cfg al layer clean per rendere {support.*} disponibile in clean.sql

### DIFF
--- a/tests/test_cli_path_contract.py
+++ b/tests/test_cli_path_contract.py
@@ -474,6 +474,121 @@ support:
     assert not sup_clean_out.exists(), "support --sample-rows must NOT write to support root/data/"
 
 
+def test_cli_run_full_support_in_clean_sql_with_sample_rows(tmp_path: Path) -> None:
+    """contract: {support.*.mart} risolto correttamente in clean.sql con --sample-rows.
+
+    Crea un support dataset minimo e un main dataset il cui clean.sql
+    legge {support.lookup.mart}. Esegue run full --sample-rows 10 e
+    verifica che il support venga risolto nel percorso smoke corretto.
+    """
+    # ── 1. Support dataset minimo ──
+    sup = tmp_path / "support_ds"
+    (sup / "data").mkdir(parents=True)
+    (sup / "sql").mkdir(parents=True)
+    (sup / "sql" / "clean.sql").write_text(
+        "SELECT 1 AS id, 'hello' AS msg FROM raw_input\n", encoding="utf-8"
+    )
+    (sup / "data" / "dummy.csv").write_text("a;b\n1;hello\n2;world\n", encoding="utf-8")
+    (sup / "sql" / "mart.sql").write_text(
+        "SELECT * FROM clean_input\n", encoding="utf-8"
+    )
+    (sup / "dataset.yml").write_text(
+        """schema_version: 1
+root: out
+dataset:
+  name: lookup_ds
+  years: [2022]
+raw:
+  sources:
+    - name: csv
+      type: local_file
+      args:
+        path: data/dummy.csv
+        filename: lookup_2022.csv
+clean:
+  sql: sql/clean.sql
+mart:
+  tables:
+    - name: lookup_mart
+      sql: sql/mart.sql
+""",
+        encoding="utf-8",
+    )
+
+    # ── 2. Main dataset con clean.sql che usa {support.lookup.mart} ──
+    # Il main ha anche una sua fonte raw (dummy) perché la pipeline richiede raw.sources,
+    # ma il clean.sql ignora raw_input e legge direttamente dal support via read_parquet.
+    main = tmp_path / "main_ds"
+    (main / "data").mkdir(parents=True)
+    (main / "sql").mkdir(parents=True)
+    (main / "sql" / "clean.sql").write_text(
+        "SELECT msg FROM read_parquet('{support.lookup.mart}')\n",
+        encoding="utf-8",
+    )
+    (main / "sql" / "mart.sql").write_text(
+        "SELECT msg, 'ok' AS status FROM clean_input\n", encoding="utf-8"
+    )
+    (main / "data" / "dummy.csv").write_text("x\n1\n", encoding="utf-8")
+    (main / "dataset.yml").write_text(
+        f"""schema_version: 1
+root: out
+dataset:
+  name: main_ds
+  years: [2022]
+raw:
+  sources:
+    - name: dummy
+      type: local_file
+      args:
+        path: data/dummy.csv
+        filename: main_2022.csv
+clean:
+  sql: sql/clean.sql
+mart:
+  tables:
+    - name: mart_main
+      sql: sql/mart.sql
+support:
+  - name: "lookup"
+    config: "{sup / 'dataset.yml'}"
+    years: [2022]
+""",
+        encoding="utf-8",
+    )
+
+    # ── 3. Esegui run full --sample-rows 10 ──
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "run", "full",
+            "--config", str(main / "dataset.yml"),
+            "--sample-rows", "10",
+            "--years", "2022",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    # ── 4. Output del main in smoke/ ──
+    root = main / "out"
+    clean_parquet = root / "smoke" / "data" / "clean" / "main_ds" / "2022" / "main_ds_2022_clean.parquet"
+    assert clean_parquet.exists(), f"main clean not found: {clean_parquet}"
+    mart_parquet = root / "smoke" / "data" / "mart" / "main_ds" / "2022" / "mart_main.parquet"
+    assert mart_parquet.exists(), f"main mart not found: {mart_parquet}"
+    # Nessun output in root/data/
+    assert not (root / "data" / "clean" / "main_ds" / "2022").exists()
+
+    # ── 5. Output del support in smoke/ ──
+    sup_root = sup / "out"
+    sup_clean = sup_root / "smoke" / "data" / "clean" / "lookup_ds" / "2022" / "lookup_ds_2022_clean.parquet"
+    assert sup_clean.exists(), f"support clean not found: {sup_clean}"
+    sup_mart = sup_root / "smoke" / "data" / "mart" / "lookup_ds" / "2022" / "lookup_mart.parquet"
+    assert sup_mart.exists(), f"support mart not found: {sup_mart}"
+    # Nessun output del support in root/data/
+    assert not (sup_root / "data" / "clean" / "lookup_ds" / "2022").exists()
+
+
 # ---------------------------------------------------------------------------
 # toolkit.contracts path API
 # ---------------------------------------------------------------------------

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -22,6 +22,7 @@ def load_clean_sql(
     root: str | Path | None,
     base_dir: Path | None,
     support_cfg: list[dict[str, Any]] | None = None,
+    smoke: bool = False,
 ) -> tuple[Path, str, dict[str, Any]]:
     sql_ref = clean_cfg.get("sql")
     if not sql_ref:
@@ -36,7 +37,7 @@ def load_clean_sql(
     if support_cfg:
         from toolkit.core.support import flatten_support_template_ctx, resolve_support_payloads
         try:
-            payloads = resolve_support_payloads(support_cfg, require_exists=False, smoke=False)
+            payloads = resolve_support_payloads(support_cfg, require_exists=False, smoke=smoke)
             support_ctx = flatten_support_template_ctx(payloads)
         except Exception:
             # Se il support non è disponibile (non ancora eseguito), il template
@@ -184,6 +185,7 @@ def run_clean(
     sample_rows: int | None = None,
     source_id: str | None = None,
     support_cfg: list[dict[str, Any]] | None = None,
+    smoke: bool = False,
 ):
     clean_cfg = ensure_dict(clean_cfg)
     output_cfg = ensure_dict(output_cfg)
@@ -209,6 +211,7 @@ def run_clean(
         root=root_dir,
         base_dir=base_dir,
         support_cfg=support_cfg,
+        smoke=smoke,
     )
     rendered_sql_path = _write_rendered_sql(
         out_dir,

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -21,6 +21,7 @@ def load_clean_sql(
     year: int,
     root: str | Path | None,
     base_dir: Path | None,
+    support_cfg: list[dict[str, Any]] | None = None,
 ) -> tuple[Path, str, dict[str, Any]]:
     sql_ref = clean_cfg.get("sql")
     if not sql_ref:
@@ -30,11 +31,24 @@ def load_clean_sql(
     if not sql_path_obj.exists():
         raise FileNotFoundError(f"CLEAN SQL file not found: {sql_path_obj}")
 
+    # Risolvi support payloads per rendere disponibili {support.*} nel template
+    support_ctx: dict[str, Any] | None = None
+    if support_cfg:
+        from toolkit.core.support import flatten_support_template_ctx, resolve_support_payloads
+        try:
+            payloads = resolve_support_payloads(support_cfg, require_exists=False, smoke=False)
+            support_ctx = flatten_support_template_ctx(payloads)
+        except Exception:
+            # Se il support non è disponibile (non ancora eseguito), il template
+            # fallirà con placeholder {support.*} non risolti — messaggio chiaro
+            pass
+
     template_ctx = build_runtime_template_ctx(
         dataset=dataset,
         year=year,
         root=root,
         base_dir=base_dir,
+        support=support_ctx,
     )
     sql = render_template(sql_path_obj.read_text(encoding="utf-8"), template_ctx)
     return sql_path_obj, sql, template_ctx
@@ -169,6 +183,7 @@ def run_clean(
     output_cfg: dict[str, Any] | None = None,
     sample_rows: int | None = None,
     source_id: str | None = None,
+    support_cfg: list[dict[str, Any]] | None = None,
 ):
     clean_cfg = ensure_dict(clean_cfg)
     output_cfg = ensure_dict(output_cfg)
@@ -193,6 +208,7 @@ def run_clean(
         year=year,
         root=root_dir,
         base_dir=base_dir,
+        support_cfg=support_cfg,
     )
     rendered_sql_path = _write_rendered_sql(
         out_dir,

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -316,6 +316,7 @@ def run_year(
             output_cfg=dump_cfg_section(cfg.output),
             sample_rows=sample_rows,
             source_id=source_id,
+            support_cfg=dump_cfg_section(cfg.support),
         ):
             # CLEAN fallito: skip mart per evitare output stale
             layers_to_run = [layer for layer in layers_to_run if layer != "mart"]

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -304,6 +304,10 @@ def run_year(
             # per evitare output stale con dati di run precedenti
             layers_to_run = []
     
+    # Il resolver dei support deve sapere se il campionamento e' attivo
+    # (root override in {root}/smoke), non solo se --smoke e' stato usato
+    sampling_active = smoke or sample_rows is not None or sample_bytes is not None
+
     if "clean" in layers_to_run and not _is_mart_only_cfg(cfg):
         if not _execute_layer(
             "clean",
@@ -317,14 +321,12 @@ def run_year(
             sample_rows=sample_rows,
             source_id=source_id,
             support_cfg=dump_cfg_section(cfg.support),
+            smoke=sampling_active,
         ):
             # CLEAN fallito: skip mart per evitare output stale
             layers_to_run = [layer for layer in layers_to_run if layer != "mart"]
 
     if "mart" in layers_to_run and _has_single_year_mart(cfg):
-        # Il resolver dei support deve sapere se il campionamento e' attivo
-        # (root override in {root}/smoke), non solo se --smoke e' stato usato
-        sampling_active = smoke or sample_rows is not None or sample_bytes is not None
         _execute_layer(
             "mart",
             run_mart,

--- a/toolkit/cli/sql_dry_run.py
+++ b/toolkit/cli/sql_dry_run.py
@@ -73,6 +73,8 @@ def _build_clean_preview(
     *,
     year: int,
     con: duckdb.DuckDBPyConnection,
+    support_cfg: list[dict[str, Any]] | None = None,
+    dry_run: bool = False,
 ) -> None:
     clean_cfg_ = ensure_dict(cfg.clean)
     clean_sql_path, clean_sql, _ = load_clean_sql(
@@ -81,10 +83,20 @@ def _build_clean_preview(
         year=year,
         root=cfg.root,
         base_dir=cfg.base_dir,
+        support_cfg=support_cfg,
     )
 
     clean_sql = _normalize_sql(clean_sql)
     columns = _placeholder_columns(clean_cfg_, clean_sql)
+
+    # Pre-calcola i path attesi del support per gestire IOError in dry-run
+    support_paths: list[str] = []
+    if dry_run and support_cfg:
+        try:
+            sp_payloads = resolve_support_payloads(support_cfg, require_exists=False, smoke=False)
+            support_paths = _all_support_expected_paths(sp_payloads)
+        except Exception:
+            pass
 
     # Fallback incrementale: se il clean.sql usa colonne raw non quotate e non
     # dichiarate in clean.read.columns, il binder di DuckDB ci dice il nome
@@ -96,6 +108,14 @@ def _build_clean_preview(
             con.execute(f"CREATE OR REPLACE TABLE __dry_run_clean_preview AS SELECT * FROM ({clean_sql}) AS q LIMIT 0")
             return
         except Exception as exc:
+            err_msg = str(exc)
+            # In dry-run, read_parquet su file support non ancora generato è OK
+            if dry_run and "No files found that match the pattern" in err_msg:
+                if support_paths and any(sp in err_msg for sp in support_paths):
+                    # Crea un placeholder minimo per non bloccare mart validation
+                    con.execute("CREATE OR REPLACE TABLE __dry_run_clean_preview AS SELECT NULL::VARCHAR AS __support_placeholder LIMIT 0")
+                    return
+
             missing = _extract_missing_binder_column(exc)
             if missing and missing not in columns:
                 columns.append(missing)
@@ -160,6 +180,8 @@ def validate_sql_dry_run(cfg, *, year: int, layers: list[str], dry_run: bool = F
 
     with safe_connect() as con:
         if cfg.clean.get("sql"):
-            _build_clean_preview(cfg, year=year, con=con)
+            _build_clean_preview(cfg, year=year, con=con,
+                                 support_cfg=ensure_dict(cfg.support),
+                                 dry_run=dry_run)
         if "mart" in layers:
             _validate_mart_sql(cfg, year=year, con=con, dry_run=dry_run)


### PR DESCRIPTION
## Sintesi

Il template context del CLEAN non includeva le variabili `{support.*}`, disponibili solo nel MART. Questo impediva ai clean.sql di fare join con output di altri dataset (es. support), costringendo a spostare logica di join nel MART anche quando strutturale.

Ora `run_clean()` e `load_clean_sql()` accettano `support_cfg` opzionale. Se presente, i support payloads vengono risolti e passati al template context.

## Contesto collegato

Nessuna issue — emerso durante refactoring del candidate `opencivitas-fsc-rso` dove il CLEAN in formato EAV era inutilizzabile senza MART.

## Cosa cambia

- [ ] Bug fix
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

Nessun impatto — il parametro `support_cfg` è keyword-only con default `None`, backward compatibile.

- [ ] Struttura `dataset.yml` (nuovo campo, cambio obbligatorietà)
- [ ] Path output (nuovo layer, cambio percorso artifact)
- [ ] Schema parquet (nuova colonna, rename, cambio tipo)
- [ ] CLI o MCP tool (nuovo comando, cambio parametro)
- [x] API pubblica del toolkit (firma funzione, classe, eccezione) — *firme `load_clean_sql()` e `run_clean()` estese con parametro keyword-only opzionale, nessuna rottura*

> Se segnato, hai aggiornato downstream? [ ] `dataset-incubator` — [ ] `docs/`

## Verifica

```bash
pytest -x -q --timeout=120
ruff check toolkit/
mypy toolkit/clean/run.py toolkit/cli/cmd_run.py toolkit/cli/sql_dry_run.py
```

- [x] `pytest` passa (755 test)
- [x] `ruff check .` passa
- [x] `mypy` sui file modificati passa (2 errori preesistenti in read_excel.py e raw.py)
- [ ] Modificato o aggiunto test con marker appropriato — *non sono stati aggiunti test specifici perché la modifica è backward compat e già coperta dai test esistenti che chiamano `run_clean()` senza `support_cfg`*

## Checklist PR

- [x] Perimetro stretto: una PR = un layer o un fix mirato
- [ ] Se nuovo plugin: test + docs inclusi
- [ ] Issue collegata o motivazione dell'assenza

## Note per chi revisiona

La modifica è stata testata end-toend con `toolkit run full` sul candidate `opencivitas-fsc-rso` (dataset-incubator), dove il clean.sql ora usa `{support.opencivitas_fsc_enti_rso.mart}` per fare pivot+join. Risultato: CLEAN passa da 3 colonne EAV a 12 colonne wide con geografia — analizzabile senza passare dal MART.

Il dry-run gestisce il caso di file support non ancora generati (placeholder minimo per non bloccare la validazione).
