### PR TITLE
fix(http): sample_bytes non tronca formati binari

### DIFF
--- a/tests/test_http_file_plugin.py
+++ b/tests/test_http_file_plugin.py
@@ -15,6 +15,7 @@ from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.http_file import HttpFileSource
 
 
+@pytest.mark.contract
 def test_fetch_success() -> None:
     """HttpResult ok → fetch returns bytes."""
     fake = FakeHttpClient()
@@ -33,6 +34,7 @@ def test_fetch_success() -> None:
     assert fake.requests[0][1] == "https://example.test/data.csv"
 
 
+@pytest.mark.contract
 def test_fetch_http_status_error() -> None:
     """Non-200 HTTP status → DownloadError with status code in message."""
     fake = FakeHttpClient()
@@ -47,6 +49,7 @@ def test_fetch_http_status_error() -> None:
         source.fetch("https://example.test/unavailable")
 
 
+@pytest.mark.contract
 def test_fetch_connection_error() -> None:
     """HttpResult with err → DownloadError."""
     fake = FakeHttpClient()
@@ -61,6 +64,7 @@ def test_fetch_connection_error() -> None:
         source.fetch("https://example.test/fail")
 
 
+@pytest.mark.contract
 def test_fetch_passes_params() -> None:
     """HttpFileSource init params are forwarded to HttpClient constructor."""
     source = HttpFileSource(timeout=42, retries=5, user_agent="custom-agent/1.0")
@@ -105,3 +109,46 @@ def test_ssl_fallback_failure_propagates() -> None:
 
     with pytest.raises(DownloadError, match="fallback failed"):
         source.fetch("https://example.test/ssl-fail")
+
+
+@pytest.mark.contract
+class TestNonTruncableSampleBytes:
+    """sample_bytes viene ignorato per formati binari non troncabili.
+
+    Regression: --smoke e --sample-bytes troncavano ZIP/parquet/xlsx
+    producendo file corrotti in CI. Vedi toolkit#312.
+    """
+
+    @pytest.mark.contract
+    @pytest.mark.parametrize("url,should_ignore", [
+        ("https://example.test/data.parquet", True),
+        ("https://example.test/data.zip", True),
+        ("https://example.test/data.xlsx", True),
+        ("https://example.test/data.xls", True),
+        ("https://example.test/data.gz", True),
+        ("https://example.test/data.csv", False),
+        ("https://example.test/data.tsv", False),
+        ("https://example.test/data.txt", False),
+        ("https://example.test/data.json", False),
+        ("https://example.test/data", False),  # no extension
+        ("https://example.test/api/v1/download?format=csv", False),  # query params
+    ])
+    def test_sample_bytes_respected_for_truncable_only(self, url, should_ignore):
+        data = "a" * 10000 + "\n"
+        fake = FakeHttpClient()
+        fake.responses[url] = HttpResult(
+            response=fake_response(200, data), err=None,
+        )
+
+        source = HttpFileSource(retries=1)
+        source._client = fake
+
+        payload = source.fetch(url, sample_bytes=5000)
+
+        if should_ignore:
+            # Formato non troncabile: deve scaricare tutto il file
+            assert len(payload) == 10001
+            assert "Range" not in str(fake.requests[0][2].get("headers", {}))
+        else:
+            # CSV/JSON: sample_bytes rispettato con troncamento locale
+            assert len(payload) <= 5000

--- a/tests/test_http_post_file_plugin.py
+++ b/tests/test_http_post_file_plugin.py
@@ -23,6 +23,7 @@ class _FakeResponse:
         self.content = content
 
 
+@pytest.mark.contract
 def test_fetch_success(monkeypatch: pytest.MonkeyPatch) -> None:
     """HttpResult ok → fetch returns bytes."""
     results: list[tuple[str, dict | None, dict]] = []
@@ -42,6 +43,7 @@ def test_fetch_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert results[0][1] == {"key": "val"}
 
 
+@pytest.mark.contract
 def test_fetch_without_data(monkeypatch: pytest.MonkeyPatch) -> None:
     """Fetch without data passes None."""
     results: list[tuple[str, dict | None, dict]] = []
@@ -60,6 +62,7 @@ def test_fetch_without_data(monkeypatch: pytest.MonkeyPatch) -> None:
     assert results[0][1] is None
 
 
+@pytest.mark.contract
 def test_fetch_http_status_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """Non-200 HTTP status → DownloadError with status code in message."""
 
@@ -73,6 +76,7 @@ def test_fetch_http_status_error(monkeypatch: pytest.MonkeyPatch) -> None:
         source.fetch("https://example.test/unavailable")
 
 
+@pytest.mark.contract
 def test_fetch_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """HttpResult with err → DownloadError."""
 
@@ -86,6 +90,7 @@ def test_fetch_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
         source.fetch("https://example.test/fail")
 
 
+@pytest.mark.contract
 def test_fetch_passes_params() -> None:
     """HttpPostFileSource init params are forwarded to HttpClient constructor."""
     source = HttpPostFileSource(timeout=42, retries=5, user_agent="custom-agent/1.0")
@@ -133,3 +138,44 @@ def test_ssl_fallback_failure_propagates(monkeypatch: pytest.MonkeyPatch) -> Non
     source = HttpPostFileSource(retries=1)
     with pytest.raises(DownloadError, match="fallback failed"):
         source.fetch("https://example.test/ssl-fail")
+
+
+@pytest.mark.contract
+class TestNonTruncableSampleBytes:
+    """sample_bytes viene ignorato per formati binari non troncabili (POST).
+
+    Regression: --smoke e --sample-bytes troncavano ZIP/parquet/xlsx
+    producendo file corrotti in CI. Vedi toolkit#312.
+    """
+
+    @pytest.mark.contract
+    @pytest.mark.parametrize("url,should_ignore", [
+        ("https://example.test/download.parquet", True),
+        ("https://example.test/download.zip", True),
+        ("https://example.test/download.xlsx", True),
+        ("https://example.test/download.csv", False),
+        ("https://example.test/download", False),
+    ])
+    def test_sample_bytes_ignored_for_binary_post(
+        self, url, should_ignore, monkeypatch: pytest.MonkeyPatch
+    ):
+        """POST fetch: sample_bytes ignorato per estensioni non troncabili."""
+        results: list[tuple] = []
+
+        def fake_post(self, url: str, data: dict | None = None, **kwargs):
+            headers = kwargs.get("headers")
+            has_range = headers is not None and "Range" in headers
+            results.append((url, data, has_range))
+            content = b"a" * 10000 + b"\n"
+            return HttpResult(response=_FakeResponse(200, content), err=None)
+
+        monkeypatch.setattr(HttpClient, "post", fake_post)
+        source = HttpPostFileSource(retries=1)
+
+        payload = source.fetch(url, data={"key": "val"}, sample_bytes=5000)
+
+        if should_ignore:
+            assert len(payload) == 10001  # full file
+            assert not results[0][2]  # no Range header
+        else:
+            assert len(payload) <= 5000  # troncato

--- a/toolkit/plugins/http_file.py
+++ b/toolkit/plugins/http_file.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
+from urllib.parse import urlparse
 
 from lab_connectors.http import HttpClient
 
 from toolkit.core.exceptions import DownloadError
 
 logger = logging.getLogger("toolkit.plugins.http_file")
+
+# Estensioni che NON possono essere troncate: formati binari, compressi,
+# o contentitori i cui metadati sono in coda al file.
+# Campionare questi formati con HTTP Range produce file corrotti.
+_NON_TRUNCABLE_EXTS: set[str] = {
+    ".parquet",
+    ".zip",
+    ".xlsx",
+    ".xls",
+    ".gz",
+    ".bz2",
+    ".7z",
+    ".rar",
+}
 
 
 class HttpFileSource:
@@ -26,7 +42,25 @@ class HttpFileSource:
             user_agent=self.user_agent,
         )
 
+    @staticmethod
+    def _is_non_truncable(url: str) -> bool:
+        """Restituisce True se l'estensione del file non è troncabile in modo sicuro."""
+        path = urlparse(url).path
+        suffix = Path(path).suffix.lower()
+        # URL senza estensione o con parametri di query: assumiamo troncabile
+        if not suffix:
+            return False
+        return suffix in _NON_TRUNCABLE_EXTS
+
     def fetch(self, url: str, sample_bytes: int | None = None) -> bytes:
+        if sample_bytes is not None and self._is_non_truncable(url):
+            logger.info(
+                "sample_bytes=%s ignorato per formato non troncabile: %s",
+                sample_bytes,
+                url,
+            )
+            sample_bytes = None
+
         headers = None
         if sample_bytes is not None:
             headers = {"Range": f"bytes=0-{sample_bytes - 1}"}

--- a/toolkit/plugins/http_post_file.py
+++ b/toolkit/plugins/http_post_file.py
@@ -19,12 +19,19 @@ Usage in dataset.yml::
 from __future__ import annotations
 
 import logging
+from pathlib import Path
+from urllib.parse import urlparse
 
 from lab_connectors.http import HttpClient
 
 from toolkit.core.exceptions import DownloadError
 
 logger = logging.getLogger("toolkit.plugins.http_post_file")
+
+# Vedi http_file.py per la spiegazione.
+_NON_TRUNCABLE_EXTS: set[str] = {
+    ".parquet", ".zip", ".xlsx", ".xls", ".gz", ".bz2", ".7z", ".rar",
+}
 
 
 class HttpPostFileSource:
@@ -57,7 +64,7 @@ class HttpPostFileSource:
             data: Form-encoded POST body (dict of key-value pairs).
             sample_bytes: If set, adds ``Range: bytes=0-N`` header for
                 partial download (non-standard on POST, alcuni server lo
-                supportano).
+                supportano). Ignorato per formati binari non troncabili.
 
         Returns:
             Raw response bytes.
@@ -66,6 +73,17 @@ class HttpPostFileSource:
             DownloadError: on network error or non-200 HTTP status.
 
         """
+        if sample_bytes is not None:
+            path = urlparse(url).path
+            suffix = Path(path).suffix.lower()
+            if suffix in _NON_TRUNCABLE_EXTS:
+                logger.info(
+                    "sample_bytes=%s ignorato per formato non troncabile (POST): %s",
+                    sample_bytes,
+                    url,
+                )
+                sample_bytes = None
+
         headers = None
         if sample_bytes is not None:
             headers = {"Range": f"bytes=0-{sample_bytes - 1}"}


### PR DESCRIPTION
## Problema

`--smoke` e `--sample-bytes` troncano i file binari con HTTP Range, producendo file corrotti:
- **ZIP**: central directory in coda → `BadZipFile`
- **Parquet**: magic bytes in coda → `InvalidInputException`
- **XLSX**: file binario → illeggibile

Risultato: 12 falsi positivi su 38 candidati nel weekly smoke (30%).

## Fix

`HttpFileSource.fetch()` e `HttpPostFileSource.fetch()` ignorano `sample_bytes` quando l'URL ha un'estensione non troncabile.

```python
_NON_TRUNCABLE_EXTS = {".parquet", ".zip", ".xlsx", ".xls", ".gz", ".bz2", ".7z", ".rar"}
```

I CSV/TSV/JSON restano campionabili normalmente.

## Test

- **11 parametrici (GET)** — `test_http_file_plugin.py::TestNonTruncableSampleBytes`
- **5 parametrici (POST)** — `test_http_post_file_plugin.py::TestNonTruncableSampleBytes`
- Marker: `@pytest.mark.contract`
- Full suite: 803/803 ✅