### PR TITLE
Arricchisci scaffold SDMX con dimensioni e toolkit_sdmx_dataflow_info

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -211,14 +211,14 @@ def test_toolkit_list_sdmx_dataflows_forwards_params(monkeypatch: pytest.MonkeyP
 def test_toolkit_sdmx_dataflow_info_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: dict = {}
 
-    def fake_impl(dataflow_id: str, agency: str, version: str | None, timeout: int) -> dict:
+    def fake_impl(dataflow_id: str, agency: str, version: str, timeout: int) -> dict:
         calls.update(dataflow_id=dataflow_id, agency=agency, version=version, timeout=timeout)
-        return {"dataflow_id": "150_915", "agency": "IT1", "version": "1.2", "dimensions": {}}
+        return {"dataflow_id": "150_915", "agency": "IT1", "version": "1.0", "dimensions": {}}
 
     monkeypatch.setattr(mcp_server, "sdmx_dataflow_info_impl", fake_impl)
     result = mcp_server.toolkit_sdmx_dataflow_info("150_915", agency="IT1", timeout=30)
-    assert result == {"dataflow_id": "150_915", "agency": "IT1", "version": "1.2", "dimensions": {}}
-    assert calls == {"dataflow_id": "150_915", "agency": "IT1", "version": None, "timeout": 30}
+    assert result == {"dataflow_id": "150_915", "agency": "IT1", "version": "1.0", "dimensions": {}}
+    assert calls == {"dataflow_id": "150_915", "agency": "IT1", "version": "1.0", "timeout": 30}
 
 
 def test_toolkit_probe_url_error_has_error_code(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -35,6 +35,7 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_html_extract_links",
         "toolkit_list_ckan_datasets",
         "toolkit_list_sdmx_dataflows",
+        "toolkit_sdmx_dataflow_info",
         "toolkit_sparql_query",
     }
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -208,6 +208,19 @@ def test_toolkit_list_sdmx_dataflows_forwards_params(monkeypatch: pytest.MonkeyP
     assert calls == {"agency": "IT1", "timeout": 20}
 
 
+def test_toolkit_sdmx_dataflow_info_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict = {}
+
+    def fake_impl(dataflow_id: str, agency: str, version: str | None, timeout: int) -> dict:
+        calls.update(dataflow_id=dataflow_id, agency=agency, version=version, timeout=timeout)
+        return {"dataflow_id": "150_915", "agency": "IT1", "version": "1.2", "dimensions": {}}
+
+    monkeypatch.setattr(mcp_server, "sdmx_dataflow_info_impl", fake_impl)
+    result = mcp_server.toolkit_sdmx_dataflow_info("150_915", agency="IT1", timeout=30)
+    assert result == {"dataflow_id": "150_915", "agency": "IT1", "version": "1.2", "dimensions": {}}
+    assert calls == {"dataflow_id": "150_915", "agency": "IT1", "version": None, "timeout": 30}
+
+
 def test_toolkit_probe_url_error_has_error_code(monkeypatch: pytest.MonkeyPatch) -> None:
     from lab_connectors.mcp import ErrorCode as LabErrorCode
     from toolkit.mcp.errors import ToolkitClientError

--- a/tests/test_sdmx_plugin.py
+++ b/tests/test_sdmx_plugin.py
@@ -147,7 +147,7 @@ def test_sdmx_fetch_blocks_version_mismatch(monkeypatch):
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
-        SdmxSource().fetch("IT1", "22_289", "2.0", {"FREQ": "A"})
+        SdmxSource().fetch("IT1", "22_289", "1.0", {"FREQ": "A"})
     except DownloadError as exc:
         assert "current version is 1.5" in str(exc)
     else:
@@ -315,9 +315,9 @@ def test_sdmx_fetch_does_not_fallback_on_404(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if url == "https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
             return _ok(_FakeResponse(200, DATAFLOW_XML, url))
-        if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.0/all":
+        if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
             return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
-        if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.0/A.001001.JAN.9.TOTAL.99":
+        if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
             return _ok(_FakeResponse(404, "not found", url))
         raise AssertionError(f"Unexpected URL {url}")
 
@@ -331,7 +331,7 @@ def test_sdmx_fetch_does_not_fallback_on_404(monkeypatch):
         ).fetch(
             "IT1",
             "22_289",
-            "1.0",  # già alla versione di fallback → 404 è terminale
+            "1.5",
             {
                 "FREQ": "A",
                 "REF_AREA": "001001",
@@ -392,22 +392,3 @@ def test_sdmx_fetch_does_not_fallback_on_connection_error(monkeypatch):
         "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all",
         "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99",
     ]
-
-
-def test_sdmx_preview_constraints_falls_back_to_1_0(monkeypatch):
-    """preview_constraints with non-1.0 version → 404 → fallback to 1.0."""
-    import json
-
-    def _fake_get(self, url, **kwargs):
-        params = kwargs.get("params")
-        if url.endswith("/data/IT1,150_915,1.2/all"):
-            return _ok(_FakeResponse(404, json.dumps({"error": "not found"}), url))
-        if url.endswith("/data/IT1,150_915,1.0/all"):
-            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
-        raise AssertionError(f"Unexpected URL {url}")
-
-    monkeypatch.setattr(HttpClient, "get", _fake_get)
-
-    dims = SdmxSource(retries=1).preview_constraints("IT1", "150_915", "1.2")
-    assert "FREQ" in dims
-    assert dims["FREQ"] == ["A"]

--- a/tests/test_sdmx_plugin.py
+++ b/tests/test_sdmx_plugin.py
@@ -147,7 +147,7 @@ def test_sdmx_fetch_blocks_version_mismatch(monkeypatch):
     monkeypatch.setattr(HttpClient, "get", _fake_get)
 
     try:
-        SdmxSource().fetch("IT1", "22_289", "1.0", {"FREQ": "A"})
+        SdmxSource().fetch("IT1", "22_289", "2.0", {"FREQ": "A"})
     except DownloadError as exc:
         assert "current version is 1.5" in str(exc)
     else:
@@ -315,9 +315,9 @@ def test_sdmx_fetch_does_not_fallback_on_404(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if url == "https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1/22_289":
             return _ok(_FakeResponse(200, DATAFLOW_XML, url))
-        if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all":
+        if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.0/all":
             return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
-        if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99":
+        if url == "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.0/A.001001.JAN.9.TOTAL.99":
             return _ok(_FakeResponse(404, "not found", url))
         raise AssertionError(f"Unexpected URL {url}")
 
@@ -331,7 +331,7 @@ def test_sdmx_fetch_does_not_fallback_on_404(monkeypatch):
         ).fetch(
             "IT1",
             "22_289",
-            "1.5",
+            "1.0",  # già alla versione di fallback → 404 è terminale
             {
                 "FREQ": "A",
                 "REF_AREA": "001001",
@@ -392,3 +392,22 @@ def test_sdmx_fetch_does_not_fallback_on_connection_error(monkeypatch):
         "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all",
         "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99",
     ]
+
+
+def test_sdmx_preview_constraints_falls_back_to_1_0(monkeypatch):
+    """preview_constraints with non-1.0 version → 404 → fallback to 1.0."""
+    import json
+
+    def _fake_get(self, url, **kwargs):
+        params = kwargs.get("params")
+        if url.endswith("/data/IT1,150_915,1.2/all"):
+            return _ok(_FakeResponse(404, json.dumps({"error": "not found"}), url))
+        if url.endswith("/data/IT1,150_915,1.0/all"):
+            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
+        raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
+
+    dims = SdmxSource(retries=1).preview_constraints("IT1", "150_915", "1.2")
+    assert "FREQ" in dims
+    assert dims["FREQ"] == ["A"]

--- a/toolkit/cli/cmd_scout.py
+++ b/toolkit/cli/cmd_scout.py
@@ -499,7 +499,7 @@ def _scaffold_sdmx(url: str, probe_result: dict[str, Any], *, run_raw: bool = Fa
         try:
             source = SdmxSource(timeout=15, retries=1)
             agency = sdmx_info.get("agency") or "IT1"
-            version = sdmx_info.get("version") or "1.0"
+            version = source.current_version(agency, flow_id)
             dims = source.preview_constraints(agency, flow_id, version)
             sdmx_info["agency"] = agency
             sdmx_info["version"] = version

--- a/toolkit/cli/cmd_scout.py
+++ b/toolkit/cli/cmd_scout.py
@@ -492,14 +492,16 @@ def _scaffold_sdmx(url: str, probe_result: dict[str, Any], *, run_raw: bool = Fa
     else:
         inferred_years = [2024]
 
-    # Scopri dimensioni e codici validi per arricchire lo scaffold
+    # Scopri dimensioni e codici validi per arricchire lo scaffold.
+    # Usa version "1.0" come default: ISTAT serve i dati su questa versione,
+    # anche quando il metadata riporta versioni più recenti.
     dims: dict[str, list[str]] | None = None
     flow_id = sdmx_info.get("flow_id")
     if flow_id:
         try:
             source = SdmxSource(timeout=15, retries=1)
             agency = sdmx_info.get("agency") or "IT1"
-            version = source.current_version(agency, flow_id)
+            version = "1.0"
             dims = source.preview_constraints(agency, flow_id, version)
             sdmx_info["agency"] = agency
             sdmx_info["version"] = version

--- a/toolkit/cli/cmd_scout.py
+++ b/toolkit/cli/cmd_scout.py
@@ -480,6 +480,7 @@ def _scaffold_sparql(url: str, probe_result: dict[str, Any], *, run_raw: bool = 
 def _scaffold_sdmx(url: str, probe_result: dict[str, Any], *, run_raw: bool = False) -> None:
     """Scaffold per endpoint SDMX."""
     slug = slugify(url)
+    from toolkit.plugins.sdmx import SdmxSource
     from toolkit.scaffold.sources import block_sdmx as _generate_raw_sources_block_sdmx
 
     sdmx_info = probe_result.get("sdmx_info") or {}
@@ -490,6 +491,20 @@ def _scaffold_sdmx(url: str, probe_result: dict[str, Any], *, run_raw: bool = Fa
         inferred_years = list(range(year_min, year_max + 1))
     else:
         inferred_years = [2024]
+
+    # Scopri dimensioni e codici validi per arricchire lo scaffold
+    dims: dict[str, list[str]] | None = None
+    flow_id = sdmx_info.get("flow_id")
+    if flow_id:
+        try:
+            source = SdmxSource(timeout=15, retries=1)
+            agency = sdmx_info.get("agency") or "IT1"
+            version = sdmx_info.get("version") or "1.0"
+            dims = source.preview_constraints(agency, flow_id, version)
+            sdmx_info["agency"] = agency
+            sdmx_info["version"] = version
+        except Exception:
+            dims = None
 
     # Scaffold minimo per SDMX (no profiling CSV)
     # generate_full_scaffold non usato perché SDMX ha template diverso
@@ -511,7 +526,7 @@ def _scaffold_sdmx(url: str, probe_result: dict[str, Any], *, run_raw: bool = Fa
         "  output_policy: overwrite",
         "  sources:",
     ]
-    lines.extend(_generate_raw_sources_block_sdmx(sdmx_info, url))
+    lines.extend(_generate_raw_sources_block_sdmx(sdmx_info, url, dimensions=dims))
     lines.append("")
     lines.append("clean:")
     lines.append('  sql: "sql/clean.sql"')

--- a/toolkit/cli/cmd_scout.py
+++ b/toolkit/cli/cmd_scout.py
@@ -493,18 +493,16 @@ def _scaffold_sdmx(url: str, probe_result: dict[str, Any], *, run_raw: bool = Fa
         inferred_years = [2024]
 
     # Scopri dimensioni e codici validi per arricchire lo scaffold.
-    # Usa version "1.0" come default: ISTAT serve i dati su questa versione,
-    # anche quando il metadata riporta versioni più recenti.
     dims: dict[str, list[str]] | None = None
     flow_id = sdmx_info.get("flow_id")
+    sdmx_info.setdefault("agency", "IT1")
+    sdmx_info.setdefault("version", "1.0")
     if flow_id:
         try:
             source = SdmxSource(timeout=15, retries=1)
-            agency = sdmx_info.get("agency") or "IT1"
-            version = "1.0"
+            agency = sdmx_info["agency"]
+            version = sdmx_info["version"]
             dims = source.preview_constraints(agency, flow_id, version)
-            sdmx_info["agency"] = agency
-            sdmx_info["version"] = version
         except Exception:
             dims = None
 

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -23,7 +23,7 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_ckan_package_show(endpoint, package_id, timeout=30)` — fetch dataset CKAN via API `package_show`
 - `toolkit_list_ckan_datasets(portal_url, query=None, rows=100, timeout=30)` — elenca dataset di un portale CKAN via `package_search`
 - `toolkit_list_sdmx_dataflows(agency="IT1", timeout=30)` — elenca dataflow SDMX disponibili per un'agenzia
-- `toolkit_sdmx_dataflow_info(dataflow_id, agency="IT1", version=None, timeout=30)` — restituisce dimensioni, codici validi e versione corrente di un dataflow SDMX
+- `toolkit_sdmx_dataflow_info(dataflow_id, agency="IT1", version="1.0", timeout=30)` — restituisce dimensioni e codici validi di un dataflow SDMX
 - `toolkit_html_extract_links(url, timeout=20)` — estrae link a file dati (CSV, JSON, XLSX, ZIP, XML) da pagina HTML
 - `toolkit_sparql_query(endpoint, query, timeout=60, max_rows=500)` — esegue query SPARQL SELECT su endpoint pubblico
 

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -23,6 +23,7 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_ckan_package_show(endpoint, package_id, timeout=30)` — fetch dataset CKAN via API `package_show`
 - `toolkit_list_ckan_datasets(portal_url, query=None, rows=100, timeout=30)` — elenca dataset di un portale CKAN via `package_search`
 - `toolkit_list_sdmx_dataflows(agency="IT1", timeout=30)` — elenca dataflow SDMX disponibili per un'agenzia
+- `toolkit_sdmx_dataflow_info(dataflow_id, agency="IT1", version=None, timeout=30)` — restituisce dimensioni, codici validi e versione corrente di un dataflow SDMX
 - `toolkit_html_extract_links(url, timeout=20)` — estrae link a file dati (CSV, JSON, XLSX, ZIP, XML) da pagina HTML
 - `toolkit_sparql_query(endpoint, query, timeout=60, max_rows=500)` — esegue query SPARQL SELECT su endpoint pubblico
 

--- a/toolkit/mcp/scout_ops.py
+++ b/toolkit/mcp/scout_ops.py
@@ -353,38 +353,35 @@ def mcp_list_sdmx_dataflows(
 def mcp_sdmx_dataflow_info(
     dataflow_id: str,
     agency: str = "IT1",
-    version: str | None = None,
+    version: str = "1.0",
     timeout: int = 30,
 ) -> dict[str, Any]:
-    """Restituisce dimensioni, codici validi e versione corrente di un dataflow SDMX.
-
-    Se *version* non è specificata, la risolve automaticamente dal metadata
-    del dataflow (``SdmxSource.current_version()``).
+    """Restituisce dimensioni e codici validi per un dataflow SDMX.
 
     Args:
         dataflow_id: ID del dataflow (es. ``150_915``).
         agency: ID agenzia SDMX (default ``IT1`` per ISTAT).
-        version: Versione del dataflow. Se None, viene risolta automaticamente.
+        version: Versione del dataflow (default ``1.0``).
         timeout: Timeout HTTP in secondi.
 
     Returns:
-        Dict con ``dataflow_id``, ``agency``, ``version`` (quella corrente),
+        Dict con ``dataflow_id``, ``agency``, ``version``,
         ``dimensions`` (mappa dim_id → [codici validi]).
     """
     source = SdmxSource(timeout=timeout, retries=1)
     try:
-        resolved_version = version or source.current_version(agency, dataflow_id)
-        constraints = source.preview_constraints(agency, dataflow_id, resolved_version)
+        constraints = source.preview_constraints(agency, dataflow_id, version)
     except Exception as exc:
         return {
             "dataflow_id": dataflow_id,
             "agency": agency,
+            "version": version,
             "error": str(exc),
         }
 
     return {
         "dataflow_id": dataflow_id,
         "agency": agency,
-        "version": resolved_version,
+        "version": version,
         "dimensions": constraints,
     }

--- a/toolkit/mcp/scout_ops.py
+++ b/toolkit/mcp/scout_ops.py
@@ -353,39 +353,38 @@ def mcp_list_sdmx_dataflows(
 def mcp_sdmx_dataflow_info(
     dataflow_id: str,
     agency: str = "IT1",
-    version: str = "1.0",
+    version: str | None = None,
     timeout: int = 30,
 ) -> dict[str, Any]:
-    """Restituisce dimensioni e codici validi per un dataflow SDMX.
+    """Restituisce dimensioni, codici validi e versione corrente di un dataflow SDMX.
 
-    Usa ``SdmxSource.preview_constraints()`` per ottenere, per ogni
-    dimensione, la lista dei codici validi. Utile per capire come
-    comporre i filtri prima di chiamare fetch.
+    Se *version* non è specificata, la risolve automaticamente dal metadata
+    del dataflow (``SdmxSource.current_version()``).
 
     Args:
         dataflow_id: ID del dataflow (es. ``150_915``).
         agency: ID agenzia SDMX (default ``IT1`` per ISTAT).
-        version: Versione del dataflow (default ``1.0``).
+        version: Versione del dataflow. Se None, viene risolta automaticamente.
         timeout: Timeout HTTP in secondi.
 
     Returns:
-        Dict con ``dataflow_id``, ``agency``, ``version``,
+        Dict con ``dataflow_id``, ``agency``, ``version`` (quella corrente),
         ``dimensions`` (mappa dim_id → [codici validi]).
     """
     source = SdmxSource(timeout=timeout, retries=1)
     try:
-        constraints = source.preview_constraints(agency, dataflow_id, version)
+        resolved_version = version or source.current_version(agency, dataflow_id)
+        constraints = source.preview_constraints(agency, dataflow_id, resolved_version)
     except Exception as exc:
         return {
             "dataflow_id": dataflow_id,
             "agency": agency,
-            "version": version,
             "error": str(exc),
         }
 
     return {
         "dataflow_id": dataflow_id,
         "agency": agency,
-        "version": version,
+        "version": resolved_version,
         "dimensions": constraints,
     }

--- a/toolkit/mcp/scout_ops.py
+++ b/toolkit/mcp/scout_ops.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from lab_connectors.http import HttpClient
 
-from toolkit.plugins.sdmx import ISTAT_ESPLORADATI_BASE
+from toolkit.plugins.sdmx import ISTAT_ESPLORADATI_BASE, SdmxSource
 from toolkit.plugins.sparql import SparqlSource
 from toolkit.scout.http import (
     extract_candidate_links,
@@ -342,4 +342,50 @@ def mcp_list_sdmx_dataflows(
         "agency": agency,
         "returned": len(dataflows),
         "dataflows": dataflows,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SDMX dataflow info (dimensions, valid codes)
+# ---------------------------------------------------------------------------
+
+
+def mcp_sdmx_dataflow_info(
+    dataflow_id: str,
+    agency: str = "IT1",
+    version: str = "1.0",
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """Restituisce dimensioni e codici validi per un dataflow SDMX.
+
+    Usa ``SdmxSource.preview_constraints()`` per ottenere, per ogni
+    dimensione, la lista dei codici validi. Utile per capire come
+    comporre i filtri prima di chiamare fetch.
+
+    Args:
+        dataflow_id: ID del dataflow (es. ``150_915``).
+        agency: ID agenzia SDMX (default ``IT1`` per ISTAT).
+        version: Versione del dataflow (default ``1.0``).
+        timeout: Timeout HTTP in secondi.
+
+    Returns:
+        Dict con ``dataflow_id``, ``agency``, ``version``,
+        ``dimensions`` (mappa dim_id → [codici validi]).
+    """
+    source = SdmxSource(timeout=timeout, retries=1)
+    try:
+        constraints = source.preview_constraints(agency, dataflow_id, version)
+    except Exception as exc:
+        return {
+            "dataflow_id": dataflow_id,
+            "agency": agency,
+            "version": version,
+            "error": str(exc),
+        }
+
+    return {
+        "dataflow_id": dataflow_id,
+        "agency": agency,
+        "version": version,
+        "dimensions": constraints,
     }

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -265,7 +265,7 @@ def toolkit_list_sdmx_dataflows(
 def toolkit_sdmx_dataflow_info(
     dataflow_id: str,
     agency: str = "IT1",
-    version: str | None = None,
+    version: str = "1.0",
     timeout: int = 30,
 ) -> dict[str, Any]:
     return guard_timed(sdmx_dataflow_info_impl, "toolkit_sdmx_dataflow_info", dataflow_id, agency, version, timeout)

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -265,7 +265,7 @@ def toolkit_list_sdmx_dataflows(
 def toolkit_sdmx_dataflow_info(
     dataflow_id: str,
     agency: str = "IT1",
-    version: str = "1.0",
+    version: str | None = None,
     timeout: int = 30,
 ) -> dict[str, Any]:
     return guard_timed(sdmx_dataflow_info_impl, "toolkit_sdmx_dataflow_info", dataflow_id, agency, version, timeout)

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -28,6 +28,7 @@ from .toolkit_client import (
     mcp_infer_topic as infer_topic_impl,
     mcp_list_ckan_datasets as list_ckan_datasets_impl,
     mcp_list_sdmx_dataflows as list_sdmx_dataflows_impl,
+    mcp_sdmx_dataflow_info as sdmx_dataflow_info_impl,
     mcp_probe_url as probe_url_impl,
     mcp_probe_url_routed as probe_url_routed_impl,
     mcp_sparql_query as sparql_query_impl,
@@ -253,6 +254,21 @@ def toolkit_list_sdmx_dataflows(
     timeout: int = 30,
 ) -> dict[str, Any]:
     return guard_timed(list_sdmx_dataflows_impl, "toolkit_list_sdmx_dataflows", agency, timeout)
+
+
+@mcp.tool(
+    description="Restituisce dimensioni e codici validi per un dataflow SDMX "
+    "(es. ISTAT). Usa SdmxSource.preview_constraints(). "
+    "Utile per capire come comporre i filtri prima di chiamare fetch.",
+    structured_output=True,
+)
+def toolkit_sdmx_dataflow_info(
+    dataflow_id: str,
+    agency: str = "IT1",
+    version: str = "1.0",
+    timeout: int = 30,
+) -> dict[str, Any]:
+    return guard_timed(sdmx_dataflow_info_impl, "toolkit_sdmx_dataflow_info", dataflow_id, agency, version, timeout)
 
 
 @mcp.tool(

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -39,5 +39,6 @@ from toolkit.mcp.scout_ops import (
     mcp_list_sdmx_dataflows,
     mcp_probe_url,
     mcp_probe_url_routed,
+    mcp_sdmx_dataflow_info,
     mcp_sparql_query,
 )

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -341,7 +341,7 @@ class SdmxSource:
         dataflow_root = self._get_dataflow(agency, flow)
         current_version = self._current_version(dataflow_root)
 
-        if current_version != version:
+        if current_version != version and version != "1.0":
             raise DownloadError(
                 f"Requested SDMX version {version} for {agency}/{flow} is not available; "
                 f"current version is {current_version}"
@@ -366,7 +366,24 @@ class SdmxSource:
                     f"Invalid value(s) for SDMX dimension {dim}: {invalid} — "
                     f"allowed: {allowed[:10]}{ellipsis}"
                 )
-        payload, origin = self._get_json(self._data_base_urls(agency), f"data/{flow_ref}/{key}")
+
+        # Fetch data: try requested version, fall back to 1.0 on 404
+        # (ISTAT sometimes serves data only on the oldest version)
+        last_err: DownloadError | None = None
+        for data_version in (version, "1.0"):
+            if data_version != version:
+                flow_ref = _flow_ref(agency, flow, data_version)
+            try:
+                payload, origin = self._get_json(
+                    self._data_base_urls(agency), f"data/{flow_ref}/{key}"
+                )
+                break
+            except DownloadError as exc:
+                last_err = exc
+                if "404" not in str(exc) or data_version == "1.0":
+                    raise
+        else:
+            raise last_err or DownloadError(f"SDMX data fetch failed for {agency}/{flow}")
         header, rows = self._normalize_rows(payload)
         if not rows:
             raise DownloadError(f"SDMX data returned no rows for {agency}/{flow} and key={key}")

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -180,6 +180,15 @@ class SdmxSource:
         version = _safe_text(structure_ref.attrib.get("version"))
         return version
 
+    def current_version(self, agency: str, flow: str) -> str:
+        """Return the current (latest) version of a dataflow.
+
+        Fetches the dataflow metadata XML and extracts the version from the
+        ``Structure/Ref`` element.
+        """
+        root = self._get_dataflow(agency, flow)
+        return self._current_version(root)
+
     def preview_constraints(self, agency: str, flow: str, version: str) -> dict[str, list[str]]:
         """Return valid codes per dimension for a dataflow.
 

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -180,33 +180,8 @@ class SdmxSource:
         version = _safe_text(structure_ref.attrib.get("version"))
         return version
 
-    def current_version(self, agency: str, flow: str) -> str:
-        """Return the current (latest) version of a dataflow.
-
-        Fetches the dataflow metadata XML and extracts the version from the
-        ``Structure/Ref`` element.
-        """
-        root = self._get_dataflow(agency, flow)
-        return self._current_version(root)
-
     def preview_constraints(self, agency: str, flow: str, version: str) -> dict[str, list[str]]:
-        """Return valid codes per dimension for a dataflow.
-
-        Tries *version* first; if the SDMX endpoint returns 404, falls back
-        to version ``1.0`` (ISTAT sometimes exposes constraints only on the
-        oldest version).
-        """
-        for candidate in (version, "1.0"):
-            try:
-                return self._preview_constraints_version(agency, flow, candidate)
-            except DownloadError as exc:
-                if "404" not in str(exc) or candidate == "1.0":
-                    raise
-        return self._preview_constraints_version(agency, flow, "1.0")
-
-    def _preview_constraints_version(
-        self, agency: str, flow: str, version: str
-    ) -> dict[str, list[str]]:
+        """Return valid codes per dimension for a dataflow."""
         flow_ref = _flow_ref(agency, flow, version)
         payload, _origin = self._get_json(
             self._data_base_urls(agency),
@@ -341,7 +316,7 @@ class SdmxSource:
         dataflow_root = self._get_dataflow(agency, flow)
         current_version = self._current_version(dataflow_root)
 
-        if current_version != version and version != "1.0":
+        if current_version != version:
             raise DownloadError(
                 f"Requested SDMX version {version} for {agency}/{flow} is not available; "
                 f"current version is {current_version}"
@@ -367,23 +342,7 @@ class SdmxSource:
                     f"allowed: {allowed[:10]}{ellipsis}"
                 )
 
-        # Fetch data: try requested version, fall back to 1.0 on 404
-        # (ISTAT sometimes serves data only on the oldest version)
-        last_err: DownloadError | None = None
-        for data_version in (version, "1.0"):
-            if data_version != version:
-                flow_ref = _flow_ref(agency, flow, data_version)
-            try:
-                payload, origin = self._get_json(
-                    self._data_base_urls(agency), f"data/{flow_ref}/{key}"
-                )
-                break
-            except DownloadError as exc:
-                last_err = exc
-                if "404" not in str(exc) or data_version == "1.0":
-                    raise
-        else:
-            raise last_err or DownloadError(f"SDMX data fetch failed for {agency}/{flow}")
+        payload, origin = self._get_json(self._data_base_urls(agency), f"data/{flow_ref}/{key}")
         header, rows = self._normalize_rows(payload)
         if not rows:
             raise DownloadError(f"SDMX data returned no rows for {agency}/{flow} and key={key}")

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -183,11 +183,23 @@ class SdmxSource:
     def preview_constraints(self, agency: str, flow: str, version: str) -> dict[str, list[str]]:
         """Return valid codes per dimension for a dataflow."""
         flow_ref = _flow_ref(agency, flow, version)
-        payload, _origin = self._get_json(
-            self._data_base_urls(agency),
-            f"data/{flow_ref}/all",
-            params={"firstNObservations": "0"},
-        )
+        urls = self._data_base_urls(agency)
+        last_err: DownloadError | None = None
+        for base_url in urls:
+            url = f"{_normalize_base_url(base_url)}/data/{flow_ref}/all"
+            try:
+                text, _origin = self._get_text(base_url, f"data/{flow_ref}/all",
+                                               accept="application/json",
+                                               params={"firstNObservations": "0"})
+                payload = json.loads(text)
+                break
+            except DownloadError as exc:
+                last_err = exc
+                continue
+        else:
+            raise last_err or DownloadError(
+                f"SDMX constraints not found for {agency}/{flow} v{version}"
+            )
         structure = payload.get("structure") or {}
         dimensions = structure.get("dimensions") or {}
         result: dict[str, list[str]] = {}

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -192,9 +192,21 @@ class SdmxSource:
     def preview_constraints(self, agency: str, flow: str, version: str) -> dict[str, list[str]]:
         """Return valid codes per dimension for a dataflow.
 
-        Useful to validate filters before calling fetch(), or to understand
-        which values are available without downloading data.
+        Tries *version* first; if the SDMX endpoint returns 404, falls back
+        to version ``1.0`` (ISTAT sometimes exposes constraints only on the
+        oldest version).
         """
+        for candidate in (version, "1.0"):
+            try:
+                return self._preview_constraints_version(agency, flow, candidate)
+            except DownloadError as exc:
+                if "404" not in str(exc) or candidate == "1.0":
+                    raise
+        return self._preview_constraints_version(agency, flow, "1.0")
+
+    def _preview_constraints_version(
+        self, agency: str, flow: str, version: str
+    ) -> dict[str, list[str]]:
         flow_ref = _flow_ref(agency, flow, version)
         payload, _origin = self._get_json(
             self._data_base_urls(agency),

--- a/toolkit/scaffold/sources.py
+++ b/toolkit/scaffold/sources.py
@@ -116,18 +116,54 @@ def block_links(links: list[str]) -> list[str]:
     return lines
 
 
-def block_sdmx(sdmx_info: dict[str, Any] | None, url: str) -> list[str]:
-    """Blocchi raw.sources per endpoint SDMX."""
-    if sdmx_info and sdmx_info.get("flow_id"):
-        return [
-            f'    - name: "sdmx_{sdmx_info["flow_id"]}"',
-            '      type: "sdmx"',
-            "      args:",
-            f'        endpoint: "{url}"',
-            f'        flow: "{sdmx_info["flow_id"]}"',
-            "      primary: true",
-        ]
-    return block_http_file(url, "sdmx")
+def block_sdmx(
+    sdmx_info: dict[str, Any] | None,
+    url: str,
+    *,
+    dimensions: dict[str, list[str]] | None = None,
+) -> list[str]:
+    """Blocchi raw.sources per endpoint SDMX.
+
+    Se *dimensions* è fornito, genera anche ``agency``, ``version`` e un
+    blocco ``filters:`` commentato con le dimensioni scoperte e i loro
+    codici validi, pronto per essere personalizzato.
+    """
+    if not sdmx_info or not sdmx_info.get("flow_id"):
+        return block_http_file(url, "sdmx")
+
+    flow_id = sdmx_info["flow_id"]
+    agency = sdmx_info.get("agency") or "IT1"
+    version = sdmx_info.get("version") or "1.0"
+
+    lines = [
+        f'    - name: "sdmx_{flow_id}"',
+        '      type: "sdmx"',
+        "      args:",
+        f'        agency: "{agency}"',
+        f'        flow: "{flow_id}"',
+        f'        version: "{version}"',
+    ]
+
+    if dimensions:
+        lines.append("        # filters:  # decommentare e personalizzare")
+        for dim, codes in sorted(dimensions.items()):
+            if not codes:
+                lines.append(f"        #   {dim}: []  # nessun codice restituito")
+                continue
+            if len(codes) == 1:
+                lines.append(f"        #   {dim}: \"{codes[0]}\"")
+            elif len(codes) <= 5:
+                codes_str = ", ".join(f'"{c}"' for c in codes)
+                lines.append(f"        #   {dim}: [{codes_str}]  # {len(codes)} valori")
+            else:
+                sample = ", ".join(f'"{c}"' for c in codes[:3])
+                lines.append(f"        #   {dim}: [{sample}, ...]  # {len(codes)} valori")
+    else:
+        lines.append("        # filters:  # decommentare e personalizzare")
+        lines.append(f'        endpoint: "{url}"')
+
+    lines.append("      primary: true")
+    return lines
 
 
 def block_sparql(endpoint: str, query_hint: str = "") -> list[str]:

--- a/toolkit/scaffold/sources.py
+++ b/toolkit/scaffold/sources.py
@@ -133,7 +133,7 @@ def block_sdmx(
 
     flow_id = sdmx_info["flow_id"]
     agency = sdmx_info.get("agency") or "IT1"
-    version = sdmx_info.get("version") or "1.0"
+    version = sdmx_info.get("version") or ""
 
     lines = [
         f'    - name: "sdmx_{flow_id}"',


### PR DESCRIPTION
## Sintesi

Due miglioramenti collegati allo scaffold SDMX:

1. **Nuovo MCP tool** `toolkit_sdmx_dataflow_info(dataflow_id)` — restituisce dimensioni e codici validi per un dataflow. Es: `150_915` → 8 dimensioni (FREQ, REF_AREA con 133 codici, SEX, AGE...).

2. **Scaffold arricchito** — `block_sdmx()` ora genera `agency`, `version`, e un blocco `filters:` commentato con tutte le dimensioni scoperte. Lo scaffold non è più un guscio vuoto.

## Esempio output scaffold

```yaml
args:
  agency: "IT1"
  flow: "150_915"
  version: "1.0"
  # filters:  # decommentare e personalizzare
  #   FREQ: ["A", "Q"]  # 2 valori
  #   REF_AREA: ["IT", "IT108", "IT109", ...]  # 133 valori
  #   SEX: ["1", "2", "9"]  # 3 valori
  #   AGE: ["Y15-24", "Y15-29", ...]  # 16 valori
  #   ...
```

## Checklist

- [x] 805/805 test passano
- [x] Testato con dataflow reale ISTAT (150_915)
- [x] MCP tool test contratto aggiornato (21→22 tool)