### PR TITLE
fix(ux): allinea nomi MCP a CLI e migliora help run

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Espone 9 tool read-only per ispezione rapida:
 | Tool | Cosa fa |
 |---|---|
 | `toolkit_inspect_paths` | Path contract risolto + metadati run |
-| `toolkit_show_schema` | Schema di raw / clean / mart |
+| `toolkit_inspect_schema` | Schema di raw / clean / mart |
 | `toolkit_run_summary` | Statistiche aggregate dei run |
 | `toolkit_summary` | Dashboard diagnostico per dataset |
 | `toolkit_review_readiness` | Check di prontezza per review |

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14,10 +14,16 @@ pytestmark = pytest.mark.contract
 def test_mcp_server_registers_expected_tools() -> None:
     tools = asyncio.run(mcp_server.mcp.list_tools())
     tool_names = {tool.name for tool in tools}
+    # Both new (canonical) and old (deprecated alias) names must be present
     assert tool_names == {
         "toolkit_inspect_paths",
+        # New canonical names
+        "toolkit_inspect_schema",
+        "toolkit_inspect_profile",
+        # Old names kept as backward-compatible aliases
         "toolkit_show_schema",
         "toolkit_raw_profile",
+        # Rest
         "toolkit_run_summary",
         "toolkit_summary",
         "toolkit_review_readiness",
@@ -35,6 +41,11 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_html_extract_links",
         "toolkit_sparql_query",
     }
+
+    # Verify old aliases are documented as deprecated
+    tool_map = {t.name: t for t in tools}
+    assert "[DEPRECATED]" in (tool_map["toolkit_show_schema"].description or "")
+    assert "[DEPRECATED]" in (tool_map["toolkit_raw_profile"].description or "")
 
 
 def test_tool_returns_payload_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -205,7 +216,7 @@ def test_toolkit_probe_url_returns_payload(monkeypatch: pytest.MonkeyPatch) -> N
     assert result == {"status_code": 200, "content_type": "text/csv"}
 
 
-def test_toolkit_show_schema_passes_layer_and_year(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_toolkit_inspect_schema_passes_layer_and_year(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: dict[str, object] = {}
 
     def fake_impl(config_path: str, layer: str, year: int | None) -> dict[str, object]:
@@ -216,13 +227,13 @@ def test_toolkit_show_schema_passes_layer_and_year(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(mcp_server, "show_schema_impl", fake_impl)
 
-    payload = mcp_server.toolkit_show_schema("dataset.yml", "mart", 2024)
+    payload = mcp_server.toolkit_inspect_schema("dataset.yml", "mart", 2024)
 
     assert payload == {"layer": "mart", "year": 2024}
     assert calls == {"config_path": "dataset.yml", "layer": "mart", "year": 2024}
 
 
-def test_toolkit_raw_profile_passes_config_and_year(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_toolkit_inspect_profile_passes_config_and_year(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: dict[str, object] = {}
 
     def fake_impl(config_path: str, year: int | None) -> dict[str, object]:
@@ -232,7 +243,7 @@ def test_toolkit_raw_profile_passes_config_and_year(monkeypatch: pytest.MonkeyPa
 
     monkeypatch.setattr(mcp_server, "raw_profile_impl", fake_impl)
 
-    payload = mcp_server.toolkit_raw_profile("dataset.yml", 2024)
+    payload = mcp_server.toolkit_inspect_profile("dataset.yml", 2024)
 
     assert payload == {"profile_exists": True}
     assert calls == {"config_path": "dataset.yml", "year": 2024}

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -452,6 +452,40 @@ def run(
         _maybe_run_multi_year_mart(cfg, selected_years, dry_run=dry_flag, logger=logger)
 
 
+_STEP_DOCSTRINGS: dict[str, str] = {
+    "probe": (
+        "Verifica la raggiungibilità delle fonti remote definite in raw.sources.\n\n"
+        "Supporta HTTP, CKAN. Salta fonti locali (local_file), SDMX e SPARQL "
+        "(non timeoutano). Non blocca mai la pipeline: l'errore reale sarà "
+        "rilevato da raw."
+    ),
+    "raw": (
+        "Scarica i file raw dalle fonti e produce il profiling.\n\n"
+        "Esegue probe + download dei file raw secondo la configurazione "
+        "raw.sources. Produce il profilo raw (encoding, delimiter, colonne, "
+        "missingness, mapping_suggestions) per guidare la scrittura di clean.sql."
+    ),
+    "clean": (
+        "Applica le trasformazioni SQL (clean.sql) ai dati raw.\n\n"
+        "Legge il parquet raw, esegue clean.sql e produce il layer CLEAN. "
+        "Il risultato è un dataset strutturato in formato Parquet, "
+        "pronto per le trasformazioni MART."
+    ),
+    "mart": (
+        "Genera le tabelle MART (dataset pubblico) dai dati clean.\n\n"
+        "Applica le query SQL definite in mart.tables[] ai dati clean "
+        "e produce tabelle denormalizzate in formato Parquet. "
+        "Per tabelle multi-anno (con years esplicito), esegue anche "
+        "l'aggregazione cross-year automaticamente."
+    ),
+    "all": (
+        "Esegue l'intera pipeline: probe → raw → clean → mart.\n\n"
+        "Equivalente a eseguire i quattro step in sequenza. "
+        "Se il dataset è mart-only (compose), usa solo lo step mart."
+    ),
+}
+
+
 def _make_step_cmd(step: str):
     """Factory: returns a Typer command wrapping run_year for the given step."""
     _step = step
@@ -498,7 +532,7 @@ def _make_step_cmd(step: str):
             _maybe_run_multi_year_mart(cfg, selected_years, dry_run=dry_flag, logger=logger, sampling_active=_sampling)
 
     cmd.__name__ = f"run_{_step}_cmd"
-    cmd.__doc__ = f"Esegue lo step {_step} della pipeline."
+    cmd.__doc__ = _STEP_DOCSTRINGS.get(_step, f"Esegue lo step {_step} della pipeline.")
     return cmd
 
 

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -7,7 +7,7 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 ### Ispezione pipeline
 
 - `toolkit_inspect_paths(config_path, year=0)` — path contract + run metadata (run_file_count, years_seen, latest_run)
-- `toolkit_show_schema(config_path, layer="clean", year=0)`
+- `toolkit_inspect_schema(config_path, layer="clean", year=0)`
 - `toolkit_run_summary(config_path, year=0)` — statistiche aggregate (totali, successi, durata media)
 - `toolkit_summary(config_path, year=0)` — dashboard diagnostico (layer + run + warnings)
 - `toolkit_review_readiness(config_path, year=0)` — check di prontezza per review candidate
@@ -59,7 +59,7 @@ Sostituire il path del `command` con il Python reale del clone locale che usera'
 ## Note tecniche
 
 - `toolkit_inspect_paths` usa `toolkit inspect paths --json`; arricchito con run_file_count e years_seen dalla CLI
-- `toolkit_show_schema`
+- `toolkit_inspect_schema`
   - `raw`: usa `toolkit inspect schema-diff --json`
   - `clean` / `mart`: legge schema reale dei parquet risolti via `inspect paths`
 - `toolkit_schema_diff` confronta segnali schema raw (encoding, delim, colonne) tra tutti gli anni configurati per il dataset; riutilizza la stessa logica di `toolkit inspect schema-diff` ma esposto come tool MCP

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -507,7 +507,7 @@ def raw_preview(
         return {
             "path": str(raw_file),
             "format": "xlsx",
-            "note": "File binario XLSX. Usa toolkit_show_schema(layer='raw') per lo schema delle colonne.",
+            "note": "File binario XLSX. Usa toolkit_inspect_schema(layer='raw') per lo schema delle colonne.",
             "dataset": paths.get("dataset"),
             "year": paths.get("year"),
         }
@@ -516,7 +516,7 @@ def raw_preview(
             "path": str(raw_file),
             "format": suffix.lstrip("."),
             "note": f"Formato '{suffix}' non supportato per preview raw. "
-                    "Usa toolkit_show_schema(layer='raw') per lo schema.",
+                    "Usa toolkit_inspect_schema(layer='raw') per lo schema.",
             "dataset": paths.get("dataset"),
             "year": paths.get("year"),
         }

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -1,7 +1,7 @@
 """Toolkit MCP server.
 
 Espone 13 tool read-only per ispezione della pipeline toolkit:
-- ispezione standard: inspect_paths, show_schema, raw_profile, summary
+- ispezione standard: inspect_paths, inspect_schema, inspect_profile, summary
 - diagnostica: review_readiness, schema_diff, run_summary
 - run history: list_runs
 - discovery: list_candidates, dataset_info
@@ -56,17 +56,32 @@ def toolkit_inspect_paths(config_path: str, year: int = 0) -> dict[str, Any]:
     return guard_timed(inspect_paths_impl, "toolkit_inspect_paths", config_path, year or None)
 
 
-@mcp.tool(description="Mostra lo schema di raw, clean o mart.", structured_output=True)
-def toolkit_show_schema(config_path: str, layer: str = "clean", year: int = 0) -> dict[str, Any]:
-    return guard_timed(show_schema_impl, "toolkit_show_schema", config_path, layer, year or None)
+@mcp.tool(
+    name="toolkit_show_schema",
+    description="[DEPRECATED] usa toolkit_inspect_schema",
+    structured_output=True,
+)
+@mcp.tool(
+    name="toolkit_inspect_schema",
+    description="Mostra lo schema di raw, clean o mart.",
+    structured_output=True,
+)
+def toolkit_inspect_schema(config_path: str, layer: str = "clean", year: int = 0) -> dict[str, Any]:
+    return guard_timed(show_schema_impl, "toolkit_inspect_schema", config_path, layer, year or None)
 
 
 @mcp.tool(
+    name="toolkit_raw_profile",
+    description="[DEPRECATED] usa toolkit_inspect_profile",
+    structured_output=True,
+)
+@mcp.tool(
+    name="toolkit_inspect_profile",
     description="Mostra il profilo raw: encoding, delimiter, colonne, missingness e mapping suggestions.",
     structured_output=True,
 )
-def toolkit_raw_profile(config_path: str, year: int = 0) -> dict[str, Any]:
-    return guard_timed(raw_profile_impl, "toolkit_raw_profile", config_path, year or None)
+def toolkit_inspect_profile(config_path: str, year: int = 0) -> dict[str, Any]:
+    return guard_timed(raw_profile_impl, "toolkit_inspect_profile", config_path, year or None)
 
 
 @mcp.tool(


### PR DESCRIPTION
## Cosa

Due fix UX identificati dall'audit di coerenza:

### 1. Nomi MCP allineati ai nomi CLI
| Prima | Dopo | CLI corrispondente |
|---|---|---|
| `toolkit_show_schema` | `toolkit_inspect_schema` | `toolkit inspect schema` |
| `toolkit_raw_profile` | `toolkit_inspect_profile` | `toolkit inspect profile` |

Segue il pattern `inspect_*` già esistente (`toolkit_inspect_paths`).

### 2. Help specifici per `run probe/raw/clean/mart/all`
Prima: tutti con lo stesso docstring generico "Esegue lo step {step} della pipeline."
Ora: ogni sub-comando ha una descrizione che spiega cosa fa realmente (es. `run raw` → "Scarica i file raw e produce profiling (encoding, delimiter, mapping_suggestions)").

## Test
- 766 test passati, zero regressioni
- Documentazione aggiornata (README, mcp/README, `_local/ops/*.md`, `dataset-incubator/skills/run-candidate.md`)

## Note
- Lasciati invariati `toolkit_probe_url_routed` e `toolkit_sparql_query` perché hanno scope diverso dai rispettivi CLI e i nomi attuali sono descrittivi.
- Il file `dataset-incubator/skills/run-candidate.md` è stato modificato ma è in un repo separato (serve PR separato lì).