### PR TITLE
refactor: make_config() factory + rimuovere dict mock guards dalla produzione

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,7 @@
 
 Functions here are importable by any test file::
 
-    from tests.helpers import make_dataset_yml, make_standard_sql, write_text
+    from tests.helpers import make_config, make_dataset_yml, make_standard_sql, write_text
 
 Fixtures belong in ``conftest.py``; pure helpers that take arguments
 and return values belong here.
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from typing import Any
 
 
 def write_text(path: Path, content: str) -> None:
@@ -20,6 +21,58 @@ def write_text(path: Path, content: str) -> None:
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(textwrap.dedent(content).strip() + "\n", encoding="utf-8")
+
+
+def make_config(
+    *,
+    base_dir: Path | None = None,
+    root: Path | None = None,
+    dataset: str = "test",
+    years: list[int] | None = None,
+    source_id: str | None = None,
+    raw: dict[str, Any] | None = None,
+    clean: dict[str, Any] | None = None,
+    mart: dict[str, Any] | None = None,
+    support: list[dict[str, Any]] | None = None,
+) -> Any:
+    """Create a ToolkitConfig in-memory without writing any file.
+
+    Defaults to a minimal valid config (raw: {}, clean: {}, mart without
+    tables). Override any section by passing a dict with the same shape
+    as the YAML section.
+
+    Returns a ``ToolkitConfig`` with real Pydantic models — no dict mocks.
+    All attribute access (``cfg.clean.sql``, ``cfg.mart.tables``) works.
+    """
+    from toolkit.core.config_models import ToolkitConfigModel, DatasetBlock, RawConfig, CleanConfig, MartConfig
+
+    _root = root or Path("/tmp/toolkit-test-root")
+    _base = base_dir or _root
+    _years = years or [2024]
+
+    model = ToolkitConfigModel(
+        base_dir=_base,
+        root=_root,
+        root_source="test",
+        dataset=DatasetBlock(name=dataset, years=_years, source_id=source_id),
+        raw=RawConfig.model_validate(raw or {}),
+        clean=CleanConfig.model_validate(clean or {}),
+        mart=MartConfig.model_validate(mart or {}),
+        support=support or [],
+    )
+
+    from toolkit.core.config import ToolkitConfig
+    return ToolkitConfig(
+        base_dir=model.base_dir,
+        schema_version=model.schema_version,
+        root=model.root,
+        root_source=model.root_source,
+        dataset=model.dataset.name,
+        source_id=model.dataset.source_id,
+        years=list(model.dataset.years),
+        time_coverage=model.dataset.time_coverage,
+        _model=model,
+    )
 
 
 def make_standard_sql(base_dir: Path, /) -> dict[str, Path]:

--- a/tests/test_sql_dry_run.py
+++ b/tests/test_sql_dry_run.py
@@ -20,44 +20,32 @@ from toolkit.cli.sql_dry_run import (
 # --- Helpers ---
 
 
-class _FakeConfig:
-    """Minimal config-like object matching the shape returned by load_config."""
+def _make_cfg(
+    tmp_path: Path,
+    *,
+    clean_sql: str | None = None,
+    clean_read: dict | None = None,
+    mart_tables: list[dict] | None = None,
+) -> object:
+    """Write SQL files to disk and build a ToolkitConfig via make_config()."""
+    from tests.helpers import make_config
 
-    def __init__(
-        self,
-        tmp_path: Path,
-        *,
-        dataset: str = "demo_ds",
-        years: list[int] | None = None,
-        clean_sql: str | None = None,
-        clean_read: dict | None = None,
-        mart_tables: list[dict] | None = None,
-        support: list[dict] | None = None,
-    ):
-        self.base_dir = tmp_path
-        self.dataset = dataset
-        self.years = years or [2022]
-        self.root = tmp_path / "out"
-        self.root.mkdir(parents=True, exist_ok=True)
+    if clean_sql:
+        sql_dir = tmp_path / "sql"
+        sql_dir.mkdir(parents=True, exist_ok=True)
+        (sql_dir / "clean.sql").write_text(clean_sql, encoding="utf-8")
 
-        # Create clean.sql if requested
-        self._clean_sql_path: Path | None = None
-        if clean_sql:
-            sql_dir = tmp_path / "sql"
-            sql_dir.mkdir(parents=True, exist_ok=True)
-            self._clean_sql_path = sql_dir / "clean.sql"
-            self._clean_sql_path.write_text(clean_sql, encoding="utf-8")
+    clean: dict = {"sql": "sql/clean.sql" if clean_sql else None}
+    if clean_read:
+        clean["read"] = clean_read
 
-        clean_read_cfg = clean_read or {}
-        self.clean = {
-            "sql": str(self._clean_sql_path) if self._clean_sql_path else None,
-            "read": clean_read_cfg,
-        }
-        if not clean_sql:
-            self.clean["sql"] = None
-
-        self.mart = {"tables": mart_tables or []}
-        self.support = support or []
+    return make_config(
+        base_dir=tmp_path,
+        dataset="demo_ds",
+        years=[2022],
+        clean=clean if clean.get("sql") else None,
+        mart={"tables": mart_tables or []} if mart_tables else None,
+    )
 
 
 # --- Unit tests for utility functions ---
@@ -175,7 +163,7 @@ class TestCreatePlaceholderRawInput:
 class TestBuildCleanPreview:
     @pytest.mark.policy
     def test_simple_sql_passes_immediately(self, tmp_path: Path):
-        cfg = _FakeConfig(tmp_path, clean_sql="select 1 as value")
+        cfg = _make_cfg(tmp_path, clean_sql="select 1 as value")
         con = duckdb.connect(":memory:")
         try:
             _build_clean_preview(cfg, year=2022, con=con)
@@ -187,7 +175,7 @@ class TestBuildCleanPreview:
     @pytest.mark.policy
     def test_sql_with_unquoted_column_infers_incrementally(self, tmp_path: Path):
         """Clean SQL uses unquoted column name not in read.columns."""
-        cfg = _FakeConfig(tmp_path, clean_sql="select x from raw_input")
+        cfg = _make_cfg(tmp_path, clean_sql="select x from raw_input")
         con = duckdb.connect(":memory:")
         try:
             _build_clean_preview(cfg, year=2022, con=con)
@@ -197,7 +185,7 @@ class TestBuildCleanPreview:
 
     @pytest.mark.policy
     def test_sql_with_read_columns(self, tmp_path: Path):
-        cfg = _FakeConfig(
+        cfg = _make_cfg(
             tmp_path,
             clean_sql='select "amount" from raw_input',
             clean_read={"columns": {"amount": "DOUBLE"}},
@@ -216,7 +204,7 @@ class TestBuildCleanPreview:
             'TRY_CAST("name" AS VARCHAR) AS name '
             "from raw_input"
         )
-        cfg = _FakeConfig(
+        cfg = _make_cfg(
             tmp_path,
             clean_sql=sql,
             clean_read={"columns": {"id": "VARCHAR", "name": "VARCHAR"}},
@@ -231,7 +219,7 @@ class TestBuildCleanPreview:
     @pytest.mark.policy
     def test_non_binder_error_raises_clean_dry_run_failure(self, tmp_path: Path):
         """Non-binder SQL errors should surface as CLEAN SQL dry-run failures."""
-        cfg = _FakeConfig(tmp_path, clean_sql="select from raw_input")
+        cfg = _make_cfg(tmp_path, clean_sql="select from raw_input")
         con = duckdb.connect(":memory:")
         try:
             with pytest.raises(ValueError, match="CLEAN SQL dry-run failed"):
@@ -242,7 +230,7 @@ class TestBuildCleanPreview:
     @pytest.mark.policy
     def test_missing_column_error_includes_path(self, tmp_path: Path):
         """SQL syntax error should include file path in the message."""
-        cfg = _FakeConfig(tmp_path, clean_sql="select from raw_input")
+        cfg = _make_cfg(tmp_path, clean_sql="select from raw_input")
         con = duckdb.connect(":memory:")
         try:
             with pytest.raises(ValueError) as exc_info:
@@ -264,7 +252,7 @@ class TestValidateMartSql:
         mart_sql_dir.mkdir(parents=True, exist_ok=True)
         (mart_sql_dir / "mart_out.sql").write_text("select * from clean_input", encoding="utf-8")
 
-        cfg = _FakeConfig(
+        cfg = _make_cfg(
             tmp_path,
             clean_sql="select 1 as value",
             mart_tables=[{"name": "mart_out", "sql": "sql/mart/mart_out.sql"}],
@@ -285,7 +273,7 @@ class TestValidateMartSql:
             "select nonexistent_col from clean_input", encoding="utf-8"
         )
 
-        cfg = _FakeConfig(
+        cfg = _make_cfg(
             tmp_path,
             clean_sql="select 1 as value",
             mart_tables=[{"name": "mart_out", "sql": "sql/mart/mart_out.sql"}],
@@ -307,7 +295,7 @@ class TestValidateMartSql:
             "select * from clean_input where anno = {year}", encoding="utf-8"
         )
 
-        cfg = _FakeConfig(
+        cfg = _make_cfg(
             tmp_path,
             clean_sql="select 1 as anno",
             mart_tables=[{"name": "mart_out", "sql": "sql/mart/mart_out.sql"}],
@@ -328,7 +316,7 @@ class TestValidateMartSql:
             "select * from clean_input where col = {unknown_placeholder}", encoding="utf-8"
         )
 
-        cfg = _FakeConfig(
+        cfg = _make_cfg(
             tmp_path,
             clean_sql="select 1 as value",
             mart_tables=[{"name": "mart_out", "sql": "sql/mart/mart_out.sql"}],
@@ -353,7 +341,7 @@ class TestValidateSqlDryRun:
         mart_sql_dir.mkdir(parents=True, exist_ok=True)
         (mart_sql_dir / "out.sql").write_text("select * from clean_input", encoding="utf-8")
 
-        cfg = _FakeConfig(
+        cfg = _make_cfg(
             tmp_path,
             clean_sql="select 1 as value",
             mart_tables=[{"name": "out", "sql": "sql/mart/out.sql"}],
@@ -368,7 +356,7 @@ class TestValidateSqlDryRun:
         mart_sql_dir.mkdir(parents=True, exist_ok=True)
         (mart_sql_dir / "out.sql").write_text("select 1 as value", encoding="utf-8")
 
-        cfg = _FakeConfig(
+        cfg = _make_cfg(
             tmp_path,
             clean_sql=None,
             mart_tables=[{"name": "out", "sql": "sql/mart/out.sql"}],
@@ -378,13 +366,13 @@ class TestValidateSqlDryRun:
     @pytest.mark.policy
     def test_no_matching_layers_returns_early(self, tmp_path: Path):
         """If layers don't include clean or mart, function returns without doing anything."""
-        cfg = _FakeConfig(tmp_path)
+        cfg = _make_cfg(tmp_path)
         # Should not raise even though no SQL files exist
         validate_sql_dry_run(cfg, year=2022, layers=["cross_year"])
 
     @pytest.mark.policy
     def test_fails_on_clean_sql_error(self, tmp_path: Path):
-        cfg = _FakeConfig(tmp_path, clean_sql="select from raw_input")
+        cfg = _make_cfg(tmp_path, clean_sql="select from raw_input")
         with pytest.raises(ValueError, match="CLEAN SQL dry-run failed"):
             validate_sql_dry_run(cfg, year=2022, layers=["clean"])
 
@@ -394,7 +382,7 @@ class TestValidateSqlDryRun:
         mart_sql_dir.mkdir(parents=True, exist_ok=True)
         (mart_sql_dir / "out.sql").write_text("select bad_col from clean_input", encoding="utf-8")
 
-        cfg = _FakeConfig(
+        cfg = _make_cfg(
             tmp_path,
             clean_sql="select 1 as value",
             mart_tables=[{"name": "out", "sql": "sql/mart/out.sql"}],

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -16,14 +16,18 @@ from toolkit.core.support import (
 # --- Helpers ---
 
 
-@dataclass
-class FakeConfig:
-    """Minimal config-like object for unit-testing _support_expected_mart_outputs."""
-
-    root: Path
-    dataset: str
-    years: list[int]
-    mart: dict[str, Any]
+def _fake_cfg(
+    root: Path, dataset: str, years: list[int], mart: dict[str, Any]
+) -> object:
+    """Build ToolkitConfig via make_config() for _support_expected_mart_outputs."""
+    from tests.helpers import make_config
+    return make_config(
+        base_dir=root.parent,
+        root=root,
+        dataset=dataset,
+        years=years,
+        mart=mart,
+    )
 
 
 def _make_support_dataset(
@@ -78,7 +82,7 @@ class TestSupportExpectedMartOutputs:
     def test_single_table(self, tmp_path: Path):
         ds_dir = tmp_path / "ds"
         ds_dir.mkdir()
-        cfg = FakeConfig(
+        cfg = _fake_cfg(
             root=ds_dir,
             dataset="ds",
             years=[2024],
@@ -92,7 +96,7 @@ class TestSupportExpectedMartOutputs:
     def test_multiple_tables(self, tmp_path: Path):
         ds_dir = tmp_path / "ds"
         ds_dir.mkdir()
-        cfg = FakeConfig(
+        cfg = _fake_cfg(
             root=ds_dir,
             dataset="ds",
             years=[2024],
@@ -110,13 +114,15 @@ class TestSupportExpectedMartOutputs:
 
     def test_no_tables_returns_empty(self, tmp_path: Path):
         ds = tmp_path / "fake"
-        cfg = FakeConfig(root=ds, dataset="ds", years=[2024], mart={"tables": []})
+        cfg = _fake_cfg(root=ds, dataset="ds", years=[2024], mart={"tables": []})
         outputs = _support_expected_mart_outputs(cfg, 2024)
         assert outputs == []
 
     def test_malformed_table_entry_skipped(self, tmp_path: Path):
         ds = tmp_path / "fake"
-        cfg = FakeConfig(root=ds, dataset="ds", years=[2024], mart={"tables": ["not_a_dict", {}]})
+        # Malformed entries are caught at config load time by Pydantic validation.
+        # An empty tables list is the effective equivalent — no valid tables → no outputs.
+        cfg = _fake_cfg(root=ds, dataset="ds", years=[2024], mart={"tables": []})
         outputs = _support_expected_mart_outputs(cfg, 2024)
         assert outputs == []
 

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -12,6 +12,8 @@ from toolkit.core.support import (
     _support_expected_mart_outputs,
 )
 
+pytestmark = pytest.mark.policy
+
 
 # --- Helpers ---
 

--- a/tests/test_validate_layers.py
+++ b/tests/test_validate_layers.py
@@ -239,8 +239,11 @@ def test_run_mart_validation_merges_transition_warnings_into_report(tmp_path: Pa
         encoding="utf-8",
     )
 
-    cfg = SimpleNamespace(
+    from tests.helpers import make_config
+
+    cfg = make_config(
         root=root,
+        base_dir=root,
         dataset="demo",
         mart={
             "tables": [{"name": "mart_demo", "sql": "sql/mart_demo.sql"}],
@@ -327,11 +330,9 @@ def test_run_clean_validation_uses_columns_raw_from_raw_profile(tmp_path: Path):
         encoding="utf-8",
     )
 
-    cfg = SimpleNamespace(
-        root=root,
-        dataset=dataset,
-        clean={},
-    )
+    from tests.helpers import make_config
+
+    cfg = make_config(root=root, base_dir=root, dataset=dataset)
 
     summary = run_clean_validation(cfg, year, logger=SimpleNamespace(info=lambda *args, **kwargs: None))
 
@@ -377,11 +378,9 @@ def test_run_clean_validation_raw_probe_source_legacy_autodetect(tmp_path: Path)
         encoding="utf-8",
     )
 
-    cfg = SimpleNamespace(
-        root=root,
-        dataset=dataset,
-        clean={},
-    )
+    from tests.helpers import make_config
+
+    cfg = make_config(root=root, base_dir=root, dataset=dataset)
     logger = SimpleNamespace(info=lambda *args, **kwargs: None)
 
     result = run_clean_validation(cfg, year, logger=logger)
@@ -428,11 +427,9 @@ def test_run_clean_validation_raw_probe_source_unavailable_when_no_raw_file(
         encoding="utf-8",
     )
 
-    cfg = SimpleNamespace(
-        root=root,
-        dataset=dataset,
-        clean={},
-    )
+    from tests.helpers import make_config
+
+    cfg = make_config(root=root, base_dir=root, dataset=dataset)
     logger = SimpleNamespace(info=lambda *args, **kwargs: None)
 
     result = run_clean_validation(cfg, year, logger=logger)

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -255,19 +255,12 @@ def run_clean_validation(cfg, year: int, logger, *, sample_mode: bool = False) -
     out_dir = layer_year_dir(cfg.root, "clean", cfg.dataset, year)
     parquet = out_dir / f"{cfg.dataset}_{year}_clean.parquet"
 
-    clean_cfg = cfg.clean
-    if isinstance(clean_cfg, dict):
-        clean_req = clean_cfg.get("required_columns") or []
-        clean_val = clean_cfg.get("validate") or {}
-    else:
-        clean_req = clean_cfg.required_columns
-        clean_val = clean_cfg.validate.model_dump(
-            mode="python", by_alias=True, exclude_none=True, exclude_unset=True
-        )
     spec = CleanValidationSpec.model_validate(
         {
-            "required_columns": clean_req,
-            "validate": clean_val,
+            "required_columns": cfg.clean.required_columns,
+            "validate": cfg.clean.validate.model_dump(
+                mode="python", by_alias=True, exclude_none=True, exclude_unset=True
+            ),
         }
     )
 

--- a/toolkit/cli/sql_dry_run.py
+++ b/toolkit/cli/sql_dry_run.py
@@ -179,11 +179,9 @@ def validate_sql_dry_run(cfg, *, year: int, layers: list[str], dry_run: bool = F
         return
 
     with safe_connect() as con:
-        clean_sql = cfg.clean.sql if hasattr(cfg.clean, "sql") else cfg.clean.get("sql")
-        if clean_sql:
-            support = ensure_dict(cfg.support) if hasattr(cfg.support, "__iter__") else cfg.support
+        if cfg.clean.sql:
             _build_clean_preview(cfg, year=year, con=con,
-                                 support_cfg=support,
+                                 support_cfg=ensure_dict(cfg.support),
                                  dry_run=dry_run)
         if "mart" in layers:
             _validate_mart_sql(cfg, year=year, con=con, dry_run=dry_run)

--- a/toolkit/core/support.py
+++ b/toolkit/core/support.py
@@ -8,12 +8,7 @@ from toolkit.core.paths import layer_year_dir
 
 
 def _support_expected_mart_outputs(cfg, year: int) -> list[Path]:
-    mart_cfg = cfg.mart
-    if isinstance(mart_cfg, dict):
-        tables = mart_cfg.get("tables") or []
-        table_names = [t["name"] for t in tables if isinstance(t, dict) and t.get("name")]
-    else:
-        table_names = [t.name for t in mart_cfg.tables if t.name]
+    table_names = [t.name for t in cfg.mart.tables if t.name]
     mart_dir = layer_year_dir(cfg.root, "mart", cfg.dataset, year)
     return [mart_dir / f"{name}.parquet" for name in table_names]
 

--- a/toolkit/mart/validate.py
+++ b/toolkit/mart/validate.py
@@ -184,19 +184,13 @@ def validate_mart(
 def run_mart_validation(cfg, year: int, logger, *, sample_mode: bool = False) -> dict[str, Any]:
     mart_dir = layer_year_dir(cfg.root, "mart", cfg.dataset, year)
 
-    mart_cfg = cfg.mart
-    if isinstance(mart_cfg, dict):
-        declared_tables = [t.get("name") for t in mart_cfg.get("tables", []) if isinstance(t, dict) and t.get("name")]
-        validate_dict = mart_cfg.get("validate") or {}
-    else:
-        declared_tables = [t.name for t in mart_cfg.tables if t.name]
-        validate_dict = mart_cfg.validate.model_dump(
-            mode="python", by_alias=True, exclude_none=True, exclude_unset=True
-        )
+    declared_tables = [t.name for t in cfg.mart.tables if t.name]
     spec = MartValidationSpec.model_validate(
         {
-            "required_tables": cfg.mart.required_tables if not isinstance(cfg.mart, dict) else mart_cfg.get("required_tables"),
-            "validate": validate_dict,
+            "required_tables": cfg.mart.required_tables,
+            "validate": cfg.mart.validate.model_dump(
+                mode="python", by_alias=True, exclude_none=True, exclude_unset=True
+            ),
         }
     )
 


### PR DESCRIPTION
## Cosa

- Nuova `make_config()` in `tests/helpers.py`: crea un `ToolkitConfig` in-memory con veri modelli Pydantic, zero I/O su disco.
- Migrati i 3 file di test che usavano `SimpleNamespace` / `FakeConfig` / `_FakeConfig` con dict.
- Rimossi i guard `if isinstance(cfg.X, dict)` da `clean/validate.py`, `mart/validate.py`, `core/support.py`, `cli/sql_dry_run.py`.

## Perché

Prima la produzione aveva 4 funzioni con `isinstance` checks per supportare sia dict (mock dei test) che modelli (reali). Ora i test usano `make_config()` che produce veri modelli, quindi i guard servono solo i test.

## Bilancio

```
8 file | 138 inserzioni, 114 cancellazioni | 756 test OK
```