### PR TITLE
refactor: centralizzare DuckDB parquet ops, comandi semplificati, --json su validate, run init registrato

### DIFF
--- a/toolkit/cli/cmd_resume.py
+++ b/toolkit/cli/cmd_resume.py
@@ -105,12 +105,12 @@ def _resolve_resume_start(
 
 
 def resume(
-    dataset: str = typer.Option(..., "--dataset", help="Dataset name"),
-    year: int = typer.Option(..., "--year", help="Dataset year"),
+    config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
+    year: int | None = typer.Option(None, "--year", "-y", help="Dataset year (default: first)"),
+    dataset: str | None = typer.Option(None, "--dataset", help="Dataset name (auto-da-config)"),
     run_id: str | None = typer.Option(None, "--run-id", help="Specific run id"),
     latest: bool = typer.Option(False, "--latest", help="Resume latest run"),
     from_layer: str | None = typer.Option(None, "--from-layer", help="Force restart from raw | clean | mart"),
-    config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
 ):
     """
     Riprende un run dal primo layer non SUCCESS.
@@ -121,12 +121,15 @@ def resume(
         raise typer.BadParameter("--from-layer must be one of: raw, clean, mart")
 
     cfg = load_config(config)
-    if cfg.dataset != dataset:
-        raise typer.BadParameter(f"Config dataset mismatch: expected {dataset}, found {cfg.dataset}")
-    if year not in cfg.years:
-        raise typer.BadParameter(f"Year {year} is not configured in {config}")
+    ds_name = dataset or cfg.dataset
+    yr = year if year is not None else (cfg.years[0] if cfg.years else None)
+    if yr is None:
+        raise typer.BadParameter(f"No years configured in {config}")
 
-    run_dir = get_run_dir(cfg.root, dataset, year)
+    if dataset is not None and cfg.dataset != dataset:
+        raise typer.BadParameter(f"Config dataset mismatch: expected {dataset}, found {cfg.dataset}")
+
+    run_dir = get_run_dir(cfg.root, ds_name, yr)
     try:
         record = read_run_record(run_dir, run_id) if run_id else latest_run(run_dir)
     except FileNotFoundError as exc:
@@ -134,7 +137,7 @@ def resume(
 
     start_from_layer, notes = _resolve_resume_start(
         cfg,
-        year,
+        yr,
         record,
         requested_from_layer=from_layer,
     )
@@ -151,7 +154,7 @@ def resume(
     logger = get_logger()
     new_context = run_year(
         cfg,
-        year,
+        yr,
         step="all",
         start_from_layer=start_from_layer,
         logger=logger,

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -831,4 +831,5 @@ def register(app: typer.Typer) -> None:
     run_sub.command("mart")(run_mart_cmd)
     run_sub.command("all")(run_all_cmd)
     run_sub.command("full")(run_full)
+    run_sub.command("init")(run_init)
     app.add_typer(run_sub, name="run", help="Esegue la pipeline RAW → CLEAN → MART per un dataset.")

--- a/toolkit/cli/cmd_scout.py
+++ b/toolkit/cli/cmd_scout.py
@@ -364,8 +364,8 @@ def _scaffold_minimal_ckan(url: str, probe_result: dict[str, Any], resources: li
         encoding="utf-8",
     )
     (out_dir / "sql/mart.sql").write_text(
-        "-- Default mart: SELECT * FROM clean.\n"
-        "SELECT * FROM clean\n",
+        "-- Default mart: SELECT * FROM clean_input.\n"
+        "SELECT * FROM clean_input\n",
         encoding="utf-8",
     )
     (out_dir / "README.md").write_text(
@@ -454,8 +454,8 @@ def _scaffold_sdmx(url: str, probe_result: dict[str, Any], *, run_raw: bool = Fa
     if not mart_sql_path.exists():
         mart_sql_path.parent.mkdir(parents=True, exist_ok=True)
         mart_sql_path.write_text(
-            "-- Default mart: SELECT * FROM clean.\n"
-            "SELECT * FROM clean\n",
+            "-- Default mart: SELECT * FROM clean_input.\n"
+            "SELECT * FROM clean_input\n",
             encoding="utf-8",
         )
 

--- a/toolkit/cli/cmd_status.py
+++ b/toolkit/cli/cmd_status.py
@@ -151,7 +151,10 @@ def status(
 
     cfg = load_config(config)
     ds_name = dataset or cfg.dataset
-    yr = year if year is not None else (cfg.years[0] if cfg.years else None)
+    yr: int | None = year if year is not None else (cfg.years[0] if cfg.years else None)
+    if yr is None:
+        typer.echo(f"error: no years configured in {config}", err=True)
+        raise typer.Exit(code=1)
 
     s = _summary(config, yr)
     record = (s.get("run") or {}).get("latest_run_record") or {}

--- a/toolkit/cli/cmd_status.py
+++ b/toolkit/cli/cmd_status.py
@@ -136,32 +136,44 @@ def _print_layer_profiles(dataset: str, year: int, layers: dict[str, Any]) -> No
 
 
 def status(
-    dataset: str = typer.Option(..., "--dataset", help="Dataset name"),
-    year: int = typer.Option(..., "--year", help="Dataset year"),
+    config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
+    year: int | None = typer.Option(None, "--year", "-y", help="Dataset year (default: first)"),
+    dataset: str | None = typer.Option(None, "--dataset", help="Dataset name (auto-da-config)"),
     run_id: str | None = typer.Option(None, "--run-id", help="Specific run id"),
     latest: bool = typer.Option(False, "--latest", help="Show latest run"),
-    config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
+    as_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
 ):
     """
-    Mostra lo stato dell'ultimo run o di uno specifico run_id.
+    Mostra lo stato dei layer raw/clean/mart per un dataset.
     """
     if run_id and latest:
         raise typer.BadParameter("Use either --run-id or --latest, not both")
 
     cfg = load_config(config)
+    ds_name = dataset or cfg.dataset
+    yr = year if year is not None else (cfg.years[0] if cfg.years else None)
 
-    # Usa summary() per i dati centralizzati
-    s = _summary(config, year or None)
+    s = _summary(config, yr)
     record = (s.get("run") or {}).get("latest_run_record") or {}
 
     # Se run_id specifico, carica quel record invece del latest
     if run_id:
-        run_dir = get_run_dir(cfg.root, dataset, year)
+        run_dir = get_run_dir(cfg.root, ds_name, yr)
         specific = read_run_record(run_dir, run_id)
         if specific:
             record = specific
 
     layers = s.get("layers", {})
+
+    if as_json:
+        typer.echo(json.dumps({
+            "dataset": ds_name,
+            "year": yr,
+            "layers": layers,
+            "record": record,
+            "warnings": s.get("warnings", []),
+        }, indent=2, ensure_ascii=False))
+        return
 
     # Layer run status: da summary di default, dal record specifico se --run-id
     if run_id:
@@ -181,13 +193,13 @@ def status(
             for name in ("raw", "clean", "mart")
         }
 
-    typer.echo(f"dataset: {record.get('dataset', dataset)}")
-    typer.echo(f"year: {record.get('year', year)}")
+    typer.echo(f"dataset: {record.get('dataset', ds_name)}")
+    typer.echo(f"year: {record.get('year', yr)}")
     typer.echo(f"run_id: {record.get('run_id')}")
     typer.echo(f"started_at: {record.get('started_at')}")
     typer.echo(f"status: {record.get('status')}")
 
-    # Raw hints da summary + inspect_paths per suggested_read_path
+    # Raw hints
     raw_layer = layers.get("raw") or {}
     raw_hints = {
         "primary_output_file": raw_layer.get("primary_output_file"),
@@ -199,7 +211,6 @@ def status(
         "skip": raw_layer.get("skip_suggested"),
         "warnings": raw_layer.get("raw_warnings", []),
     }
-    # suggested_read_path non è in summary — lo ricostruiamo
     raw_dir = (layers.get("raw") or {}).get("dir")
     if raw_dir and raw_hints.get("suggested_read_exists"):
         raw_hints["suggested_read_path"] = str(Path(raw_dir) / RAW_PROFILE_DIR / RAW_SUGGESTED_READ)
@@ -220,10 +231,10 @@ def status(
 
     _print_validation_summaries(layers)
 
-    # multi-year mart (ex cross_year)
+    # multi-year mart
     multi_year_tables = [t for t in cfg.mart.tables if t.years]
     if multi_year_tables:
-        my_dir = layer_dataset_dir(cfg.root, "mart", dataset)
+        my_dir = layer_dataset_dir(cfg.root, "mart", ds_name)
         my_meta = my_dir / METADATA
         if my_meta.exists():
             content = json.loads(my_meta.read_text(encoding="utf-8"))
@@ -235,7 +246,7 @@ def status(
                 for t in my_tables:
                     typer.echo(f"    - {t.get('name', '?')} years={t.get('years', [])}")
 
-    _print_layer_profiles(dataset, year, layers)
+    _print_layer_profiles(ds_name, yr, layers)
 
     if record.get("status") == "FAILED" and record.get("error"):
         typer.echo("")

--- a/toolkit/cli/cmd_validate.py
+++ b/toolkit/cli/cmd_validate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import typer
 
 from toolkit.cli.common import iter_selected_years, load_cfg_and_logger
@@ -7,10 +9,11 @@ from toolkit.clean.validate import run_clean_validation
 from toolkit.mart.validate import run_mart_validation
 from toolkit.raw.validate import run_raw_validation
 
-
-def _raise_on_failed_summary(summary: dict[str, object]) -> None:
-    if not bool(summary.get("passed")):
-        raise typer.Exit(code=1)
+_VALIDATORS = {
+    "raw": lambda cfg, yr, lg: run_raw_validation(cfg.root, cfg.dataset, yr, lg),
+    "clean": run_clean_validation,
+    "mart": run_mart_validation,
+}
 
 
 def validate(
@@ -18,6 +21,7 @@ def validate(
     config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
     year: int | None = typer.Option(None, "--year", "-y", help="Single dataset year"),
     years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
+    as_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
 ):
     """
     Quality gate per RAW, CLEAN (include cross-layer raw→clean) e MART.
@@ -30,23 +34,32 @@ def validate(
     year_arg = year if isinstance(year, int) else None
     selected_years = iter_selected_years(cfg, year_arg=year_arg, years_arg=years_arg)
 
-    for year in selected_years:
-        if step == "all":
-            _raise_on_failed_summary(run_raw_validation(cfg.root, cfg.dataset, year, logger))
-            _raise_on_failed_summary(run_clean_validation(cfg, year, logger))
-            _raise_on_failed_summary(run_mart_validation(cfg, year, logger))
+    layers = ["raw", "clean", "mart"] if step == "all" else [step]
+    results: list[dict[str, object]] = []
 
-        elif step == "raw":
-            _raise_on_failed_summary(run_raw_validation(cfg.root, cfg.dataset, year, logger))
+    for yr in selected_years:
+        for layer in layers:
+            fn = _VALIDATORS[layer]
+            summary = fn(cfg, yr, logger)
+            results.append({
+                "year": yr,
+                "layer": layer,
+                "passed": summary.get("passed"),
+                "errors_count": summary.get("errors_count", 0),
+                "warnings_count": summary.get("warnings_count", 0),
+            })
 
-        elif step == "clean":
-            _raise_on_failed_summary(run_clean_validation(cfg, year, logger))
+    if as_json:
+        typer.echo(json.dumps(results, indent=2, ensure_ascii=False))
+        return
 
-        elif step == "mart":
-            _raise_on_failed_summary(run_mart_validation(cfg, year, logger))
+    any_failed = any(not r["passed"] for r in results)
+    for r in results:
+        icon = "✅" if r["passed"] else "🔴"
+        typer.echo(f"{icon} {r['year']}/{r['layer']}  errors={r['errors_count']} warnings={r['warnings_count']}")
 
-        else:
-            raise typer.BadParameter("step must be one of: raw, clean, mart, all")
+    if any_failed:
+        raise typer.Exit(code=1)
 
 
 def register(app: typer.Typer) -> None:

--- a/toolkit/cli/cmd_validate.py
+++ b/toolkit/cli/cmd_validate.py
@@ -49,11 +49,13 @@ def validate(
                 "warnings_count": summary.get("warnings_count", 0),
             })
 
+    any_failed = any(not r["passed"] for r in results)
+
     if as_json:
         typer.echo(json.dumps(results, indent=2, ensure_ascii=False))
+        if any_failed:
+            raise typer.Exit(code=1)
         return
-
-    any_failed = any(not r["passed"] for r in results)
     for r in results:
         icon = "✅" if r["passed"] else "🔴"
         typer.echo(f"{icon} {r['year']}/{r['layer']}  errors={r['errors_count']} warnings={r['warnings_count']}")

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -9,8 +9,6 @@ import json
 from pathlib import Path
 from typing import Any
 
-import duckdb
-
 from toolkit.cli.common import load_layer_profile_summaries
 from toolkit.core.config import ensure_dict
 from toolkit.core.metadata import read_layer_metadata
@@ -219,6 +217,9 @@ def _payload_for_year(cfg, year: int) -> dict[str, Any]:
 # DuckDB helpers — schema, row count, preview da parquet e CSV
 # Condivise da cli/inspect e mcp (MCP wrappa con ToolkitClientError).
 # ---------------------------------------------------------------------------
+# Le implementazioni reali sono in toolkit.core.parquet.
+# Questi wrapper servono solo per chiudere errori con
+# FileNotFoundError/RuntimeError invece di return silenziosi.
 
 
 def _sql_literal(value: str) -> str:
@@ -227,87 +228,33 @@ def _sql_literal(value: str) -> str:
 
 
 def _schema_from_parquet(parquet_path: Path) -> dict[str, Any]:
-    """Return schema (columns + count) of a parquet file via DuckDB.
+    from toolkit.core.parquet import parquet_schema
 
-    Raises:
-        FileNotFoundError: if the file doesn't exist.
-        RuntimeError: if DuckDB can't read the file.
-    """
     if not parquet_path.exists():
         raise FileNotFoundError(f"Parquet non trovato: {parquet_path}")
-    relation = f"read_parquet('{_sql_literal(str(parquet_path))}')"
-    try:
-        with duckdb.connect(database=":memory:") as conn:
-            conn.execute("PRAGMA disable_progress_bar")
-            describe_rows = conn.execute(f"DESCRIBE SELECT * FROM {relation}").fetchall()
-    except Exception as exc:
-        raise RuntimeError(f"Lettura schema parquet fallita per {parquet_path}: {exc}") from exc
-
-    columns = [{"name": row[0], "type": row[1]} for row in describe_rows]
-    return {"path": str(parquet_path), "column_count": len(columns), "columns": columns}
+    cols = parquet_schema(parquet_path)
+    if not cols:
+        raise RuntimeError(f"Lettura schema parquet fallita per {parquet_path}")
+    return {"path": str(parquet_path), "column_count": len(cols), "columns": cols}
 
 
 def _read_parquet_row_count(parquet_path: Path | None) -> int | None:
-    """Return row count of a parquet file, or None if unreadable."""
-    if parquet_path is None or not parquet_path.exists():
+    from toolkit.core.parquet import parquet_row_count
+
+    if parquet_path is None:
         return None
-    try:
-        with duckdb.connect(database=":memory:") as conn:
-            conn.execute("PRAGMA disable_progress_bar")
-            result = conn.execute(
-                f"SELECT COUNT(*) FROM read_parquet('{_sql_literal(str(parquet_path))}')"
-            ).fetchone()
-            return int(result[0]) if result else None
-    except Exception:
-        return None
+    return parquet_row_count(parquet_path)
 
 
 def _read_parquet_preview(parquet_path: Path, limit: int = 10) -> dict[str, Any]:
-    """Return schema + row preview of a parquet file via DuckDB.
+    from toolkit.core.parquet import parquet_preview
 
-    Returns:
-        dict with keys: path, column_count, columns (list of {name, type}),
-        row_count, preview (list of dicts), truncated (bool).
-
-    Raises:
-        FileNotFoundError: if the file doesn't exist.
-        RuntimeError: if DuckDB can't read the file.
-    """
     if not parquet_path.exists():
         raise FileNotFoundError(f"Parquet non trovato: {parquet_path}")
-
-    rel = f"read_parquet('{_sql_literal(str(parquet_path))}')"
-    try:
-        with duckdb.connect(database=":memory:") as conn:
-            conn.execute("PRAGMA disable_progress_bar")
-
-            # schema
-            describe = conn.execute(f"DESCRIBE SELECT * FROM {rel}").fetchall()
-            columns = [{"name": row[0], "type": row[1]} for row in describe]
-
-            # row count
-            count_row = conn.execute(f"SELECT COUNT(*) FROM {rel}").fetchone()
-            row_count = int(count_row[0]) if count_row else None
-
-            # preview
-            preview_rows = conn.execute(
-                f"SELECT * FROM {rel} LIMIT {int(limit)}"
-            ).fetchall()
-            col_names = [c["name"] for c in columns]
-            preview = [dict(zip(col_names, row)) for row in preview_rows]
-
-            truncated = bool(row_count and row_count > limit)
-
-            return {
-                "path": str(parquet_path),
-                "column_count": len(columns),
-                "columns": columns,
-                "row_count": row_count,
-                "preview": preview,
-                "truncated": truncated,
-            }
-    except Exception as exc:
-        raise RuntimeError(f"Lettura parquet fallita per {parquet_path}: {exc}") from exc
+    result = parquet_preview(parquet_path, limit=limit)
+    if not result["columns"]:
+        raise RuntimeError(f"Lettura schema parquet fallita per {parquet_path}")
+    return result
 
 
 def _exists(path: str | None) -> bool:

--- a/toolkit/cli/inspect/readiness_ops.py
+++ b/toolkit/cli/inspect/readiness_ops.py
@@ -14,11 +14,11 @@ from toolkit.cli.inspect._helpers import (
     _check_run_record_coherence,
     _exists,
     _payload_for_year,
-    _read_parquet_row_count,
     _read_validation_content,
     _validation_summary_for_layer,
 )
 from toolkit.core.config import load_config
+from toolkit.core.parquet import parquet_row_count
 from toolkit.core.paths import (
     RAW_VALIDATION,
     CLEAN_VALIDATION,
@@ -258,9 +258,14 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
 
     # --- Clean layer ---
     clean = s.get("layers", {}).get("clean", {})
-    clean_path_str = clean.get("output")
-    clean_path = Path(clean_path_str) if clean_path_str else None
-    clean_rows = _read_parquet_row_count(clean_path) if clean_path else None
+    clean_val = clean.get("validation") or {}
+    clean_rows = clean_val.get("row_count")
+    # Fallback: se validation non disponibile, leggi dal parquet diretto
+    if clean_rows is None:
+        clean_path_str = clean.get("output")
+        clean_path = Path(clean_path_str) if clean_path_str else None
+        if clean_path and clean_path.exists():
+            clean_rows = parquet_row_count(clean_path)
     clean_ok = clean.get("output_exists") and (clean_rows is not None)
     checks.append({
         "check": "clean_output_readable",
@@ -272,11 +277,15 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
 
     # --- Mart layer ---
     mart = s.get("layers", {}).get("mart", {})
+    mart_val = mart.get("validation") or {}
     mart_outputs = mart.get("outputs", [])
     mart_checks: list[dict[str, Any]] = []
     for output_name in mart_outputs:
         o_path = Path(output_name)
-        rows = _read_parquet_row_count(o_path)
+        rows = mart_val.get("row_count") if o_path.exists() else None
+        # Fallback: leggi dal parquet se validation non disponibile
+        if rows is None and o_path.exists():
+            rows = parquet_row_count(o_path)
         mart_checks.append({
             "name": o_path.name,
             "exists": o_path.exists(),

--- a/toolkit/core/parquet.py
+++ b/toolkit/core/parquet.py
@@ -1,0 +1,100 @@
+"""Operazioni DuckDB comuni su file Parquet.
+
+Centralizza DESCRIBE, COUNT e preview per evitare SQL inline
+sparso in 4 file diversi del toolkit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from lab_connectors.duckdb import safe_connect
+
+
+def _sql_literal(path: str) -> str:
+    return path.replace("'", "''")
+
+
+def _rel(path: Path) -> str:
+    return f"read_parquet('{_sql_literal(str(path))}')"
+
+
+def parquet_schema(path: Path) -> list[dict[str, str]]:
+    """Legge lo schema di un file Parquet (nomi colonne + tipo DuckDB).
+
+    Returns:
+        Lista di ``{"name": str, "type": str}``.
+        Lista vuota se il file non esiste o non è leggibile.
+    """
+    if not path.exists():
+        return []
+    try:
+        with safe_connect() as con:
+            con.execute("PRAGMA disable_progress_bar")
+            rows = con.execute(f"DESCRIBE SELECT * FROM {_rel(path)}").fetchall()
+            return [{"name": str(r[0]), "type": str(r[1])} for r in rows]
+    except Exception:
+        return []
+
+
+def parquet_row_count(path: Path) -> int | None:
+    """Conta le righe di un file Parquet.
+
+    Returns:
+        Numero di righe, ``None`` se il file non esiste o non è leggibile.
+    """
+    if not path.exists():
+        return None
+    try:
+        with safe_connect() as con:
+            con.execute("PRAGMA disable_progress_bar")
+            result = con.execute(f"SELECT COUNT(*) FROM {_rel(path)}").fetchone()
+            return int(result[0]) if result else None
+    except Exception:
+        return None
+
+
+def parquet_preview(
+    path: Path,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Schema + conteggio + preview righe di un file Parquet.
+
+    Returns:
+        ``{"path": str, "column_count": int, "columns": [...],
+          "row_count": int | None, "preview": [...], "truncated": bool}``.
+    """
+    if not path.exists():
+        return {"path": str(path), "column_count": 0, "columns": [],
+                "row_count": None, "preview": [], "truncated": False}
+
+    try:
+        with safe_connect() as con:
+            con.execute("PRAGMA disable_progress_bar")
+            rel = _rel(path)
+
+            # schema
+            describe = con.execute(f"DESCRIBE SELECT * FROM {rel}").fetchall()
+            columns = [{"name": str(r[0]), "type": str(r[1])} for r in describe]
+
+            # row count
+            count_row = con.execute(f"SELECT COUNT(*) FROM {rel}").fetchone()
+            row_count = int(count_row[0]) if count_row else None
+
+            # preview
+            preview = con.execute(f"SELECT * FROM {rel} LIMIT {int(limit)}").fetchall()
+            col_names = [c["name"] for c in columns]
+            preview_rows = [dict(zip(col_names, row)) for row in preview]
+
+            return {
+                "path": str(path),
+                "column_count": len(columns),
+                "columns": columns,
+                "row_count": row_count,
+                "preview": preview_rows,
+                "truncated": bool(row_count and row_count > limit),
+            }
+    except Exception:
+        return {"path": str(path), "column_count": 0, "columns": [],
+                "row_count": None, "preview": [], "truncated": False}

--- a/toolkit/scaffold/full.py
+++ b/toolkit/scaffold/full.py
@@ -181,7 +181,7 @@ def suggest_mart_sql(columns: list[dict[str, Any]] | list[str], profile: dict[st
     else:
         col_names = list(columns) if columns else []
     if not col_names:
-        return "-- Default mart: SELECT * FROM clean.\nSELECT * FROM clean\n"
+        return "-- Default mart: SELECT * FROM clean_input.\nSELECT * FROM clean_input\n"
     has_year = _has_year_column(col_names)
     has_region = _has_region_column(col_names)
     has_numeric = _has_numeric_column(col_names, profile)
@@ -230,7 +230,7 @@ def suggest_mart_sql(columns: list[dict[str, Any]] | list[str], profile: dict[st
                     f"SELECT\n"
                     f"  {group_expr},\n"
                     f'  SUM("{numeric_col}") AS totale_{numeric_col}\n'
-                    f"FROM clean\n"
+                    f"FROM clean_input\n"
                     f"GROUP BY {group_expr}\n"
                     f"ORDER BY {group_expr}\n"
                 )
@@ -243,7 +243,7 @@ def suggest_mart_sql(columns: list[dict[str, Any]] | list[str], profile: dict[st
             f'SELECT\n'
             f'  "{year_col}" AS year,\n'
             f'  COUNT(*) AS record_count\n'
-            f'FROM clean\n'
+            f'FROM clean_input\n'
             f'GROUP BY "{year_col}"\n'
             f'ORDER BY "{year_col}"\n'
         )
@@ -256,11 +256,11 @@ def suggest_mart_sql(columns: list[dict[str, Any]] | list[str], profile: dict[st
             f'SELECT\n'
             f'  "{region_col}" AS {region_col},\n'
             f'  COUNT(*) AS record_count\n'
-            f'FROM clean\n'
+            f'FROM clean_input\n'
             f'GROUP BY "{region_col}"\n'
             f'ORDER BY "{region_col}"\n'
         )
-    return "-- Default mart: SELECT * FROM clean.\n-- Personalizza per aggregazioni.\nSELECT * FROM clean\n"
+    return "-- Default mart: SELECT * FROM clean_input.\n-- Personalizza per aggregazioni.\nSELECT * FROM clean_input\n"
 
 
 # ---------------------------------------------------------------------------
@@ -363,7 +363,7 @@ def generate_full_scaffold(
         norm_cols = profile.get("columns_norm") or profile.get("columns_raw") or profile.get("columns") or []
         mart_sql = suggest_mart_sql(norm_cols, profile)
     else:
-        mart_sql = "-- Default mart: SELECT * FROM clean.\nSELECT * FROM clean\n"
+        mart_sql = "-- Default mart: SELECT * FROM clean_input.\nSELECT * FROM clean_input\n"
         clean_sql = "-- ATTENZIONE: profiling non ha rilevato colonne.\nSELECT 1 AS placeholder FROM raw_input\n"
 
     if profile:


### PR DESCRIPTION
## Cosa

8 commit in uno (squash):

### Centralizzazione DuckDB
- Nuovo `toolkit/core/parquet.py` con `parquet_schema()`, `parquet_row_count()`, `parquet_preview()`
- `_helpers.py` delega a `parquet.py` (-60 righe)
- `review_readiness()` ora usa row count da validation JSON (fallback su parquet diretto)

### Comandi semplificati
- **`status`**: `--dataset` e `--year` diventano opzionali (auto-rilevati dal config). Aggiunto `--json`.
- **`resume`**: `--dataset` e `--year` diventano opzionali (auto-rilevati dal config).
- **`validate`**: aggiunto `--json` per output strutturato.
- **`run init`**: registrato come CLI (era solo funzione interna, usata da `scout --run`).

### Scaffold
- `mart.sql` ora genera `FROM clean_input` invece di `FROM clean`.

### Bilancio

```
8 file | 205 inserzioni, 121 cancellazioni | 756 test OK
```