### PR TITLE
refactor: unifica logica SPARQL su lab-connectors, aggiungi GET fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "requests>=2.33.1",
   "typer>=0.12.0",
   "rich>=13.0",
-  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.1"
+  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.11.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -87,9 +87,9 @@ def test_sparql_fetch_http_error():
 def test_sparql_fetch_network_error():
     """Network error raises DownloadError."""
     with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
-        mock_cls.return_value.post.return_value = HttpResult(
-            response=None, err=Exception("connection refused"),
-        )
+        err_result = HttpResult(response=None, err=Exception("connection refused"))
+        mock_cls.return_value.post.return_value = err_result
+        mock_cls.return_value.get.return_value = err_result
         source = SparqlSource()
         with pytest.raises(DownloadError, match="connection refused"):
             source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
@@ -231,23 +231,13 @@ def test_sparql_json_to_csv_binding_types():
 
 def test_sparql_probe_returns_schema_and_stats():
     """Probe returns schema, stats, and warnings."""
-    json_response = """{
-  "head": { "vars": ["name", "value"] },
-  "results": {
-    "bindings": [
-      { "name": { "type": "literal", "value": "Alice" }, "value": { "type": "literal", "value": "42" } },
-      { "name": { "type": "literal", "value": "Bob" }, "value": { "type": "literal", "value": null } },
-      { "name": { "type": "literal", "value": "Charlie" }, "value": { "type": "literal", "value": "7" } }
+    bindings = [
+        {"name": {"type": "literal", "value": "Alice"}, "value": {"type": "literal", "value": "42"}},
+        {"name": {"type": "literal", "value": "Bob"}, "value": {"type": "literal", "value": None}},
+        {"name": {"type": "literal", "value": "Charlie"}, "value": {"type": "literal", "value": "7"}},
     ]
-  }
-}"""
-    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
-        mock_cls.return_value.post.return_value = _http_ok(
-            status=200,
-            text=json_response,
-            headers={"Content-Type": "application/sparql-results+json"},
-        )
-        source = SparqlSource(timeout=30)
+    source = SparqlSource(timeout=30)
+    with patch.object(source, "_fetch_bindings", return_value=bindings):
         result = source.probe(
             "https://example.test/sparql",
             "SELECT ?name ?value WHERE { }",
@@ -268,41 +258,42 @@ def test_sparql_probe_returns_schema_and_stats():
 
 def test_sparql_probe_adds_limit_if_missing():
     """Probe appends LIMIT if not in query."""
-    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
-        mock_cls.return_value.post.return_value = _http_ok(
-            status=200,
-            text='{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"literal","value":"1"}}]}}',
-            headers={"Content-Type": "application/sparql-results+json"},
-        )
-        source = SparqlSource()
+    captured_query = None
+
+    def _mock_fetch(endpoint, query):
+        nonlocal captured_query
+        captured_query = query
+        return [{"x": {"type": "literal", "value": "1"}}]
+
+    source = SparqlSource()
+    with patch.object(source, "_fetch_bindings", side_effect=_mock_fetch):
         source.probe("https://example.test/sparql", "SELECT ?x WHERE { }", limit=50)
 
-        sent_query = mock_cls.return_value.post.call_args[1]["data"]["query"]
-        assert "LIMIT 50" in sent_query.upper()
+    assert captured_query is not None
+    assert "LIMIT 50" in captured_query.upper()
 
 
 def test_sparql_probe_preserves_existing_limit():
     """Probe does not double-LIMIT."""
-    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
-        mock_cls.return_value.post.return_value = _http_ok(
-            status=200,
-            text='{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"literal","value":"1"}}]}}',
-            headers={"Content-Type": "application/sparql-results+json"},
-        )
-        source = SparqlSource()
+    captured_query = None
+
+    def _mock_fetch(endpoint, query):
+        nonlocal captured_query
+        captured_query = query
+        return [{"x": {"type": "literal", "value": "1"}}]
+
+    source = SparqlSource()
+    with patch.object(source, "_fetch_bindings", side_effect=_mock_fetch):
         source.probe("https://example.test/sparql", "SELECT ?x WHERE { } LIMIT 10", limit=50)
 
-        sent_query = mock_cls.return_value.post.call_args[1]["data"]["query"]
-        assert sent_query.upper().count("LIMIT") == 1
+    assert captured_query is not None
+    assert captured_query.upper().count("LIMIT") == 1
 
 
 def test_sparql_probe_http_error():
-    """Non-200 during probe raises DownloadError."""
-    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
-        mock_cls.return_value.post.return_value = _http_ok(
-            status=500, text="Internal Server Error",
-        )
-        source = SparqlSource()
+    """Error during probe raises DownloadError."""
+    source = SparqlSource()
+    with patch.object(source, "_fetch_bindings", side_effect=DownloadError("HTTP 500 from SPARQL")):
         with pytest.raises(DownloadError, match="HTTP 500"):
             source.probe("https://example.test/sparql", "SELECT * WHERE { }")
 
@@ -383,7 +374,7 @@ class TestSparqlPagination:
             )
             # La seconda chiamata deve avere LIMIT 100 + OFFSET 100
             second_call = mock_cls.return_value.post.call_args_list[1]
-            query_body = second_call.kwargs.get("data", {}).get("query", "")
+            query_body = second_call.args[1].get("query", "")
             assert "LIMIT 100" in query_body
             assert "OFFSET 100" in query_body
 

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -1,6 +1,6 @@
 """SPARQL source plugin.
 
-Fetches tabular data from a SPARQL endpoint via HTTP POST.
+Fetches tabular data from a SPARQL endpoint via HTTP (POST + GET fallback).
 Supports direct CSV responses and SPARQL Results JSON (converted to CSV).
 """
 
@@ -9,6 +9,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import urllib.parse
 from typing import Any
 
 from lab_connectors.http import HttpClient
@@ -19,12 +20,94 @@ from toolkit.core.exceptions import DownloadError
 class SparqlSource:
     """Query a SPARQL endpoint and return results as CSV bytes.
 
-    Uses HttpClient.post() with retries=2 (safe because SPARQL POST
-    is idempotent: same query → same result).
+    Tenta POST form-encoded (standard SPARQL protocol).
+    Se POST fallisce (403, timeout), prova GET URL-encoded (Virtuoso, WAF).
     """
 
     def __init__(self, timeout: int = 60):
         self._client = HttpClient(timeout=timeout)
+
+    def _do_fetch(self, endpoint: str, q: str, accept_format: str) -> bytes:
+        """Esegue una singola query SPARQL, restituisce CSV bytes.
+
+        Tenta POST → GET fallback.
+        Supporta CSV diretto e SPARQL Results JSON (convertito a CSV).
+        """
+        is_json = accept_format == "sparql-results+json"
+        headers: dict[str, str] = {
+            "Accept": (
+                "application/sparql-results+json"
+                if is_json
+                else "text/csv,text/plain;q=0.5"
+            ),
+        }
+        post_data = {"query": q}
+
+        # --- Tentativo 1: POST ---
+        result = self._client.post(
+            endpoint, post_data, headers=headers, retries=2,
+        )
+        if result.is_ok:
+            return self._parse_response(result.response, is_json)
+
+        # --- Tentativo 2: GET fallback ---
+        url = f"{endpoint}?query={urllib.parse.quote(q)}"
+        get_headers = {
+            "Accept": (
+                "application/sparql-results+xml,"
+                "application/sparql-results+json,application/json,text/csv"
+            ),
+        }
+        result = self._client.get(url, headers=get_headers)
+        if result.is_ok:
+            return self._parse_response(result.response, is_json)
+
+        raise DownloadError(
+            f"SPARQL request failed for {endpoint}: "
+            f"POST → {result.err or 'unknown'}"
+        )
+
+    def _parse_response(self, r: Any, prefer_json: bool) -> bytes:
+        """Parsa la risposta HTTP in CSV bytes."""
+        content_type = (r.headers.get("Content-Type") or "").lower()
+
+        if r.status_code != 200:
+            raise DownloadError(
+                f"SPARQL endpoint returned HTTP {r.status_code} "
+                f"for {r.url}: {r.text[:200]}"
+            )
+
+        # CSV diretto
+        if "text/csv" in content_type:
+            return r.content
+
+        # SPARQL Results JSON (standard o fallback)
+        if prefer_json or "sparql-results+json" in content_type or "json" in content_type:
+            return _sparql_json_to_csv(r.text)
+
+        # text/plain: potrebbe essere CSV o JSON con Content-Type sbagliato
+        if "text/plain" in content_type:
+            stripped = r.text.strip()
+            if stripped.startswith("{"):
+                try:
+                    return _sparql_json_to_csv(r.text)
+                except (DownloadError, json.JSONDecodeError):
+                    pass
+            else:
+                # Assume CSV — se non è CSV, fallirà in CLEAN con errore chiaro
+                return r.content
+
+        # XML SPARQL Results — non supportato
+        if "sparql-results+xml" in content_type:
+            raise DownloadError(
+                "SPARQL endpoint returned XML results. "
+                "Request JSON or CSV format."
+            )
+
+        raise DownloadError(
+            f"Unsupported Content-Type '{content_type}' for SPARQL fetch. "
+            "Expected 'text/csv' or 'application/sparql-results+json'."
+        )
 
     def fetch(
         self,
@@ -66,51 +149,22 @@ class SparqlSource:
         # Se e' richiesta paginazione, assicura che la query abbia LIMIT
         if pages > 1:
             if "limit" not in query.lower():
-                # Inietta LIMIT {step} prima di eventuali OFFSET o clausole finali
                 query = f"{query.rstrip().rstrip(';')} LIMIT {step}"
 
-        # Esegue una singola pagina con OFFSET opzionale
-        def _do_fetch(offset: int = 0) -> bytes:
-            q = query
-            if offset > 0:
-                q = f"{q.rstrip().rstrip(';')} OFFSET {offset}"
-            headers: dict[str, str] = {
-                "Accept": "application/sparql-results+json" if accept_format == "sparql-results+json" else "text/csv",
-                "Content-Type": "application/x-www-form-urlencoded",
-            }
-            params: dict[str, Any] = {"query": q}
-            result = self._client.post(endpoint, data=params, headers=headers, retries=2)
-            if result.is_error:
-                raise DownloadError(f"SPARQL request failed for {endpoint}: {result.err}") from result.err
-            r = result.response
-            if r.status_code != 200:
-                raise DownloadError(f"SPARQL endpoint returned HTTP {r.status_code} for {endpoint}: {r.text[:200]}")
-            content_type = r.headers.get("Content-Type", "")
-            if "text/csv" in content_type:
-                return r.content
-            if "sparql-results+json" in content_type:
-                return _sparql_json_to_csv(r.text)
-            if "text/plain" in content_type:
-                stripped = r.text.strip()
-                if stripped.startswith("{"):
-                    try:
-                        return _sparql_json_to_csv(r.text)
-                    except (DownloadError, json.JSONDecodeError):
-                        pass
-                else:
-                    return r.content
-            raise DownloadError(
-                f"Unsupported Content-Type '{content_type}' for SPARQL fetch. "
-                "Expected 'text/csv' or 'application/sparql-results+json'."
-            )
-
         # Prima pagina
-        all_bytes = _do_fetch(offset=0)
+        all_bytes = self._do_fetch(endpoint, query, accept_format)
 
         # Paginazione: pagine successive, concatena CSV (saltando l'header)
         for page in range(1, pages):
             try:
-                page_bytes = _do_fetch(offset=page * step)
+                q = query
+                if "offset" not in q.lower():
+                    q = f"{q.rstrip().rstrip(';')} OFFSET {page * step}"
+                else:
+                    q = f"{q.rstrip().rstrip(';')} OFFSET {page * step}"
+
+                page_bytes = self._do_fetch(endpoint, q, accept_format)
+
                 # Se la pagina e' vuota (solo header, nessun dato), fermati
                 data_start = page_bytes.find(b"\n")
                 if data_start < 0 or len(page_bytes) <= data_start + 1:
@@ -127,57 +181,20 @@ class SparqlSource:
 
         return all_bytes, endpoint
 
-        headers: dict[str, str] = {
-            "Accept": "application/sparql-results+json" if accept_format == "sparql-results+json" else "text/csv",
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-        params: dict[str, Any] = {"query": query}
+    def _fetch_bindings(
+        self, endpoint: str, query: str,
+    ) -> list[dict[str, Any]]:
+        """Esegue query SPARQL e restituisce i bindings JSON (per probe).
 
-        result = self._client.post(
-            endpoint,
-            data=params,
-            headers=headers,
-            retries=2,
-        )
-        if result.is_error:
-            raise DownloadError(
-                f"SPARQL request failed for {endpoint}: {result.err}"
-            ) from result.err
+        Separato da _do_fetch per consentire ai test di mockare
+        solo il recupero bindings senza toccare la logica CSV.
+        """
+        from lab_connectors.http.sparql import execute_sparql
 
-        r = result.response
-        if r.status_code != 200:
-            raise DownloadError(
-                f"SPARQL endpoint returned HTTP {r.status_code} for {endpoint}: {r.text[:200]}"
-            )
-
-        content_type = r.headers.get("Content-Type", "")
-
-        if "text/csv" in content_type:
-            return r.content, endpoint
-
-        if "sparql-results+json" in content_type:
-            csv_bytes = _sparql_json_to_csv(r.text)
-            return csv_bytes, endpoint
-
-        # Fallback per Content-Type text/plain: alcuni endpoint SPARQL
-        # (es. dati.camera.it) rispondono con Content-Type sbagliato
-        # ma corpo CSV o JSON valido. Altri Content-Type (es. application/xml)
-        # rimangono errore.
-        if "text/plain" in content_type:
-            stripped = r.text.strip()
-            if stripped.startswith("{"):
-                try:
-                    return _sparql_json_to_csv(r.text), endpoint
-                except (DownloadError, json.JSONDecodeError):
-                    pass
-            else:
-                # Assume CSV — se non è CSV, fallirà in CLEAN con errore chiaro
-                return r.content, endpoint
-
-        raise DownloadError(
-            f"Unsupported Content-Type '{content_type}' for SPARQL fetch. "
-            "Expected 'text/csv' or 'application/sparql-results+json'."
-        )
+        try:
+            return execute_sparql(endpoint, query, timeout=self._client.timeout)
+        except RuntimeError as e:
+            raise DownloadError(str(e)) from e
 
     def probe(
         self,
@@ -211,51 +228,14 @@ class SparqlSource:
         if "limit" not in safe_query.lower():
             safe_query = f"{safe_query.rstrip(';')} LIMIT {limit}"
 
-        headers: dict[str, str] = {
-            "Accept": "application/sparql-results+json",
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-        params: dict[str, Any] = {"query": safe_query}
-
         start = time.monotonic()
-        result = self._client.post(
-            endpoint,
-            data=params,
-            headers=headers,
-            retries=0,
-        )
-        if result.is_error:
-            raise DownloadError(
-                f"SPARQL probe failed for {endpoint}: {result.err}"
-            ) from result.err
-
-        r = result.response
+        bindings = self._fetch_bindings(endpoint, safe_query)
         query_time_ms = int((time.monotonic() - start) * 1000)
 
-        if r.status_code != 200:
-            raise DownloadError(
-                f"SPARQL endpoint returned HTTP {r.status_code} for {endpoint}: {r.text[:200]}"
-            )
+        if not bindings:
+            raise DownloadError("SPARQL probe: query returned no results")
 
-        try:
-            payload = json.loads(r.text)
-        except json.JSONDecodeError as e:
-            raise DownloadError(f"Invalid SPARQL JSON response during probe: {e}") from e
-
-        bindings: list[dict[str, Any]] = (
-            (payload.get("results") or {}).get("bindings") or []
-        )
-        if not isinstance(bindings, list):
-            raise DownloadError("SPARQL probe: unexpected payload structure")
-
-        vars_list: list[str] = (payload.get("head") or {}).get("vars") or []
-        if not bindings and not vars_list:
-            raise DownloadError("SPARQL probe: query returned no variables")
-
-        # If vars_list is empty but we have bindings, infer from first binding
-        if not vars_list and bindings:
-            vars_list = list(bindings[0].keys())
-
+        vars_list = list(bindings[0].keys())
         row_count = len(bindings)
 
         # Compute null and distinct counts per variable
@@ -267,16 +247,7 @@ class SparqlSource:
             row: dict[str, str] = {}
             for var in vars_list:
                 cell = binding.get(var)
-                value: str
-                if cell and isinstance(cell, dict):
-                    raw_value = cell.get("value")
-                    # SPARQL JSON can have null values as JSON null
-                    if raw_value is None:
-                        value = ""
-                    else:
-                        value = str(raw_value)
-                else:
-                    value = str(cell if cell is not None else "")
+                value: str = (cell.get("value") or "") if cell else ""
                 row[var] = value
                 if not value:
                     null_counts[var] = null_counts.get(var, 0) + 1
@@ -288,7 +259,9 @@ class SparqlSource:
         warnings: list[str] = []
         for var in vars_list:
             if null_counts.get(var, 0) > 0:
-                warnings.append(f"variable '{var}' has {null_counts[var]} null/unbound value(s)")
+                warnings.append(
+                    f"variable '{var}' has {null_counts[var]} null/unbound value(s)"
+                )
 
         return {
             "endpoint": endpoint,
@@ -322,8 +295,9 @@ def _sparql_json_to_csv(json_text: str) -> bytes:
     if not bindings:
         raise DownloadError("SPARQL query returned no results")
 
-    # Use head.vars as canonical column list; bindings may omit unbound variables.
-    var_names: list[str] = (payload.get("head") or {}).get("vars") or list(bindings[0].keys())
+    var_names: list[str] = (
+        (payload.get("head") or {}).get("vars") or list(bindings[0].keys())
+    )
     rows: list[dict[str, str]] = []
 
     for binding in bindings:
@@ -331,7 +305,6 @@ def _sparql_json_to_csv(json_text: str) -> bytes:
         for var in var_names:
             cell = binding.get(var)
             if cell and isinstance(cell, dict):
-                # SPARQL JSON binding: {"value": "...", "type": "..."}
                 row[var] = str(cell.get("value", ""))
             else:
                 row[var] = str(cell if cell is not None else "")

--- a/toolkit/scout/__init__.py
+++ b/toolkit/scout/__init__.py
@@ -8,11 +8,17 @@ Strato indipendente dalla CLI, usabile da:
 
 Moduli:
   http      → HTTP transport: probe, fetch, format detection, CKAN/SDMX
+  sparql    → SPARQL scout: named graph discovery, schema inference
   infer     → Inferenze pure: anni, granularità, topic
   probe     → Orchestrazione: probe_url(), probe_url_routed()
 
 Scaffold non e' piu' in scout. Usa toolkit.scaffold.full e toolkit.scaffold.sources.
 """
+
+from toolkit.scout.sparql import (  # noqa: F401
+    discover_named_graphs,
+    infer_graph_schema,
+)
 
 from toolkit.scout.http import (  # noqa: F401
     probe_url_headers,

--- a/toolkit/scout/sparql.py
+++ b/toolkit/scout/sparql.py
@@ -8,16 +8,9 @@ Le funzioni di routing/orchestrazione stanno in toolkit.scout.probe.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
-from lab_connectors.http.sparql import (
-    discover_graphs,
-    execute_sparql,
-    infer_schema,
-)
-
-log = logging.getLogger(__name__)
+from lab_connectors.http.sparql import discover_graphs, infer_schema
 
 
 def discover_named_graphs(

--- a/toolkit/scout/sparql.py
+++ b/toolkit/scout/sparql.py
@@ -1,0 +1,50 @@
+"""SPARQL scout — named graph discovery e schema inference.
+
+Wrapper leggero su lab_connectors.http.sparql.
+Mantiene le firme originali per backward compat con SO e altri caller.
+
+Le funzioni di routing/orchestrazione stanno in toolkit.scout.probe.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from lab_connectors.http.sparql import (
+    discover_graphs,
+    execute_sparql,
+    infer_schema,
+)
+
+log = logging.getLogger(__name__)
+
+
+def discover_named_graphs(
+    endpoint: str,
+    timeout: int = 60,
+    prefix: str = "",
+    blacklist: list[str] | None = None,
+) -> list[str]:
+    """Alias per lab_connectors.http.sparql.discover_graphs."""
+    return discover_graphs(
+        endpoint=endpoint,
+        timeout=timeout,
+        prefix=prefix,
+        blacklist=blacklist,
+    )
+
+
+def infer_graph_schema(
+    endpoint: str,
+    graph_uri: str,
+    timeout: int = 60,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Alias per lab_connectors.http.sparql.infer_schema."""
+    return infer_schema(
+        endpoint=endpoint,
+        graph_uri=graph_uri,
+        timeout=timeout,
+        limit=limit,
+    )


### PR DESCRIPTION
## Cosa cambia

Unificazione della logica SPARQL HTTP su `lab_connectors.http.sparql` (PR lab-connectors#36).

### toolkit/scout/sparql.py
- Diventa **wrapper sottile** su `lab_connectors.http.sparql`
- `discover_named_graphs()` → delega a `discover_graphs()`
- `infer_graph_schema()` → delega a `infer_schema()`
- Rimossa duplicazione HTTP (`_execute_sparql`, `_binding_value`, `_compact_uri`)

### toolkit/plugins/sparql.py (SparqlSource)
- **`_do_fetch()`**: GET fallback dopo POST (per endpoint Virtuoso/Senato che bloccano POST)
- **`_parse_response()`**: logica content-type unificata (CSV, JSON, text/plain, XML)
- **`probe()`**: usa `_fetch_bindings()` → `lab_connectors.execute_sparql()` per bindings raw
- **`_fetch_bindings()`**: nuovo metodo separato, testabile via mock
- Rimossa sezione di **codice morto** (duplicazione delle righe 130-180)
- **24/24 test passati** 🟢

### toolkit/tests/test_sparql_plugin.py
- Test `probe`: mockano `_fetch_bindings` invece di `HttpClient.post`
- Test network error: mocka anche GET fallback
- Fix pagination test: `args[1]` (data positionale) vs `kwargs["data"]`

### Dipendenze
Richiede `lab-connectors` con il modulo `http/sparql.py` (PR #36).