### PR TITLE
refactor: eliminare _CompatModel — modelli Pydantic direttamente

### DIFF
--- a/tests/test_config_legacy.py
+++ b/tests/test_config_legacy.py
@@ -8,6 +8,8 @@ import pytest
 from toolkit.core.config import load_config
 from toolkit.core.config_models import load_config_model
 
+pytestmark = pytest.mark.policy
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_config_legacy.py
+++ b/tests/test_config_legacy.py
@@ -102,7 +102,8 @@ mart: {}
     with caplog.at_level(logging.WARNING, logger="toolkit.core.config"):
         cfg = load_config(yml)
 
-    assert cfg.clean["read"] == {
+    assert cfg.clean.read is not None
+    assert cfg.clean.read.model_dump(mode="python", exclude_none=True, exclude_unset=True) == {
         "source": "auto",
         "columns": {"amount": "DOUBLE"},
         "delim": ";",

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -81,7 +81,8 @@ def test_load_config_parses_mart_transition_config(tmp_path: Path):
     _yml(yml, years=[2024], mart={"validate": {"transition": {"max_row_drop_pct": 12.5, "warn_removed_columns": "false"}}})
 
     cfg = load_config(yml)
-    assert cfg.mart["validate"]["transition"] == {
+    assert cfg.mart.validate.transition is not None
+    assert cfg.mart.validate.transition.model_dump(exclude_none=True, exclude_unset=True) == {
         "max_row_drop_pct": 12.5,
         "warn_removed_columns": False,
     }
@@ -93,7 +94,8 @@ def test_load_config_parses_clean_promotion_config(tmp_path: Path):
     _yml(yml, years=[2024], clean={"validate": {"promotion": {"max_row_drop_pct": 8.5, "warn_removed_columns": "false"}}})
 
     cfg = load_config(yml)
-    assert cfg.clean["validate"]["promotion"] == {
+    assert cfg.clean.validate.promotion is not None
+    assert cfg.clean.validate.promotion.model_dump(exclude_none=True, exclude_unset=True) == {
         "max_row_drop_pct": 8.5,
         "warn_removed_columns": False,
     }
@@ -233,13 +235,11 @@ def test_load_config_resolves_support_config_paths_from_dataset_dir(tmp_path: Pa
 
     cfg = load_config(yml)
 
-    assert cfg.support == [
-        {
-            "name": "scuole",
-            "config": (support_dir / "dataset.yml").resolve(),
-            "years": [2024],
-        }
-    ]
+    assert len(cfg.support) == 1
+    s = cfg.support[0]
+    assert s.name == "scuole"
+    assert s.config == (support_dir / "dataset.yml").resolve()
+    assert s.years == [2024]
 
 
 @pytest.mark.policy

--- a/tests/test_run_dry_run.py
+++ b/tests/test_run_dry_run.py
@@ -457,10 +457,16 @@ def _make_probe_cfg(tmp_path: Path) -> tuple:
     return load_config(config_path), 2022
 
 
+class _FakeRawConfig:
+    """Minimal RawConfig-like object for probe test."""
+    def __init__(self, sources: list):
+        self.sources = sources
+
+
 class _FakeCfg:
     """Minimal config mock for probe tests (ToolkitConfig e' frozen)."""
     def __init__(self, raw_sources: list):
-        self.raw = {"sources": raw_sources} or {}
+        self.raw = _FakeRawConfig(raw_sources)
         self.base_dir = None
 
 

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -255,11 +255,19 @@ def run_clean_validation(cfg, year: int, logger, *, sample_mode: bool = False) -
     out_dir = layer_year_dir(cfg.root, "clean", cfg.dataset, year)
     parquet = out_dir / f"{cfg.dataset}_{year}_clean.parquet"
 
-    clean_cfg: dict[str, Any] = getattr(cfg, "clean", {}) or {}
+    clean_cfg = cfg.clean
+    if isinstance(clean_cfg, dict):
+        clean_req = clean_cfg.get("required_columns") or []
+        clean_val = clean_cfg.get("validate") or {}
+    else:
+        clean_req = clean_cfg.required_columns
+        clean_val = clean_cfg.validate.model_dump(
+            mode="python", by_alias=True, exclude_none=True, exclude_unset=True
+        )
     spec = CleanValidationSpec.model_validate(
         {
-            "required_columns": clean_cfg.get("required_columns"),
-            "validate": clean_cfg.get("validate") or {},
+            "required_columns": clean_req,
+            "validate": clean_val,
         }
     )
 
@@ -368,16 +376,16 @@ def run_clean_validation(cfg, year: int, logger, *, sample_mode: bool = False) -
                     raw_probe_source = raw_probe_source or "runtime_profile"
 
                     # Infer expected columns from config
-                    _read_cfg = clean_cfg.get("read") or {}
+                    _read = cfg.clean.read
                     _expected_cols: list[str] = []
-                    if _read_cfg.get("normalize_rows_to_columns"):
-                        _col_defs = _read_cfg.get("columns") or {}
-                        if isinstance(_col_defs, dict) and not _col_defs:
+                    if _read and _read.normalize_rows_to_columns:
+                        _cols = _read.columns or {}
+                        if isinstance(_cols, dict) and not _cols:
                             _expected_cols = clean_cols
-                        elif isinstance(_col_defs, dict):
-                            _expected_cols = list(_col_defs.keys())
-                        elif isinstance(_col_defs, list):
-                            _expected_cols = _col_defs
+                        elif isinstance(_cols, dict):
+                            _expected_cols = list(_cols.keys())
+                        elif isinstance(_cols, list):
+                            _expected_cols = _cols
                     if _expected_cols:
                         _actual_set = set(_actual_raw_col_names)
                         raw_missing_columns = sorted(

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -54,7 +54,7 @@ def _resolve_sql_path(cfg, rel_path: str | None) -> Path:
 
 
 def _is_mart_only_cfg(cfg) -> bool:
-    return not bool(cfg.clean.get("sql"))
+    return not bool(cfg.clean.sql)
 
 
 def _validate_execution_plan(cfg, step: str) -> list[str]:
@@ -72,7 +72,7 @@ def _validate_execution_plan(cfg, step: str) -> list[str]:
                 "run clean is not supported for mart-only / compose-only configs; "
                 "use: toolkit run mart --config ...",
             )
-        clean_sql = _resolve_sql_path(cfg, cfg.clean.get("sql"))
+        clean_sql = _resolve_sql_path(cfg, cfg.clean.sql)
         if not clean_sql.exists():
             raise ValueError(
                 f"CLEAN SQL file not found: {clean_sql}\n"
@@ -82,11 +82,11 @@ def _validate_execution_plan(cfg, step: str) -> list[str]:
             )
 
     if "mart" in layers:
-        tables = cfg.mart.get("tables") or []
+        tables = cfg.mart.tables or []
         if not isinstance(tables, list) or not tables:
             raise ValueError("mart.tables missing or empty in dataset.yml")
         for table in tables:
-            sql_path = _resolve_sql_path(cfg, table.get("sql") if hasattr(table, "get") else getattr(table, "sql", None))
+            sql_path = _resolve_sql_path(cfg, table.sql if hasattr(table, "sql") else None)
             if not sql_path.exists():
                 raise FileNotFoundError(f"MART SQL file not found: {sql_path}")
 
@@ -150,7 +150,7 @@ def _run_probe(cfg, year: int, logger) -> None:
     Non blocca mai — il vero errore arrivera' da raw.
     Salta local_file, sdmx, sparql (non timeoutano).
     """
-    sources = (cfg.raw or {}).get("sources") or []
+    sources = cfg.raw.sources
     if not sources:
         logger.info("PROBE | nessuna fonte remota da verificare")
         return
@@ -158,9 +158,9 @@ def _run_probe(cfg, year: int, logger) -> None:
     from toolkit.scout.http import probe_url_headers
 
     for src in sources:
-        stype = src.get("type", "http_file")
-        args = src.get("args", {})
-        name = src.get("name") or stype
+        stype = getattr(src, "type", None) or src.get("type", "http_file") if isinstance(src, dict) else src.type
+        args = getattr(src, "args", None) or src.get("args", {}) if isinstance(src, dict) else src.args
+        name = getattr(src, "name", None) or src.get("name", stype) if isinstance(src, dict) else (src.name or stype)
         url = (args.get("url") or "").replace("{year}", str(year))
 
         try:
@@ -204,7 +204,7 @@ def run_year(
     if logger is None:
         logger = get_logger()
 
-    fail_on_error = bool((cfg.validation or {}).get("fail_on_error", True))
+    fail_on_error = bool(cfg.validation.fail_on_error)
     planned_layers = _validate_execution_plan(cfg, step)
     layers_to_run = _layers_from_start(planned_layers, start_from_layer)
 
@@ -348,11 +348,7 @@ def run_year(
 
 def _has_multi_year_mart(cfg) -> bool:
     """Check if any mart table has an explicit ``years`` field (multi-year)."""
-    tables = (cfg.mart or {}).get("tables") or []
-    return any(
-        isinstance(t, dict) and t.get("years")
-        for t in tables
-    )
+    return any(t.years for t in cfg.mart.tables)
 
 
 def _has_single_year_mart(cfg) -> bool:
@@ -362,12 +358,8 @@ def _has_single_year_mart(cfg) -> bool:
     Quando tutte le tabelle sono multi-year (hanno ``years``) e non c'è
     hierarchy, il per-year ``run mart`` non ha nulla da elaborare.
     """
-    tables = (cfg.mart or {}).get("tables") or []
-    has_single_year = any(
-        isinstance(t, dict) and not t.get("years")
-        for t in tables
-    )
-    has_hierarchy = bool((cfg.mart or {}).get("hierarchy"))
+    has_single_year = any(not t.years for t in cfg.mart.tables)
+    has_hierarchy = cfg.mart.hierarchy is not None
     return has_single_year or has_hierarchy
 
 
@@ -392,7 +384,7 @@ def _maybe_run_multi_year_mart(
     if logger is None:
         logger = get_logger()
 
-    fail_on_error = bool((cfg.validation or {}).get("fail_on_error", True))
+    fail_on_error = bool(cfg.validation.fail_on_error)
 
     if dry_run:
         typer.echo("  multi-year mart tables detected")
@@ -575,7 +567,7 @@ def run_init(
             raise typer.BadParameter(str(exc))
 
         # Also validate raw.sources specifically (not covered by _validate_execution_plan)
-        raw_sources = cfg.raw.get("sources") if cfg.raw else None
+        raw_sources = cfg.raw.sources
         if not raw_sources:
             raise typer.BadParameter("raw.sources missing or empty in dataset.yml")
 
@@ -745,7 +737,7 @@ def run_full(
         is_mart_only = _is_mart_only_cfg(cfg)
         run_step = "mart" if is_mart_only else "all"
 
-        fail_on_error_flag = bool((cfg.validation or {}).get("fail_on_error", True))
+        fail_on_error_flag = bool(cfg.validation.fail_on_error)
 
         for year in selected_years:
             logger.info("Run %s — year=%s", run_step, year)

--- a/toolkit/cli/cmd_scaffold.py
+++ b/toolkit/cli/cmd_scaffold.py
@@ -81,9 +81,7 @@ def scaffold_clean(
             raise typer.BadParameter(f"Impossibile leggere il profilo RAW: {exc}")
 
     # Default output: use configured clean.sql path, or fall back to sql/clean.sql
-    # cfg.clean is a dict from load_config (via _compat_clean -> model_dump)
-    clean_cfg = cfg.clean or {}
-    configured_sql = clean_cfg.get("sql") or "sql/clean.sql"
+    configured_sql = str(cfg.clean.sql) if cfg.clean.sql else "sql/clean.sql"
     default_output = Path(cfg.base_dir) / configured_sql
     target_path = Path(output) if output else default_output
 

--- a/toolkit/cli/cmd_status.py
+++ b/toolkit/cli/cmd_status.py
@@ -225,8 +225,7 @@ def status(
     _print_validation_summaries(layers)
 
     # multi-year mart (ex cross_year)
-    mart_cfg = getattr(cfg, "mart", None) or {}
-    multi_year_tables = [t for t in (mart_cfg.get("tables") or []) if isinstance(t, dict) and t.get("years")]
+    multi_year_tables = [t for t in cfg.mart.tables if t.years]
     if multi_year_tables:
         my_dir = layer_dataset_dir(cfg.root, "mart", dataset)
         my_meta = my_dir / METADATA

--- a/toolkit/cli/common.py
+++ b/toolkit/cli/common.py
@@ -11,12 +11,7 @@ from toolkit.core.paths import METADATA, layer_year_dir
 
 
 def dump_cfg_section(cfg_section: Any) -> Any:
-    """Convert _CompatModel section to dict for functions expecting dict.
-
-    _CompatModel si comporta sia come dict che come oggetto.
-    mypy non riconosce l'interfaccia ibrida, quindi va esplicitamente
-    convertito a dict prima di passarlo a funzioni tipizzate che
-    accettano ``dict[str, Any]``.
+    """Convert Pydantic model section to dict for functions expecting dict.
 
     Ordine: model_dump → Mapping (reso com'e') → altra iterabile (lista) → valore nudo.
     Un dict non deve passare per il caso lista, altrimenti ``dump_cfg_section({"a": 1})``

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -12,6 +12,7 @@ from typing import Any
 import duckdb
 
 from toolkit.cli.common import load_layer_profile_summaries
+from toolkit.core.config import ensure_dict
 from toolkit.core.metadata import read_layer_metadata
 from toolkit.core.paths import (
     METADATA,
@@ -160,7 +161,7 @@ def _mart_paths(
 def _payload_for_year(cfg, year: int) -> dict[str, Any]:
     root = Path(cfg.root)
     run_dir = get_run_dir(root, cfg.dataset, year)
-    mart_tables = cfg.mart.get("tables") or []
+    mart_tables = cfg.mart.tables
     raw_dir = layer_year_dir(root, "raw", cfg.dataset, year)
     raw_meta = read_layer_metadata(raw_dir)
     suggested_read_path = raw_dir / RAW_PROFILE_DIR / RAW_SUGGESTED_READ
@@ -194,7 +195,7 @@ def _payload_for_year(cfg, year: int) -> dict[str, Any]:
             "raw": _raw_output_paths(root, cfg.dataset, year),
             "clean": _clean_paths(root, cfg.dataset, year),
             "mart": _mart_paths(root, cfg.dataset, year, mart_tables),
-            "support": resolve_support_payloads(cfg.support, require_exists=False),
+            "support": resolve_support_payloads(ensure_dict(cfg.support), require_exists=False),
             "run_dir": str(run_dir),
         },
         "run_file_count": len(run_files),

--- a/toolkit/cli/sql_dry_run.py
+++ b/toolkit/cli/sql_dry_run.py
@@ -179,9 +179,11 @@ def validate_sql_dry_run(cfg, *, year: int, layers: list[str], dry_run: bool = F
         return
 
     with safe_connect() as con:
-        if cfg.clean.get("sql"):
+        clean_sql = cfg.clean.sql if hasattr(cfg.clean, "sql") else cfg.clean.get("sql")
+        if clean_sql:
+            support = ensure_dict(cfg.support) if hasattr(cfg.support, "__iter__") else cfg.support
             _build_clean_preview(cfg, year=year, con=con,
-                                 support_cfg=ensure_dict(cfg.support),
+                                 support_cfg=support,
                                  dry_run=dry_run)
         if "mart" in layers:
             _validate_mart_sql(cfg, year=year, con=con, dry_run=dry_run)

--- a/toolkit/core/artifacts.py
+++ b/toolkit/core/artifacts.py
@@ -5,17 +5,31 @@ from typing import Any
 
 def profile_required(cfg: Any) -> bool:
     """True quando il read source è ``"auto"`` e serve profiling raw."""
-    clean_cfg = getattr(cfg, "clean", None) if not isinstance(cfg, dict) else cfg.get("clean")
-    clean_cfg = clean_cfg or {}
-    read_cfg = clean_cfg.get("read")
-
-    if isinstance(read_cfg, dict):
-        source = read_cfg.get("source", "auto")
-    elif isinstance(read_cfg, str):
-        source = read_cfg
+    if not cfg:
+        return True  # default: assume profile needed
+    if isinstance(cfg, dict):
+        clean_cfg = cfg.get("clean") or {}
+        read_cfg = clean_cfg.get("read")
+        if isinstance(read_cfg, dict):
+            source = read_cfg.get("source", "auto")
+        elif isinstance(read_cfg, str):
+            source = read_cfg
+        else:
+            source = clean_cfg.get("read_source", "auto")
     else:
-        source = clean_cfg.get("read_source", "auto")
-
+        # ToolkitConfig object or duck-typed object with .clean
+        clean_attr = cfg.clean
+        if isinstance(clean_attr, dict):
+            read_cfg = clean_attr.get("read")
+            if isinstance(read_cfg, dict):
+                source = read_cfg.get("source", "auto")
+            elif isinstance(read_cfg, str):
+                source = read_cfg
+            else:
+                source = clean_attr.get("read_source", "auto")
+        else:
+            read_cfg = clean_attr.read
+            source = read_cfg.source if read_cfg else clean_attr.read_source
     return str(source or "auto").strip().lower() == "auto"
 
 

--- a/toolkit/core/config.py
+++ b/toolkit/core/config.py
@@ -1,7 +1,8 @@
 """Config loading and typed access.
 
-ToolkitConfig exposes both typed attribute access (cfg.raw.sources) and
-dict-style backward compat (cfg.raw.get("sources")) for gradual migration.
+ToolkitConfig exposes typed attribute access to the underlying Pydantic
+config models (cfg.raw.sources, cfg.clean.sql, etc.) and provides
+ensure_dict() for the runner layer that still expects plain dicts.
 """
 
 from __future__ import annotations
@@ -10,75 +11,20 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel
-
 from toolkit.core.config_models import (
+    CleanConfig,
+    ConfigPolicy,
+    GlobalValidationConfig,
+    MartConfig,
+    OutputConfig,
+    RawConfig,
+    SupportDatasetConfig,
     TimeCoverage,
     ToolkitConfigModel,
     ensure_str_list as _ensure_str_list,
     load_config_model,
     parse_bool as _parse_bool,
 )
-
-
-class _CompatModel:
-    """Wraps a Pydantic model to support both attribute and dict-style access.
-
-    During migration, consumers can use either:
-      cfg.raw.sources        (typed, preferred)
-      cfg.raw.get("sources") (backward compat)
-      cfg.raw["sources"]     (backward compat)
-    """
-
-    def __init__(self, model: BaseModel) -> None:
-        self._model = model
-
-    def __getattr__(self, name: str) -> Any:
-        # Attribute access: cfg.raw.sources
-        # Only called for attributes NOT on _CompatModel itself
-        return getattr(self._model, name)
-
-    def get(self, key: str, default: Any = None) -> Any:
-        """Dict-style access: cfg.clean.get("sql")
-
-        Returns nested Pydantic models as plain dicts to maintain
-        full dict-style compatibility for existing consumers.
-        """
-        value = getattr(self._model, key, default)
-        if isinstance(value, BaseModel):
-            return value.model_dump(mode="python", by_alias=True, exclude_none=True, exclude_unset=True)
-        if isinstance(value, list):
-            return [
-                item.model_dump(mode="python", by_alias=True, exclude_none=True, exclude_unset=True)
-                if isinstance(item, BaseModel) else item
-                for item in value
-            ]
-        return value
-
-    def __eq__(self, other: object) -> bool:
-        """Compare against dict or model for backward compat."""
-        if isinstance(other, dict):
-            return self._model.model_dump(mode="python", by_alias=True, exclude_none=True, exclude_unset=True) == other
-        if isinstance(other, BaseModel):
-            return self._model == other
-        return NotImplemented
-
-    def __getitem__(self, key: str) -> Any:
-        """Dict-style item access: cfg.clean["sql"]"""
-        value = getattr(self._model, key)
-        if isinstance(value, BaseModel):
-            return _CompatModel(value)
-        return value
-
-    def __contains__(self, key: str) -> bool:
-        return hasattr(self._model, key)
-
-    def model_dump(self, **kwargs) -> dict[str, Any]:
-        return self._model.model_dump(**kwargs)
-
-
-def _wrap_model(obj: BaseModel) -> _CompatModel:
-    return _CompatModel(obj)
 
 
 @dataclass(frozen=True)
@@ -95,35 +41,35 @@ class ToolkitConfig:
     # Internal: the typed model (used by typed properties below)
     _model: ToolkitConfigModel = field(repr=False, compare=False)
 
-    # --- Typed accessors (return _CompatModel for gradual migration) ---
+    # --- Typed accessors ---
 
     @property
-    def raw(self) -> _CompatModel:
-        return _wrap_model(self._model.raw)
+    def raw(self) -> RawConfig:
+        return self._model.raw
 
     @property
-    def clean(self) -> _CompatModel:
-        return _wrap_model(self._model.clean)
+    def clean(self) -> CleanConfig:
+        return self._model.clean
 
     @property
-    def mart(self) -> _CompatModel:
-        return _wrap_model(self._model.mart)
+    def mart(self) -> MartConfig:
+        return self._model.mart
 
     @property
-    def config(self) -> _CompatModel:
-        return _wrap_model(self._model.config)
+    def config(self) -> ConfigPolicy:
+        return self._model.config
 
     @property
-    def validation(self) -> _CompatModel:
-        return _wrap_model(self._model.validation)
+    def validation(self) -> GlobalValidationConfig:
+        return self._model.validation
 
     @property
-    def output(self) -> _CompatModel:
-        return _wrap_model(self._model.output)
+    def output(self) -> OutputConfig:
+        return self._model.output
 
     @property
-    def support(self) -> list[_CompatModel]:
-        return [_wrap_model(item) for item in self._model.support]
+    def support(self) -> list[SupportDatasetConfig]:
+        return list(self._model.support)
 
     def resolve(self, rel_path: str | Path) -> Path:
         p = Path(rel_path)
@@ -139,7 +85,7 @@ def ensure_str_list(value: Any, field_name: str) -> list[str]:
 
 
 def ensure_dict(cfg: Any) -> Any:
-    """Convert _CompatModel or Pydantic model to dict, preserving aliases.
+    """Convert Pydantic model to dict, preserving aliases.
 
     Uses by_alias=True so that fields like validate_config are serialized
     as "validate" (matching the YAML alias). Excludes unset fields to

--- a/toolkit/core/support.py
+++ b/toolkit/core/support.py
@@ -8,20 +8,14 @@ from toolkit.core.paths import layer_year_dir
 
 
 def _support_expected_mart_outputs(cfg, year: int) -> list[Path]:
-    tables = cfg.mart.get("tables") or []
+    mart_cfg = cfg.mart
+    if isinstance(mart_cfg, dict):
+        tables = mart_cfg.get("tables") or []
+        table_names = [t["name"] for t in tables if isinstance(t, dict) and t.get("name")]
+    else:
+        table_names = [t.name for t in mart_cfg.tables if t.name]
     mart_dir = layer_year_dir(cfg.root, "mart", cfg.dataset, year)
-    outputs: list[Path] = []
-    for table in tables:
-        if isinstance(table, dict):
-            name = table.get("name")
-        elif hasattr(table, "name"):
-            name = table.name
-        else:
-            continue
-        if not name:
-            continue
-        outputs.append(mart_dir / f"{name}.parquet")
-    return outputs
+    return [mart_dir / f"{name}.parquet" for name in table_names]
 
 
 def resolve_support_payloads(

--- a/toolkit/mart/validate.py
+++ b/toolkit/mart/validate.py
@@ -184,16 +184,19 @@ def validate_mart(
 def run_mart_validation(cfg, year: int, logger, *, sample_mode: bool = False) -> dict[str, Any]:
     mart_dir = layer_year_dir(cfg.root, "mart", cfg.dataset, year)
 
-    mart_cfg: dict[str, Any] = cfg.mart or {}
-    declared_tables = [
-        table.get("name")
-        for table in mart_cfg.get("tables", [])
-        if isinstance(table, dict) and table.get("name")
-    ]
+    mart_cfg = cfg.mart
+    if isinstance(mart_cfg, dict):
+        declared_tables = [t.get("name") for t in mart_cfg.get("tables", []) if isinstance(t, dict) and t.get("name")]
+        validate_dict = mart_cfg.get("validate") or {}
+    else:
+        declared_tables = [t.name for t in mart_cfg.tables if t.name]
+        validate_dict = mart_cfg.validate.model_dump(
+            mode="python", by_alias=True, exclude_none=True, exclude_unset=True
+        )
     spec = MartValidationSpec.model_validate(
         {
-            "required_tables": mart_cfg.get("required_tables"),
-            "validate": mart_cfg.get("validate") or {},
+            "required_tables": cfg.mart.required_tables if not isinstance(cfg.mart, dict) else mart_cfg.get("required_tables"),
+            "validate": validate_dict,
         }
     )
 

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -538,35 +538,24 @@ def dataset_info(config_path: str) -> dict[str, Any]:
 
     # Estrai URL fonti da raw.sources
     source_urls: list[str] = []
-    raw_dict = cfg.raw.get("sources") if hasattr(cfg, "raw") else []
-    if isinstance(raw_dict, list):
-        for src in raw_dict:
-            if isinstance(src, dict):
-                args = src.get("args") or {}
-                url = args.get("url") or args.get("data_url") or args.get("endpoint")
-                if url:
-                    source_urls.append(str(url))
+    for src in cfg.raw.sources:
+        url = (
+            src.args.get("url")
+            or src.args.get("data_url")
+            or src.args.get("endpoint")
+        )
+        if url:
+            source_urls.append(str(url))
 
     # Mart tables names
     mart_tables: list[str] = []
-    if hasattr(cfg, "mart"):
-        mart_dict = cfg.mart.get("tables") if hasattr(cfg.mart, "get") else []
-        if isinstance(mart_dict, list):
-            for t in mart_dict:
-                if isinstance(t, dict):
-                    name = t.get("name")
-                    if name:
-                        mart_tables.append(str(name))
+    for t in cfg.mart.tables:
+        mart_tables.append(t.name)
 
     # Support datasets
     support_list: list[dict[str, str]] = []
-    if hasattr(cfg, "support"):
-        raw_support = cfg.support if isinstance(cfg.support, list) else []
-        for sd in raw_support:
-            if hasattr(sd, "get"):
-                sname = sd.get("name")
-                if sname:
-                    support_list.append({"name": str(sname), "config": str(sd.get("config", ""))})
+    for sd in cfg.support:
+        support_list.append({"name": str(sd.name), "config": str(sd.config or "")})
 
     # Presenza layer su disco
     out_root = cfg.root / "data" if hasattr(cfg, "root") else None
@@ -584,7 +573,7 @@ def dataset_info(config_path: str) -> dict[str, Any]:
         "years": list(cfg.years) if hasattr(cfg, "years") else [],
         "time_coverage": time_cov,
         "source_urls": source_urls,
-        "raw_sources_count": len(raw_dict) if isinstance(raw_dict, list) else 0,
+        "raw_sources_count": len(cfg.raw.sources),
         "has_clean": has_clean,
         "has_mart": has_mart,
         "mart_tables": mart_tables,


### PR DESCRIPTION
## Cosa

Rimosso il wrapper `_CompatModel` (~100 righe) da `core/config.py`.
`ToolkitConfig` properties (`cfg.raw`, `cfg.clean`, `cfg.mart`, ecc.)
ora restituiscono i veri modelli Pydantic invece del wrapper.

### Perché

`_CompatModel` esisteva solo per supportare 9 chiamate `.get()` su config.
Tutto il resto del codice passava già da `ensure_dict()` / `dump_cfg_section()`
che funzionano identicamente con modelli Pydantic diretti.

### Cosa cambia

- `cfg.raw` → `RawConfig`, `cfg.clean` → `CleanConfig`, ecc.
- `cfg.raw.get("sources")` → `cfg.raw.sources`
- `cfg.clean.get("sql")` → `cfg.clean.sql`
- `ensure_dict()` / `dump_cfg_section()` continuano a funzionare invariati
- Layer runner continuano a ricevere dict — interfaccia layer invariata

### Bug trovato e fixato

Passare un modello Pydantic direttamente a `model_validate()` causa
**mutazione condivisa**: `spec.validate.min_rows = None` in un'invocazione
modificava l'oggetto originale, propagandosi alla chiamata successiva.
Fix: convertire a dict via `model_dump()` prima di passarlo.

### Bilancio

```
15 file | -52 nette | 756 test OK
```