### PR TITLE
feat(batch): aggiungi --step probe per verifica raggiungibilità fonti

### DIFF
--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -199,6 +199,47 @@ def test_batch_json_output(tmp_path: Path) -> None:
     assert report["rows"][0]["status"] == "SUCCESS"
 
 
+def test_batch_step_probe(tmp_path: Path) -> None:
+    """--step probe esegue probe (salta local_file) e produce report JSON."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "batch_probe", 2023)
+    configs_file = _write_configs_file(tmp_path, "project")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "probe"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "Batch Report" in result.output
+    assert "batch_probe" in result.output
+    assert "SUCCESS" in result.output
+
+
+def test_batch_step_probe_json_output(tmp_path: Path) -> None:
+    """--step probe --json produce JSON valido."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "batch_probe_json", 2023)
+    configs_file = _write_configs_file(tmp_path, "project")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "probe", "--json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    report = json.loads(result.output)
+    assert report["summary"]["total"] == 1
+    assert report["summary"]["passed"] == 1
+    assert report["rows"][0]["dataset"] == "batch_probe_json"
+    assert report["rows"][0]["step"] == "probe"
+    assert report["rows"][0]["status"] == "SUCCESS"
+
+
 def test_batch_dry_run_with_json(tmp_path: Path) -> None:
     """--dry-run --json: stdout JSON puro (execution plan silenziato)."""
     project = tmp_path / "project"

--- a/tests/test_cmd_batch.py
+++ b/tests/test_cmd_batch.py
@@ -55,6 +55,56 @@ class TestReadConfigList:
         result = _read_config_list(configs_file)
         assert result == [dataset_file.resolve()]
 
+    def test_relative_path_resolved_from_cwd_first(self, tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Se il path relativo esiste sia in CWD che nel parent del batch,
+        viene usato quello della CWD."""
+        # Setup: crea due file con lo stesso path relativo
+        batch_parent = tmp_path / "batches"
+        batch_parent.mkdir()
+        configs_file = batch_parent / "configs.txt"
+
+        # File in CWD (tmp_path / "project" / "dataset.yml")
+        cwd_project = tmp_path / "project"
+        cwd_project.mkdir()
+        cwd_file = cwd_project / "dataset.yml"
+        cwd_file.write_text("from_cwd", encoding="utf-8")
+
+        # File in batch_parent (tmp_path / "batches" / "project" / "dataset.yml")
+        batch_project = batch_parent / "project"
+        batch_project.mkdir()
+        batch_file = batch_project / "dataset.yml"
+        batch_file.write_text("from_batch_parent", encoding="utf-8")
+
+        configs_file.write_text("project/dataset.yml\n", encoding="utf-8")
+
+        # Cambia CWD a tmp_path e verifica che prenda cwd_file
+        monkeypatch.chdir(tmp_path)
+        result = _read_config_list(configs_file)
+        assert len(result) == 1
+        assert result[0] == cwd_file.resolve()
+        assert result[0].read_text() == "from_cwd"
+
+    def test_relative_path_fallback_to_batch_parent(self, tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Se il path relativo NON esiste in CWD, viene usato il parent del batch."""
+        batch_parent = tmp_path / "batches"
+        batch_parent.mkdir()
+        configs_file = batch_parent / "configs.txt"
+
+        # File solo nel batch_parent
+        batch_project = batch_parent / "project"
+        batch_project.mkdir()
+        batch_file = batch_project / "dataset.yml"
+        batch_file.write_text("from_batch_parent", encoding="utf-8")
+
+        configs_file.write_text("project/dataset.yml\n", encoding="utf-8")
+
+        # CWD è tmp_path dove NON esiste project/dataset.yml
+        monkeypatch.chdir(tmp_path)
+        result = _read_config_list(configs_file)
+        assert len(result) == 1
+        assert result[0] == batch_file.resolve()
+        assert result[0].read_text() == "from_batch_parent"
+
     def test_multiple_paths_with_comments_and_blanks(
         self, tmp_path: pytest.TempPathFactory
     ) -> None:

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -12,7 +12,7 @@ import typer
 from toolkit.cli.common import load_cfg_and_logger
 from toolkit.cli.cmd_run import run_year
 
-_ALLOWED_STEPS = {"raw", "clean", "mart", "all"}
+_ALLOWED_STEPS = {"probe", "raw", "clean", "mart", "all"}
 
 
 @contextlib.contextmanager
@@ -52,7 +52,14 @@ def _read_config_list(configs_file: Path) -> list[Path]:
 
         config_path = Path(line)
         if not config_path.is_absolute():
-            config_path = (configs_file.parent / config_path).resolve()
+            # Risolvi prima rispetto alla CWD (caso d'uso normale:
+            # lancio da root progetto con path relativi al root),
+            # poi rispetto al file batch come fallback.
+            cwd_resolved = (Path.cwd() / config_path).resolve()
+            if cwd_resolved.exists():
+                config_path = cwd_resolved
+            else:
+                config_path = (configs_file.parent / config_path).resolve()
         config_paths.append(config_path)
 
     if not config_paths:
@@ -111,7 +118,7 @@ def batch(
     configs: str = typer.Option(
         ..., "--configs", help="Path to a text file with one dataset.yml path per line"
     ),
-    step: str = typer.Option("all", "--step", help="raw | clean | mart | all"),
+    step: str = typer.Option("all", "--step", help="probe | raw | clean | mart | all"),
     smoke: bool = typer.Option(
         False, "--smoke", help="Alias per --sample-rows 1000 --sample-bytes 1048576"
     ),
@@ -137,7 +144,7 @@ def batch(
     con # sono ignorati) e li esegue uno dopo l'altro per lo step indicato.
     """
     if step not in _ALLOWED_STEPS:
-        raise typer.BadParameter("step must be one of: raw, clean, mart, all")
+        raise typer.BadParameter("step must be one of: probe, raw, clean, mart, all")
 
     dry_flag = dry_run if isinstance(dry_run, bool) else False
     sample_rows_final = 1000 if smoke else sample_rows


### PR DESCRIPTION
## Cosa

Aggiunge `"probe"` agli step permessi in `toolkit batch`, così si può usare:

```bash
toolkit batch --configs batches/green.txt --step probe --json report.json
```

Invece di eseguire l'intera pipeline (raw → clean → mart), esegue solo `toolkit run probe` su ogni candidate: verifica raggiungibilità HTTP/CKAN, salta SDMX/SPARQL (non timeoutano), non blocca mai.

Serve per sostituire il weekly smoke test in dataset-incubator con un probe leggero.

## Modifiche

- `toolkit/cli/cmd_batch.py`:
  - Aggiunto `"probe"` a `_ALLOWED_STEPS`
  - Aggiornato help e messaggio errore
  - Fixato `_read_config_list`: i path relativi vengono risolti prima rispetto alla CWD, poi rispetto al file batch come fallback. I path nei file batch sono tipicamente relativi al root del progetto, non alla directory del file batch.

## Test

```bash
cd dataset-incubator
python -m toolkit.cli.app batch --configs batches/green.txt --step probe --json
# 91 run totali (27 candidate × anni), 0 failed
```