### PR TITLE
refactor: centralizzare NoopLogger e write_parquet in tests/helpers.py

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,7 @@
 
 Functions here are importable by any test file::
 
-    from tests.helpers import make_config, make_dataset_yml, make_standard_sql, write_text
+    from tests.helpers import NoopLogger, make_config, make_dataset_yml, make_standard_sql, write_text, write_parquet
 
 Fixtures belong in ``conftest.py``; pure helpers that take arguments
 and return values belong here.
@@ -12,6 +12,29 @@ from __future__ import annotations
 import textwrap
 from pathlib import Path
 from typing import Any
+
+
+class NoopLogger:
+    """Logger finto che non stampa nulla. Usato nei test che richiedono un logger ma non ne verificano l'output."""
+    def debug(self, *_a, **_kw): return None
+    def info(self, *_a, **_kw): return None
+    def warning(self, *_a, **_kw): return None
+    def error(self, *_a, **_kw): return None
+
+
+def write_parquet(path: Path, sql: str, *, table: str = "t") -> None:
+    """Crea un parquet da una query SQL DuckDB in memoria.
+    
+    Args:
+        path: Output path per il parquet.
+        sql: CREATE TABLE + INSERT (es. ``CREATE TABLE t AS SELECT 1 AS x``).
+        table: Nome della tabella temporanea (default ``t``).
+    """
+    import duckdb
+    con = duckdb.connect(":memory:")
+    con.execute(sql)
+    con.execute(f"COPY {table} TO '{path.as_posix()}' (FORMAT 'parquet')")
+    con.close()
 
 
 def write_text(path: Path, content: str) -> None:

--- a/tests/test_clean_csv_columns.py
+++ b/tests/test_clean_csv_columns.py
@@ -2,6 +2,8 @@ import pytest
 import duckdb
 from pathlib import Path
 
+from tests.helpers import NoopLogger
+
 from toolkit.clean.read_csv_normalized import (
     _execute_normalized_csv_read,
     _load_normalized_csv_frame,
@@ -9,12 +11,7 @@ from toolkit.clean.read_csv_normalized import (
 from toolkit.clean.run import run_clean
 
 
-class _NoopLogger:
-    def info(self, *_args, **_kwargs):
-        return None
 
-    def warning(self, *_args, **_kwargs):
-        return None
 
 
 @pytest.mark.policy
@@ -49,7 +46,7 @@ def test_run_clean_csv_columns_reads_trailing_delimiter_csv(tmp_path: Path):
                 },
             },
         },
-        _NoopLogger(),
+        NoopLogger(),
     )
 
     out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
@@ -231,7 +228,7 @@ def test_run_clean_compact_columns_format_renames_and_types(tmp_path: Path):
                 },
             },
         },
-        _NoopLogger(),
+        NoopLogger(),
     )
 
     out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
@@ -273,7 +270,7 @@ def test_run_clean_compact_columns_format_with_int_type(tmp_path: Path):
                 },
             },
         },
-        _NoopLogger(),
+        NoopLogger(),
     )
 
     out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
@@ -320,7 +317,7 @@ def test_run_clean_compact_columns_format_no_trim_whitespace(tmp_path: Path):
                 },
             },
         },
-        _NoopLogger(),
+        NoopLogger(),
     )
 
     out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"

--- a/tests/test_clean_input_selection.py
+++ b/tests/test_clean_input_selection.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import duckdb
 import pytest
 
+from tests.helpers import NoopLogger
+
 from toolkit.clean.input_selection import _metadata_candidates, list_raw_candidates, select_inputs
 from toolkit.clean.run import run_clean
 from toolkit.core.io import write_json_atomic
@@ -14,12 +16,7 @@ from toolkit.core.io import write_json_atomic
 pytestmark = pytest.mark.contract
 
 
-class _NoopLogger:
-    def info(self, *_args, **_kwargs):
-        return None
 
-    def warning(self, *_args, **_kwargs):
-        return None
 
 
 def _write_csv(path: Path, content: str) -> Path:
@@ -52,7 +49,7 @@ def _run_clean_capture_inputs(
         return ("strict", {"delim": ";", "decimal": ",", "encoding": "utf-8"}, 42)
 
     monkeypatch.setattr("toolkit.clean.run._run_sql", _fake_run_sql)
-    run_clean("demo", 2024, str(tmp_path), clean_cfg, logger or _NoopLogger())
+    run_clean("demo", 2024, str(tmp_path), clean_cfg, logger or NoopLogger())
     return seen
 
 
@@ -248,7 +245,7 @@ def test_run_clean_rejects_php_only_inputs_with_clear_error(tmp_path: Path):
             2024,
             str(tmp_path),
             {"sql": str(sql_path), "read": {}},
-            _NoopLogger(),
+            NoopLogger(),
         )
 
 
@@ -273,7 +270,7 @@ def test_run_clean_dirty_csv_needs_auto_detect_false(tmp_path: Path):
                 "encoding": "utf-8",
             },
         },
-        _NoopLogger(),
+        NoopLogger(),
     )
 
     out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
@@ -306,7 +303,7 @@ def test_run_clean_dirty_csv_strict_mode_fails(tmp_path: Path):
                 "read_mode": "strict",
                 "read": {"header": True, "delim": ";", "encoding": "utf-8"},
             },
-            _NoopLogger(),
+            NoopLogger(),
         )
 
 
@@ -329,7 +326,7 @@ def test_run_clean_csv_error_message_includes_columns_hint(tmp_path: Path):
                 "read_mode": "strict",
                 "read": {"header": True, "delim": ";", "encoding": "utf-8"},
             },
-            _NoopLogger(),
+            NoopLogger(),
         )
 
 
@@ -356,7 +353,7 @@ def test_run_clean_accepts_decimal_read_option(tmp_path: Path):
                 "auto_detect": False,
             },
         },
-        _NoopLogger(),
+        NoopLogger(),
     )
 
     out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import duckdb
 import pytest
+from tests.helpers import NoopLogger
 
 from toolkit.clean.run import run_clean
 from toolkit.cli.inspect.profile_ops import run_profile as run_profile_fn
@@ -15,17 +16,6 @@ from toolkit.mart.validate import run_mart_validation
 from toolkit.raw.run import run_raw
 
 pytestmark = pytest.mark.policy
-
-
-class _NoopLogger:
-    def info(self, *_args, **_kwargs):
-        return None
-
-    def warning(self, *_args, **_kwargs):
-        return None
-
-    def error(self, *_args, **_kwargs):
-        return None
 
 
 def _append_output_cfg(config_path: Path, *, artifacts: str) -> None:
@@ -53,7 +43,7 @@ def test_artifacts_policy_minimal_behaves_like_standard(
     monkeypatch.chdir(project_example)
     cfg = load_config(config_path)
     year = cfg.years[0]
-    logger = _NoopLogger()
+    logger = NoopLogger()
 
     run_raw(
         cfg.dataset, year, cfg.root, cfg.raw, logger,
@@ -89,7 +79,7 @@ def test_artifacts_policy_standard_keeps_expected_artifacts(
     monkeypatch.chdir(project_example)
     cfg = load_config(config_path)
     year = cfg.years[0]
-    logger = _NoopLogger()
+    logger = NoopLogger()
 
     run_raw(
         cfg.dataset, year, cfg.root, cfg.raw, logger,
@@ -159,7 +149,7 @@ def test_run_mart_supports_root_posix_placeholder(tmp_path: Path) -> None:
     (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
 
     cfg = load_config(config_path)
-    logger = _NoopLogger()
+    logger = NoopLogger()
     result = run_mart(
         cfg.dataset,
         year,
@@ -245,7 +235,7 @@ def test_run_mart_supports_support_placeholder(tmp_path: Path) -> None:
     (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
 
     cfg = load_config(config_path)
-    logger = _NoopLogger()
+    logger = NoopLogger()
     result = run_mart(
         cfg.dataset,
         year,

--- a/tests/test_project_example_e2e.py
+++ b/tests/test_project_example_e2e.py
@@ -5,6 +5,7 @@ import re
 
 import duckdb
 import pytest
+from tests.helpers import NoopLogger
 
 from toolkit.clean.run import run_clean
 from toolkit.cli.cmd_validate import validate as validate_cmd
@@ -13,17 +14,6 @@ from toolkit.mart.run import run_mart
 from toolkit.raw.run import run_raw
 
 pytestmark = pytest.mark.smoke
-
-
-class _NoopLogger:
-    def info(self, *_args, **_kwargs):
-        return None
-
-    def warning(self, *_args, **_kwargs):
-        return None
-
-    def error(self, *_args, **_kwargs):
-        return None
 
 
 def _assert_file_can_be_replaced(path: Path) -> None:
@@ -48,7 +38,7 @@ def test_project_example_golden_path(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(dst)
     cfg = load_config(dst / "dataset.yml")
     year = cfg.years[0]
-    logger = _NoopLogger()
+    logger = NoopLogger()
 
     run_raw(
         cfg.dataset,
@@ -203,7 +193,7 @@ def test_project_example_outputs_can_be_replaced_after_run(tmp_path: Path, monke
     monkeypatch.chdir(dst)
     cfg = load_config(dst / "dataset.yml")
     year = cfg.years[0]
-    logger = _NoopLogger()
+    logger = NoopLogger()
 
     run_raw(
         cfg.dataset,

--- a/tests/test_raw_ext_inference.py
+++ b/tests/test_raw_ext_inference.py
@@ -5,19 +5,9 @@ import pytest
 from toolkit.core.metadata import read_layer_metadata
 from toolkit.raw._fetch_utils import _infer_ext
 from toolkit.raw.run import run_raw
+from tests.helpers import NoopLogger
 
 pytestmark = pytest.mark.contract
-
-
-class _NoopLogger:
-    def info(self, *_args, **_kwargs):
-        return None
-
-    def warning(self, *_args, **_kwargs):
-        return None
-
-    def error(self, *_args, **_kwargs):
-        return None
 
 
 def test_infer_ext_http_csv_php_and_zip_php():
@@ -56,7 +46,7 @@ def test_run_raw_ckan_filename_inferred_from_resolved_url(monkeypatch, tmp_path:
         ]
     }
 
-    run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger())
+    run_raw("demo", 2024, str(tmp_path), raw_cfg, NoopLogger())
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
     assert (out_dir / "bdap_resource.csv").exists()
@@ -81,7 +71,7 @@ def test_run_raw_filename_override_has_priority(monkeypatch, tmp_path: Path):
         ]
     }
 
-    run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger())
+    run_raw("demo", 2024, str(tmp_path), raw_cfg, NoopLogger())
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
     assert (out_dir / "forced_name.data").exists()
@@ -109,7 +99,7 @@ def test_run_raw_avoids_overwrite_with_incremental_suffix(monkeypatch, tmp_path:
         ]
     }
 
-    run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger())
+    run_raw("demo", 2024, str(tmp_path), raw_cfg, NoopLogger())
 
     assert existing.read_bytes() == b"old-content\n"
     assert (out_dir / "file_1.csv").exists()
@@ -132,7 +122,7 @@ def test_manifest_created(monkeypatch, tmp_path: Path):
         ]
     }
 
-    run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-123")
+    run_raw("demo", 2024, str(tmp_path), raw_cfg, NoopLogger(), run_id="run-123")
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
     manifest = read_layer_metadata(out_dir)
@@ -163,8 +153,8 @@ def test_manifest_points_to_latest_in_versioned(monkeypatch, tmp_path: Path):
         ]
     }
 
-    run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-1")
-    run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-2")
+    run_raw("demo", 2024, str(tmp_path), raw_cfg, NoopLogger(), run_id="run-1")
+    run_raw("demo", 2024, str(tmp_path), raw_cfg, NoopLogger(), run_id="run-2")
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
     manifest = read_layer_metadata(out_dir)
@@ -194,8 +184,8 @@ def test_manifest_overwrite_policy(monkeypatch, tmp_path: Path):
         ],
     }
 
-    run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-1")
-    run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-2")
+    run_raw("demo", 2024, str(tmp_path), raw_cfg, NoopLogger(), run_id="run-1")
+    run_raw("demo", 2024, str(tmp_path), raw_cfg, NoopLogger(), run_id="run-2")
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
     manifest = read_layer_metadata(out_dir)
@@ -228,7 +218,7 @@ def test_multisource_primary_selection(monkeypatch, tmp_path: Path):
         ]
     }
 
-    run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-123")
+    run_raw("demo", 2024, str(tmp_path), raw_cfg, NoopLogger(), run_id="run-123")
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
     manifest = read_layer_metadata(out_dir)
@@ -271,7 +261,7 @@ def test_multisource_year_filter_skips_non_matching(monkeypatch, tmp_path: Path)
         ]
     }
 
-    run_raw("demo", 2022, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-2022")
+    run_raw("demo", 2022, str(tmp_path), raw_cfg, NoopLogger(), run_id="run-2022")
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2022"
     manifest = read_layer_metadata(out_dir)
@@ -307,7 +297,7 @@ def test_multisource_year_filter_all_matching(monkeypatch, tmp_path: Path):
         ]
     }
 
-    run_raw("demo", 2024, str(tmp_path), raw_cfg, _NoopLogger(), run_id="run-all")
+    run_raw("demo", 2024, str(tmp_path), raw_cfg, NoopLogger(), run_id="run-all")
 
     out_dir = tmp_path / "data" / "raw" / "demo" / "2024"
     manifest = read_layer_metadata(out_dir)

--- a/tests/test_validate_layers.py
+++ b/tests/test_validate_layers.py
@@ -1,9 +1,9 @@
 import json
+from tests.helpers import write_parquet
 from pathlib import Path
 import re
 from types import SimpleNamespace
 
-import duckdb
 import pytest
 
 from toolkit.raw.validate import validate_raw_output
@@ -12,13 +12,6 @@ from toolkit.core.config_models import TransitionConfig
 from toolkit.core.validation import check_transitions
 from toolkit.mart.validate import run_mart_validation, validate_mart
 from toolkit.core.validation import write_validation_json
-
-
-def _write_parquet(path: Path, sql: str):
-    con = duckdb.connect(":memory:")
-    con.execute(sql)
-    con.execute(f"COPY t TO '{path}' (FORMAT 'parquet')")
-    con.close()
 
 
 def _assert_portable_json_report(path: Path, *, root: Path, field: str, expected: str):
@@ -51,7 +44,7 @@ def test_validate_raw_detects_html_in_csv(tmp_path: Path):
 @pytest.mark.policy
 def test_validate_clean_ok_and_missing_required(tmp_path: Path):
     p = tmp_path / "clean.parquet"
-    _write_parquet(p, "CREATE TABLE t AS SELECT 1 AS a, 'x' AS b")
+    write_parquet(p, "CREATE TABLE t AS SELECT 1 AS a, 'x' AS b")
 
     ok = validate_clean(p, required=["a", "b"])
     assert ok.ok is True
@@ -67,7 +60,7 @@ def test_validate_clean_report_uses_root_relative_path(tmp_path: Path):
     root = tmp_path / "root"
     parquet = root / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
     parquet.parent.mkdir(parents=True, exist_ok=True)
-    _write_parquet(parquet, "CREATE TABLE t AS SELECT 1 AS a, 'x' AS b")
+    write_parquet(parquet, "CREATE TABLE t AS SELECT 1 AS a, 'x' AS b")
 
     result = validate_clean(parquet, required=["a", "b"], root=root)
     report = write_validation_json(parquet.parent / "_validate" / "clean_validation.json", result)
@@ -85,7 +78,7 @@ def test_validate_mart_required_tables(tmp_path: Path):
     d = tmp_path / "mart"
     d.mkdir(parents=True, exist_ok=True)
 
-    _write_parquet(d / "foo.parquet", "CREATE TABLE t AS SELECT 1 AS k")
+    write_parquet(d / "foo.parquet", "CREATE TABLE t AS SELECT 1 AS k")
 
     res = validate_mart(d, required_tables=["foo", "bar"])
     assert res.ok is False
@@ -97,7 +90,7 @@ def test_validate_mart_min_rows_rule(tmp_path: Path):
     d = tmp_path / "mart"
     d.mkdir(parents=True, exist_ok=True)
 
-    _write_parquet(d / "foo.parquet", "CREATE TABLE t AS SELECT 1 AS k")
+    write_parquet(d / "foo.parquet", "CREATE TABLE t AS SELECT 1 AS k")
 
     bad = validate_mart(d, table_rules={"foo": {"min_rows": 2}})
     assert bad.ok is False
@@ -112,7 +105,7 @@ def test_validate_mart_warns_on_orphan_table_rules_against_declared_tables(tmp_p
     d = tmp_path / "mart"
     d.mkdir(parents=True, exist_ok=True)
 
-    _write_parquet(d / "foo.parquet", "CREATE TABLE t AS SELECT 1 AS k")
+    write_parquet(d / "foo.parquet", "CREATE TABLE t AS SELECT 1 AS k")
 
     result = validate_mart(
         d,
@@ -131,7 +124,7 @@ def test_validate_mart_report_uses_root_relative_dir(tmp_path: Path):
     root = tmp_path / "root"
     mart_dir = root / "data" / "mart" / "demo" / "2024"
     mart_dir.mkdir(parents=True, exist_ok=True)
-    _write_parquet(mart_dir / "foo.parquet", "CREATE TABLE t AS SELECT 1 AS k")
+    write_parquet(mart_dir / "foo.parquet", "CREATE TABLE t AS SELECT 1 AS k")
 
     result = validate_mart(mart_dir, required_tables=["foo"], root=root)
     report = write_validation_json(mart_dir / "_validate" / "mart_validation.json", result)
@@ -150,7 +143,7 @@ def test_validate_mart_max_null_pct_rule(tmp_path: Path):
     d.mkdir(parents=True, exist_ok=True)
 
     # Two rows: one has NULL (50% nulls > 10% threshold)
-    _write_parquet(
+    write_parquet(
         d / "foo.parquet",
         "CREATE TABLE t AS SELECT * FROM (VALUES (1), (NULL)) v(valore)",
     )
@@ -220,7 +213,7 @@ def test_run_mart_validation_merges_transition_warnings_into_report(tmp_path: Pa
     root = tmp_path / "root"
     mart_dir = root / "data" / "mart" / "demo" / "2024"
     mart_dir.mkdir(parents=True, exist_ok=True)
-    _write_parquet(mart_dir / "mart_demo.parquet", "CREATE TABLE t AS SELECT 1 AS k")
+    write_parquet(mart_dir / "mart_demo.parquet", "CREATE TABLE t AS SELECT 1 AS k")
 
     (mart_dir / "metadata.json").write_text(
         json.dumps(
@@ -310,7 +303,7 @@ def test_run_clean_validation_uses_columns_raw_from_raw_profile(tmp_path: Path):
 
     clean_dir = root / "data" / "clean" / dataset / str(year)
     clean_dir.mkdir(parents=True, exist_ok=True)
-    _write_parquet(clean_dir / f"{dataset}_{year}_clean.parquet", "CREATE TABLE t AS SELECT 1 AS col_alpha, 2 AS col_beta")
+    write_parquet(clean_dir / f"{dataset}_{year}_clean.parquet", "CREATE TABLE t AS SELECT 1 AS col_alpha, 2 AS col_beta")
 
     (clean_dir / "metadata.json").write_text(
         json.dumps(
@@ -358,7 +351,7 @@ def test_run_clean_validation_raw_probe_source_legacy_autodetect(tmp_path: Path)
 
     clean_dir = root / "data" / "clean" / dataset / str(year)
     clean_dir.mkdir(parents=True, exist_ok=True)
-    _write_parquet(clean_dir / f"{dataset}_{year}_clean.parquet", "CREATE TABLE t AS SELECT 1 AS col1, 2 AS col2")
+    write_parquet(clean_dir / f"{dataset}_{year}_clean.parquet", "CREATE TABLE t AS SELECT 1 AS col1, 2 AS col2")
 
     (clean_dir / "metadata.json").write_text(
         json.dumps(
@@ -410,7 +403,7 @@ def test_run_clean_validation_raw_probe_source_unavailable_when_no_raw_file(
 
     clean_dir = root / "data" / "clean" / dataset / str(year)
     clean_dir.mkdir(parents=True, exist_ok=True)
-    _write_parquet(clean_dir / f"{dataset}_{year}_clean.parquet", "CREATE TABLE t AS SELECT 1 AS col1")
+    write_parquet(clean_dir / f"{dataset}_{year}_clean.parquet", "CREATE TABLE t AS SELECT 1 AS col1")
 
     (clean_dir / "metadata.json").write_text(
         json.dumps(

--- a/tests/test_validate_rules.py
+++ b/tests/test_validate_rules.py
@@ -1,25 +1,15 @@
 from pathlib import Path
+from tests.helpers import write_parquet
 
 import pytest
-import duckdb
 
 from toolkit.clean.validate import validate_clean
-
-
-def _write_parquet(path: Path, sql_create_table_t: str) -> None:
-    """
-    sql_create_table_t must create a table named 't'
-    """
-    con = duckdb.connect(":memory:")
-    con.execute(sql_create_table_t)
-    con.execute(f"COPY t TO '{path.as_posix()}' (FORMAT 'parquet')")
-    con.close()
 
 
 @pytest.mark.policy
 def test_validate_clean_pk_duplicates_fails(tmp_path: Path):
     p = tmp_path / "clean.parquet"
-    _write_parquet(
+    write_parquet(
         p,
         """
         CREATE TABLE t AS
@@ -42,7 +32,7 @@ def test_validate_clean_pk_duplicates_fails(tmp_path: Path):
 @pytest.mark.policy
 def test_validate_clean_range_fails(tmp_path: Path):
     p = tmp_path / "clean.parquet"
-    _write_parquet(
+    write_parquet(
         p,
         """
         CREATE TABLE t AS
@@ -65,7 +55,7 @@ def test_validate_clean_range_fails(tmp_path: Path):
 @pytest.mark.policy
 def test_validate_clean_null_pct_fails(tmp_path: Path):
     p = tmp_path / "clean.parquet"
-    _write_parquet(
+    write_parquet(
         p,
         """
         CREATE TABLE t AS


### PR DESCRIPTION
## Cosa

Estratto boilerplate di test duplicato in `tests/helpers.py`:

- **`NoopLogger`**: classe logger finto presente in 5 file con stessa definizione. Ora in `helpers.py`.
- **`write_parquet()`**: helper DuckDB per creare parquet in memoria, presente in 2 file con signature leggermente diverse. Unificato in `helpers.py`.

Nessun cambiamento ai test — solo spostamento di setup boilerplate.

```
8 file | +75 / -102 | 766 test OK
```