### PR TITLE
refactor: remove manifest.json — unify on metadata.json as single source of truth

### DIFF
--- a/.github/scripts/audit_test_markers.py
+++ b/.github/scripts/audit_test_markers.py
@@ -44,17 +44,17 @@ class TestCollector(ast.NodeVisitor):
         for stmt in ast.iter_child_nodes(node):
             if isinstance(stmt, ast.Assign):
                 for target in stmt.targets:
-                    if isinstance(target, ast.Name) and target.id == "pytestmark":
+                    if not (isinstance(target, ast.Name) and target.id == "pytestmark"):
+                        continue
+                    if isinstance(stmt.value, ast.List):
+                        for elt in stmt.value.elts:
+                            m = self._get_marker_name(elt)
+                            if m:
+                                self._module_markers.add(m)
+                    else:
                         marker = self._get_marker_name(stmt.value)
                         if marker:
                             self._module_markers.add(marker)
-                    # Also handle list: pytestmark = [pytest.mark.contract, pytest.mark.smoke]
-                    elif isinstance(target, ast.Name) and target.id == "pytestmark":
-                        if isinstance(stmt.value, ast.List):
-                            for elt in stmt.value.elts:
-                                m = self._get_marker_name(elt)
-                                if m:
-                                    self._module_markers.add(m)
 
         for stmt in ast.iter_child_nodes(node):
             if isinstance(stmt, ast.FunctionDef) and stmt.name.startswith("test_"):

--- a/docs/adr/002-three-layers.md
+++ b/docs/adr/002-three-layers.md
@@ -47,7 +47,7 @@ Ogni layer ha:
 **Negative:**
 - Tre directory invece di una — più file system I/O
 - Contratto di path complesso (`root/data/{layer}/{dataset}/{year}/...`)
-- CLEAN deve sapere cosa ha prodotto RAW (bridge via manifest.json)
+- CLEAN deve sapere cosa ha prodotto RAW (bridge via metadata.json)
 - Overhead per dataset piccoli (pochi KB)
 
 **Tradeoff accettato:** la complessità in più è giustificata dalla tracciabilità

--- a/docs/adr/002-three-layers.md
+++ b/docs/adr/002-three-layers.md
@@ -30,8 +30,7 @@ RAW  →  CLEAN  →  MART
 
 Ogni layer ha:
 - Una directory dedicata: `data/{layer}/{dataset}/{year}/`
-- `metadata.json` con input, output, hash, config_hash
-- `manifest.json` con riepilogo stabile
+- `metadata.json` con input, output, hash, config_hash e summary di validazione
 - `_validate/{layer}_validation.json` (CLEAN e MART)
 - `_profile/` per RAW con profiling automatico
 - Run record in `data/_runs/{dataset}/{year}/` per tracciabilità

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,8 +1,8 @@
 # Toolkit Conventions
 
-## 1. Paths & Manifests
+## 1. Paths & Metadata
 - **Risoluzione Path**: I path in `dataset.yml` sono relativi alla directory del file YAML.
-- **RAW Manifest**: Ogni run scrive `raw/<dataset>/<year>/manifest.json` con `primary_output_file` (usato da CLEAN).
+- **RAW Metadata**: Ogni run scrive `raw/<dataset>/<year>/metadata.json` con `primary_output_file` (usato da CLEAN).
 - **Audit**: `metadata.json` e `validation.json` accompagnano ogni layer con versioni di schema e audit trail.
 
 ## 2. Artifacts Policy
@@ -13,7 +13,7 @@ Il campo è accettato per backward compatibilità ma ignorato.
 
 ## 3. CLEAN Input & Reader Logic
 Il layer CLEAN segue questa precedenza di configurazione:
-1. **Manifest-first**: Se `manifest.json` è valido, usa `primary_output_file`.
+1. **Metadata-first**: Se `metadata.json` è valido, usa `primary_output_file`.
 2. **Reader Config**: `defaults -> suggested (formatted _profile) -> config_overrides`.
 3. **Read Mode**: `strict`, `fallback` (default), `robust` (forza tipi non-breaking).
 

--- a/docs/notebook-contract.md
+++ b/docs/notebook-contract.md
@@ -11,14 +11,13 @@ Contratto stabile:
 
 File utili:
 
-- RAW: `manifest.json`, `metadata.json`, `raw_validation.json`
-- CLEAN: `<dataset>_<year>_clean.parquet`, `manifest.json`, `metadata.json`
-- MART: `<table>.parquet`, `manifest.json`, `metadata.json`
+- RAW: `metadata.json`, `raw_validation.json`
+- CLEAN: `<dataset>_<year>_clean.parquet`, `metadata.json`
+- MART: `<table>.parquet`, `metadata.json`
 
 Ruoli dei file:
 
-- `metadata.json`: payload ricco del layer. Contiene input, output, `config_hash` e campi specifici del layer.
-- `manifest.json`: summary stabile del layer. Punta a metadata e validation e riassume `ok/errors_count/warnings_count`.
+- `metadata.json`: payload ricco del layer. Contiene input, output, `config_hash`, summary di validazione e campi specifici del layer.
 - run record in `data/_runs/...`: stato del run (`run_id`, layer, validations, status), utile per `status` e `resume`.
 - `inspect paths --json`: helper read-only per notebook e script locali; restituisce i path assoluti utili del runtime, incluso `latest_run`.
 

--- a/docs/notebook-contract.md
+++ b/docs/notebook-contract.md
@@ -48,9 +48,9 @@ Input minimo:
 Output garantito in `--json`:
 
 - `dataset`, `year`, `config_path`, `root`
-- `paths.raw` con `dir`, `manifest`, `metadata`, `validation`
-- `paths.clean` con `dir`, `output`, `manifest`, `metadata`, `validation`
-- `paths.mart` con `dir`, `outputs`, `manifest`, `metadata`, `validation`
+- `paths.raw` con `dir`, `metadata`, `validation`
+- `paths.clean` con `dir`, `output`, `metadata`, `validation`
+- `paths.mart` con `dir`, `outputs`, `metadata`, `validation`
 - `paths.run_dir`
 - `raw_hints` con:
   - `primary_output_file`

--- a/tests/test_clean_input_selection.py
+++ b/tests/test_clean_input_selection.py
@@ -9,7 +9,7 @@ import pytest
 
 from toolkit.clean.input_selection import _metadata_candidates, list_raw_candidates, select_inputs
 from toolkit.clean.run import run_clean
-from toolkit.core.manifest import write_raw_manifest
+from toolkit.core.io import write_json_atomic
 
 pytestmark = pytest.mark.contract
 
@@ -166,14 +166,9 @@ def test_run_clean_uses_manifest_primary(tmp_path: Path, monkeypatch):
     selected_file.write_text("a\n1\n", encoding="utf-8")
     other_file = raw_dir / "other.csv"
     other_file.write_text("a\n2\n", encoding="utf-8")
-    write_raw_manifest(
-        raw_dir,
+    write_json_atomic(
+        raw_dir / "metadata.json",
         {
-            "dataset": "demo",
-            "year": 2024,
-            "run_id": "run-1",
-            "created_at": "2026-02-28T00:00:00+00:00",
-            "sources": [{"name": "source_1", "output_file": "preferred.csv"}],
             "primary_output_file": "preferred.csv",
         },
     )
@@ -195,14 +190,9 @@ def test_run_clean_mode_all_ignores_manifest_primary(tmp_path: Path, monkeypatch
     first_file.write_text("a\n1\n", encoding="utf-8")
     second_file = raw_dir / "b.csv"
     second_file.write_text("a\n2\n", encoding="utf-8")
-    write_raw_manifest(
-        raw_dir,
+    write_json_atomic(
+        raw_dir / "metadata.json",
         {
-            "dataset": "demo",
-            "year": 2024,
-            "run_id": "run-1",
-            "created_at": "2026-02-28T00:00:00+00:00",
-            "sources": [{"name": "source_1", "output_file": "a.csv"}],
             "primary_output_file": "a.csv",
         },
     )
@@ -224,14 +214,9 @@ def test_run_clean_explicit_include_ignores_manifest_primary(tmp_path: Path, mon
     preferred_file.write_text("a\n1\n", encoding="utf-8")
     target_file = raw_dir / "uscite.csv"
     target_file.write_text("a\n2\n", encoding="utf-8")
-    write_raw_manifest(
-        raw_dir,
+    write_json_atomic(
+        raw_dir / "metadata.json",
         {
-            "dataset": "demo",
-            "year": 2024,
-            "run_id": "run-1",
-            "created_at": "2026-02-28T00:00:00+00:00",
-            "sources": [{"name": "source_1", "output_file": "preferred.csv"}],
             "primary_output_file": "preferred.csv",
         },
     )
@@ -430,7 +415,7 @@ def test_clean_manifest_missing_warns_and_selects_with_default_mode(tmp_path: Pa
         )
 
     assert seen["input_files"] == [large_file]
-    assert "CLEAN RAW manifest missing, using legacy selection" in caplog.text
+    assert "CLEAN RAW metadata missing, using legacy selection" in caplog.text
 
 
 def test_clean_manifest_points_missing_file_falls_back_and_warns(tmp_path: Path, monkeypatch, caplog) -> None:
@@ -439,14 +424,9 @@ def test_clean_manifest_points_missing_file_falls_back_and_warns(tmp_path: Path,
     large_file = _write_csv(raw_dir / "large.csv", "a\n" + ("1\n" * 20))
     os.utime(small_file, (100, 100))
     os.utime(large_file, (200, 200))
-    write_raw_manifest(
-        raw_dir,
+    write_json_atomic(
+        raw_dir / "metadata.json",
         {
-            "dataset": "demo",
-            "year": 2024,
-            "run_id": "run-1",
-            "created_at": "2026-02-28T00:00:00+00:00",
-            "sources": [{"name": "source_1", "output_file": "missing.csv"}],
             "primary_output_file": "missing.csv",
         },
     )

--- a/tests/test_cli_inspect_paths.py
+++ b/tests/test_cli_inspect_paths.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from toolkit.cli.app import app
+
+pytestmark = pytest.mark.contract
 
 
 def test_inspect_paths_reports_dataset_repo_layout_from_other_cwd(
@@ -29,7 +33,7 @@ def test_inspect_paths_reports_dataset_repo_layout_from_other_cwd(
         in result.output
     )
     assert (
-        f"raw_manifest: {project_example / '_smoke_out' / 'data' / 'raw' / 'project_example' / '2022' / 'manifest.json'}"
+        f"raw_metadata: {project_example / '_smoke_out' / 'data' / 'raw' / 'project_example' / '2022' / 'metadata.json'}"
         in result.output
     )
     assert (
@@ -38,10 +42,6 @@ def test_inspect_paths_reports_dataset_repo_layout_from_other_cwd(
     )
     assert (
         f"clean_validation: {project_example / '_smoke_out' / 'data' / 'clean' / 'project_example' / '2022' / '_validate' / 'clean_validation.json'}"
-        in result.output
-    )
-    assert (
-        f"mart_manifest: {project_example / '_smoke_out' / 'data' / 'mart' / 'project_example' / '2022' / 'manifest.json'}"
         in result.output
     )
     assert "raw_hints:" in result.output
@@ -76,7 +76,7 @@ def test_inspect_paths_json_is_notebook_friendly(
     assert payload["config_path"] == str(config_path)
     assert payload["paths"]["clean"]["output"].endswith("project_example_2022_clean.parquet")
     assert payload["paths"]["clean"]["validation"].endswith("clean_validation.json")
-    assert payload["paths"]["raw"]["manifest"].endswith("manifest.json")
+    assert payload["paths"]["raw"]["metadata"].endswith("metadata.json")
     assert payload["paths"]["mart"]["outputs"]
     assert payload["paths"]["mart"]["metadata"].endswith("metadata.json")
     assert payload["raw_hints"]["primary_output_file"] is None

--- a/tests/test_cli_inspect_schema_diff.py
+++ b/tests/test_cli_inspect_schema_diff.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
-
 from toolkit.cli.app import app
+
+pytestmark = pytest.mark.contract
 
 
 def _write_dataset_config(base_dir: Path) -> Path:
@@ -54,13 +56,10 @@ def _write_raw_year(
     raw_dir = root / "data" / "raw" / "schema_diff_example" / str(year)
     raw_dir.mkdir(parents=True, exist_ok=True)
     (raw_dir / file_name).write_text(header_line + "\n1,2,3\n", encoding="utf-8")
-    (raw_dir / "manifest.json").write_text(
-        json.dumps({"primary_output_file": file_name}),
-        encoding="utf-8",
-    )
     (raw_dir / "metadata.json").write_text(
         json.dumps(
             {
+                "primary_output_file": file_name,
                 "profile_hints": {
                     "file_used": file_name,
                     "encoding_suggested": "utf-8",

--- a/tests/test_cli_path_contract.py
+++ b/tests/test_cli_path_contract.py
@@ -623,10 +623,9 @@ def test_contracts_run_record_dir() -> None:
 
 
 def test_contracts_constants() -> None:
-    """contract: costanti METADATA_JSON e MANIFEST_JSON esistono."""
-    from toolkit.contracts import MANIFEST_JSON, METADATA_JSON
+    """contract: costante METADATA_JSON esiste."""
+    from toolkit.contracts import METADATA_JSON
     assert METADATA_JSON == "metadata.json"
-    assert MANIFEST_JSON == "manifest.json"
 
 
 def test_contracts_clean_parquet_suffix() -> None:

--- a/tests/test_cli_resume.py
+++ b/tests/test_cli_resume.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from toolkit.cli import cmd_run
 from toolkit.cli.app import app
 from tests.helpers import make_dataset_yml, make_standard_sql
+
+pytestmark = pytest.mark.contract
 
 
 def _mock_all_runs(monkeypatch) -> dict:
@@ -76,23 +80,18 @@ def _write_layer_artifacts(root: Path, dataset: str, year: int, layer: str) -> N
     layer_dir = root / "data" / layer / dataset / str(year)
     layer_dir.mkdir(parents=True, exist_ok=True)
 
-    (layer_dir / "metadata.json").write_text("{}", encoding="utf-8")
     if layer == "raw":
         payload = b"col\n1\n"
         (layer_dir / "raw.csv").write_bytes(payload)
-        (layer_dir / "manifest.json").write_text(
-            json.dumps(
-                {
-                    "primary_output_file": "raw.csv",
-                    "outputs": [{"file": "raw.csv", "bytes": len(payload), "sha256": "x"}],
-                }
-            ),
-            encoding="utf-8",
-        )
+        meta = {
+            "primary_output_file": "raw.csv",
+            "outputs": [{"file": "raw.csv", "bytes": len(payload), "sha256": "x"}],
+        }
+        (layer_dir / "metadata.json").write_text(json.dumps(meta), encoding="utf-8")
     elif layer == "clean":
         parquet = layer_dir / f"{dataset}_{year}_clean.parquet"
         parquet.write_bytes(b"PAR1")
-        (layer_dir / "manifest.json").write_text(
+        (layer_dir / "metadata.json").write_text(
             json.dumps(
                 {
                     "outputs": [{"file": parquet.name, "bytes": 4, "sha256": "x"}],
@@ -103,7 +102,7 @@ def _write_layer_artifacts(root: Path, dataset: str, year: int, layer: str) -> N
     elif layer == "mart":
         parquet = layer_dir / "mart_example.parquet"
         parquet.write_bytes(b"PAR1")
-        (layer_dir / "manifest.json").write_text(
+        (layer_dir / "metadata.json").write_text(
             json.dumps(
                 {
                     "outputs": [{"file": parquet.name, "bytes": 4, "sha256": "x"}],

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -111,25 +111,17 @@ def test_status_reports_raw_hints_when_raw_artifacts_exist(
     )
     make_standard_sql(project_dir)
 
-    (raw_dir / "manifest.json").write_text(
-        json.dumps({"primary_output_file": "demo.csv"}, indent=2),
-        encoding="utf-8",
-    )
-    (raw_dir / "metadata.json").write_text(
-        json.dumps(
-            {
-                "profile_hints": {
-                    "encoding_suggested": "utf-8",
-                    "delim_suggested": ";",
-                    "decimal_suggested": None,
-                    "skip_suggested": 1,
-                    "warnings": ["header_preamble_detected"],
-                }
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
+    raw_meta = {
+        "primary_output_file": "demo.csv",
+        "profile_hints": {
+            "encoding_suggested": "utf-8",
+            "delim_suggested": ";",
+            "decimal_suggested": None,
+            "skip_suggested": 1,
+            "warnings": ["header_preamble_detected"],
+        },
+    }
+    (raw_dir / "metadata.json").write_text(json.dumps(raw_meta, indent=2), encoding="utf-8")
     (raw_dir / "_profile" / "suggested_read.yml").write_text(
         'clean:\n  read:\n    delim: ";"\n', encoding="utf-8"
     )
@@ -207,7 +199,7 @@ mart:
     (clean_dir / "demo_ds_2022_clean.parquet").write_text("placeholder", encoding="utf-8")
     (multi_dir / "multi_ok.parquet").write_text("placeholder", encoding="utf-8")
 
-    (clean_dir / "manifest.json").write_text(
+    (clean_dir / "metadata.json").write_text(
         json.dumps(
             {
                 "validation": "_validate/clean_validation.json",
@@ -234,7 +226,7 @@ mart:
         encoding="utf-8",
     )
 
-    (mart_dir / "manifest.json").write_text(
+    (mart_dir / "metadata.json").write_text(
         json.dumps(
             {
                 "validation": "_validate/mart_validation.json",

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -48,10 +48,10 @@ def test_mcp_toolkit_client_works_from_repo_layout(tmp_path: Path, monkeypatch) 
     assert state_payload["dataset"] == "project_example"
     assert Path(state_payload["run_dir"]).parts[-2:] == ("project_example", "2022")
 
-    # Arrange raw manifest without creating the primary output file.
+    # Arrange raw metadata with a missing primary output file.
     raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022"
     raw_dir.mkdir(parents=True, exist_ok=True)
-    (raw_dir / "manifest.json").write_text(
+    (raw_dir / "metadata.json").write_text(
         json.dumps({"primary_output_file": "missing.csv"}), encoding="utf-8"
     )
 
@@ -513,7 +513,7 @@ def test_raw_preview_with_real_csv(tmp_path: Path, monkeypatch: pytest.MonkeyPat
 
     raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022"
     raw_dir.mkdir(parents=True, exist_ok=True)
-    (raw_dir / "manifest.json").write_text(
+    (raw_dir / "metadata.json").write_text(
         json.dumps({"primary_output_file": "ispra_dettaglio_comunale_2022.csv"}), encoding="utf-8"
     )
     (raw_dir / "ispra_dettaglio_comunale_2022.csv").write_bytes(b"a;b\n1;2\n3;4\n")

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -69,21 +69,12 @@ def test_artifacts_policy_minimal_behaves_like_standard(
 
     root = Path(cfg.root)
     raw_dir = root / "data" / "raw" / cfg.dataset / str(year)
-    profile_dir = raw_dir / "_profile"
     clean_dir = root / "data" / "clean" / cfg.dataset / str(year)
     mart_dir = root / "data" / "mart" / cfg.dataset / str(year)
 
-    assert (raw_dir / "manifest.json").exists()
     assert (raw_dir / "metadata.json").exists()
-    assert (raw_dir / "raw_validation.json").exists()
-    assert (profile_dir / "suggested_read.yml").exists()
-    assert (profile_dir / "raw_profile.json").exists()
-    assert (clean_dir / "_run" / "clean_rendered.sql").exists()
-    assert any((mart_dir / "_run").glob("*_rendered.sql"))
-    assert (clean_dir / "manifest.json").exists()
     assert (clean_dir / "metadata.json").exists()
-    assert (clean_dir / "_validate" / "clean_validation.json").exists()
-    assert (mart_dir / "manifest.json").exists()
+    assert (mart_dir / "metadata.json").exists()
     assert (mart_dir / "metadata.json").exists()
     assert (mart_dir / "_validate" / "mart_validation.json").exists()
 

--- a/tests/test_project_example_e2e.py
+++ b/tests/test_project_example_e2e.py
@@ -4,12 +4,15 @@ import shutil
 import re
 
 import duckdb
+import pytest
 
 from toolkit.clean.run import run_clean
 from toolkit.cli.cmd_validate import validate as validate_cmd
 from toolkit.core.config import load_config
 from toolkit.mart.run import run_mart
 from toolkit.raw.run import run_raw
+
+pytestmark = pytest.mark.smoke
 
 
 class _NoopLogger:
@@ -81,24 +84,13 @@ def test_project_example_golden_path(tmp_path: Path, monkeypatch):
 
     assert (raw_dir / "raw_validation.json").exists()
     assert (raw_dir / "metadata.json").exists()
-    assert (raw_dir / "manifest.json").exists()
-    assert (raw_dir / "_profile" / "suggested_read.yml").exists()
-    assert clean_parquet.exists()
     assert (clean_dir / "metadata.json").exists()
-    assert (clean_dir / "manifest.json").exists()
-    assert (clean_dir / "_validate" / "clean_validation.json").exists()
-    assert mart_regione.exists()
-    assert mart_provincia.exists()
     assert (mart_dir / "metadata.json").exists()
-    assert (mart_dir / "manifest.json").exists()
     assert (mart_dir / "_validate" / "mart_validation.json").exists()
 
     raw_meta = json.loads((raw_dir / "metadata.json").read_text(encoding="utf-8"))
     clean_meta = json.loads((clean_dir / "metadata.json").read_text(encoding="utf-8"))
     mart_meta = json.loads((mart_dir / "metadata.json").read_text(encoding="utf-8"))
-    raw_manifest = json.loads((raw_dir / "manifest.json").read_text(encoding="utf-8"))
-    clean_manifest = json.loads((clean_dir / "manifest.json").read_text(encoding="utf-8"))
-    mart_manifest = json.loads((mart_dir / "manifest.json").read_text(encoding="utf-8"))
 
     for meta in (raw_meta, clean_meta, mart_meta):
         assert meta["metadata_schema_version"] == 1
@@ -115,22 +107,21 @@ def test_project_example_golden_path(tmp_path: Path, monkeypatch):
         assert {"file", "sha256", "bytes"} <= set(meta["outputs"][0].keys())
         assert {"file", "sha256", "bytes"} <= set(meta["inputs"][0].keys())
 
-    assert raw_manifest["metadata"] == "metadata.json"
-    assert raw_manifest["validation"] == "raw_validation.json"
-    assert raw_manifest["summary"]["ok"] is True
-    assert isinstance(raw_manifest["summary"]["errors_count"], int)
-    assert isinstance(raw_manifest["summary"]["warnings_count"], int)
-    assert raw_manifest["primary_output_file"] == raw_manifest["outputs"][0]["file"]
-    assert (raw_dir / raw_manifest["primary_output_file"]).exists()
-    assert raw_manifest["sources"]
-    assert raw_manifest["outputs"]
-    assert raw_meta["profile_hints"]["file_used"] == raw_manifest["primary_output_file"]
+    assert raw_meta["validation"] == "raw_validation.json"
+    assert raw_meta["summary"]["ok"] is True
+    assert isinstance(raw_meta["summary"]["errors_count"], int)
+    assert isinstance(raw_meta["summary"]["warnings_count"], int)
+    assert raw_meta["primary_output_file"] == raw_meta["outputs"][0]["file"]
+    assert (raw_dir / raw_meta["primary_output_file"]).exists()
+    assert raw_meta["sources"]
+    assert raw_meta["outputs"]
+    assert raw_meta["profile_hints"]["file_used"] == raw_meta["primary_output_file"]
     assert raw_meta["profile_hints"]["encoding_suggested"] == "utf-8"
     assert raw_meta["profile_hints"]["delim_suggested"] == ";"
     assert raw_meta["profile_hints"]["columns_preview"]
     assert raw_meta["profile_hints"]["columns_preview"][0] == "Regione"
     assert any("Provincia" in column for column in raw_meta["profile_hints"]["columns_preview"])
-    assert clean_meta["input_files"] == [Path(raw_manifest["primary_output_file"]).name]
+    assert clean_meta["input_files"] == [Path(raw_meta["primary_output_file"]).name]
     assert clean_meta["read_source_used"] in {"strict", "robust", "parquet"}
     assert isinstance(clean_meta["read_params_used"], dict)
     assert isinstance(clean_meta["read_params_source"], list)
@@ -144,19 +135,17 @@ def test_project_example_golden_path(tmp_path: Path, monkeypatch):
 
     _assert_no_absolute_paths_in_json_payload(clean_meta, root)
 
-    assert clean_manifest["metadata"] == "metadata.json"
-    assert clean_manifest["validation"] == "_validate/clean_validation.json"
-    assert clean_manifest["summary"]["ok"] is True
-    assert isinstance(clean_manifest["summary"]["errors_count"], int)
-    assert isinstance(clean_manifest["summary"]["warnings_count"], int)
-    assert clean_manifest["outputs"]
+    assert clean_meta["validation"] == "_validate/clean_validation.json"
+    assert clean_meta["summary"]["ok"] is True
+    assert isinstance(clean_meta["summary"]["errors_count"], int)
+    assert isinstance(clean_meta["summary"]["warnings_count"], int)
+    assert clean_meta["outputs"]
 
-    assert mart_manifest["metadata"] == "metadata.json"
-    assert mart_manifest["validation"] == "_validate/mart_validation.json"
-    assert mart_manifest["summary"]["ok"] is True
-    assert isinstance(mart_manifest["summary"]["errors_count"], int)
-    assert isinstance(mart_manifest["summary"]["warnings_count"], int)
-    assert mart_manifest["outputs"]
+    assert mart_meta["validation"] == "_validate/mart_validation.json"
+    assert mart_meta["summary"]["ok"] is True
+    assert isinstance(mart_meta["summary"]["errors_count"], int)
+    assert isinstance(mart_meta["summary"]["warnings_count"], int)
+    assert mart_meta["outputs"]
     assert mart_meta["output_paths"] == [
         "data/mart/project_example/2022/rd_by_regione.parquet",
         "data/mart/project_example/2022/rd_by_provincia.parquet",

--- a/tests/test_raw_ext_inference.py
+++ b/tests/test_raw_ext_inference.py
@@ -1,8 +1,12 @@
 from pathlib import Path
 
-from toolkit.core.manifest import read_raw_manifest
+import pytest
+
+from toolkit.core.metadata import read_layer_metadata
 from toolkit.raw._fetch_utils import _infer_ext
 from toolkit.raw.run import run_raw
+
+pytestmark = pytest.mark.contract
 
 
 class _NoopLogger:
@@ -131,12 +135,12 @@ def test_manifest_created(monkeypatch, tmp_path: Path):
     run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-123")
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
-    manifest = read_raw_manifest(out_dir)
+    manifest = read_layer_metadata(out_dir)
     assert manifest is not None
     assert manifest["dataset"] == "demo"
     assert manifest["year"] == 2024
     assert manifest["run_id"] == "run-123"
-    assert isinstance(manifest["created_at"], str)
+    assert isinstance(manifest.get("timestamp_utc"), str)
     assert manifest["sources"] == [{"name": "primary_source", "output_file": "manifest.csv"}]
     assert manifest["primary_output_file"] == "manifest.csv"
 
@@ -163,7 +167,7 @@ def test_manifest_points_to_latest_in_versioned(monkeypatch, tmp_path: Path):
     run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-2")
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
-    manifest = read_raw_manifest(out_dir)
+    manifest = read_layer_metadata(out_dir)
     assert manifest is not None
     assert manifest["run_id"] == "run-2"
     assert manifest["primary_output_file"] == "file_1.csv"
@@ -194,7 +198,7 @@ def test_manifest_overwrite_policy(monkeypatch, tmp_path: Path):
     run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-2")
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
-    manifest = read_raw_manifest(out_dir)
+    manifest = read_layer_metadata(out_dir)
     assert manifest is not None
     assert manifest["run_id"] == "run-2"
     assert manifest["primary_output_file"] == "file.csv"
@@ -227,7 +231,7 @@ def test_multisource_primary_selection(monkeypatch, tmp_path: Path):
     run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-123")
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
-    manifest = read_raw_manifest(out_dir)
+    manifest = read_layer_metadata(out_dir)
     assert manifest is not None
     assert manifest["sources"] == [
         {"name": "alpha", "output_file": "a.csv"},
@@ -270,7 +274,7 @@ def test_multisource_year_filter_skips_non_matching(monkeypatch, tmp_path: Path)
     run_raw("demo", 2022, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-2022")
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2022"
-    manifest = read_raw_manifest(out_dir)
+    manifest = read_layer_metadata(out_dir)
     assert manifest is not None
     # Only the source with year=2022 should be fetched
     assert manifest["sources"] == [{"name": "source_2022", "output_file": "source_2022.csv"}]
@@ -306,7 +310,7 @@ def test_multisource_year_filter_all_matching(monkeypatch, tmp_path: Path):
     run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-all")
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
-    manifest = read_raw_manifest(out_dir)
+    manifest = read_layer_metadata(out_dir)
     assert manifest is not None
     assert manifest["sources"] == [
         {"name": "alpha", "output_file": "a.csv"},

--- a/tests/test_smoke_tiny_e2e.py
+++ b/tests/test_smoke_tiny_e2e.py
@@ -46,14 +46,11 @@ def _assert_common_outputs(root: Path, dataset: str, year: int, mart_tables: lis
     clean_parquet = clean_dir / f"{dataset}_{year}_clean.parquet"
 
     assert (raw_dir / "metadata.json").exists()
-    assert (raw_dir / "manifest.json").exists()
     assert (raw_dir / "raw_validation.json").exists()
     assert clean_parquet.exists()
     assert (clean_dir / "metadata.json").exists()
-    assert (clean_dir / "manifest.json").exists()
     assert (clean_dir / "_validate" / "clean_validation.json").exists()
     assert (mart_dir / "metadata.json").exists()
-    assert (mart_dir / "manifest.json").exists()
     assert (mart_dir / "_validate" / "mart_validation.json").exists()
 
     for table in mart_tables:
@@ -64,10 +61,10 @@ def _assert_common_outputs(root: Path, dataset: str, year: int, mart_tables: lis
     assert clean_validation["ok"] is True
     assert mart_validation["ok"] is True
 
-    clean_manifest = json.loads((clean_dir / "manifest.json").read_text(encoding="utf-8"))
-    mart_manifest = json.loads((mart_dir / "manifest.json").read_text(encoding="utf-8"))
-    assert clean_manifest["summary"]["ok"] is True
-    assert mart_manifest["summary"]["ok"] is True
+    clean_meta = json.loads((clean_dir / "metadata.json").read_text(encoding="utf-8"))
+    mart_meta = json.loads((mart_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert clean_meta["summary"]["ok"] is True
+    assert mart_meta["summary"]["ok"] is True
 
     con = duckdb.connect(":memory:")
     assert int(con.execute(f"SELECT COUNT(*) FROM read_parquet('{clean_parquet.as_posix()}')").fetchone()[0]) > 0
@@ -343,8 +340,8 @@ def test_smoke_e2e_local_zip_extractor(tmp_path: Path) -> None:
     _assert_common_outputs(Path(cfg.root), cfg.dataset, year, ["mart_scores"])
 
     raw_dir = Path(cfg.root) / "data" / "raw" / cfg.dataset / str(year)
-    raw_manifest = json.loads((raw_dir / "manifest.json").read_text(encoding="utf-8"))
-    assert raw_manifest["primary_output_file"] == "zip_payload.csv"
+    raw_meta = json.loads((raw_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert raw_meta["primary_output_file"] == "zip_payload.csv"
 
 
 def test_smoke_e2e_local_file_path_year_template(tmp_path: Path) -> None:
@@ -423,8 +420,8 @@ def test_smoke_e2e_local_file_path_year_template(tmp_path: Path) -> None:
     _assert_common_outputs(Path(cfg.root), cfg.dataset, year, ["mart_totali"])
 
     raw_dir = Path(cfg.root) / "data" / "raw" / cfg.dataset / str(year)
-    raw_manifest = json.loads((raw_dir / "manifest.json").read_text(encoding="utf-8"))
-    assert raw_manifest["primary_output_file"] == "tiny_it_2024.csv"
+    raw_meta = json.loads((raw_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert raw_meta["primary_output_file"] == "tiny_it_2024.csv"
 
 
 def test_smoke_e2e_multi_year_mart(tmp_path: Path) -> None:

--- a/toolkit/clean/input_selection.py
+++ b/toolkit/clean/input_selection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from toolkit.core.manifest import read_raw_manifest
+from toolkit.core.metadata import read_layer_metadata
 from toolkit.core.paths import from_root_relative, layer_year_dir, resolve_root
 from toolkit.core.run_context import get_run_dir, list_runs
 
@@ -126,13 +126,13 @@ def list_raw_candidates(
 
 
 def _manifest_primary_input(raw_year_dir: Path) -> tuple[Path | None, str | None]:
-    manifest = read_raw_manifest(raw_year_dir)
-    if not manifest:
-        return None, "CLEAN RAW manifest missing, using legacy selection."
+    meta = read_layer_metadata(raw_year_dir)
+    if not meta:
+        return None, "CLEAN RAW metadata missing, using legacy selection."
 
-    primary_output_file = manifest.get("primary_output_file")
+    primary_output_file = meta.get("primary_output_file")
     if not isinstance(primary_output_file, str) or not primary_output_file.strip():
-        return None, "CLEAN RAW manifest missing primary_output_file; using legacy selection."
+        return None, "CLEAN RAW metadata missing primary_output_file; using legacy selection."
 
     manifest_path = from_root_relative(primary_output_file, raw_year_dir)
     if _is_usable_input_file(manifest_path):
@@ -140,7 +140,7 @@ def _manifest_primary_input(raw_year_dir: Path) -> tuple[Path | None, str | None
 
     return (
         None,
-        "CLEAN RAW manifest primary_output_file is missing or invalid: "
+        "CLEAN RAW metadata primary_output_file is missing or invalid: "
         f"{primary_output_file}; using legacy selection.",
     )
 

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -8,7 +8,7 @@ from toolkit.clean.read_config import resolve_clean_read_cfg
 from toolkit.clean.input_selection import select_raw_input
 from toolkit.core.artifacts import should_write
 from toolkit.core.config import ensure_dict
-from toolkit.core.metadata import config_hash_for_year, file_record, write_layer_manifest, write_metadata
+from toolkit.core.metadata import config_hash_for_year, file_record, merge_layer_manifest, write_metadata
 from toolkit.core.paths import layer_year_dir, resolve_root, resolve_sql_path, serialize_metadata_path
 from toolkit.core.template import build_runtime_template_ctx, public_template_ctx, render_template
 from toolkit.clean.sql_execute import _normalize_output_profile, _run_sql
@@ -264,14 +264,11 @@ def run_clean(
         out_dir,
         metadata_payload,
     )
-    write_layer_manifest(
+    merge_layer_manifest(
         out_dir,
         metadata_path=metadata_path.name,
         validation_path="_validate/clean_validation.json",
         outputs=outputs,
-        ok=None,
-        errors_count=None,
-        warnings_count=None,
     )
     logger.info(f"CLEAN -> {output_path}")
     output_rows = int(output_profile.get("row_count") or 0)

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -18,7 +18,7 @@ from toolkit.clean._column_rules import (
 from toolkit.clean._helpers import _input_files_from_clean_metadata, _profile_raw_input
 from toolkit.core.config_models import CleanValidationSpec, RangeRuleConfig, TransitionConfig
 from toolkit.core.layer_profile import compare_layer_profiles
-from toolkit.core.metadata import write_layer_manifest
+from toolkit.core.metadata import merge_layer_manifest
 from toolkit.core.paths import layer_year_dir, to_root_relative
 from toolkit.core.validation import (
     ValidationResult,
@@ -437,7 +437,7 @@ def run_clean_validation(cfg, year: int, logger, *, sample_mode: bool = False) -
 
     report = write_validation_json(Path(out_dir) / "_validate" / "clean_validation.json", result)
     metadata = json.loads((out_dir / "metadata.json").read_text(encoding="utf-8"))
-    write_layer_manifest(
+    merge_layer_manifest(
         out_dir,
         metadata_path="metadata.json",
         validation_path="_validate/clean_validation.json",

--- a/toolkit/cli/cmd_resume.py
+++ b/toolkit/cli/cmd_resume.py
@@ -34,9 +34,8 @@ def _resume_layer(record: dict[str, object]) -> str | None:
 def _layer_artifacts_ok(root: Path, dataset: str, year: int, layer: str) -> tuple[bool, str]:
     layer_dir = layer_year_dir(root, layer, dataset, year)
     metadata_path = layer_dir / "metadata.json"
-    manifest_path = layer_dir / "manifest.json"
 
-    if not _artifact_exists(metadata_path) and not _artifact_exists(manifest_path):
+    if not _artifact_exists(metadata_path):
         return False, f"missing {layer}/metadata.json"
 
     meta = read_layer_metadata(layer_dir)

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -104,7 +104,6 @@ def _raw_output_paths(root: Path, dataset: str, year: int) -> dict[str, str]:
     return {
         "dir": str(raw_dir),
         "metadata": str(raw_dir / "metadata.json"),
-        "manifest": str(raw_dir / "manifest.json"),
         "validation": str(raw_dir / "raw_validation.json"),
     }
 
@@ -119,7 +118,6 @@ def _clean_paths(root: Path, dataset: str, year: int) -> dict[str, str]:
         "dir": str(clean_dir),
         "output": str(_clean_output_path(root, dataset, year)),
         "metadata": str(clean_dir / "metadata.json"),
-        "manifest": str(clean_dir / "manifest.json"),
         "validation": str(clean_dir / "_validate" / "clean_validation.json"),
     }
 
@@ -146,7 +144,6 @@ def _mart_paths(
         "dir": str(mart_dir),
         "outputs": [str(path) for path in _mart_output_paths(root, mart_dir, tables)],
         "metadata": str(mart_dir / "metadata.json"),
-        "manifest": str(mart_dir / "manifest.json"),
         "validation": str(mart_dir / "_validate" / "mart_validation.json"),
     }
 

--- a/toolkit/cli/inspect/paths_ops.py
+++ b/toolkit/cli/inspect/paths_ops.py
@@ -41,7 +41,6 @@ def paths(
         typer.echo(f"root: {item['root']}")
         typer.echo(f"raw_dir: {item['paths']['raw']['dir']}")
         typer.echo(f"raw_metadata: {item['paths']['raw']['metadata']}")
-        typer.echo(f"raw_manifest: {item['paths']['raw']['manifest']}")
         typer.echo(f"raw_validation: {item['paths']['raw']['validation']}")
         typer.echo("raw_hints:")
         typer.echo(f"  - primary_output_file: {item['raw_hints']['primary_output_file']}")
@@ -81,14 +80,12 @@ def paths(
                     )
         typer.echo(f"clean_dir: {item['paths']['clean']['dir']}")
         typer.echo(f"clean_output: {item['paths']['clean']['output']}")
-        typer.echo(f"clean_manifest: {item['paths']['clean']['manifest']}")
         typer.echo(f"clean_metadata: {item['paths']['clean']['metadata']}")
         typer.echo(f"clean_validation: {item['paths']['clean']['validation']}")
         typer.echo(f"mart_dir: {item['paths']['mart']['dir']}")
         typer.echo("mart_outputs:")
         for output in item["paths"]["mart"]["outputs"]:
             typer.echo(f"  - {output}")
-        typer.echo(f"mart_manifest: {item['paths']['mart']['manifest']}")
         typer.echo(f"mart_metadata: {item['paths']['mart']['metadata']}")
         typer.echo(f"mart_validation: {item['paths']['mart']['validation']}")
         if item["paths"]["support"]:

--- a/toolkit/cli/inspect/readiness_ops.py
+++ b/toolkit/cli/inspect/readiness_ops.py
@@ -151,7 +151,6 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
             "raw": {
                 "dir": str(raw_dir),
                 "dir_exists": raw_dir.exists(),
-                "manifest_exists": _exists(raw_paths.get("manifest")),
                 "metadata_exists": _exists(raw_paths.get("metadata")),
                 "primary_output_file": primary_output_file,
                 "primary_output_exists": _exists(primary_output_path),
@@ -171,7 +170,6 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
                 "dir_exists": clean_dir.exists(),
                 "output": clean_paths.get("output"),
                 "output_exists": _exists(clean_paths.get("output")),
-                "manifest_exists": _exists(clean_paths.get("manifest")),
                 "metadata_exists": _exists(clean_paths.get("metadata")),
                 "validation": _validation_summary_for_layer(clean_dir, "_validate/clean_validation.json"),
                 "run_status": layer_run_statuses.get("clean"),
@@ -183,7 +181,6 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
                 "output_count": len(mart_outputs),
                 "output_exists_count": len(mart_outputs) - len(missing_mart_outputs),
                 "missing_outputs": missing_mart_outputs,
-                "manifest_exists": _exists(mart_paths.get("manifest")),
                 "metadata_exists": _exists(mart_paths.get("metadata")),
                 "validation": _validation_summary_for_layer(mart_dir, "_validate/mart_validation.json"),
                 "run_status": layer_run_statuses.get("mart"),

--- a/toolkit/contracts/__init__.py
+++ b/toolkit/contracts/__init__.py
@@ -24,7 +24,6 @@ Costanti utili::
 
     CLEAN_PARQUET_SUFFIX   # "_clean.parquet" — per filtrare/globbare
     METADATA_JSON          # "metadata.json"
-    MANIFEST_JSON          # "manifest.json"
 """
 
 from __future__ import annotations
@@ -50,7 +49,6 @@ __all__ = [
     # Costanti file
     "CLEAN_PARQUET_SUFFIX",
     "METADATA_JSON",
-    "MANIFEST_JSON",
 ]
 
 # ---------------------------------------------------------------------------
@@ -67,7 +65,6 @@ Esempio::
 """
 
 METADATA_JSON = "metadata.json"
-MANIFEST_JSON = "manifest.json"
 
 
 # ---------------------------------------------------------------------------

--- a/toolkit/core/manifest.py
+++ b/toolkit/core/manifest.py
@@ -1,34 +1,6 @@
-from __future__ import annotations
+"""Deprecated — ``manifest.json`` has been removed in favor of ``metadata.json``.
 
-from pathlib import Path
-from typing import Any
-
-from toolkit.core.io import read_json, write_json_atomic
-from toolkit.core.metadata import merge_layer_manifest
-
-
-def write_raw_manifest(folder: Path, payload: dict[str, Any]) -> Path:
-    path = folder / "manifest.json"
-    write_json_atomic(path, payload)
-
-    summary = payload.get("summary")
-    merge_layer_manifest(
-        folder,
-        metadata_path="metadata.json",
-        validation_path=payload.get("validation"),
-        outputs=payload.get("outputs"),
-        ok=summary.get("ok") if isinstance(summary, dict) else None,
-        errors_count=summary.get("errors_count") if isinstance(summary, dict) else None,
-        warnings_count=summary.get("warnings_count") if isinstance(summary, dict) else None,
-        primary_output_file=payload.get("primary_output_file"),
-        sources=payload.get("sources"),
-    )
-
-    return path
-
-
-def read_raw_manifest(folder: Path) -> dict[str, Any] | None:
-    path = folder / "manifest.json"
-    if not path.exists():
-        return None
-    return read_json(path)
+Previously this module contained ``write_raw_manifest()`` and
+``read_raw_manifest()`` which wrote/read ``manifest.json``.
+All data is now stored in ``metadata.json`` via ``toolkit.core.metadata``.
+"""

--- a/toolkit/core/metadata.py
+++ b/toolkit/core/metadata.py
@@ -126,6 +126,3 @@ def merge_layer_manifest(
     out = folder / metadata_path
     write_json_atomic(out, meta)
     return out
-
-
-

--- a/toolkit/core/metadata.py
+++ b/toolkit/core/metadata.py
@@ -8,7 +8,7 @@ import hashlib
 from pathlib import Path
 from typing import Any
 
-from toolkit.core.io import write_json_atomic, read_json_or_none as _read_json
+from toolkit.core.io import write_json_atomic
 from toolkit.version import __version__
 
 
@@ -76,44 +76,19 @@ def _read_metadata(folder: Path, filename: str = "metadata.json") -> dict[str, A
 
 
 def read_layer_metadata(layer_dir: Path) -> dict[str, Any]:
+    """Read ``metadata.json`` from a layer directory.
+
+    ``metadata.json`` is the single source of truth — it contains runtime
+    metadata from the pipeline run and validation fields written by
+    ``merge_layer_manifest()``.
     """
-    Read layer metadata as the canonical source, with fallback to manifest.json
-    for fields that may not yet be migrated.
+    return _read_metadata(layer_dir) or {}
 
-    Migration path:
-    - metadata.json is the source of truth for: outputs, validation, summary,
-      primary_output_file (raw), sources (raw), and all standard metadata fields
-    - manifest.json is kept as a compat alias on write and as a fallback for
-      read when metadata.json does not yet contain the field
-    """
-    meta = _read_metadata(layer_dir) or {}
 
-    manifest = None
-    if not meta.get("primary_output_file"):
-        manifest = _read_json(layer_dir / "manifest.json") if manifest is None else manifest
-        pof = manifest.get("primary_output_file") if manifest else None
-        if isinstance(pof, str):
-            meta["primary_output_file"] = pof
-
-    if not meta.get("outputs"):
-        manifest = _read_json(layer_dir / "manifest.json") if manifest is None else manifest
-        outputs = manifest.get("outputs") if manifest else None
-        if isinstance(outputs, list):
-            meta["outputs"] = outputs
-
-    if not meta.get("summary"):
-        manifest = _read_json(layer_dir / "manifest.json") if manifest is None else manifest
-        summary = manifest.get("summary") if manifest else None
-        if isinstance(summary, dict):
-            meta["summary"] = summary
-
-    if not meta.get("validation"):
-        manifest = _read_json(layer_dir / "manifest.json") if manifest is None else manifest
-        validation = manifest.get("validation") if manifest else None
-        if isinstance(validation, str):
-            meta["validation"] = validation
-
-    return meta
+# ---------------------------------------------------------------------------
+# merge_layer_manifest — merge validation fields into metadata.json
+# ---------------------------------------------------------------------------
+    return _read_metadata(layer_dir) or {}
 
 
 
@@ -154,31 +129,4 @@ def merge_layer_manifest(
     return out
 
 
-def write_layer_manifest(
-    folder: Path,
-    *,
-    metadata_path: str = "metadata.json",
-    validation_path: str | None = None,
-    outputs: list[dict[str, Any]] | None = None,
-    ok: bool | None = None,
-    errors_count: int | None = None,
-    warnings_count: int | None = None,
-    filename: str = "manifest.json",
-) -> Path:
-    # Single write: compute payload once, write only manifest.json.
-    # metadata.json is NOT updated here — it stays as the run-time source of truth
-    # written by the run step. manifest.json is the validation-time alias that
-    # always reflects the latest validation outcome.
-    payload = {
-        "metadata": metadata_path,
-        "validation": validation_path,
-        "summary": {
-            "ok": ok,
-            "errors_count": errors_count,
-            "warnings_count": warnings_count,
-        },
-        "outputs": outputs,
-    }
-    out = folder / filename
-    write_json_atomic(out, payload)
-    return out
+

--- a/toolkit/core/metadata.py
+++ b/toolkit/core/metadata.py
@@ -88,7 +88,6 @@ def read_layer_metadata(layer_dir: Path) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # merge_layer_manifest — merge validation fields into metadata.json
 # ---------------------------------------------------------------------------
-    return _read_metadata(layer_dir) or {}
 
 
 

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -9,7 +9,7 @@ from lab_connectors.duckdb import safe_connect
 from toolkit.core.artifacts import should_write
 from toolkit.core.config import ensure_dict
 from toolkit.core.layer_profile import compare_layer_profiles, profile_relation, profile_parquet_files
-from toolkit.core.metadata import config_hash_for_year, file_record, write_layer_manifest, write_metadata
+from toolkit.core.metadata import config_hash_for_year, file_record, merge_layer_manifest, write_metadata
 from toolkit.core.multi_year_source import bind_multi_year_view, collect_multi_year_files
 from toolkit.core.paths import layer_dataset_dir, layer_year_dir, resolve_root, resolve_sql_path, serialize_metadata_path
 from toolkit.core.support import flatten_support_template_ctx, resolve_support_payloads
@@ -141,14 +141,10 @@ def run_mart_multi_year(
     if source_id:
         metadata_payload["source_id"] = source_id
     metadata_path = write_metadata(multi_year_dir, metadata_payload)
-    write_layer_manifest(
+    merge_layer_manifest(
         multi_year_dir,
         metadata_path=metadata_path.name,
-        validation_path=None,
         outputs=outputs,
-        ok=None,
-        errors_count=None,
-        warnings_count=None,
     )
     total_bytes = sum(p.stat().st_size for p in written if p.exists())
     col_count = sum(
@@ -456,14 +452,11 @@ def run_mart(
         mart_dir,
         metadata_payload,
     )
-    write_layer_manifest(
+    merge_layer_manifest(
         mart_dir,
         metadata_path=metadata_path.name,
         validation_path="_validate/mart_validation.json",
         outputs=outputs,
-        ok=None,
-        errors_count=None,
-        warnings_count=None,
     )
     total_bytes = sum(p.stat().st_size for p in written if p.exists())
     col_count = sum(len(tp.get("columns", [])) for tp in table_profiles.values()) if table_profiles else None

--- a/toolkit/mart/validate.py
+++ b/toolkit/mart/validate.py
@@ -7,7 +7,7 @@ from typing import Any
 from lab_connectors.duckdb import safe_connect
 
 from toolkit.core.config_models import MartTableRuleConfig, MartValidationSpec
-from toolkit.core.metadata import write_layer_manifest
+from toolkit.core.metadata import merge_layer_manifest
 from toolkit.core.paths import layer_year_dir, to_root_relative
 from toolkit.core.sql_utils import q_ident
 from toolkit.core.validation import (
@@ -261,7 +261,7 @@ def run_mart_validation(cfg, year: int, logger, *, sample_mode: bool = False) ->
         )
 
     report = write_validation_json(Path(mart_dir) / "_validate" / "mart_validation.json", result)
-    write_layer_manifest(
+    merge_layer_manifest(
         mart_dir,
         metadata_path="metadata.json",
         validation_path="_validate/mart_validation.json",

--- a/toolkit/mcp/types.py
+++ b/toolkit/mcp/types.py
@@ -13,7 +13,6 @@ from typing import Any, TypedDict
 class RawPaths(TypedDict):
     dir: str
     metadata: str
-    manifest: str
     validation: str
 
 
@@ -21,7 +20,6 @@ class CleanPaths(TypedDict):
     dir: str
     output: str
     metadata: str
-    manifest: str
     validation: str
 
 
@@ -29,7 +27,6 @@ class MartPaths(TypedDict):
     dir: str
     outputs: list[str]
     metadata: str
-    manifest: str
     validation: str
 
 

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -5,8 +5,7 @@ from pathlib import Path
 
 from toolkit.core.artifacts import should_write
 from toolkit.core.config import ensure_dict, parse_bool
-from toolkit.core.manifest import write_raw_manifest
-from toolkit.core.metadata import config_hash_for_year, sha256_bytes, write_metadata
+from toolkit.core.metadata import config_hash_for_year, merge_layer_manifest, sha256_bytes, write_metadata
 from toolkit.core.paths import layer_year_dir, to_root_relative
 from toolkit.core.registry import register_builtin_plugins
 from toolkit.core.validation import write_validation_json
@@ -199,35 +198,26 @@ def run_raw(
     }
     if source_id:
         metadata_payload["source_id"] = source_id
-    metadata_path = write_metadata(out_dir, metadata_payload)
+    write_metadata(out_dir, metadata_payload)
 
     # --- QA RAW ---
     result = validate_raw_output(out_dir, files_written)
     vpath = write_validation_json(out_dir / "raw_validation.json", result)
-    write_raw_manifest(
+    merge_layer_manifest(
         out_dir,
-        {
-            "dataset": dataset,
-            "year": year,
-            "run_id": run_id,
-            "created_at": datetime.now(timezone.utc).isoformat(),
-            "sources": [
-                {"name": entry["name"], "output_file": entry["output_file"]}
-                for entry in manifest_sources
-            ],
-            "primary_output_file": primary_output_file,
-            "metadata": metadata_path.name,
-            "validation": vpath.name,
-            "summary": {
-                "ok": result.ok,
-                "errors_count": len(result.errors),
-                "warnings_count": len(result.warnings),
-            },
-            "outputs": [
-                {"file": f["file"], "sha256": f["sha256"], "bytes": f["bytes"]}
-                for f in files_written
-            ],
-        },
+        validation_path=vpath.name,
+        outputs=[
+            {"file": f["file"], "sha256": f["sha256"], "bytes": f["bytes"]}
+            for f in files_written
+        ],
+        ok=result.ok,
+        errors_count=len(result.errors),
+        warnings_count=len(result.warnings),
+        primary_output_file=primary_output_file,
+        sources=[
+            {"name": entry["name"], "output_file": entry["output_file"]}
+            for entry in manifest_sources
+        ],
     )
 
     if result.warnings:

--- a/toolkit/raw/validate.py
+++ b/toolkit/raw/validate.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any
 import json
 
-from toolkit.core.manifest import read_raw_manifest, write_raw_manifest
+from toolkit.core.metadata import merge_layer_manifest
 from toolkit.core.paths import layer_year_dir
 from toolkit.core.validation import ValidationResult, build_validation_summary, write_validation_json
 
@@ -124,26 +124,13 @@ def run_raw_validation(root: str | None, dataset: str, year: int, logger) -> dic
         sections=result.sections,
     )
     report = write_validation_json(out_dir / "raw_validation.json", result)
-    existing_manifest = read_raw_manifest(out_dir) or {
-        "dataset": dataset,
-        "year": year,
-        "run_id": str(metadata.get("run_id") or "unknown"),
-        "created_at": str(metadata.get("timestamp_utc") or ""),
-        "sources": [],
-        "primary_output_file": "",
-    }
-    existing_manifest.update(
-        {
-            "metadata": "metadata.json",
-            "validation": report.name,
-            "summary": {
-                "ok": result.ok,
-                "errors_count": len(result.errors),
-                "warnings_count": len(result.warnings),
-            },
-            "outputs": metadata.get("outputs", []),
-        }
+    merge_layer_manifest(
+        out_dir,
+        validation_path=report.name,
+        outputs=metadata.get("outputs", []),
+        ok=result.ok,
+        errors_count=len(result.errors),
+        warnings_count=len(result.warnings),
     )
-    write_raw_manifest(out_dir, existing_manifest)
     logger.info(f"VALIDATE RAW -> {report} (ok={result.ok})")
     return build_validation_summary(result)


### PR DESCRIPTION
## Cosa

Rimuove `manifest.json` da tutti i layer (RAW, CLEAN, MART). Unifica su `metadata.json` come unica source of truth.

### Cambiamenti principali

- **`write_layer_manifest()` rimossa** — i 5 caller (clean/mart run+validate) chiamano `merge_layer_manifest()` direttamente
- **`write_raw_manifest()` / `read_raw_manifest()` rimosse** da `manifest.py` (ora guscio vuoto)
- **`read_layer_metadata()`** non ha più fallback su `manifest.json` — legge solo da `metadata.json`
- **`raw/run.py`** usa `merge_layer_manifest()` invece di `write_raw_manifest()`
- **`raw/validate.py`** usa `merge_layer_manifest()` invece di read/write_raw_manifest
- **`clean/input_selection.py`** usa `read_layer_metadata()` invece di `read_raw_manifest()`
- **CLI `inspect paths`** non espone più la chiave `manifest` (TypedDict aggiornato in `mcp/types.py`)
- **`MANIFEST_JSON`** rimosso da `toolkit.contracts`

### Impatto downstream

`manifest.json` non viene più scritto. dataset-incubator aggiornato nella PR parallela #(DI PR).

### Verifica

- 758 test passano (+0 / -0)
- Ruff OK, marker audit OK
- Nessuna referenza residua a `write_layer_manifest`, `read_raw_manifest`, `write_raw_manifest`

### Stat

25 file, +152 / -328 righe