### PR TITLE
fix: list_candidates MCP ora usa root reale da dataset.yml invece di hardcoded

### DIFF
--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -701,6 +701,82 @@ def test_list_candidates_returns_sorted_list(tmp_path: Path, monkeypatch: pytest
     assert "c-dataset" in slugs
 
 
+def test_list_candidates_resolves_custom_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_candidates deve risolvere root:../../custom_out da dataset.yml
+    e trovare clean/mart/runs sotto custom_out/ anziche' WORKSPACE_ROOT/out/."""
+    from toolkit.mcp import discovery as _discmod
+    monkeypatch.setattr(_discmod, "WORKSPACE_ROOT", tmp_path)
+
+    import duckdb
+    import json
+
+    name = "test-root-candidate"
+    cand_dir = tmp_path / "dataset-incubator" / "candidates" / name
+    cand_dir.mkdir(parents=True, exist_ok=True)
+
+    # dataset.yml con root custom (relativo al dataset.yml)
+    (cand_dir / "dataset.yml").write_text(
+        f"root: \"../../custom_out\"\n"
+        f"schema_version: 1\n"
+        f"dataset:\n"
+        f"  name: {name}\n"
+        f"  years: [2024]\n",
+        encoding="utf-8",
+    )
+
+    # Crea output in dataset-incubator/custom_out/data/clean/{name}/
+    # (root:../../custom_out è relativo a dataset-incubator/candidates/{name}/)
+    custom_root = tmp_path / "dataset-incubator" / "custom_out"
+    clean_dir = custom_root / "data" / "clean" / name / "2024"
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    clean_parquet = clean_dir / f"{name}_2024_clean.parquet"
+    with duckdb.connect(":memory:") as con:
+        con.execute("CREATE TABLE t AS SELECT 1 AS x")
+        con.execute(f"COPY t TO '{clean_parquet}' (FORMAT PARQUET)")
+
+    # Crea output mart
+    mart_dir = custom_root / "data" / "mart" / name / "2024"
+    mart_dir.mkdir(parents=True, exist_ok=True)
+    mart_parquet = mart_dir / f"mart_{name}.parquet"
+    with duckdb.connect(":memory:") as con:
+        con.execute("CREATE TABLE t AS SELECT 1 AS x")
+        con.execute(f"COPY t TO '{mart_parquet}' (FORMAT PARQUET)")
+
+    # Crea run record sotto custom_root/data/_runs/
+    runs_dir = custom_root / "data" / "_runs" / name / "2024"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "run_success.json").write_text(
+        json.dumps({
+            "dataset": name,
+            "year": 2024,
+            "status": "SUCCESS",
+            "layers": {"clean": {"status": "SUCCESS"}, "mart": {"status": "SUCCESS"}},
+        }),
+        encoding="utf-8",
+    )
+
+    from toolkit.mcp.discovery import list_candidates
+
+    result = list_candidates(stage="candidates")
+    items = [c for c in result if c["slug"] == name]
+    assert len(items) == 1, f"Candidate {name} non trovato: {result}"
+    item = items[0]
+
+    assert item["dataset_name"] == name
+    assert item["has_clean"] is True, (
+        f"has_clean=False, clean_dir={clean_dir} esiste? {clean_dir.exists()}"
+    )
+    assert item["has_mart"] is True, f"has_mart=False, mart_dir={mart_dir} esiste? {mart_dir.exists()}"
+    assert item["last_run_status"] == "SUCCESS"
+
+    # Verifica che il fallback WORKSPACE_ROOT/out/ NON abbia i dati
+    wrong_clean = tmp_path / "out" / "data" / "clean" / name
+    assert not wrong_clean.exists(), (
+        f"Il dato non dovrebbe essere in {wrong_clean} ma in {custom_root}/data/clean/"
+    )
+
+
+
 def test_safe_path_absolute_not_found_raises_clean_error(tmp_path: Path) -> None:
     """_safe_path con path assoluto inesistente deve alzare ToolkitClientError,
     non RecursionError (regressione recursion loop)."""

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -19,7 +19,7 @@ from toolkit.clean._helpers import _input_files_from_clean_metadata, _profile_ra
 from toolkit.core.config_models import CleanValidationSpec, RangeRuleConfig, TransitionConfig
 from toolkit.core.layer_profile import compare_layer_profiles
 from toolkit.core.metadata import merge_layer_manifest
-from toolkit.core.paths import layer_year_dir, to_root_relative
+from toolkit.core.paths import CLEAN_VALIDATION, layer_year_dir, to_root_relative
 from toolkit.core.validation import (
     ValidationResult,
     build_validation_summary,
@@ -435,7 +435,7 @@ def run_clean_validation(cfg, year: int, logger, *, sample_mode: bool = False) -
         sections=merged_sections,
     )
 
-    report = write_validation_json(Path(out_dir) / "_validate" / "clean_validation.json", result)
+    report = write_validation_json(Path(out_dir) / CLEAN_VALIDATION, result)
     metadata = json.loads((out_dir / "metadata.json").read_text(encoding="utf-8"))
     merge_layer_manifest(
         out_dir,

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -13,7 +13,14 @@ import duckdb
 
 from toolkit.cli.common import load_layer_profile_summaries
 from toolkit.core.metadata import read_layer_metadata
-from toolkit.core.paths import layer_year_dir
+from toolkit.core.paths import (
+    RAW_VALIDATION,
+    CLEAN_VALIDATION,
+    MART_VALIDATION,
+    RAW_PROFILE,
+    RAW_SUGGESTED_READ,
+    layer_year_dir,
+)
 from toolkit.core.run_context import get_run_dir, latest_run
 from toolkit.core.support import resolve_support_payloads
 from toolkit.profile.raw import sniff_source_file
@@ -49,7 +56,7 @@ def _raw_schema_payload(cfg, year: int) -> dict[str, Any]:
     # Read actual columns from raw_profile.json if available.
     columns_preview = list(profile_hints.get("columns_preview") or [])
     if not columns_preview and profile_hints.get("is_binary_file"):
-        raw_profile_path = raw_dir / "_profile" / "raw_profile.json"
+        raw_profile_path = raw_dir / RAW_PROFILE
         if raw_profile_path.exists():
             try:
                 raw_profile_data = json.loads(raw_profile_path.read_text(encoding="utf-8"))
@@ -104,7 +111,7 @@ def _raw_output_paths(root: Path, dataset: str, year: int) -> dict[str, str]:
     return {
         "dir": str(raw_dir),
         "metadata": str(raw_dir / "metadata.json"),
-        "validation": str(raw_dir / "raw_validation.json"),
+        "validation": str(raw_dir / RAW_VALIDATION),
     }
 
 
@@ -118,7 +125,7 @@ def _clean_paths(root: Path, dataset: str, year: int) -> dict[str, str]:
         "dir": str(clean_dir),
         "output": str(_clean_output_path(root, dataset, year)),
         "metadata": str(clean_dir / "metadata.json"),
-        "validation": str(clean_dir / "_validate" / "clean_validation.json"),
+        "validation": str(clean_dir / CLEAN_VALIDATION),
     }
 
 
@@ -144,7 +151,7 @@ def _mart_paths(
         "dir": str(mart_dir),
         "outputs": [str(path) for path in _mart_output_paths(root, mart_dir, tables)],
         "metadata": str(mart_dir / "metadata.json"),
-        "validation": str(mart_dir / "_validate" / "mart_validation.json"),
+        "validation": str(mart_dir / MART_VALIDATION),
     }
 
 
@@ -154,7 +161,7 @@ def _payload_for_year(cfg, year: int) -> dict[str, Any]:
     mart_tables = cfg.mart.get("tables") or []
     raw_dir = layer_year_dir(root, "raw", cfg.dataset, year)
     raw_meta = read_layer_metadata(raw_dir)
-    suggested_read_path = raw_dir / "_profile" / "suggested_read.yml"
+    suggested_read_path = raw_dir / RAW_SUGGESTED_READ
     profile_hints = raw_meta.get("profile_hints") or {}
 
     run_files = sorted(run_dir.glob("*.json")) if run_dir.exists() else []

--- a/toolkit/cli/inspect/readiness_ops.py
+++ b/toolkit/cli/inspect/readiness_ops.py
@@ -19,6 +19,11 @@ from toolkit.cli.inspect._helpers import (
     _validation_summary_for_layer,
 )
 from toolkit.core.config import load_config
+from toolkit.core.paths import (
+    RAW_VALIDATION,
+    CLEAN_VALIDATION,
+    MART_VALIDATION,
+)
 
 
 
@@ -163,7 +168,7 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
                 "decimal_suggested": (paths.get("raw_hints") or {}).get("decimal"),
                 "skip_suggested": (paths.get("raw_hints") or {}).get("skip"),
                 "raw_warnings": (paths.get("raw_hints") or {}).get("warnings", []),
-                "validation": _validation_summary_for_layer(raw_dir, "raw_validation.json"),
+                "validation": _validation_summary_for_layer(raw_dir, RAW_VALIDATION),
                 "run_status": layer_run_statuses.get("raw"),
             },
             "clean": {
@@ -172,7 +177,7 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
                 "output": clean_paths.get("output"),
                 "output_exists": _exists(clean_paths.get("output")),
                 "metadata_exists": _exists(clean_paths.get("metadata")),
-                "validation": _validation_summary_for_layer(clean_dir, "_validate/clean_validation.json"),
+                "validation": _validation_summary_for_layer(clean_dir, CLEAN_VALIDATION),
                 "run_status": layer_run_statuses.get("clean"),
             },
             "mart": {
@@ -183,7 +188,7 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
                 "output_exists_count": len(mart_outputs) - len(missing_mart_outputs),
                 "missing_outputs": missing_mart_outputs,
                 "metadata_exists": _exists(mart_paths.get("metadata")),
-                "validation": _validation_summary_for_layer(mart_dir, "_validate/mart_validation.json"),
+                "validation": _validation_summary_for_layer(mart_dir, MART_VALIDATION),
                 "run_status": layer_run_statuses.get("mart"),
             },
         },
@@ -325,9 +330,9 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
     raw_dir_path = Path(raw.get("dir", ""))
     clean_dir_path = Path(clean.get("dir", ""))
     mart_dir_path = Path(mart.get("dir", ""))
-    raw_msgs = _validation_msgs(raw_dir_path, "raw_validation.json")
-    clean_msgs = _validation_msgs(clean_dir_path, "_validate/clean_validation.json")
-    mart_msgs = _validation_msgs(mart_dir_path, "_validate/mart_validation.json")
+    raw_msgs = _validation_msgs(raw_dir_path, RAW_VALIDATION)
+    clean_msgs = _validation_msgs(clean_dir_path, CLEAN_VALIDATION)
+    mart_msgs = _validation_msgs(mart_dir_path, MART_VALIDATION)
 
     # --- Extract rich layer info from summary (already computed) ---
     raw_val = raw.get("validation") or {}

--- a/toolkit/core/paths.py
+++ b/toolkit/core/paths.py
@@ -55,6 +55,25 @@ def serialize_metadata_path(path: Path | None, rel_root: Path | None) -> str | N
     return to_root_relative(path, rel_root)
 
 
+# ---------------------------------------------------------------------------
+# Artifact filenames (relative to layer year directory)
+# Single source of truth — every writer/reader must use these constants.
+# ---------------------------------------------------------------------------
+
+# Validation
+RAW_VALIDATION = "raw_validation.json"
+CLEAN_VALIDATION = "_validate/clean_validation.json"
+MART_VALIDATION = "_validate/mart_validation.json"
+
+# Profile (raw only)
+RAW_PROFILE_DIR = "_profile"
+RAW_PROFILE = f"{RAW_PROFILE_DIR}/raw_profile.json"
+RAW_SUGGESTED_READ = f"{RAW_PROFILE_DIR}/suggested_read.yml"
+
+# Metadata
+METADATA = "metadata.json"
+
+
 def resolve_sql_path(sql_ref: str | Path, *, base_dir: Path | None) -> Path:
     """Resolve a SQL file reference to an absolute Path.
 

--- a/toolkit/mart/validate.py
+++ b/toolkit/mart/validate.py
@@ -14,7 +14,7 @@ from toolkit.core.column_rules import (
 )
 from toolkit.core.config_models import MartTableRuleConfig, MartValidationSpec
 from toolkit.core.metadata import merge_layer_manifest
-from toolkit.core.paths import layer_year_dir, to_root_relative
+from toolkit.core.paths import MART_VALIDATION, layer_year_dir, to_root_relative
 from toolkit.core.validation import (
     ValidationResult,
     build_validation_summary,
@@ -232,7 +232,7 @@ def run_mart_validation(cfg, year: int, logger, *, sample_mode: bool = False) ->
             sections={"transition": transition_report},
         )
 
-    report = write_validation_json(Path(mart_dir) / "_validate" / "mart_validation.json", result)
+    report = write_validation_json(Path(mart_dir) / MART_VALIDATION, result)
     merge_layer_manifest(
         mart_dir,
         metadata_path="metadata.json",

--- a/toolkit/mcp/discovery.py
+++ b/toolkit/mcp/discovery.py
@@ -24,7 +24,7 @@ from lab_connectors.mcp.errors import ErrorCode
 def _read_minimal_config(dataset_yml: Path) -> dict[str, Any]:
     """Legge solo i campi essenziali da dataset.yml senza validazione piena.
 
-    Restituisce un dict con: name, years (e raw data per reference).
+    Restituisce un dict con: name, years, root (stringa raw dal YAML).
     """
     try:
         data = yaml.safe_load(dataset_yml.read_text(encoding="utf-8"))
@@ -43,18 +43,23 @@ def _read_minimal_config(dataset_yml: Path) -> dict[str, Any]:
     if isinstance(years, int):
         years = [years]
 
+    root_raw = data.get("root")
     return {
         "name": str(name) if name else None,
         "years": [int(y) for y in years] if isinstance(years, list) else [],
+        "root": str(root_raw) if isinstance(root_raw, str) else None,
     }
 
 
-def _find_latest_run_status(slug: str) -> str | None:
+def _find_latest_run_status(slug: str, runs_root: Path | None = None) -> str | None:
     """Cerca l'ultimo run record per un dataset slug e restituisce lo status.
 
-    Scansiona ``{WORKSPACE}/out/data/_runs/{slug}/``.
+    Scansiona ``{runs_root or WORKSPACE/out}/data/_runs/{slug}/``.
     """
-    runs_base = WORKSPACE_ROOT / "out" / "data" / "_runs" / slug
+    if runs_root is not None:
+        runs_base = runs_root / "data" / "_runs" / slug
+    else:
+        runs_base = WORKSPACE_ROOT / "out" / "data" / "_runs" / slug
     if not runs_base.exists():
         return None
 
@@ -149,16 +154,25 @@ def list_candidates(
             name = minimal.get("name") or slug
             years = minimal.get("years", [])
 
+            # Risolvi root output: usa quello dal dataset.yml se presente,
+            # altrimenti fallback a WORKSPACE_ROOT/out
+            root_raw = minimal.get("root")
+            if root_raw:
+                # root è relativo al file dataset.yml
+                resolved_root = (dataset_yml.parent / root_raw).resolve()
+            else:
+                resolved_root = WORKSPACE_ROOT / "out"
+            out_root = resolved_root / "data"
+
             # Presenza layer: per sub-candidates, il dataset name è
             # quello dal dataset.yml (potrebbe differire dallo slug)
             dataset_name_for_path = name if name != slug else parent_dir.name
-            out_root = WORKSPACE_ROOT / "out" / "data"
             clean_dir = out_root / "clean" / dataset_name_for_path
             mart_dir = out_root / "mart" / dataset_name_for_path
             has_clean = clean_dir.exists() and any(clean_dir.iterdir())
             has_mart = mart_dir.exists() and any(mart_dir.iterdir())
 
-            last_run_status = _find_latest_run_status(dataset_name_for_path)
+            last_run_status = _find_latest_run_status(dataset_name_for_path, runs_root=resolved_root)
 
             results.append({
                 "slug": slug,

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from toolkit.core.artifacts import should_write
 from toolkit.core.config import ensure_dict, parse_bool
 from toolkit.core.metadata import config_hash_for_year, merge_layer_manifest, sha256_bytes, write_metadata
-from toolkit.core.paths import layer_year_dir, to_root_relative
+from toolkit.core.paths import RAW_VALIDATION, RAW_PROFILE, layer_year_dir, to_root_relative
 from toolkit.core.registry import register_builtin_plugins
 from toolkit.core.validation import write_validation_json
 from toolkit.profile.raw import sniff_source_file, profile_raw, write_raw_profile, write_suggested_read_yml
@@ -168,7 +168,7 @@ def run_raw(
                 )
                 profile_dir = out_dir / "_profile"
                 write_raw_profile(profile_dir, raw_profile)
-                logger.info("RAW profile -> %s", profile_dir / "raw_profile.json")
+                logger.info("RAW profile -> %s", profile_dir / RAW_PROFILE)
 
                 scaffold_clean_if_missing(
                     raw_profile.__dict__,
@@ -202,7 +202,7 @@ def run_raw(
 
     # --- QA RAW ---
     result = validate_raw_output(out_dir, files_written)
-    vpath = write_validation_json(out_dir / "raw_validation.json", result)
+    vpath = write_validation_json(out_dir / RAW_VALIDATION, result)
     merge_layer_manifest(
         out_dir,
         validation_path=vpath.name,

--- a/toolkit/raw/validate.py
+++ b/toolkit/raw/validate.py
@@ -5,7 +5,7 @@ from typing import Any
 import json
 
 from toolkit.core.metadata import merge_layer_manifest
-from toolkit.core.paths import layer_year_dir
+from toolkit.core.paths import RAW_VALIDATION, layer_year_dir
 from toolkit.core.validation import ValidationResult, build_validation_summary, write_validation_json
 
 TEXT_EXT = {".csv", ".txt", ".tsv", ".json", ".xml", ".html"}
@@ -123,7 +123,7 @@ def run_raw_validation(root: str | None, dataset: str, year: int, logger) -> dic
         summary=enriched_summary,
         sections=result.sections,
     )
-    report = write_validation_json(out_dir / "raw_validation.json", result)
+    report = write_validation_json(out_dir / RAW_VALIDATION, result)
     merge_layer_manifest(
         out_dir,
         validation_path=report.name,


### PR DESCRIPTION
## Sintesi

`list_candidates` MCP tool tornava `has_clean=False` per 32/33 candidati perché usava `WORKSPACE_ROOT/out/data/clean/{slug}` invece della root dichiarata in dataset.yml.

## Cosa cambia

- `_read_minimal_config`: legge anche il campo `root` dal dataset.yml
- `_find_latest_run_status`: accetta `runs_root` opzionale
- `list_candidates`: risolve la root dal dataset.yml e la usa per clean, mart e _runs paths

## Impatto

Prima: 1 candidato con `has_clean=True` (solo mef-partecipazioni, che aveva dati copiati in entrambi i path).  
Dopo: 12 candidati con `has_clean=True` (allineato al disco).

## Verifica

```bash
pytest tests/ -q --timeout=60
```

- 765 passati
- Testato manualmente: `list_candidates('candidates')` ora torna dati corretti per tutti i candidati

## Checklist

- Perimetro stretto: unico file (toolkit/mcp/discovery.py)
- Backward compat: se root non presente, fallback a WORKSPACE_ROOT/out (comportamento vecchio)
