### PR TITLE
review-readiness arricchito: validation messages, transition, profile -- integrato in run full e MCP

### DIFF
--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -120,6 +120,106 @@ def test_review_readiness_ready_when_all_layers_present(tmp_path: Path, monkeypa
     assert payload["ok_count"] == len(payload["checks"])
 
 
+def test_review_readiness_enriched_layers_shape(tmp_path: Path, monkeypatch) -> None:
+    """review_readiness()['layers'] deve contenere validation, validation_msgs, profile, transition."""
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
+    config_path = dst / "dataset.yml"
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+    import duckdb
+
+    # Crea raw output + raw_validation.json (raw NON usa _validate/)
+    raw_dir = dst / "_smoke_out" / "data" / "raw" / "project_example" / "2022"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "data.csv").write_bytes(b"a;b\n1;2\n")
+    (raw_dir / "raw_validation.json").write_text(
+        '{"ok":true,"errors":[],"warnings":["test warning raw"],"summary":{}}',
+        encoding="utf-8",
+    )
+
+    # Crea clean output + clean validation con messaggi
+    clean_dir = dst / "_smoke_out" / "data" / "clean" / "project_example" / "2022"
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    clean_parquet = clean_dir / "project_example_2022_clean.parquet"
+    with duckdb.connect(":memory:") as conn:
+        conn.execute("CREATE TABLE t AS SELECT 1 AS x")
+        conn.execute(f"COPY t TO '{clean_parquet}' (FORMAT PARQUET)")
+    clean_val_dir = clean_dir / "_validate"
+    clean_val_dir.mkdir(parents=True, exist_ok=True)
+    (clean_val_dir / "clean_validation.json").write_text(
+        json.dumps({
+            "ok": True,
+            "errors": [],
+            "warnings": ["[transition:clean] columns removed: [col_a]"],
+            "summary": {
+                "stats": {"clean_rows": 1, "clean_cols": 1, "raw_rows": 2, "row_drop_pct": 50.0},
+            },
+            "sections": {
+                "transition": {
+                    "raw_row_count": 2,
+                    "clean_row_count": 1,
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    # Crea mart output + mart validation con messaggi
+    mart_dir = dst / "_smoke_out" / "data" / "mart" / "project_example" / "2022"
+    mart_dir.mkdir(parents=True, exist_ok=True)
+    mart_p = mart_dir / "mart_t.parquet"
+    with duckdb.connect(":memory:") as conn:
+        conn.execute("CREATE TABLE t AS SELECT 1 AS x")
+        conn.execute(f"COPY t TO '{mart_p}' (FORMAT PARQUET)")
+    mart_val_dir = mart_dir / "_validate"
+    mart_val_dir.mkdir(parents=True, exist_ok=True)
+    (mart_val_dir / "mart_validation.json").write_text(
+        json.dumps({
+            "ok": False,
+            "errors": ["[mart_t] row_count too small"],
+            "warnings": [],
+            "summary": {"row_counts": {"mart_t": 1}},
+        }),
+        encoding="utf-8",
+    )
+
+    payload = review_readiness(str(config_path), 2022)
+    layers = payload.get("layers", {})
+
+    # --- Asserts sulla struttura layers ---
+    assert "raw" in layers
+    assert "clean" in layers
+    assert "mart" in layers
+
+    # Raw: deve leggere raw_validation.json (non _validate/)
+    raw_msgs = layers["raw"].get("validation_msgs", {})
+    assert "test warning raw" in raw_msgs.get("warnings", []), (
+        f"Raw validation messages non trovate: {raw_msgs}"
+    )
+
+    # Clean: validation_msgs deve contenere il warning di transizione
+    clean_msgs = layers["clean"].get("validation_msgs", {})
+    assert len(clean_msgs.get("warnings", [])) == 1
+    assert "columns removed" in clean_msgs["warnings"][0]
+
+    # Clean: transition stats
+    trans = layers["clean"].get("transition", {})
+    assert trans.get("row_drop_pct") == 50.0
+
+    # Mart: validation_msgs deve contenere l'errore
+    mart_msgs = layers["mart"].get("validation_msgs", {})
+    assert len(mart_msgs.get("errors", [])) == 1
+    assert "row_count too small" in mart_msgs["errors"][0]
+
+    # Mart: ok=False si riflette nel validation
+    assert layers["mart"].get("validation", {}).get("ok") is False
+
+    # Raw profile hints (encoding/delim da suggested_read se presente)
+    raw_profile = layers["raw"].get("profile", {})
+    assert isinstance(raw_profile, dict)
+
+
 def test_review_readiness_needs_review_with_single_failure(tmp_path: Path, monkeypatch) -> None:
     src = Path("project-example")
     dst = tmp_path / "project-example"

--- a/toolkit/cli/cmd_review_readiness.py
+++ b/toolkit/cli/cmd_review_readiness.py
@@ -85,6 +85,89 @@ def review_readiness(
         elif detail:
             typer.echo(f"      {detail}")
 
+    # --- Validation details with messages ---
+    layers = result.get("layers") or {}
+    has_val = False
+    for lname, label in [("raw", "raw"), ("clean", "clean"), ("mart", "mart")]:
+        ln = layers.get(lname) or {}
+        v = ln.get("validation") or {}
+        msgs = ln.get("validation_msgs") or {}
+        if v.get("ok") is None and not msgs.get("warnings") and not msgs.get("errors"):
+            continue
+        if not has_val:
+            typer.echo("")
+            typer.echo("validation:")
+            has_val = True
+        count_parts = []
+        if v.get("errors_count"):
+            count_parts.append(f"{v['errors_count']} errori")
+        if v.get("warnings_count"):
+            count_parts.append(f"{v['warnings_count']} warning")
+        counts = f" ({', '.join(count_parts)})" if count_parts else ""
+        status = "✅" if v.get("ok") else ("🔴" if v.get("ok") is False else "·")
+        typer.echo(f"  {label}: {status}{counts}")
+        for w in msgs.get("warnings", [])[:2]:
+            typer.echo(f"    ⚠ {w[:120]}")
+        for e in msgs.get("errors", [])[:2]:
+            typer.echo(f"    🔴 {e[:120]}")
+
+    # --- Raw profile warnings ---
+    raw_warnings = (layers.get("raw") or {}).get("profile_warnings") or []
+    if raw_warnings:
+        typer.echo("raw profile warnings:")
+        for w in raw_warnings[:5]:
+            typer.echo(f"  ⚠ {w}")
+        if len(raw_warnings) > 5:
+            typer.echo(f"  ... e {len(raw_warnings) - 5} altro(i)")
+
+    # --- Rich layer info ---
+    typer.echo("")
+
+    # Raw layer
+    raw_layer = layers.get("raw") or {}
+    raw_val = raw_layer.get("validation") or {}
+    raw_profile = raw_layer.get("profile") or {}
+    raw_warnings = raw_layer.get("profile_warnings") or []
+    raw_status = "✅" if raw_val.get("ok") else ("🔴" if raw_val.get("ok") is False else "·")
+    raw_cols = raw_val.get("col_count")
+    raw_info_parts = []
+    if raw_cols is not None:
+        raw_info_parts.append(f"{raw_cols} colonne")
+    if raw_profile.get("encoding"):
+        raw_info_parts.append(f"encoding={raw_profile['encoding']}")
+    if raw_profile.get("delim"):
+        raw_info_parts.append(f"delim={raw_profile['delim']}")
+    if raw_warnings:
+        raw_info_parts.append(f"{len(raw_warnings)} warning")
+    typer.echo(f"  raw:   {raw_status}  {'  '.join(raw_info_parts)}" if raw_info_parts else f"  raw:   {raw_status}")
+
+    # Clean layer
+    clean_layer = layers.get("clean") or {}
+    clean_val = clean_layer.get("validation") or {}
+    clean_status = "✅" if clean_val.get("ok") else ("🔴" if clean_val.get("ok") is False else "·")
+    clean_rows = clean_val.get("row_count") or clean_layer.get("row_count")
+    clean_cols = clean_val.get("col_count")
+    trans = clean_layer.get("transition") or {}
+    clean_info = []
+    if clean_rows is not None:
+        clean_info.append(f"{clean_rows} righe")
+    if clean_cols is not None:
+        clean_info.append(f"{clean_cols} colonne")
+    if trans.get("row_drop_pct") is not None:
+        clean_info.append(f"raw→clean: {trans['row_drop_pct']}% righe")
+    if trans.get("col_drop") is not None and trans["col_drop"] != 0:
+        clean_info.append(f"-{trans['col_drop']} colonne")
+    typer.echo(f"  clean: {clean_status}  {'  '.join(clean_info)}" if clean_info else f"  clean: {clean_status}")
+
+    # Mart layer
+    mart_layer = layers.get("mart") or {}
+    mart_val = mart_layer.get("validation") or {}
+    mart_status = "✅" if mart_val.get("ok") else ("🔴" if mart_val.get("ok") is False else "·")
+    mart_tables = mart_layer.get("tables") or []
+    mart_ready = sum(1 for t in mart_tables if t.get("readable"))
+    mart_total = len(mart_tables)
+    typer.echo(f"  mart:  {mart_status}  {mart_ready}/{mart_total} tabelle" if mart_tables else f"  mart:  {mart_status}  (nessuna tabella)")
+
     typer.echo("")
     if readiness == "ready":
         typer.echo("✅ Pronto per review — tutti i check passano.")

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -740,13 +740,14 @@ def run_full(
                 if not all_passed and fail_on_error_flag:
                     results["status"] = "failed"
 
-                # Review readiness (capture, not print)
+                # Review readiness (capture full result including layers)
                 from toolkit.cli.inspect.readiness_ops import review_readiness as _review_readiness
                 readiness = _review_readiness(config, year or None)
                 results["steps"][str(year)]["readiness"] = readiness.get("readiness")
                 results["steps"][str(year)]["checks"] = readiness.get("check_count", 0)
                 results["steps"][str(year)]["checks_ok"] = readiness.get("ok_count", 0)
                 results["steps"][str(year)]["checks_fail"] = readiness.get("fail_count", 0)
+                results["steps"][str(year)]["layers"] = readiness.get("layers", {})
 
         # Multi-year mart: run once per dataset after per-year processing
         if not dry_flag and _has_multi_year_mart(cfg):
@@ -766,7 +767,39 @@ def run_full(
         typer.echo(f"years: {selected_years}")
         typer.echo(f"status: {status}")
         for y, s in results["steps"].items():
-            typer.echo(f"  {y}: run={s['run']} validate={s['validate']} readiness={s.get('readiness','?')} checks={s.get('checks_ok',0)}/{s.get('checks',0)}")
+            typer.echo(f"  {y}: run={s['run']} validate={s['validate']}")
+            lyrs = s.get("layers", {})
+            for lname in ("raw", "clean", "mart"):
+                ln = lyrs.get(lname) or {}
+                lv = ln.get("validation") or {}
+                ok = lv.get("ok")
+                icon = "✅" if ok else ("🔴" if ok is False else "·")
+                parts = []
+                if lname == "raw":
+                    pf = ln.get("profile") or {}
+                    if pf.get("encoding"):
+                        parts.append(f"encoding={pf['encoding']}")
+                    if pf.get("delim"):
+                        parts.append(f"delim={pf['delim']}")
+                    pw = ln.get("profile_warnings") or []
+                    if pw:
+                        parts.append(f"{len(pw)} warning")
+                elif lname == "clean":
+                    rc = lv.get("row_count") or ln.get("row_count")
+                    cc = lv.get("col_count")
+                    if rc is not None:
+                        parts.append(f"{rc} righe")
+                    if cc is not None:
+                        parts.append(f"{cc} colonne")
+                    tr = ln.get("transition") or {}
+                    if tr.get("row_drop_pct") is not None:
+                        parts.append(f"raw->clean: {tr['row_drop_pct']}% righe")
+                elif lname == "mart":
+                    tbl = ln.get("tables") or []
+                    ready = sum(1 for t in tbl if t.get("readable"))
+                    parts.append(f"{ready}/{len(tbl)} tabelle")
+                typer.echo(f"       {lname}: {icon}  {'  '.join(parts)}" if parts else f"       {lname}: {icon}")
+            typer.echo(f"       readiness: {s.get('readiness', '?')}  ({s.get('checks_ok', 0)}/{s.get('checks', 0)})")
 
     if results["status"] != "passed":
         raise typer.Exit(code=1)

--- a/toolkit/cli/inspect/readiness_ops.py
+++ b/toolkit/cli/inspect/readiness_ops.py
@@ -15,6 +15,7 @@ from toolkit.cli.inspect._helpers import (
     _exists,
     _payload_for_year,
     _read_parquet_row_count,
+    _read_validation_content,
     _validation_summary_for_layer,
 )
 from toolkit.core.config import load_config
@@ -309,6 +310,49 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
     ok_count = sum(1 for c in checks if c["ok"])
     fail_count = sum(1 for c in checks if not c["ok"])
 
+    # --- Extract validation messages from validation JSON ---
+    def _validation_msgs(layer_dir: Path, filename: str, max_items: int = 3) -> dict:
+        """Read first N warning/error messages from a validation JSON."""
+        fpath = str(layer_dir / filename) if layer_dir.exists() else None
+        content = _read_validation_content(fpath)
+        msgs: dict[str, list[str]] = {"errors": [], "warnings": []}
+        if content:
+            msgs["errors"] = content.get("errors", [])[:max_items]
+            msgs["warnings"] = content.get("warnings", [])[:max_items]
+        return msgs
+
+    # --- Validation messages from disk ---
+    raw_dir_path = Path(raw.get("dir", ""))
+    clean_dir_path = Path(clean.get("dir", ""))
+    mart_dir_path = Path(mart.get("dir", ""))
+    raw_msgs = _validation_msgs(raw_dir_path, "_validate/raw_validation.json")
+    clean_msgs = _validation_msgs(clean_dir_path, "_validate/clean_validation.json")
+    mart_msgs = _validation_msgs(mart_dir_path, "_validate/mart_validation.json")
+
+    # --- Extract rich layer info from summary (already computed) ---
+    raw_val = raw.get("validation") or {}
+    clean_val = clean.get("validation") or {}
+    mart_val = mart.get("validation") or {}
+    raw_profile_warnings = raw.get("raw_warnings") or []
+    raw_profile_hints = {
+        "encoding": raw.get("encoding_suggested"),
+        "delim": raw.get("delim_suggested"),
+        "decimal": raw.get("decimal_suggested"),
+        "skip": raw.get("skip_suggested"),
+    }
+
+    # Transition stats from clean validation
+    raw_row_count = clean_val.get("raw_row_count")
+    clean_row_count = clean_val.get("clean_row_count")
+    col_drop = None
+    row_drop_pct = None
+    if raw_row_count is not None and clean_row_count is not None and raw_row_count > 0:
+        row_drop_pct = round((raw_row_count - clean_row_count) / raw_row_count * 100, 1)
+    raw_col_count = raw_val.get("col_count")
+    clean_col_count = clean_val.get("col_count")
+    if raw_col_count is not None and clean_col_count is not None:
+        col_drop = raw_col_count - clean_col_count
+
     if fail_count == 0:
         readiness = "ready"
     elif ok_count >= len(checks) - 1:
@@ -325,4 +369,30 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
         "ok_count": ok_count,
         "fail_count": fail_count,
         "checks": checks,
+        "layers": {
+            "raw": {
+                "validation": raw_val,
+                "validation_msgs": raw_msgs,
+                "profile": raw_profile_hints,
+                "profile_warnings": raw_profile_warnings,
+                "primary_output": raw.get("primary_output_file"),
+            },
+            "clean": {
+                "validation": clean_val,
+                "validation_msgs": clean_msgs,
+                "output": clean.get("output"),
+                "row_count": clean_rows,
+                "transition": {
+                    "raw_row_count": raw_row_count,
+                    "clean_row_count": clean_row_count,
+                    "row_drop_pct": row_drop_pct,
+                    "col_drop": col_drop,
+                },
+            },
+            "mart": {
+                "validation": mart_val,
+                "validation_msgs": mart_msgs,
+                "tables": mart_checks,
+            },
+        },
     }

--- a/toolkit/cli/inspect/readiness_ops.py
+++ b/toolkit/cli/inspect/readiness_ops.py
@@ -163,7 +163,7 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
                 "decimal_suggested": (paths.get("raw_hints") or {}).get("decimal"),
                 "skip_suggested": (paths.get("raw_hints") or {}).get("skip"),
                 "raw_warnings": (paths.get("raw_hints") or {}).get("warnings", []),
-                "validation": _validation_summary_for_layer(raw_dir, "_validate/raw_validation.json"),
+                "validation": _validation_summary_for_layer(raw_dir, "raw_validation.json"),
                 "run_status": layer_run_statuses.get("raw"),
             },
             "clean": {
@@ -325,7 +325,7 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
     raw_dir_path = Path(raw.get("dir", ""))
     clean_dir_path = Path(clean.get("dir", ""))
     mart_dir_path = Path(mart.get("dir", ""))
-    raw_msgs = _validation_msgs(raw_dir_path, "_validate/raw_validation.json")
+    raw_msgs = _validation_msgs(raw_dir_path, "raw_validation.json")
     clean_msgs = _validation_msgs(clean_dir_path, "_validate/clean_validation.json")
     mart_msgs = _validation_msgs(mart_dir_path, "_validate/mart_validation.json")
 


### PR DESCRIPTION
## Sintesi

review-readiness ora mostra molto piu dei 5 check binari: validation messages reali, transition stats (row_drop_pct, col_drop), raw profile hints (encoding, delim). Integrato in toolkit run full e MCP (gia coperto dal dict unico).

## Cosa cambia

- Nuova funzionalita del motore
- Refactor / performance

## Dettaglio

### readiness_ops.py
- Aggiunta chiave layers al return dict di review_readiness()
- Ogni layer include: validation, validation_msgs (primi 3 error/warning), transition (row_drop_pct, col_drop), profile (encoding, delim), profile_warnings

### cmd_review_readiness.py
- Mostra messaggi di validazione reali invece di solo conteggi
- Riepilogo compatto per layer (raw: encoding/delim, clean: righe/colonne, mart: tabelle)

### cmd_run.py
- run full ora mostra il layers summary per anno invece di una riga singola

### MCP
- Nessun cambio: toolkit_review_readiness restituisce gia l intero dict di review_readiness(), ora include layers

## Verifica

- pytest tests/ -- 764 passati
- review-readiness su project-example, aifa, terna, irpef
- run full su project-example e aifa

## Checklist PR

- Perimetro stretto: unica funzionalita (review-readiness arricchito)
- Test esistenti passano (nessun cambio contratto pubblico)
- Backward compat: campi esistenti invariati
