### PR TITLE
Centralizza tutti i path artifact in core/paths.py + CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,3 +133,20 @@ una issue in `dataset-incubator`.
 - [`dataset-incubator`](https://github.com/dataciviclab/dataset-incubator) — downstream: qui vivono i dataset reali
 - [`lab-connectors`](https://github.com/dataciviclab/lab-connectors) — dipendenza condivisa
 - [`.github`](https://github.com/dataciviclab/.github) — policy condivise
+
+## Regole del codice: path artifact
+
+Ogni path di file prodotto da un layer (validation, profile, metadata)
+deve essere referenziato tramite la costante in `toolkit/core/paths.py`.
+Non usare stringhe letterali.
+
+Se aggiungi un nuovo artifact, aggiungi la costante in `core/paths.py`
+e importala dove serve.
+
+Costanti definite:
+- `RAW_VALIDATION`, `CLEAN_VALIDATION`, `MART_VALIDATION`
+- `RAW_PROFILE`, `RAW_PROFILE_DIR`, `RAW_SUGGESTED_READ`
+- `METADATA`
+
+Path di directory: usa `layer_year_dir()`, `dataset_dir()`, `resolve_root()`
+da `core/paths.py` invece di costruirli a mano.

--- a/toolkit/clean/input_selection.py
+++ b/toolkit/clean/input_selection.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from toolkit.core.metadata import read_layer_metadata
-from toolkit.core.paths import from_root_relative, layer_year_dir, resolve_root
+from toolkit.core.paths import METADATA, from_root_relative, layer_year_dir, resolve_root
 from toolkit.core.run_context import get_run_dir, list_runs
 
 
@@ -44,7 +44,7 @@ def _match_patterns(paths: list[Path], patterns: list[str]) -> list[Path]:
 
 
 def _metadata_candidates(raw_dir: Path) -> list[Path]:
-    metadata_path = raw_dir / "metadata.json"
+    metadata_path = raw_dir / METADATA
     if not metadata_path.exists():
         return []
 

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -21,6 +21,7 @@ from toolkit.core.csv_read import (
     filter_suggested_format_keys,
     merge_read_cfg,
 )
+from toolkit.core.paths import RAW_PROFILE_DIR, RAW_SUGGESTED_READ
 
 
 def _read_source_mode(clean_cfg: dict[str, Any], logger=None) -> tuple[str, dict[str, Any]]:
@@ -54,7 +55,7 @@ def _split_read_cfg(explicit_cfg: dict[str, Any]) -> tuple[dict[str, Any], dict[
 
 
 def load_suggested_read(raw_year_dir: Path) -> dict[str, Any] | None:
-    suggested_path = raw_year_dir / "_profile" / "suggested_read.yml"
+    suggested_path = raw_year_dir / RAW_PROFILE_DIR / RAW_SUGGESTED_READ
     if not suggested_path.exists():
         return None
 

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -9,7 +9,7 @@ from toolkit.clean.input_selection import select_raw_input
 from toolkit.core.artifacts import should_write
 from toolkit.core.config import ensure_dict
 from toolkit.core.metadata import config_hash_for_year, file_record, merge_layer_manifest, write_metadata
-from toolkit.core.paths import layer_year_dir, resolve_root, resolve_sql_path, serialize_metadata_path
+from toolkit.core.paths import CLEAN_VALIDATION, layer_year_dir, resolve_root, resolve_sql_path, serialize_metadata_path
 from toolkit.core.template import build_runtime_template_ctx, public_template_ctx, render_template
 from toolkit.clean.sql_execute import _normalize_output_profile, _run_sql
 
@@ -267,7 +267,7 @@ def run_clean(
     merge_layer_manifest(
         out_dir,
         metadata_path=metadata_path.name,
-        validation_path="_validate/clean_validation.json",
+        validation_path=CLEAN_VALIDATION,
         outputs=outputs,
     )
     logger.info(f"CLEAN -> {output_path}")

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -19,7 +19,7 @@ from toolkit.clean._helpers import _input_files_from_clean_metadata, _profile_ra
 from toolkit.core.config_models import CleanValidationSpec, RangeRuleConfig, TransitionConfig
 from toolkit.core.layer_profile import compare_layer_profiles
 from toolkit.core.metadata import merge_layer_manifest
-from toolkit.core.paths import CLEAN_VALIDATION, layer_year_dir, to_root_relative
+from toolkit.core.paths import CLEAN_VALIDATION, METADATA, RAW_PROFILE, layer_year_dir, to_root_relative
 from toolkit.core.validation import (
     ValidationResult,
     build_validation_summary,
@@ -174,7 +174,7 @@ def validate_promotion(
     errors: list[str] = []
     warnings: list[str] = []
 
-    clean_metadata_path = clean_path / "metadata.json"
+    clean_metadata_path = clean_path / METADATA
     if not raw_path.exists():
         errors.append(f"Missing RAW dir: {raw_path}")
     if not clean_metadata_path.exists():
@@ -209,7 +209,7 @@ def validate_promotion(
     read_mode = str(clean_metadata.get("read_source_used") or "fallback")
 
     profile_dir = raw_path / "_profile"
-    saved_profile_path = profile_dir / "raw_profile.json"
+    saved_profile_path = profile_dir / RAW_PROFILE
 
     if saved_profile_path.exists():
         try:
@@ -299,7 +299,7 @@ def run_clean_validation(cfg, year: int, logger, *, sample_mode: bool = False) -
     # scaffold check: legge raw_profile.json come source of truth per raw_col_count,
     # bypassando _profile_raw_input che potrebbe rileggere il CSV con parametri header errati
     _profile_dir = raw_dir / "_profile"
-    profile_path = _profile_dir / "raw_profile.json"
+    profile_path = _profile_dir / RAW_PROFILE
     profile_parse_error: bool = False
     trusted_raw_cols: list[str] = []
     if profile_path.exists():
@@ -436,10 +436,10 @@ def run_clean_validation(cfg, year: int, logger, *, sample_mode: bool = False) -
     )
 
     report = write_validation_json(Path(out_dir) / CLEAN_VALIDATION, result)
-    metadata = json.loads((out_dir / "metadata.json").read_text(encoding="utf-8"))
+    metadata = json.loads((out_dir / METADATA).read_text(encoding="utf-8"))
     merge_layer_manifest(
         out_dir,
-        metadata_path="metadata.json",
+        metadata_path=METADATA,
         validation_path="_validate/clean_validation.json",
         outputs=metadata.get("outputs", []),
         ok=result.ok,

--- a/toolkit/cli/cmd_resume.py
+++ b/toolkit/cli/cmd_resume.py
@@ -8,7 +8,7 @@ from toolkit.cli.cmd_run import run_year
 from toolkit.core.config import load_config
 from toolkit.core.logging import get_logger
 from toolkit.core.metadata import read_layer_metadata
-from toolkit.core.paths import layer_year_dir
+from toolkit.core.paths import METADATA, layer_year_dir
 from toolkit.core.run_context import get_run_dir, latest_run, read_run_record
 
 
@@ -33,7 +33,7 @@ def _resume_layer(record: dict[str, object]) -> str | None:
 
 def _layer_artifacts_ok(root: Path, dataset: str, year: int, layer: str) -> tuple[bool, str]:
     layer_dir = layer_year_dir(root, layer, dataset, year)
-    metadata_path = layer_dir / "metadata.json"
+    metadata_path = layer_dir / METADATA
 
     if not _artifact_exists(metadata_path):
         return False, f"missing {layer}/metadata.json"

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -11,7 +11,7 @@ from toolkit.cli.sql_dry_run import validate_sql_dry_run
 from toolkit.clean.run import run_clean
 from toolkit.clean.validate import run_clean_validation
 from toolkit.core.logging import bind_logger, get_logger
-from toolkit.core.paths import layer_dataset_dir, layer_year_dir
+from toolkit.core.paths import RAW_PROFILE, layer_dataset_dir, layer_year_dir
 from toolkit.core.run_context import RunContext
 from toolkit.mart.run import run_mart, run_mart_multi_year
 from toolkit.mart.validate import run_mart_validation
@@ -570,7 +570,7 @@ def run_init(
         typer.echo(f"[init] Bootstrap completato per {cfg.dataset}/{year}")
         typer.echo("  - raw scaricato")
         profile_dir = layer_year_dir(cfg.root, "raw", cfg.dataset, year) / "_profile"
-        profile_exists = (profile_dir / "raw_profile.json").exists()
+        profile_exists = (profile_dir / RAW_PROFILE).exists()
 
         scaffolded_now = not scaffold_existed_before and clean_sql_path.exists()
         if scaffold_existed_before:

--- a/toolkit/cli/cmd_scaffold.py
+++ b/toolkit/cli/cmd_scaffold.py
@@ -8,7 +8,7 @@ import typer
 import yaml
 
 from toolkit.cli.common import iter_years, load_cfg_and_logger
-from toolkit.core.paths import layer_year_dir
+from toolkit.core.paths import RAW_PROFILE, RAW_SUGGESTED_READ, layer_year_dir
 from toolkit.scaffold.clean import format_clean_read_proposal, generate_clean_sql
 
 
@@ -46,8 +46,8 @@ def scaffold_clean(
     selected_year = years[0]
 
     raw_profile_dir = layer_year_dir(cfg.root, "raw", cfg.dataset, selected_year) / "_profile"
-    profile_path = raw_profile_dir / "raw_profile.json"
-    suggested_read_yml = raw_profile_dir / "suggested_read.yml"
+    profile_path = raw_profile_dir / RAW_PROFILE
+    suggested_read_yml = raw_profile_dir / RAW_SUGGESTED_READ
 
     profile: dict[str, Any]
 

--- a/toolkit/cli/cmd_status.py
+++ b/toolkit/cli/cmd_status.py
@@ -8,7 +8,7 @@ import typer
 
 from toolkit.cli.common import format_profile_preview, load_layer_profile_summaries
 from toolkit.core.config import load_config
-from toolkit.core.paths import layer_dataset_dir
+from toolkit.core.paths import METADATA, RAW_PROFILE_DIR, RAW_SUGGESTED_READ, layer_dataset_dir
 from toolkit.core.run_context import get_run_dir, read_run_record
 from toolkit.cli.inspect.readiness_ops import summary as _summary
 
@@ -206,7 +206,7 @@ def status(
     # suggested_read_path non è in summary — lo ricostruiamo
     raw_dir = (layers.get("raw") or {}).get("dir")
     if raw_dir and raw_hints.get("suggested_read_exists"):
-        raw_hints["suggested_read_path"] = str(Path(raw_dir) / "_profile" / "suggested_read.yml")
+        raw_hints["suggested_read_path"] = str(Path(raw_dir) / RAW_PROFILE_DIR / RAW_SUGGESTED_READ)
     _print_raw_hints(raw_hints)
 
     # Layer table
@@ -229,7 +229,7 @@ def status(
     multi_year_tables = [t for t in (mart_cfg.get("tables") or []) if isinstance(t, dict) and t.get("years")]
     if multi_year_tables:
         my_dir = layer_dataset_dir(cfg.root, "mart", dataset)
-        my_meta = my_dir / "metadata.json"
+        my_meta = my_dir / METADATA
         if my_meta.exists():
             content = json.loads(my_meta.read_text(encoding="utf-8"))
             my_layer = content.get("layer", "")

--- a/toolkit/cli/common.py
+++ b/toolkit/cli/common.py
@@ -7,7 +7,7 @@ from toolkit.core.io import read_json_or_none as _read_json
 
 from toolkit.core.config import load_config
 from toolkit.core.logging import get_logger
-from toolkit.core.paths import layer_year_dir
+from toolkit.core.paths import METADATA, layer_year_dir
 
 
 def dump_cfg_section(cfg_section: Any) -> Any:
@@ -139,9 +139,9 @@ def _transition_summary(item: dict | None) -> dict | None:
 
 def load_layer_profile_summaries(root: Path, dataset: str, year: int) -> dict[str, object] | None:
     clean_metadata = (
-        _read_json(layer_year_dir(root, "clean", dataset, year) / "metadata.json") or {}
+        _read_json(layer_year_dir(root, "clean", dataset, year) / METADATA) or {}
     )
-    mart_metadata = _read_json(layer_year_dir(root, "mart", dataset, year) / "metadata.json") or {}
+    mart_metadata = _read_json(layer_year_dir(root, "mart", dataset, year) / METADATA) or {}
 
     clean_output = _profile_summary(clean_metadata.get("output_profile"))
     mart_clean_input = _profile_summary(mart_metadata.get("clean_input_profile"))

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -14,11 +14,13 @@ import duckdb
 from toolkit.cli.common import load_layer_profile_summaries
 from toolkit.core.metadata import read_layer_metadata
 from toolkit.core.paths import (
+    METADATA,
+    RAW_PROFILE,
+    RAW_PROFILE_DIR,
+    RAW_SUGGESTED_READ,
     RAW_VALIDATION,
     CLEAN_VALIDATION,
     MART_VALIDATION,
-    RAW_PROFILE,
-    RAW_SUGGESTED_READ,
     layer_year_dir,
 )
 from toolkit.core.run_context import get_run_dir, latest_run
@@ -56,7 +58,7 @@ def _raw_schema_payload(cfg, year: int) -> dict[str, Any]:
     # Read actual columns from raw_profile.json if available.
     columns_preview = list(profile_hints.get("columns_preview") or [])
     if not columns_preview and profile_hints.get("is_binary_file"):
-        raw_profile_path = raw_dir / RAW_PROFILE
+        raw_profile_path = raw_dir / RAW_PROFILE_DIR / RAW_PROFILE
         if raw_profile_path.exists():
             try:
                 raw_profile_data = json.loads(raw_profile_path.read_text(encoding="utf-8"))
@@ -110,7 +112,7 @@ def _raw_output_paths(root: Path, dataset: str, year: int) -> dict[str, str]:
     raw_dir = layer_year_dir(root, "raw", dataset, year)
     return {
         "dir": str(raw_dir),
-        "metadata": str(raw_dir / "metadata.json"),
+        "metadata": str(raw_dir / METADATA),
         "validation": str(raw_dir / RAW_VALIDATION),
     }
 
@@ -124,7 +126,7 @@ def _clean_paths(root: Path, dataset: str, year: int) -> dict[str, str]:
     return {
         "dir": str(clean_dir),
         "output": str(_clean_output_path(root, dataset, year)),
-        "metadata": str(clean_dir / "metadata.json"),
+        "metadata": str(clean_dir / METADATA),
         "validation": str(clean_dir / CLEAN_VALIDATION),
     }
 
@@ -150,7 +152,7 @@ def _mart_paths(
     return {
         "dir": str(mart_dir),
         "outputs": [str(path) for path in _mart_output_paths(root, mart_dir, tables)],
-        "metadata": str(mart_dir / "metadata.json"),
+        "metadata": str(mart_dir / METADATA),
         "validation": str(mart_dir / MART_VALIDATION),
     }
 
@@ -161,7 +163,7 @@ def _payload_for_year(cfg, year: int) -> dict[str, Any]:
     mart_tables = cfg.mart.get("tables") or []
     raw_dir = layer_year_dir(root, "raw", cfg.dataset, year)
     raw_meta = read_layer_metadata(raw_dir)
-    suggested_read_path = raw_dir / RAW_SUGGESTED_READ
+    suggested_read_path = raw_dir / RAW_PROFILE_DIR / RAW_SUGGESTED_READ
     profile_hints = raw_meta.get("profile_hints") or {}
 
     run_files = sorted(run_dir.glob("*.json")) if run_dir.exists() else []

--- a/toolkit/contracts/__init__.py
+++ b/toolkit/contracts/__init__.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 from pathlib import Path as _Path
 
 from toolkit.core.paths import (
+    METADATA,
     layer_dataset_dir,
     layer_year_dir,
     resolve_root,
@@ -64,7 +65,7 @@ Esempio::
     # invece di: file.endswith(\"_clean.parquet\")
 """
 
-METADATA_JSON = "metadata.json"
+METADATA_JSON = METADATA
 
 
 # ---------------------------------------------------------------------------

--- a/toolkit/core/metadata.py
+++ b/toolkit/core/metadata.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from toolkit.core.io import write_json_atomic
+from toolkit.core.paths import METADATA
 from toolkit.version import __version__
 
 
@@ -50,7 +51,7 @@ def config_hash_for_year(base_dir: Path | None, year: int) -> str | None:
 def write_metadata(
     folder: Path,
     data: dict[str, Any],
-    filename: str = "metadata.json",
+    filename: str = METADATA,
 ) -> Path:
     meta = {
         "metadata_schema_version": 1,
@@ -65,7 +66,7 @@ def write_metadata(
     return out
 
 
-def _read_metadata(folder: Path, filename: str = "metadata.json") -> dict[str, Any] | None:
+def _read_metadata(folder: Path, filename: str = METADATA) -> dict[str, Any] | None:
     path = folder / filename
     if not path.exists():
         return None
@@ -96,7 +97,7 @@ def read_layer_metadata(layer_dir: Path) -> dict[str, Any]:
 def merge_layer_manifest(
     folder: Path,
     *,
-    metadata_path: str = "metadata.json",
+    metadata_path: str = METADATA,
     validation_path: str | None = None,
     outputs: list[dict[str, Any]] | None = None,
     ok: bool | None = None,

--- a/toolkit/core/paths.py
+++ b/toolkit/core/paths.py
@@ -67,8 +67,8 @@ MART_VALIDATION = "_validate/mart_validation.json"
 
 # Profile (raw only)
 RAW_PROFILE_DIR = "_profile"
-RAW_PROFILE = f"{RAW_PROFILE_DIR}/raw_profile.json"
-RAW_SUGGESTED_READ = f"{RAW_PROFILE_DIR}/suggested_read.yml"
+RAW_PROFILE = "raw_profile.json"          # sotto _profile/
+RAW_SUGGESTED_READ = "suggested_read.yml" # sotto _profile/
 
 # Metadata
 METADATA = "metadata.json"

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -11,7 +11,7 @@ from toolkit.core.config import ensure_dict
 from toolkit.core.layer_profile import compare_layer_profiles, profile_relation, profile_parquet_files
 from toolkit.core.metadata import config_hash_for_year, file_record, merge_layer_manifest, write_metadata
 from toolkit.core.multi_year_source import bind_multi_year_view, collect_multi_year_files
-from toolkit.core.paths import layer_dataset_dir, layer_year_dir, resolve_root, resolve_sql_path, serialize_metadata_path
+from toolkit.core.paths import MART_VALIDATION, layer_dataset_dir, layer_year_dir, resolve_root, resolve_sql_path, serialize_metadata_path
 from toolkit.core.support import flatten_support_template_ctx, resolve_support_payloads
 from toolkit.core.template import build_runtime_template_ctx, public_template_ctx, render_template
 
@@ -455,7 +455,7 @@ def run_mart(
     merge_layer_manifest(
         mart_dir,
         metadata_path=metadata_path.name,
-        validation_path="_validate/mart_validation.json",
+        validation_path=MART_VALIDATION,
         outputs=outputs,
     )
     total_bytes = sum(p.stat().st_size for p in written if p.exists())

--- a/toolkit/mart/validate.py
+++ b/toolkit/mart/validate.py
@@ -14,7 +14,7 @@ from toolkit.core.column_rules import (
 )
 from toolkit.core.config_models import MartTableRuleConfig, MartValidationSpec
 from toolkit.core.metadata import merge_layer_manifest
-from toolkit.core.paths import MART_VALIDATION, layer_year_dir, to_root_relative
+from toolkit.core.paths import MART_VALIDATION, METADATA, layer_year_dir, to_root_relative
 from toolkit.core.validation import (
     ValidationResult,
     build_validation_summary,
@@ -210,7 +210,7 @@ def run_mart_validation(cfg, year: int, logger, *, sample_mode: bool = False) ->
         declared_tables=declared_tables,
     )
 
-    metadata = json.loads((mart_dir / "metadata.json").read_text(encoding="utf-8"))
+    metadata = json.loads((mart_dir / METADATA).read_text(encoding="utf-8"))
     transition_report = check_transitions(
         metadata.get("transition_profiles") or [],
         spec.validate.transition,
@@ -235,7 +235,7 @@ def run_mart_validation(cfg, year: int, logger, *, sample_mode: bool = False) ->
     report = write_validation_json(Path(mart_dir) / MART_VALIDATION, result)
     merge_layer_manifest(
         mart_dir,
-        metadata_path="metadata.json",
+        metadata_path=METADATA,
         validation_path="_validate/mart_validation.json",
         outputs=metadata.get("outputs", []),
         ok=result.ok,

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -20,6 +20,7 @@ from lab_connectors.mcp.errors import ErrorCode
 
 from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.path_safety import _load_cfg, _safe_path
+from toolkit.core.paths import RAW_PROFILE, RAW_PROFILE_DIR, RAW_SUGGESTED_READ
 from toolkit.core.run_records import get_run_dir_dataset, list_runs as _list_runs_records
 
 
@@ -69,8 +70,8 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
     paths = _inspect_paths(str(config), year)
     raw_dir = Path(paths["paths"]["raw"]["dir"])
     profile_path = raw_dir / "_profile"
-    raw_profile_json = profile_path / "raw_profile.json"
-    suggested_read_yml = profile_path / "suggested_read.yml"
+    raw_profile_json = profile_path / RAW_PROFILE
+    suggested_read_yml = profile_path / RAW_SUGGESTED_READ
 
     if raw_profile_json.exists():
         try:

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -20,7 +20,7 @@ from lab_connectors.mcp.errors import ErrorCode
 
 from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.path_safety import _load_cfg, _safe_path
-from toolkit.core.paths import RAW_PROFILE, RAW_PROFILE_DIR, RAW_SUGGESTED_READ
+from toolkit.core.paths import RAW_PROFILE, RAW_SUGGESTED_READ
 from toolkit.core.run_records import get_run_dir_dataset, list_runs as _list_runs_records
 
 

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -20,6 +20,7 @@ from toolkit.core.csv_read import (
     robust_preset,
     sql_str,
 )
+from toolkit.core.paths import RAW_PROFILE, RAW_SUGGESTED_READ
 from toolkit.core.io import write_json_atomic
 from toolkit.profile._sniff_encoding import is_binary_file as _is_binary_file, sniff_encoding
 from toolkit.profile._sniff_delimiter import sniff_decimal, sniff_delim, suggest_skip
@@ -195,7 +196,7 @@ def write_suggested_read_yml(out_dir: Path, profile: "RawProfile | Dict[str, Any
             rendered = str(value)
         lines.append(f"    {key}: {rendered}")
 
-    p = out_dir / "suggested_read.yml"
+    p = out_dir / RAW_SUGGESTED_READ
     p.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return p
 
@@ -610,7 +611,7 @@ def write_raw_profile(
 ) -> Dict[str, Path]:
     _safe_mkdir(out_dir)
 
-    p_raw_json = out_dir / "raw_profile.json"
+    p_raw_json = out_dir / RAW_PROFILE
     payload = asdict(profile)
     written: Dict[str, Path] = {}
 

--- a/toolkit/raw/validate.py
+++ b/toolkit/raw/validate.py
@@ -5,7 +5,7 @@ from typing import Any
 import json
 
 from toolkit.core.metadata import merge_layer_manifest
-from toolkit.core.paths import RAW_VALIDATION, layer_year_dir
+from toolkit.core.paths import METADATA, RAW_VALIDATION, layer_year_dir
 from toolkit.core.validation import ValidationResult, build_validation_summary, write_validation_json
 
 TEXT_EXT = {".csv", ".txt", ".tsv", ".json", ".xml", ".html"}
@@ -101,7 +101,7 @@ def validate_raw_output(out_dir: Path, files_written: list[dict]) -> ValidationR
 
 def run_raw_validation(root: str | None, dataset: str, year: int, logger) -> dict[str, Any]:
     out_dir = layer_year_dir(root, "raw", dataset, year)
-    metadata = json.loads((out_dir / "metadata.json").read_text(encoding="utf-8"))
+    metadata = json.loads((out_dir / METADATA).read_text(encoding="utf-8"))
     files = metadata.get("files") or metadata.get("outputs") or []
 
     result = validate_raw_output(out_dir, files)


### PR DESCRIPTION
## Sintesi

Tutti i path di validation, profile e metadata ora referenziano le costanti in core/paths.py invece di stringhe letterali. 18 file modificati. Aggiunto CONTRIBUTING.md con la regola.

## Costanti

- RAW_VALIDATION, CLEAN_VALIDATION, MART_VALIDATION -- validation JSON paths
- RAW_PROFILE, RAW_PROFILE_DIR, RAW_SUGGESTED_READ -- raw profile paths
- METADATA -- metadata.json (importato in contracts come METADATA_JSON)

## Verifica

pytest tests/ -q --timeout=60 -> 766 test passati, nessuna regressione

## Checklist

- Perimetro stretto: path artifact (nessuna logica modificata)
- CONTRIBUTING.md aggiunto con regola dei path
