### PR TITLE
Centralizza regole validazione e utility SQL cross-layer (RAW→CLEAN→MART)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ disallow_untyped_defs = false
 module = [
   "toolkit.mart.validate",
   "toolkit.clean.validate",
-  "toolkit.clean._column_rules",
+  "toolkit.core.column_rules",
   "toolkit.core.layer_profile",
 ]
 disable_error_code = [

--- a/tests/test_sql_utils.py
+++ b/tests/test_sql_utils.py
@@ -1,6 +1,8 @@
 """Tests for toolkit/core/sql_utils.py."""
 
-from toolkit.core.sql_utils import q_ident
+from pathlib import Path
+
+from toolkit.core.sql_utils import q_ident, quote_list, sql_path
 
 
 class TestQIdent:
@@ -37,3 +39,37 @@ class TestQIdent:
         result = q_ident("anything")
         assert result.startswith('"')
         assert result.endswith('"')
+
+
+class TestSqlPath:
+    def test_absolute_path_to_sql_literal(self) -> None:
+        p = Path("/tmp/test/file.csv")
+        result = sql_path(p)
+        expected = p.resolve().as_posix()
+        assert result == expected
+
+    def test_quotes_single_quote_in_path(self) -> None:
+        p = Path("/tmp/test/it's.csv")
+        result = sql_path(p)
+        assert "'" not in result.replace("''", "")
+        assert "''" in result
+
+
+class TestQuoteList:
+    def test_single_path(self) -> None:
+        p = Path("/tmp/a.csv")
+        result = quote_list([p])
+        expected = f"'{p.resolve().as_posix()}'"
+        assert result == expected
+
+    def test_multiple_paths(self) -> None:
+        p1 = Path("/tmp/a.csv")
+        p2 = Path("/tmp/b.csv")
+        result = quote_list([p1, p2])
+        assert result.startswith("'")
+        assert result.endswith("'")
+        assert p1.resolve().as_posix() in result
+        assert p2.resolve().as_posix() in result
+
+    def test_empty_list(self) -> None:
+        assert quote_list([]) == ""

--- a/tests/test_sql_utils.py
+++ b/tests/test_sql_utils.py
@@ -1,8 +1,14 @@
 """Tests for toolkit/core/sql_utils.py."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
+import pytest
+
 from toolkit.core.sql_utils import q_ident, quote_list, sql_path
+
+pytestmark = pytest.mark.pure_unit
 
 
 class TestQIdent:

--- a/tests/test_validate_layers.py
+++ b/tests/test_validate_layers.py
@@ -145,6 +145,25 @@ def test_validate_mart_report_uses_root_relative_dir(tmp_path: Path):
 
 
 @pytest.mark.policy
+def test_validate_mart_max_null_pct_rule(tmp_path: Path):
+    d = tmp_path / "mart"
+    d.mkdir(parents=True, exist_ok=True)
+
+    # Two rows: one has NULL (50% nulls > 10% threshold)
+    _write_parquet(
+        d / "foo.parquet",
+        "CREATE TABLE t AS SELECT * FROM (VALUES (1), (NULL)) v(valore)",
+    )
+
+    bad = validate_mart(d, table_rules={"foo": {"max_null_pct": {"valore": 0.1}}})
+    assert bad.ok is False
+    assert any("null_pct too high" in e for e in bad.errors)
+
+    ok = validate_mart(d, table_rules={"foo": {"max_null_pct": {"valore": 0.6}}})
+    assert ok.ok is True
+
+
+@pytest.mark.policy
 def test_check_transitions_warns_on_row_drop_over_threshold_and_removed_columns() -> None:
     transition_profiles = [
         {

--- a/toolkit/clean/duckdb_read.py
+++ b/toolkit/clean/duckdb_read.py
@@ -11,10 +11,8 @@ from toolkit.clean.read_excel import _execute_excel_read
 from toolkit.clean.read_sql_utils import (
     _parse_column_value,
     csv_trim_projection,
-    q_ident,
-    quote_list,
-    sql_path,
 )
+from toolkit.core.sql_utils import q_ident, quote_list, sql_path
 from toolkit.core.csv_read import (
     csv_read_option_strings,
     normalize_read_cfg,

--- a/toolkit/clean/read_sql_utils.py
+++ b/toolkit/clean/read_sql_utils.py
@@ -1,22 +1,13 @@
+"""SQL utility functions specific to the clean layer.
+
+Layer-specific SQL helpers (not shared across layers).
+For shared utilities like ``q_ident``, ``sql_path``, ``quote_list``
+see ``toolkit.core.sql_utils``.
+"""
+
 from __future__ import annotations
 
-from pathlib import Path
-
-
-def q_ident(name: str) -> str:
-    """Quote a SQL identifier, escaping embedded double quotes."""
-    return '"' + name.replace('"', '""') + '"'
-
-
-def sql_path(p: Path) -> str:
-    """Quote a file-system path for use in a DuckDB SQL string literal."""
-    s = p.resolve().as_posix()
-    return s.replace("'", "''")
-
-
-def quote_list(paths: list[Path]) -> str:
-    """Return a SQL comma-separated list of quoted path literals."""
-    return ", ".join([f"'{sql_path(p)}'" for p in paths])
+from toolkit.core.sql_utils import q_ident
 
 
 def _parse_column_value(raw_name: str, value: str) -> tuple[str, str]:

--- a/toolkit/clean/sql_execute.py
+++ b/toolkit/clean/sql_execute.py
@@ -12,8 +12,9 @@ from typing import Any
 
 from lab_connectors.duckdb import safe_connect
 
-from toolkit.clean.duckdb_read import read_raw_to_relation, sql_path
+from toolkit.clean.duckdb_read import read_raw_to_relation
 from toolkit.core.layer_profile import profile_relation
+from toolkit.core.sql_utils import sql_path
 
 
 def _normalize_output_profile(output_profile: dict[str, Any] | int) -> dict[str, Any]:

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -9,11 +9,11 @@ from typing import Any
 
 from lab_connectors.duckdb import safe_connect
 
-from toolkit.clean._column_rules import (
-    _check_max_null_pct,
-    _check_not_null,
-    _check_primary_key,
-    _check_ranges,
+from toolkit.core.column_rules import (
+    check_max_null_pct,
+    check_not_null,
+    check_primary_key,
+    check_ranges,
 )
 from toolkit.clean._helpers import _input_files_from_clean_metadata, _profile_raw_input
 from toolkit.core.config_models import CleanValidationSpec, RangeRuleConfig, TransitionConfig
@@ -120,20 +120,20 @@ def validate_clean(
         if min_rows is not None and row_count < min_rows:
             errors.append(f"CLEAN row_count too small: {row_count} < {min_rows}")
 
-        err_warn = _check_not_null(con, "t", not_null, cols)
+        err_warn = check_not_null(con, "t", not_null, cols)
         errors.extend(err_warn[0])
         warnings.extend(err_warn[1])
 
         if row_count > 0:
-            err_warn = _check_max_null_pct(con, "t", max_null_pct, cols, row_count)
+            err_warn = check_max_null_pct(con, "t", max_null_pct, cols, row_count)
             errors.extend(err_warn[0])
             warnings.extend(err_warn[1])
 
-        err_warn = _check_primary_key(con, "t", primary_key, cols)
+        err_warn = check_primary_key(con, "t", primary_key, cols)
         errors.extend(err_warn[0])
         warnings.extend(err_warn[1])
 
-        err_warn = _check_ranges(con, "t", ranges, cols)
+        err_warn = check_ranges(con, "t", ranges, cols)
         errors.extend(err_warn[0])
         warnings.extend(err_warn[1])
 

--- a/toolkit/core/column_rules.py
+++ b/toolkit/core/column_rules.py
@@ -112,6 +112,7 @@ def check_max_null_pct(
     max_null_pct: dict[str, float],
     cols: list[str],
     row_count: int,
+    prefix: str = "",
 ) -> tuple[list[str], list[str]]:
     """Check max null percentage constraints. Returns (errors, warnings)."""
     errors: list[str] = []
@@ -126,5 +127,6 @@ def check_max_null_pct(
         nnull = int(con.execute(f"SELECT COUNT(*) FROM {table} WHERE {qc} IS NULL").fetchone()[0])
         pct = nnull / row_count
         if pct > thr:
-            errors.append(f"Column '{c}' null_pct too high: {pct:.3%} > {thr:.3%}")
+            err_msg = f"Column '{c}' null_pct too high: {pct:.3%} > {thr:.3%}"
+            errors.append(f"{prefix}{err_msg}" if prefix else err_msg)
     return errors, warnings

--- a/toolkit/core/column_rules.py
+++ b/toolkit/core/column_rules.py
@@ -1,6 +1,7 @@
 """Column-level validation rules for clean/mart parquet files.
 
-Not part of the public API — internal utility module.
+Canonical location for reusable validation rules.
+Consumed by ``clean.validate`` and ``mart.validate``.
 """
 
 from __future__ import annotations
@@ -12,7 +13,13 @@ import duckdb
 from toolkit.core.sql_utils import q_ident
 
 
-def _check_not_null(con: duckdb.DuckDBPyConnection, table: str, columns: list[str], cols: list[str]) -> tuple[list[str], list[str]]:
+def check_not_null(
+    con: duckdb.DuckDBPyConnection,
+    table: str,
+    columns: list[str],
+    cols: list[str],
+    prefix: str = "",
+) -> tuple[list[str], list[str]]:
     """Check not-null constraints. Returns (errors, warnings)."""
     errors: list[str] = []
     warnings: list[str] = []
@@ -23,11 +30,18 @@ def _check_not_null(con: duckdb.DuckDBPyConnection, table: str, columns: list[st
         qc = q_ident(c)
         nnull = int(con.execute(f"SELECT COUNT(*) FROM {table} WHERE {qc} IS NULL").fetchone()[0])
         if nnull > 0:
-            errors.append(f"Column '{c}' has NULLs: {nnull}")
+            err_msg = f"Column '{c}' has NULLs: {nnull}"
+            errors.append(f"{prefix}{err_msg}" if prefix else err_msg)
     return errors, warnings
 
 
-def _check_primary_key(con: duckdb.DuckDBPyConnection, table: str, pk: list[str], cols: list[str], prefix: str = "") -> tuple[list[str], list[str]]:
+def check_primary_key(
+    con: duckdb.DuckDBPyConnection,
+    table: str,
+    pk: list[str],
+    cols: list[str],
+    prefix: str = "",
+) -> tuple[list[str], list[str]]:
     """Check primary key uniqueness. Returns (errors, warnings)."""
     errors: list[str] = []
     warnings: list[str] = []
@@ -55,7 +69,13 @@ def _check_primary_key(con: duckdb.DuckDBPyConnection, table: str, pk: list[str]
     return errors, warnings
 
 
-def _check_ranges(con: duckdb.DuckDBPyConnection, table: str, ranges: dict[str, Any], cols: list[str], prefix: str = "") -> tuple[list[str], list[str]]:
+def check_ranges(
+    con: duckdb.DuckDBPyConnection,
+    table: str,
+    ranges: dict[str, Any],
+    cols: list[str],
+    prefix: str = "",
+) -> tuple[list[str], list[str]]:
     """Check min/max range constraints. Returns (errors, warnings)."""
     errors: list[str] = []
     warnings: list[str] = []
@@ -86,7 +106,13 @@ def _check_ranges(con: duckdb.DuckDBPyConnection, table: str, ranges: dict[str, 
     return errors, warnings
 
 
-def _check_max_null_pct(con: duckdb.DuckDBPyConnection, table: str, max_null_pct: dict[str, float], cols: list[str], row_count: int) -> tuple[list[str], list[str]]:
+def check_max_null_pct(
+    con: duckdb.DuckDBPyConnection,
+    table: str,
+    max_null_pct: dict[str, float],
+    cols: list[str],
+    row_count: int,
+) -> tuple[list[str], list[str]]:
     """Check max null percentage constraints. Returns (errors, warnings)."""
     errors: list[str] = []
     warnings: list[str] = []

--- a/toolkit/core/column_rules.py
+++ b/toolkit/core/column_rules.py
@@ -13,6 +13,11 @@ import duckdb
 from toolkit.core.sql_utils import q_ident
 
 
+def _prefixed(prefix: str, msg: str) -> str:
+    """Prepend prefix if non-empty."""
+    return f"{prefix}{msg}" if prefix else msg
+
+
 def check_not_null(
     con: duckdb.DuckDBPyConnection,
     table: str,
@@ -25,13 +30,12 @@ def check_not_null(
     warnings: list[str] = []
     for c in columns:
         if c not in cols:
-            warnings.append(f"Not-null rule column missing in data: '{c}'")
+            warnings.append(_prefixed(prefix, f"Not-null rule column missing in data: '{c}'"))
             continue
         qc = q_ident(c)
         nnull = int(con.execute(f"SELECT COUNT(*) FROM {table} WHERE {qc} IS NULL").fetchone()[0])
         if nnull > 0:
-            err_msg = f"Column '{c}' has NULLs: {nnull}"
-            errors.append(f"{prefix}{err_msg}" if prefix else err_msg)
+            errors.append(_prefixed(prefix, f"Column '{c}' has NULLs: {nnull}"))
     return errors, warnings
 
 
@@ -48,7 +52,7 @@ def check_primary_key(
     if not pk:
         return errors, warnings
     if not all(c in cols for c in pk):
-        warnings.append(f"Primary key columns not all present: {pk}")
+        warnings.append(_prefixed(prefix, f"Primary key columns not all present: {pk}"))
     else:
         key_expr = ", ".join(q_ident(c) for c in pk)
         dup_groups = int(
@@ -64,8 +68,7 @@ def check_primary_key(
             ).fetchone()[0]
         )
         if dup_groups > 0:
-            err_msg = f"Primary key duplicates found for {pk}: groups={dup_groups}"
-            errors.append(f"{prefix}{err_msg}" if prefix else err_msg)
+            errors.append(_prefixed(prefix, f"Primary key duplicates found for {pk}: groups={dup_groups}"))
     return errors, warnings
 
 
@@ -81,7 +84,7 @@ def check_ranges(
     warnings: list[str] = []
     for c, rule in ranges.items():
         if c not in cols:
-            warnings.append(f"Range rule column missing in data: '{c}'")
+            warnings.append(_prefixed(prefix, f"Range rule column missing in data: '{c}'"))
             continue
 
         qc = q_ident(c)
@@ -92,17 +95,19 @@ def check_ranges(
             violations.append(f"{qc} > {rule.max}")
 
         if not violations:
-            warnings.append(f"Range rule for '{c}' has no min/max, skipping")
+            warnings.append(_prefixed(prefix, f"Range rule for '{c}' has no min/max, skipping"))
             continue
 
         where = f"{qc} IS NOT NULL AND (" + " OR ".join(violations) + ")"
         bad = int(con.execute(f"SELECT COUNT(*) FROM {table} WHERE {where}").fetchone()[0])
         if bad > 0:
-            err_msg = (
-                f"Range check failed for '{c}': bad_rows={bad} "
-                f"rules={{'min': {rule.min}, 'max': {rule.max}}}"
+            errors.append(
+                _prefixed(
+                    prefix,
+                    f"Range check failed for '{c}': bad_rows={bad} "
+                    f"rules={{'min': {rule.min}, 'max': {rule.max}}}",
+                )
             )
-            errors.append(f"{prefix}{err_msg}" if prefix else err_msg)
     return errors, warnings
 
 
@@ -121,12 +126,11 @@ def check_max_null_pct(
         return errors, warnings
     for c, thr in max_null_pct.items():
         if c not in cols:
-            warnings.append(f"Null-pct rule column missing in data: '{c}'")
+            warnings.append(_prefixed(prefix, f"Null-pct rule column missing in data: '{c}'"))
             continue
         qc = q_ident(c)
         nnull = int(con.execute(f"SELECT COUNT(*) FROM {table} WHERE {qc} IS NULL").fetchone()[0])
         pct = nnull / row_count
         if pct > thr:
-            err_msg = f"Column '{c}' null_pct too high: {pct:.3%} > {thr:.3%}"
-            errors.append(f"{prefix}{err_msg}" if prefix else err_msg)
+            errors.append(_prefixed(prefix, f"Column '{c}' null_pct too high: {pct:.3%} > {thr:.3%}"))
     return errors, warnings

--- a/toolkit/core/config_models/mart.py
+++ b/toolkit/core/config_models/mart.py
@@ -48,6 +48,7 @@ class MartTableRuleConfig(BaseModel):
     not_null: list[str] = Field(default_factory=list)
     primary_key: list[str] = Field(default_factory=list)
     ranges: dict[str, RangeRuleConfig] = Field(default_factory=dict)
+    max_null_pct: dict[str, float] = Field(default_factory=dict)
     min_rows: int | None = None
 
     @field_validator("required_columns", "not_null", "primary_key", mode="before")

--- a/toolkit/core/sql_utils.py
+++ b/toolkit/core/sql_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 
 def q_ident(value: str) -> str:
     """Quote a SQL identifier for DuckDB (handles reserved words / special chars).
@@ -10,3 +12,20 @@ def q_ident(value: str) -> str:
     This is safe for any identifier including those containing spaces or special chars.
     """
     return '"' + value.replace('"', '""') + '"'
+
+
+def sql_path(p: Path) -> str:
+    """Quote a file-system path for use in a DuckDB SQL string literal.
+
+    Escapes single quotes in the resolved absolute path.
+    """
+    s = p.resolve().as_posix()
+    return s.replace("'", "''")
+
+
+def quote_list(paths: list[Path]) -> str:
+    """Return a SQL comma-separated list of quoted path literals.
+
+    Each path is quoted via :func:`sql_path` for use in DuckDB SQL statements.
+    """
+    return ", ".join([f"'{sql_path(p)}'" for p in paths])

--- a/toolkit/mart/validate.py
+++ b/toolkit/mart/validate.py
@@ -132,7 +132,7 @@ def validate_mart(
 
             # max_null_pct — centralizzato in core.column_rules
             if rules.max_null_pct:
-                err_warn = check_max_null_pct(con, "t", rules.max_null_pct, cols, rc)
+                err_warn = check_max_null_pct(con, "t", rules.max_null_pct, cols, rc, prefix=prefix)
                 errors.extend(err_warn[0])
                 warnings.extend(err_warn[1])
 

--- a/toolkit/mart/validate.py
+++ b/toolkit/mart/validate.py
@@ -6,10 +6,15 @@ from typing import Any
 
 from lab_connectors.duckdb import safe_connect
 
+from toolkit.core.column_rules import (
+    check_max_null_pct,
+    check_not_null,
+    check_primary_key,
+    check_ranges,
+)
 from toolkit.core.config_models import MartTableRuleConfig, MartValidationSpec
 from toolkit.core.metadata import merge_layer_manifest
 from toolkit.core.paths import layer_year_dir, to_root_relative
-from toolkit.core.sql_utils import q_ident
 from toolkit.core.validation import (
     ValidationResult,
     build_validation_summary,
@@ -109,62 +114,27 @@ def validate_mart(
             required_result = required_columns_check(cols, req_cols)
             errors.extend([f"[{name}] {error}" for error in required_result.errors])
 
-            # not null
-            for c in rules.not_null:
-                if c not in cols:
-                    warnings.append(f"[{name}] Not-null rule column missing: '{c}'")
-                    continue
-                qc = q_ident(c)
-                nnull = int(con.execute(f"SELECT COUNT(*) FROM t WHERE {qc} IS NULL").fetchone()[0])
-                if nnull > 0:
-                    errors.append(f"[{name}] Column '{c}' has NULLs: {nnull}")
+            # not null — centralizzato in core.column_rules
+            prefix = f"[{name}] "
+            err_warn = check_not_null(con, "t", rules.not_null, cols, prefix=prefix)
+            errors.extend(err_warn[0])
+            warnings.extend(err_warn[1])
 
-            # primary key duplicates
-            pk = rules.primary_key
-            if pk:
-                if not all(c in cols for c in pk):
-                    warnings.append(f"[{name}] Primary key columns not all present: {pk}")
-                else:
-                    key_expr = ", ".join(q_ident(c) for c in pk)
-                    dup_groups = int(
-                        con.execute(
-                            f"""
-                            SELECT COUNT(*) FROM (
-                              SELECT {key_expr}, COUNT(*) AS n
-                              FROM t
-                              GROUP BY {key_expr}
-                              HAVING COUNT(*) > 1
-                            ) d
-                            """
-                        ).fetchone()[0]
-                    )
-                    if dup_groups > 0:
-                        errors.append(f"[{name}] PK duplicates for {pk}: groups={dup_groups}")
+            # primary key duplicates — centralizzato in core.column_rules
+            err_warn = check_primary_key(con, "t", rules.primary_key, cols, prefix=prefix)
+            errors.extend(err_warn[0])
+            warnings.extend(err_warn[1])
 
-            # ranges (violation = below min OR above max)
-            for c, rule in rules.ranges.items():
-                if c not in cols:
-                    warnings.append(f"[{name}] Range rule column missing: '{c}'")
-                    continue
+            # ranges — centralizzato in core.column_rules
+            err_warn = check_ranges(con, "t", rules.ranges, cols, prefix=prefix)
+            errors.extend(err_warn[0])
+            warnings.extend(err_warn[1])
 
-                qc = q_ident(c)
-                violations: list[str] = []
-                if rule.min is not None:
-                    violations.append(f"{qc} < {rule.min}")
-                if rule.max is not None:
-                    violations.append(f"{qc} > {rule.max}")
-
-                if not violations:
-                    warnings.append(f"[{name}] Range rule for '{c}' has no min/max, skipping")
-                    continue
-
-                where = f"{qc} IS NOT NULL AND (" + " OR ".join(violations) + ")"
-                bad = int(con.execute(f"SELECT COUNT(*) FROM t WHERE {where}").fetchone()[0])
-                if bad > 0:
-                    errors.append(
-                        f"[{name}] Range check failed for '{c}': bad_rows={bad} "
-                        f"rules={{'min': {rule.min}, 'max': {rule.max}}}"
-                    )
+            # max_null_pct — centralizzato in core.column_rules
+            if rules.max_null_pct:
+                err_warn = check_max_null_pct(con, "t", rules.max_null_pct, cols, rc)
+                errors.extend(err_warn[0])
+                warnings.extend(err_warn[1])
 
             per_table[name] = {
                 "columns": cols,
@@ -176,6 +146,7 @@ def validate_mart(
                         column: {"min": range_rule.min, "max": range_rule.max}
                         for column, range_rule in rules.ranges.items()
                     },
+                    "max_null_pct": rules.max_null_pct,
                     "min_rows": rules.min_rows,
                 },
             }
@@ -200,6 +171,7 @@ def validate_mart(
                         column: {"min": range_rule.min, "max": range_rule.max}
                         for column, range_rule in rule.ranges.items()
                     },
+                    "max_null_pct": rule.max_null_pct,
                     "min_rows": rule.min_rows,
                 }
                 for table, rule in table_rules.items()


### PR DESCRIPTION
## Sintesi

Centralizza in `core/` le regole di validazione colonne e le utility SQL che erano duplicate tra i layer CLEAN e MART. Colma il feature gap `max_null_pct` in MART. Rimuove ~67 righe nette.

## Contesto collegato

Nessuna issue — emerso da analisi strutturale delle duplicazioni tra layer RAW→CLEAN→MART.

## Cosa cambia

- [ ] Bug fix
- [x] Nuova funzionalità del motore (max_null_pct in MART)
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

Nessun impatto. I campi aggiunti (`max_null_pct`) sono opzionali e backward-compatibili.

- [ ] Struttura `dataset.yml` (nuovo campo, cambio obbligatorietà)
- [ ] Path output (nuovo layer, cambio percorso artifact)
- [ ] Schema parquet (nuova colonna, rename, cambio tipo)
- [ ] CLI o MCP tool (nuovo comando, cambio parametro)
- [ ] API pubblica del toolkit (firma funzione, classe, eccezione)

## Verifica

```bash
pytest tests/ -v --timeout=60
ruff check toolkit/
```

- [x] `pytest tests/` — 764 passati
- [x] `ruff check .` — nessun errore

## Checklist PR

- [x] Perimetro stretto: una PR = un layer o un fix mirato
- [x] Test aggiunti con marker appropriato (`policy`, `pure_unit`)
- [x] Nessuna issue collegata (analisi esplorativa)

## Note per chi revisiona

Le modifiche vanno dal centro verso i bordi:
1. `core/sql_utils.py` — aggiunte `sql_path()`, `quote_list()`
2. `core/column_rules.py` — nuovo file (rename da `clean/_column_rules.py`)
3. `clean/validate.py` — import diretto da `core/column_rules`
4. `mart/validate.py` — 55 righe inline sostituite con 6 chiamate centralizzate
5. `core/config_models/mart.py` — aggiunto `max_null_pct`

Backward compat eliminata perché tutti i consumer sono interni al toolkit.