### PR TITLE
feat: paginazione OFFSET nel plugin SPARQL (pages/step)

### DIFF
--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -319,3 +319,113 @@ def test_sparql_probe_missing_query_raises():
     source = SparqlSource()
     with pytest.raises(DownloadError, match="requires a query"):
         source.probe("https://example.test/sparql", "")
+
+
+# ── Pagination (pages/step) ────────────────────────────────────────────────────
+
+
+class TestSparqlPagination:
+    """Multipage fetch with OFFSET: concatenazione CSV, LIMIT guard, early stop."""
+
+    CSV_P1 = "name,value\nfoo,1\nbar,2\n"
+    CSV_P2 = "name,value\nbaz,3\nqux,4\n"
+    CSV_P3 = "name,value\nquux,5\n"
+
+    def test_pages_1_default_no_pagination(self):
+        """Con pages=1 (default) si fa una sola POST."""
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.return_value = _http_ok(
+                text=self.CSV_P1, headers={"Content-Type": "text/csv"},
+            )
+            source = SparqlSource()
+            payload, _ = source.fetch(
+                "https://example.test/sparql", "SELECT * WHERE { ?s ?p ?o } LIMIT 10",
+            )
+            assert mock_cls.return_value.post.call_count == 1
+            assert payload == self.CSV_P1.encode()
+
+    def test_pages_3_concatenates_without_header_duplication(self):
+        """3 pagine devono concatenare i dati saltando l'header delle pagine successive."""
+        call = [0]
+
+        def side_effect(*a, **kw):
+            call[0] += 1
+            if call[0] == 1:
+                return _http_ok(text=self.CSV_P1, headers={"Content-Type": "text/csv"})
+            if call[0] == 2:
+                return _http_ok(text=self.CSV_P2, headers={"Content-Type": "text/csv"})
+            return _http_ok(text=self.CSV_P3, headers={"Content-Type": "text/csv"})
+
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.side_effect = side_effect
+            source = SparqlSource()
+            payload, _ = source.fetch(
+                "https://example.test/sparql", "SELECT ?s WHERE { ?s ?p ?o } LIMIT 10",
+                pages=3, step=10,
+            )
+            assert mock_cls.return_value.post.call_count == 3
+            # Header deve apparire una sola volta
+            text = payload.decode()
+            assert text.count("name,value") == 1
+            # Tutti i dati devono essere presenti
+            assert "foo" in text and "bar" in text and "baz" in text and "qux" in text and "quux" in text
+
+    def test_pages_without_limit_injects_step(self):
+        """Se la query non ha LIMIT e pages>1, deve iniettare LIMIT step."""
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.return_value = _http_ok(
+                text=self.CSV_P1, headers={"Content-Type": "text/csv"},
+            )
+            source = SparqlSource()
+            source.fetch(
+                "https://example.test/sparql", "SELECT * WHERE { ?s ?p ?o }",
+                pages=2, step=100,
+            )
+            # La seconda chiamata deve avere LIMIT 100 + OFFSET 100
+            second_call = mock_cls.return_value.post.call_args_list[1]
+            query_body = second_call.kwargs.get("data", {}).get("query", "")
+            assert "LIMIT 100" in query_body
+            assert "OFFSET 100" in query_body
+
+    def test_pages_stops_when_page_empty(self):
+        """Se una pagina restituisce 0 righe, ci si ferma prima di pages totali."""
+        call = [0]
+
+        def side_effect(*a, **kw):
+            call[0] += 1
+            if call[0] == 1:
+                return _http_ok(text=self.CSV_P1, headers={"Content-Type": "text/csv"})
+            # Pagine successive vuote (solo header)
+            return _http_ok(text="name,value\n", headers={"Content-Type": "text/csv"})
+
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.side_effect = side_effect
+            source = SparqlSource()
+            payload, _ = source.fetch(
+                "https://example.test/sparql", "SELECT ?s WHERE { ?s ?p ?o } LIMIT 10",
+                pages=5, step=10,
+            )
+            # Pagina 0 ok, pagina 1 vuota → stop (2 chiamate)
+            assert mock_cls.return_value.post.call_count == 2
+
+    def test_pages_early_stop_on_http_error(self):
+        """Se una pagina successiva da HTTP error, ci si ferma senza crash."""
+        from toolkit.core.exceptions import DownloadError
+        call = [0]
+
+        def side_effect(*a, **kw):
+            call[0] += 1
+            if call[0] == 1:
+                return _http_ok(text=self.CSV_P1, headers={"Content-Type": "text/csv"})
+            raise DownloadError("endpoint returned HTTP 500 for page 2")
+
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.side_effect = side_effect
+            source = SparqlSource()
+            payload, _ = source.fetch(
+                "https://example.test/sparql", "SELECT ?s WHERE { ?s ?p ?o } LIMIT 10",
+                pages=3, step=10,
+            )
+            # Prima pagina ok, seconda fallisce → stop, ritorna solo pagina 1
+            assert payload.decode().count("foo") == 1
+            assert payload.decode().count("baz") == 0

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -63,8 +63,13 @@ class SparqlSource:
                 "Supported values: 'csv', 'sparql-results+json'."
             )
 
-        # Se e' richiesta paginazione, appende OFFSET alla query
-        # (dopo LIMIT, che deve essere presente nella query)
+        # Se e' richiesta paginazione, assicura che la query abbia LIMIT
+        if pages > 1:
+            if "limit" not in query.lower():
+                # Inietta LIMIT {step} prima di eventuali OFFSET o clausole finali
+                query = f"{query.rstrip().rstrip(';')} LIMIT {step}"
+
+        # Esegue una singola pagina con OFFSET opzionale
         def _do_fetch(offset: int = 0) -> bytes:
             q = query
             if offset > 0:
@@ -106,17 +111,18 @@ class SparqlSource:
         for page in range(1, pages):
             try:
                 page_bytes = _do_fetch(offset=page * step)
-                # Trova la prima riga (header) e concatena solo i dati
+                # Se la pagina e' vuota (solo header, nessun dato), fermati
+                data_start = page_bytes.find(b"\n")
+                if data_start < 0 or len(page_bytes) <= data_start + 1:
+                    break
+                # Concatena solo i dati (salta l'header)
                 header_end = all_bytes.find(b"\n")
                 if header_end >= 0:
-                    # Mantieni l'header della prima pagina, aggiungi solo i dati
-                    data_start = page_bytes.find(b"\n")
-                    if data_start >= 0 and len(page_bytes) > data_start + 1:
-                        all_bytes = all_bytes + page_bytes[data_start + 1:]
+                    all_bytes = all_bytes + page_bytes[data_start + 1:]
                 else:
                     all_bytes = all_bytes + page_bytes
             except DownloadError:
-                # Endpoint non ha piu' pagine → esci
+                # Endpoint non ha piu' pagine (es. OFFSET oltre la fine) → esci
                 break
 
         return all_bytes, endpoint

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -31,13 +31,21 @@ class SparqlSource:
         endpoint: str,
         query: str,
         accept_format: str = "csv",
+        pages: int = 1,
+        step: int = 10000,
     ) -> tuple[bytes, str]:
         """Execute a SPARQL query and return CSV data.
+
+        Quando l'endpoint SPARQL ha un limite di righe per risposta (WAF),
+        usa ``pages`` e ``step`` per fare piu' query con OFFSET incrementale
+        e concatenare i risultati in un unico CSV.
 
         Args:
             endpoint: SPARQL endpoint URL.
             query: SPARQL SELECT query string.
             accept_format: 'csv' for direct CSV, 'sparql-results+json' for JSON conversion.
+            pages: Numero di pagine da fetchare (default 1 = nessuna paginazione).
+            step: Righe per pagina (default 10000).
 
         Returns:
             (csv_bytes, endpoint) tuple.
@@ -54,6 +62,64 @@ class SparqlSource:
                 f"Unsupported accept_format '{accept_format}'. "
                 "Supported values: 'csv', 'sparql-results+json'."
             )
+
+        # Se e' richiesta paginazione, appende OFFSET alla query
+        # (dopo LIMIT, che deve essere presente nella query)
+        def _do_fetch(offset: int = 0) -> bytes:
+            q = query
+            if offset > 0:
+                q = f"{q.rstrip().rstrip(';')} OFFSET {offset}"
+            headers: dict[str, str] = {
+                "Accept": "application/sparql-results+json" if accept_format == "sparql-results+json" else "text/csv",
+                "Content-Type": "application/x-www-form-urlencoded",
+            }
+            params: dict[str, Any] = {"query": q}
+            result = self._client.post(endpoint, data=params, headers=headers, retries=2)
+            if result.is_error:
+                raise DownloadError(f"SPARQL request failed for {endpoint}: {result.err}") from result.err
+            r = result.response
+            if r.status_code != 200:
+                raise DownloadError(f"SPARQL endpoint returned HTTP {r.status_code} for {endpoint}: {r.text[:200]}")
+            content_type = r.headers.get("Content-Type", "")
+            if "text/csv" in content_type:
+                return r.content
+            if "sparql-results+json" in content_type:
+                return _sparql_json_to_csv(r.text)
+            if "text/plain" in content_type:
+                stripped = r.text.strip()
+                if stripped.startswith("{"):
+                    try:
+                        return _sparql_json_to_csv(r.text)
+                    except (DownloadError, json.JSONDecodeError):
+                        pass
+                else:
+                    return r.content
+            raise DownloadError(
+                f"Unsupported Content-Type '{content_type}' for SPARQL fetch. "
+                "Expected 'text/csv' or 'application/sparql-results+json'."
+            )
+
+        # Prima pagina
+        all_bytes = _do_fetch(offset=0)
+
+        # Paginazione: pagine successive, concatena CSV (saltando l'header)
+        for page in range(1, pages):
+            try:
+                page_bytes = _do_fetch(offset=page * step)
+                # Trova la prima riga (header) e concatena solo i dati
+                header_end = all_bytes.find(b"\n")
+                if header_end >= 0:
+                    # Mantieni l'header della prima pagina, aggiungi solo i dati
+                    data_start = page_bytes.find(b"\n")
+                    if data_start >= 0 and len(page_bytes) > data_start + 1:
+                        all_bytes = all_bytes + page_bytes[data_start + 1:]
+                else:
+                    all_bytes = all_bytes + page_bytes
+            except DownloadError:
+                # Endpoint non ha piu' pagine → esci
+                break
+
+        return all_bytes, endpoint
 
         headers: dict[str, str] = {
             "Accept": "application/sparql-results+json" if accept_format == "sparql-results+json" else "text/csv",

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -129,10 +129,14 @@ def _fetch_sdmx(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, 
 @_register_fetch("sparql")
 def _fetch_sparql(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
     src = registry.create(stype, **(client or {}))
+    pages = int(formatted_args.get("pages", 1))
+    step = int(formatted_args.get("step", 10000))
     return src.fetch(
         str(formatted_args["endpoint"]),
         str(formatted_args["query"]),
         str(formatted_args.get("accept_format", "csv")),
+        pages=pages,
+        step=step,
     )
 
 


### PR DESCRIPTION
## Sintesi

Aggiunge supporto per paginazione automatica nel plugin SPARQL. Quando un endpoint ha un WAF che limita le risposte (es. Camera dei deputati: 10k righe max), si possono specificare `pages` e `step` nel dataset.yml per eseguire query multiple con OFFSET e concatenare i risultati.

## Cosa cambia

- [x] Nuova funzionalita del motore

### Plugin SPARQL (`plugins/sparql.py`)

- `SparqlSource.fetch()`: nuovi parametri opzionali `pages` (default 1) e `step` (default 10000)
- Paginazione implementata con `_do_fetch()` interna che appende `OFFSET {offset}` alla query
- Concatena i CSV risultanti saltando lheader nelle pagine successive

### Raw fetch (`raw/_fetch_utils.py`)

- `_fetch_sparql()` ora passa `pages` e `step` da `formatted_args` al plugin

## Esempio

```yaml
raw:
  sources:
    - name: "deputati"
      type: "sparql"
      args:
        endpoint: "https://dati.camera.it/sparql"
        query: "SELECT ... LIMIT 10000"
        pages: 3
        step: 10000
```

Esegue 3 query (OFFSET 0, 10000, 20000) e restituisce un unico CSV con 30k righe.

## Verifica

- [x] Testato su `camera-deputati-legislature`: 27.764 deputati (prima 10.000, limitati dal WAF)
- [x] `pytest tests/test_sparql_plugin.py` passa (19 test)