### PR TITLE
feat(contracts): espandi API pubblica — CLEAN_PARQUET_SUFFIX, resolve_root, __all__

### DIFF
--- a/tests/test_cli_path_contract.py
+++ b/tests/test_cli_path_contract.py
@@ -627,3 +627,25 @@ def test_contracts_constants() -> None:
     from toolkit.contracts import MANIFEST_JSON, METADATA_JSON
     assert METADATA_JSON == "metadata.json"
     assert MANIFEST_JSON == "manifest.json"
+
+
+def test_contracts_clean_parquet_suffix() -> None:
+    """contract: CLEAN_PARQUET_SUFFIX costante pubblica."""
+    from toolkit.contracts import CLEAN_PARQUET_SUFFIX
+    assert CLEAN_PARQUET_SUFFIX == "_clean.parquet"
+
+
+def test_contracts_resolve_root() -> None:
+    """contract: resolve_root esportato e funzionante."""
+    from toolkit.contracts import resolve_root
+    from pathlib import Path
+    result = resolve_root("/some/absolute/path")
+    assert isinstance(result, Path)
+    assert result.is_absolute()
+
+
+def test_contracts_all_exports_match() -> None:
+    """contract: __all__ copre tutte le esportazioni pubbliche."""
+    import toolkit.contracts as c
+    for name in c.__all__:
+        assert hasattr(c, name), f"{name} dichiarato in __all__ ma non esportato"

--- a/toolkit/contracts/__init__.py
+++ b/toolkit/contracts/__init__.py
@@ -4,14 +4,27 @@ Consumer esterni (dataset-incubator, data-explorer) importano da qui
 invece di hardcodare i path. Le funzioni sono re-export da
 ``toolkit.core.paths`` — il modulo interno puo` cambiare, questo no.
 
-Esempio::
+Esempi::
 
-    from toolkit.contracts import layer_year_dir
+    from toolkit.contracts import clean_parquet_path, layer_year_dir
 
-    clean_path = layer_year_dir(
-        root="/path/to/out", layer="clean", dataset="mio_dataset", year=2024
-    )
-    # -> PosixPath('/path/to/out/data/clean/mio_dataset/2024')
+    # Directory CLEAN per un dataset/anno
+    layer_year_dir("/out", "clean", "mio_dataset", 2024)
+    # -> PosixPath('/out/data/clean/mio_dataset/2024')
+
+    # Path completo al parquet CLEAN
+    clean_parquet_path("/out", "mio_dataset", 2024)
+    # -> PosixPath('/out/data/clean/mio_dataset/2024/mio_dataset_2024_clean.parquet')
+
+    # Directory radice risolta (abs, expanduser)
+    resolve_root("~/projects/out")
+    # -> PosixPath('/home/user/projects/out')
+
+Costanti utili::
+
+    CLEAN_PARQUET_SUFFIX   # "_clean.parquet" — per filtrare/globbare
+    METADATA_JSON          # "metadata.json"
+    MANIFEST_JSON          # "manifest.json"
 """
 
 from __future__ import annotations
@@ -21,25 +34,45 @@ from pathlib import Path as _Path
 from toolkit.core.paths import (
     layer_dataset_dir,
     layer_year_dir,
+    resolve_root,
 )
-from toolkit.core.paths import resolve_root as _resolve_root
 
 __all__ = [
+    # Layer directories
     "layer_year_dir",
     "layer_dataset_dir",
-    "METADATA_JSON",
-    "MANIFEST_JSON",
+    # File paths
     "clean_parquet_path",
     "mart_table_path",
     "run_record_dir",
+    # Utilities
+    "resolve_root",
+    # Costanti file
+    "CLEAN_PARQUET_SUFFIX",
+    "METADATA_JSON",
+    "MANIFEST_JSON",
 ]
 
 # ---------------------------------------------------------------------------
-# Costanti di path — pattern di file canonici
+# Costanti — pattern di file canonici
 # ---------------------------------------------------------------------------
+
+CLEAN_PARQUET_SUFFIX = "_clean.parquet"
+"""Suffisso del parquet CLEAN. Usato per filtrare/globbare i file.
+
+Esempio::
+
+    file.endswith(CLEAN_PARQUET_SUFFIX)
+    # invece di: file.endswith(\"_clean.parquet\")
+"""
 
 METADATA_JSON = "metadata.json"
 MANIFEST_JSON = "manifest.json"
+
+
+# ---------------------------------------------------------------------------
+# Funzioni path — layer specifici
+# ---------------------------------------------------------------------------
 
 
 def clean_parquet_path(
@@ -55,7 +88,7 @@ def clean_parquet_path(
         # -> PosixPath('/out/data/clean/mio_dataset/2024/mio_dataset_2024_clean.parquet')
     """
     base = layer_year_dir(str(root), "clean", dataset, year)
-    return base / f"{dataset}_{year}_clean.parquet"
+    return base / f"{dataset}_{year}{CLEAN_PARQUET_SUFFIX}"
 
 
 def mart_table_path(
@@ -87,4 +120,4 @@ def run_record_dir(
         run_record_dir("/out", "mio_dataset", 2024)
         # -> PosixPath('/out/data/_runs/mio_dataset/2024')
     """
-    return _Path(str(_resolve_root(root))) / "data" / "_runs" / dataset / str(year)
+    return _Path(str(resolve_root(root))) / "data" / "_runs" / dataset / str(year)


### PR DESCRIPTION
## Cosa

Espande `toolkit.contracts` come API pubblica stabile per path contract, come richiesto in #244.

### Aggiunte

- **`CLEAN_PARQUET_SUFFIX`** (`"_clean.parquet"`) — costante pubblica per filtrare/globbare file CLEAN. Sostituisce gli hardcode tipo `file.endswith("_clean.parquet")` sparsi in dataset-incubator
- **`resolve_root`** — esportato pubblicamente (era importato come `_resolve_root` privato). Utile per consumer che devono risolvere la root directory
- **`__all__`** completo — verificato dal test `test_contracts_all_exports_match()` per garantire che ogni nome in `__all__` sia effettivamente esportato
- **Docstring** arricchita con esempi concreti per ogni funzione

### Test

- 3 nuovi test: suffix, resolve_root, `__all__` match
- 758 test totali passano (+3 rispetto a main)
- Ruff OK, marker audit OK

### Perché

Consumer come dataset-incubator hardcodano ancora pattern di path (es. `"{slug}_{year}_clean.parquet"`, `"_clean.parquet"`). Con queste costanti pubbliche possono importare da `toolkit.contracts` invece di duplicare i contratti.

Closes #244