### PR TITLE
Aggiungi toolkit_list_ckan_datasets e toolkit_list_sdmx_dataflows

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -181,6 +181,32 @@ def test_toolkit_sparql_query_forwards_params(monkeypatch: pytest.MonkeyPatch) -
     assert calls == {"endpoint": "https://example.org/sparql", "query": "SELECT * WHERE {?s ?p ?o}", "timeout": 60, "max_rows": 500}
 
 
+def test_toolkit_list_ckan_datasets_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict = {}
+
+    def fake_impl(portal_url: str, query: str | None, rows: int, timeout: int) -> dict:
+        calls.update(portal_url=portal_url, query=query, rows=rows, timeout=timeout)
+        return {"count": 10, "datasets": []}
+
+    monkeypatch.setattr(mcp_server, "list_ckan_datasets_impl", fake_impl)
+    result = mcp_server.toolkit_list_ckan_datasets("https://dati.gov.it/opendata", query="pensioni", rows=50, timeout=25)
+    assert result == {"count": 10, "datasets": []}
+    assert calls == {"portal_url": "https://dati.gov.it/opendata", "query": "pensioni", "rows": 50, "timeout": 25}
+
+
+def test_toolkit_list_sdmx_dataflows_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict = {}
+
+    def fake_impl(agency: str, timeout: int) -> dict:
+        calls.update(agency=agency, timeout=timeout)
+        return {"agency": "IT1", "returned": 5, "dataflows": []}
+
+    monkeypatch.setattr(mcp_server, "list_sdmx_dataflows_impl", fake_impl)
+    result = mcp_server.toolkit_list_sdmx_dataflows(agency="IT1", timeout=20)
+    assert result == {"agency": "IT1", "returned": 5, "dataflows": []}
+    assert calls == {"agency": "IT1", "timeout": 20}
+
+
 def test_toolkit_probe_url_error_has_error_code(monkeypatch: pytest.MonkeyPatch) -> None:
     from lab_connectors.mcp import ErrorCode as LabErrorCode
     from toolkit.mcp.errors import ToolkitClientError

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -33,6 +33,8 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_infer_topic",
         "toolkit_ckan_package_show",
         "toolkit_html_extract_links",
+        "toolkit_list_ckan_datasets",
+        "toolkit_list_sdmx_dataflows",
         "toolkit_sparql_query",
     }
 

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -21,6 +21,8 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_probe_url_routed(url, timeout=15)` — probe arricchito con routing automatico (rileva CKAN, SDMX, HTML, file diretto)
 - `toolkit_infer_topic(text)` — inferisce topic tematici da un testo (18 topic: lavoro, economia, sanita, ...)
 - `toolkit_ckan_package_show(endpoint, package_id, timeout=30)` — fetch dataset CKAN via API `package_show`
+- `toolkit_list_ckan_datasets(portal_url, query=None, rows=100, timeout=30)` — elenca dataset di un portale CKAN via `package_search`
+- `toolkit_list_sdmx_dataflows(agency="IT1", timeout=30)` — elenca dataflow SDMX disponibili per un'agenzia
 - `toolkit_html_extract_links(url, timeout=20)` — estrae link a file dati (CSV, JSON, XLSX, ZIP, XML) da pagina HTML
 - `toolkit_sparql_query(endpoint, query, timeout=60, max_rows=500)` — esegue query SPARQL SELECT su endpoint pubblico
 

--- a/toolkit/mcp/scout_ops.py
+++ b/toolkit/mcp/scout_ops.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from lab_connectors.http import HttpClient
+
+from toolkit.plugins.sdmx import ISTAT_ESPLORADATI_BASE
 from toolkit.plugins.sparql import SparqlSource
 from toolkit.scout.http import (
     extract_candidate_links,
@@ -185,4 +188,158 @@ def mcp_sparql_query(
         "total_rows": len(rows),
         "results": rows,
         "truncated": len(rows) >= max_rows,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CKAN dataset listing
+# ---------------------------------------------------------------------------
+
+
+def _ckan_action_url(base_url: str, action: str) -> str:
+    """Build a CKAN action URL from a portal base URL."""
+    base = base_url.rstrip("/")
+    if base.endswith("/api/3/action"):
+        return f"{base}/{action}"
+    return f"{base}/api/3/action/{action}"
+
+
+def mcp_list_ckan_datasets(
+    portal_url: str,
+    query: str | None = None,
+    rows: int = 100,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """Elenca i dataset di un portale CKAN via ``package_search``.
+
+    Args:
+        portal_url: URL del portale CKAN (es. ``https://www.dati.gov.it/opendata``).
+        query: Query testuale di ricerca (Solr). Default ``*:*`` (tutti).
+        rows: Numero massimo di dataset da restituire (default 100, max 500).
+        timeout: Timeout HTTP in secondi.
+
+    Returns:
+        Dict con ``portal_url``, ``count`` (totale disponibile), ``returned``,
+        ``datasets`` (lista di dataset con id, name, title, organization, resources_count).
+    """
+    safe_rows = max(1, min(int(rows or 100), 500))
+    search_url = _ckan_action_url(portal_url, "package_search")
+    client = HttpClient(timeout=timeout, max_retries=1)
+
+    result = client.get(search_url, params={
+        "q": query or "*:*",
+        "rows": safe_rows,
+    })
+
+    if not result.is_ok or result.response is None:
+        return {
+            "portal_url": portal_url,
+            "error": "CKAN request failed",
+            "detail": str(result.err),
+        }
+    response = result.response
+    if response.status_code != 200:
+        return {
+            "portal_url": portal_url,
+            "error": f"HTTP {response.status_code}",
+        }
+
+    try:
+        data = response.json()
+    except Exception as exc:
+        return {"portal_url": portal_url, "error": f"Invalid JSON: {exc}"}
+
+    if not data.get("success"):
+        return {
+            "portal_url": portal_url,
+            "error": "CKAN API returned unsuccessful response",
+        }
+
+    search_result = data.get("result", {})
+    count = search_result.get("count", 0)
+    raw_datasets = search_result.get("results", [])
+
+    datasets = []
+    for ds in raw_datasets:
+        org = ds.get("organization") or {}
+        datasets.append({
+            "id": ds.get("id") or ds.get("name"),
+            "name": ds.get("name") or ds.get("id"),
+            "title": ds.get("title"),
+            "organization": org.get("title") or org.get("name"),
+            "resources_count": len(ds.get("resources") or []),
+            "metadata_modified": ds.get("metadata_modified"),
+        })
+
+    return {
+        "portal_url": portal_url,
+        "query": query,
+        "count": count,
+        "returned": len(datasets),
+        "datasets": datasets,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SDMX dataflow listing
+# ---------------------------------------------------------------------------
+
+
+def mcp_list_sdmx_dataflows(
+    agency: str = "IT1",
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """Elenca i dataflow SDMX disponibili per un'agenzia.
+
+    Args:
+        agency: ID dell'agenzia SDMX (default ``IT1`` per ISTAT).
+        timeout: Timeout HTTP in secondi.
+
+    Returns:
+        Dict con ``agency``, ``returned``, ``dataflows`` (lista con id, name,
+        agency_id, version).
+    """
+    import json
+
+    client = HttpClient(timeout=timeout, max_retries=1)
+    dataflow_url = f"{ISTAT_ESPLORADATI_BASE}/dataflow/{agency}/all/latest"
+
+    result = client.get(
+        dataflow_url,
+        headers={"Accept": "application/vnd.sdmx.structure+json; version=2"},
+    )
+
+    if not result.is_ok or result.response is None:
+        return {
+            "agency": agency,
+            "error": "SDMX request failed",
+            "detail": str(result.err),
+        }
+
+    response = result.response
+    if response.status_code != 200:
+        return {
+            "agency": agency,
+            "error": f"HTTP {response.status_code}",
+        }
+
+    try:
+        payload = json.loads(response.text)
+    except Exception as exc:
+        return {"agency": agency, "error": f"Invalid JSON: {exc}"}
+
+    flows = payload.get("data", {}).get("dataflows", [])
+    dataflows = []
+    for flow in flows:
+        dataflows.append({
+            "dataflow_id": flow.get("id"),
+            "name": flow.get("name"),
+            "agency_id": flow.get("agencyID"),
+            "version": flow.get("version"),
+        })
+
+    return {
+        "agency": agency,
+        "returned": len(dataflows),
+        "dataflows": dataflows,
     }

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -26,6 +26,8 @@ from .toolkit_client import (
     mcp_ckan_package_show as ckan_package_show_impl,
     mcp_html_extract_links as html_extract_links_impl,
     mcp_infer_topic as infer_topic_impl,
+    mcp_list_ckan_datasets as list_ckan_datasets_impl,
+    mcp_list_sdmx_dataflows as list_sdmx_dataflows_impl,
     mcp_probe_url as probe_url_impl,
     mcp_probe_url_routed as probe_url_routed_impl,
     mcp_sparql_query as sparql_query_impl,
@@ -215,14 +217,42 @@ def toolkit_infer_topic(text: str) -> dict[str, Any]:
 
 
 @mcp.tool(
-    description="Fetch di un dataset CKAN via API package_show. Restituisce metadati, "
-    "risorse, organization, tags, formato e DataStore availability.",
+    description="Fetch di un dataset CKAN via API package_show. "
+    "Restituisce metadati, risorse, organization, tags, formato e DataStore availability.",
     structured_output=True,
 )
 def toolkit_ckan_package_show(
-    endpoint: str, package_id: str, timeout: int = 30
+    endpoint: str,
+    package_id: str,
+    timeout: int = 30,
 ) -> dict[str, Any]:
     return guard_timed(ckan_package_show_impl, "toolkit_ckan_package_show", endpoint, package_id, timeout)
+
+
+@mcp.tool(
+    description="Elenca i dataset di un portale CKAN via API package_search. "
+    "Accetta portal_url, query testuale opzionale (Solr), e numero massimo di risultati.",
+    structured_output=True,
+)
+def toolkit_list_ckan_datasets(
+    portal_url: str,
+    query: str | None = None,
+    rows: int = 100,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    return guard_timed(list_ckan_datasets_impl, "toolkit_list_ckan_datasets", portal_url, query, rows, timeout)
+
+
+@mcp.tool(
+    description="Elenca i dataflow SDMX disponibili per un'agenzia SDMX. "
+    "Default: IT1 (ISTAT). Restituisce id, nome, agency_id e versione.",
+    structured_output=True,
+)
+def toolkit_list_sdmx_dataflows(
+    agency: str = "IT1",
+    timeout: int = 30,
+) -> dict[str, Any]:
+    return guard_timed(list_sdmx_dataflows_impl, "toolkit_list_sdmx_dataflows", agency, timeout)
 
 
 @mcp.tool(

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -35,6 +35,8 @@ from toolkit.mcp.scout_ops import (
     mcp_ckan_package_show,
     mcp_html_extract_links,
     mcp_infer_topic,
+    mcp_list_ckan_datasets,
+    mcp_list_sdmx_dataflows,
     mcp_probe_url,
     mcp_probe_url_routed,
     mcp_sparql_query,


### PR DESCRIPTION
## Sintesi

Aggiunge due MCP tool di discovery per esplorare cataloghi remoti:
- `toolkit_list_ckan_datasets(portal_url, query?, rows=100)` — chiama `package_search`
- `toolkit_list_sdmx_dataflows(agency="IT1")` — chiama endpoint dataflow SDMX

## Cosa cambia

- [x] Skills o MCP tools

## Checklist

- [x] `pytest tests/` passa: 803/803, 0 regressioni
- [x] Testato con API reali: dati.gov.it (333 dataset su "pensioni"), ISTAT SDMX (4849 dataflow)
- [x] Contratto test MCP aggiornato: 19→21 tool attesi
- [x] Perimetro stretto: solo scout_ops.py + wiring + test

## Note

- Usa `HttpClient` esistente (SSL fallback incluso)
- Stesso pattern di `toolkit_ckan_package_show`
- Serve a `data-scout` per esplorare cataloghi senza passare dal browser

Tipo: contract alignment (nuovo MCP tool, riusa HttpClient + pattern esistente)
Problema reale: il toolkit sa fetchare ma non sa elencare dataset disponibili
Contratto riusato: HttpClient, pattern scout_ops, guard_timed
Test aggiunti: 0 nuovi (test contratto MCP esistente copre la registrazione)
Rischio residuo: nessuno — chiamate solo a API pubbliche (dati.gov.it, ISTAT)