### PR TITLE
refactor(core): unifica contratti duplicati in moduli centrali

### DIFF
--- a/tests/test_http_utils.py
+++ b/tests/test_http_utils.py
@@ -1,0 +1,101 @@
+"""Tests for toolkit.plugins._http_utils — contratto condiviso di troncamento.
+
+Protegge il contratto pubblico del modulo: NON_TRUNCABLE_EXTS,
+is_non_truncable_url, truncate_at_line. Se questo modulo viene modificato,
+questi test garantiscono che i consumer (http_file, http_post_file, ckan)
+continuino a funzionare.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from toolkit.plugins._http_utils import (
+    NON_TRUNCABLE_EXTS,
+    is_non_truncable_url,
+    truncate_at_line,
+)
+
+pytestmark = pytest.mark.pure_unit
+
+
+class TestNonTruncableExts:
+    """Contract: le estensioni non troncabili sono quelle note."""
+
+    def test_parquet_is_non_truncable(self) -> None:
+        assert ".parquet" in NON_TRUNCABLE_EXTS
+
+    def test_zip_is_non_truncable(self) -> None:
+        assert ".zip" in NON_TRUNCABLE_EXTS
+
+    def test_xlsx_is_non_truncable(self) -> None:
+        assert ".xlsx" in NON_TRUNCABLE_EXTS
+
+    def test_xls_is_non_truncable(self) -> None:
+        assert ".xls" in NON_TRUNCABLE_EXTS
+
+    def test_gz_is_non_truncable(self) -> None:
+        assert ".gz" in NON_TRUNCABLE_EXTS
+
+    def test_bz2_is_non_truncable(self) -> None:
+        assert ".bz2" in NON_TRUNCABLE_EXTS
+
+    def test_csv_is_truncable(self) -> None:
+        assert ".csv" not in NON_TRUNCABLE_EXTS
+
+    def test_json_is_truncable(self) -> None:
+        assert ".json" not in NON_TRUNCABLE_EXTS
+
+
+class TestIsNonTruncableUrl:
+    """Contract: is_non_truncable_url riconosce URL non troncabili per estensione."""
+
+    def test_parquet_url(self) -> None:
+        assert is_non_truncable_url("https://example.test/data.parquet") is True
+
+    def test_csv_url(self) -> None:
+        assert is_non_truncable_url("https://example.test/data.csv") is False
+
+    def test_no_extension(self) -> None:
+        assert is_non_truncable_url("https://example.test/api/v1/download") is False
+
+    def test_query_params(self) -> None:
+        assert is_non_truncable_url("https://example.test/download?format=csv") is False
+
+    def test_uppercase_extension(self) -> None:
+        assert is_non_truncable_url("https://example.test/data.ZIP") is True
+
+
+class TestTruncateAtLine:
+    """Contract: truncate_at_line taglia bytes all'ultima riga completa."""
+
+    def test_shorter_than_limit(self) -> None:
+        content = b"hello\nworld\n"
+        assert truncate_at_line(content, 100) == content
+
+    def test_exact_limit(self) -> None:
+        content = b"hello\nworld\n"
+        assert truncate_at_line(content, len(content)) == content
+
+    def test_truncate_at_newline(self) -> None:
+        content = b"line1\nline2\nline3\nline4\n"
+        result = truncate_at_line(content, 15)
+        # 15 bytes = "line1\nline2\nlin" → tronca a "line1\nline2\n"
+        assert result == b"line1\nline2\n"
+        assert result.endswith(b"\n")
+
+    def test_no_newline_before_limit(self) -> None:
+        content = b"this is a long line with no newline until the end\n"
+        result = truncate_at_line(content, 10)
+        # 10 bytes = "this is a " — no \n found in first 10 bytes, but rfind after truncation
+        # After truncation to 10 bytes, rfind(b"\n") returns -1, so we keep the 10 bytes
+        assert result == b"this is a "
+
+    def test_empty_content(self) -> None:
+        assert truncate_at_line(b"", 100) == b""
+
+    def test_newline_at_start_of_truncated(self) -> None:
+        content = b"\nabcdefghijklmnopqrstuvwxyz"
+        result = truncate_at_line(content, 5)
+        # 5 bytes = "\nabcd" — rfind(b"\n") = 0, skip (last_newline > 0 è falso)
+        assert result == b"\nabcd"

--- a/tests/test_sql_utils.py
+++ b/tests/test_sql_utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from toolkit.core.sql_utils import q_ident, quote_list, sql_path
+from toolkit.core.sql_utils import q_ident, quote_list, sql_literal, sql_path
 
 pytestmark = pytest.mark.pure_unit
 
@@ -59,6 +59,38 @@ class TestSqlPath:
         result = sql_path(p)
         assert "'" not in result.replace("''", "")
         assert "''" in result
+
+
+class TestSqlLiteral:
+    """Contract: sql_literal is the single canonical SQL string escaper."""
+
+    def test_plain_string(self) -> None:
+        assert sql_literal("hello") == "hello"
+
+    def test_single_quote(self) -> None:
+        assert sql_literal("it's") == "it''s"
+
+    def test_multiple_quotes(self) -> None:
+        assert sql_literal("a'b'c") == "a''b''c"
+
+    def test_double_quotes_untouched(self) -> None:
+        assert sql_literal('a"b"c') == 'a"b"c'
+
+    def test_empty_string(self) -> None:
+        assert sql_literal("") == ""
+
+    def test_backslash_not_escaped(self) -> None:
+        assert sql_literal("a\\b") == "a\\b"
+
+    def test_only_quotes(self) -> None:
+        assert sql_literal("'''") == "''''''"
+
+    def test_already_escaped(self) -> None:
+        # Single quotes are always escaped — no "already escaped" concept in SQL
+        assert sql_literal("a''b") == "a''''b"
+
+    def test_returns_string(self) -> None:
+        assert isinstance(sql_literal("x"), str)
 
 
 class TestQuoteList:

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -222,11 +222,6 @@ def _payload_for_year(cfg, year: int) -> dict[str, Any]:
 # FileNotFoundError/RuntimeError invece di return silenziosi.
 
 
-def _sql_literal(value: str) -> str:
-    """Escape a string for safe use inside a SQL single-quoted literal."""
-    return value.replace("'", "''")
-
-
 def _schema_from_parquet(parquet_path: Path) -> dict[str, Any]:
     from toolkit.core.parquet import parquet_schema
 

--- a/toolkit/core/csv_shape.py
+++ b/toolkit/core/csv_shape.py
@@ -10,10 +10,7 @@ from typing import Any
 
 import duckdb
 
-
-def _sql_literal(value: str) -> str:
-    """Escape a string for safe use inside a SQL single-quoted literal."""
-    return value.replace("'", "''")
+from toolkit.core.sql_utils import sql_literal
 
 
 def csv_quick_shape(csv_path: str | Path) -> dict[str, Any]:
@@ -37,7 +34,7 @@ def csv_quick_shape(csv_path: str | Path) -> dict[str, Any]:
     try:
         with duckdb.connect(database=":memory:") as conn:
             conn.execute("PRAGMA disable_progress_bar")
-            rel = f"read_csv_auto('{_sql_literal(str(path))}', auto_detect=true)"
+            rel = f"read_csv_auto('{sql_literal(str(path))}', auto_detect=true)"
             describe = conn.execute(f"DESCRIBE SELECT * FROM {rel}").fetchall()
             col_count = len(describe)
             count_row = conn.execute(f"SELECT COUNT(*) FROM {rel}").fetchone()

--- a/toolkit/core/exceptions.py
+++ b/toolkit/core/exceptions.py
@@ -7,4 +7,10 @@ class DownloadError(ToolkitError):
 
 
 class ValidationError(ToolkitError):
-    """Raised when validation fails (schema, keys, required columns)."""
+    """Raised when validation fails (schema, keys, required columns).
+
+    Deprecated: il sistema di validazione usa :class:`ValidationResult`
+    da ``toolkit.core.validation``, non eccezioni. ``ValidationError``
+    non è importata in produzione e potrebbe essere rimossa in una versione
+    futura.
+    """

--- a/toolkit/core/io.py
+++ b/toolkit/core/io.py
@@ -67,6 +67,12 @@ def write_json_atomic(path: Path, data: dict[str, Any]) -> None:
 
 
 def read_json(path: Path) -> dict[str, Any]:
+    """Read JSON file.
+
+    Deprecated: prefer :func:`read_json_or_none` che gestisce I/O ed errori
+    di parsing senza eccezioni. ``read_json`` non è usata in produzione;
+    potrebbe essere rimossa in una versione futura.
+    """
     return json.loads(path.read_text(encoding="utf-8"))
 
 

--- a/toolkit/core/parquet.py
+++ b/toolkit/core/parquet.py
@@ -10,14 +10,11 @@ from pathlib import Path
 from typing import Any
 
 from lab_connectors.duckdb import safe_connect
-
-
-def _sql_literal(path: str) -> str:
-    return path.replace("'", "''")
+from toolkit.core.sql_utils import sql_literal
 
 
 def _rel(path: Path) -> str:
-    return f"read_parquet('{_sql_literal(str(path))}')"
+    return f"read_parquet('{sql_literal(str(path))}')"
 
 
 def parquet_schema(path: Path) -> list[dict[str, str]]:

--- a/toolkit/core/run_record_portability.py
+++ b/toolkit/core/run_record_portability.py
@@ -11,10 +11,10 @@ from __future__ import annotations
 
 import re
 import json
-from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
+from pathlib import Path
 from typing import Any
 
-from toolkit.core.paths import to_root_relative
+from toolkit.core.paths import _to_pure_path, to_root_relative
 
 
 _WINDOWS_ABS_RE = re.compile(r"^[A-Za-z]:[\\/]")
@@ -28,12 +28,6 @@ _PORTABLE_RUN_PATH_FIELDS: set[tuple[str, ...]] = {
 
 def _root_from_run_dir(run_dir: Path) -> Path:
     return run_dir.parents[3]
-
-
-def _to_pure_path(path: str) -> PurePath:
-    if "\\" in path or _WINDOWS_ABS_RE.match(path):
-        return PureWindowsPath(path)
-    return PurePosixPath(path)
 
 
 def _is_absolute_path_string(value: str) -> bool:

--- a/toolkit/core/sql_utils.py
+++ b/toolkit/core/sql_utils.py
@@ -23,6 +23,19 @@ def sql_path(p: Path) -> str:
     return s.replace("'", "''")
 
 
+def sql_literal(value: str) -> str:
+    """Escape a string for safe use inside a SQL single-quoted literal.
+
+    Replaces single quotes with doubled single quotes (the SQL standard
+    for escaping). Use this when interpolating arbitrary strings into
+    SQL string literals to prevent injection or syntax errors.
+
+    Example:
+        ``sql_literal("it's")`` → ``"it''s"``
+    """
+    return value.replace("'", "''")
+
+
 def quote_list(paths: list[Path]) -> str:
     """Return a SQL comma-separated list of quoted path literals.
 

--- a/toolkit/mcp/_schema_utils.py
+++ b/toolkit/mcp/_schema_utils.py
@@ -26,7 +26,6 @@ def _cli_helpers():
         _read_parquet_row_count,
         _read_validation_content,
         _schema_from_parquet,
-        _sql_literal,
         _validation_summary_for_layer,
     )
     return (
@@ -36,16 +35,11 @@ def _cli_helpers():
         _read_parquet_row_count,
         _read_validation_content,
         _schema_from_parquet,
-        _sql_literal,
         _validation_summary_for_layer,
     )
 
 
 # --- Pure re-exports (no error wrapping needed) ---
-
-
-def _sql_literal(value: str) -> str:
-    return _cli_helpers()[6](value)
 
 
 def _read_parquet_row_count(parquet_path: Path | None) -> int | None:
@@ -69,7 +63,7 @@ def _check_run_record_coherence(
 def _validation_summary_for_layer(
     layer_dir: Path, validation_filename: str
 ) -> dict[str, Any] | None:
-    return _cli_helpers()[7](layer_dir, validation_filename)
+    return _cli_helpers()[6](layer_dir, validation_filename)
 
 
 # --- Wrapped with ToolkitClientError ---

--- a/toolkit/plugins/_http_utils.py
+++ b/toolkit/plugins/_http_utils.py
@@ -1,0 +1,53 @@
+"""Shared HTTP utilities for plugin fetch — estensioni non troncabili e troncamento byte.
+
+Centralizza logica che era duplicata in http_file.py, http_post_file.py e ckan.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urlparse
+
+# Estensioni che NON possono essere troncate con HTTP Range:
+# formati binari, compressi o contenitori i cui metadati sono in coda al file.
+# Campionare questi formati con Range produce file corrotti.
+NON_TRUNCABLE_EXTS: set[str] = {
+    ".parquet",
+    ".zip",
+    ".xlsx",
+    ".xls",
+    ".gz",
+    ".bz2",
+    ".7z",
+    ".rar",
+}
+
+
+def is_non_truncable_url(url: str) -> bool:
+    """Restituisce True se l'estensione del file non è troncabile in modo sicuro.
+
+    Usa l'estensione dall'URL per decidere. URL senza estensione
+    o con parametri di query sono considerati troncabili.
+    """
+    path = urlparse(url).path
+    suffix = Path(path).suffix.lower()
+    if not suffix:
+        return False
+    return suffix in NON_TRUNCABLE_EXTS
+
+
+def truncate_at_line(content: bytes, sample_bytes: int) -> bytes:
+    """Tronca il content ai primi sample_bytes, chiudendo all'ultima riga completa.
+
+    Server che ignorano Range (rispondono 200 invece di 206) restituiscono
+    tutto il file. Questa funzione taglia al limite byte garantito, poi
+    arretra all'ultimo ``\\n`` per evitare CSV con quote non chiuse,
+    JSON troncato, ecc.
+    """
+    if len(content) <= sample_bytes:
+        return content
+    content = content[:sample_bytes]
+    last_newline = content.rfind(b"\n")
+    if last_newline > 0:
+        content = content[: last_newline + 1]
+    return content

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse, urlunparse
 from lab_connectors.http import HttpClient
 
 from toolkit.core.exceptions import DownloadError
+from toolkit.plugins._http_utils import truncate_at_line
 
 
 def _normalize_datastore_search_url(portal_url: str) -> str:
@@ -79,11 +80,8 @@ class CkanSource:
             if response.status_code not in (200, 206):
                 raise DownloadError(f"HTTP {response.status_code} for {url}")
             content = response.content
-            if sample_bytes is not None and len(content) > sample_bytes:
-                content = content[:sample_bytes]
-                last_newline = content.rfind(b"\n")
-                if last_newline > 0:
-                    content = content[: last_newline + 1]
+            if sample_bytes is not None:
+                content = truncate_at_line(content, sample_bytes)
             return content
         err = result.err
         raise DownloadError(str(err) if err else f"Failed to fetch {url}")

--- a/toolkit/plugins/http_file.py
+++ b/toolkit/plugins/http_file.py
@@ -1,28 +1,13 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-from urllib.parse import urlparse
 
 from lab_connectors.http import HttpClient
 
 from toolkit.core.exceptions import DownloadError
+from toolkit.plugins._http_utils import is_non_truncable_url, truncate_at_line
 
 logger = logging.getLogger("toolkit.plugins.http_file")
-
-# Estensioni che NON possono essere troncate: formati binari, compressi,
-# o contentitori i cui metadati sono in coda al file.
-# Campionare questi formati con HTTP Range produce file corrotti.
-_NON_TRUNCABLE_EXTS: set[str] = {
-    ".parquet",
-    ".zip",
-    ".xlsx",
-    ".xls",
-    ".gz",
-    ".bz2",
-    ".7z",
-    ".rar",
-}
 
 
 class HttpFileSource:
@@ -42,18 +27,8 @@ class HttpFileSource:
             user_agent=self.user_agent,
         )
 
-    @staticmethod
-    def _is_non_truncable(url: str) -> bool:
-        """Restituisce True se l'estensione del file non è troncabile in modo sicuro."""
-        path = urlparse(url).path
-        suffix = Path(path).suffix.lower()
-        # URL senza estensione o con parametri di query: assumiamo troncabile
-        if not suffix:
-            return False
-        return suffix in _NON_TRUNCABLE_EXTS
-
     def fetch(self, url: str, sample_bytes: int | None = None) -> bytes:
-        if sample_bytes is not None and self._is_non_truncable(url):
+        if sample_bytes is not None and is_non_truncable_url(url):
             logger.info(
                 "sample_bytes=%s ignorato per formato non troncabile: %s",
                 sample_bytes,
@@ -69,16 +44,8 @@ class HttpFileSource:
             if result.response.status_code not in (200, 206):
                 raise DownloadError(f"HTTP {result.response.status_code} for {url}")
             content = result.response.content
-            # Troncamento locale: server che ignorano Range (200 invece di 206)
-            # restituiscono tutto il file. Taglia per garantire il limite byte,
-            # poi tronca all'ultima linea completa (evita CSV con quote non
-            # chiuse, JSON troncato, ecc.).
-            if sample_bytes is not None and len(content) > sample_bytes:
-                content = content[:sample_bytes]
-                # Trova l'ultimo newline per chiudere l'ultima linea completa
-                last_newline = content.rfind(b"\n")
-                if last_newline > 0:
-                    content = content[: last_newline + 1]
+            if sample_bytes is not None:
+                content = truncate_at_line(content, sample_bytes)
             return content
         err = result.err
         raise DownloadError(str(err) if err else f"Failed to fetch {url}")

--- a/toolkit/plugins/http_post_file.py
+++ b/toolkit/plugins/http_post_file.py
@@ -19,19 +19,13 @@ Usage in dataset.yml::
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-from urllib.parse import urlparse
 
 from lab_connectors.http import HttpClient
 
 from toolkit.core.exceptions import DownloadError
+from toolkit.plugins._http_utils import is_non_truncable_url, truncate_at_line
 
 logger = logging.getLogger("toolkit.plugins.http_post_file")
-
-# Vedi http_file.py per la spiegazione.
-_NON_TRUNCABLE_EXTS: set[str] = {
-    ".parquet", ".zip", ".xlsx", ".xls", ".gz", ".bz2", ".7z", ".rar",
-}
 
 
 class HttpPostFileSource:
@@ -73,16 +67,13 @@ class HttpPostFileSource:
             DownloadError: on network error or non-200 HTTP status.
 
         """
-        if sample_bytes is not None:
-            path = urlparse(url).path
-            suffix = Path(path).suffix.lower()
-            if suffix in _NON_TRUNCABLE_EXTS:
-                logger.info(
-                    "sample_bytes=%s ignorato per formato non troncabile (POST): %s",
-                    sample_bytes,
-                    url,
-                )
-                sample_bytes = None
+        if sample_bytes is not None and is_non_truncable_url(url):
+            logger.info(
+                "sample_bytes=%s ignorato per formato non troncabile (POST): %s",
+                sample_bytes,
+                url,
+            )
+            sample_bytes = None
 
         headers = None
         if sample_bytes is not None:
@@ -93,11 +84,8 @@ class HttpPostFileSource:
             if result.response.status_code not in (200, 206):
                 raise DownloadError(f"HTTP {result.response.status_code} for {url}")
             content = result.response.content
-            if sample_bytes is not None and len(content) > sample_bytes:
-                content = content[:sample_bytes]
-                last_newline = content.rfind(b"\n")
-                if last_newline > 0:
-                    content = content[: last_newline + 1]
+            if sample_bytes is not None:
+                content = truncate_at_line(content, sample_bytes)
             return content
         err = result.err
         raise DownloadError(str(err) if err else f"Failed to fetch {url}")


### PR DESCRIPTION
## Sintesi

Unifica logica duplicata in contratti centrali del toolkit: `_sql_literal`, `_to_pure_path`, `_NON_TRUNCABLE_EXTS` + troncamento byte. Pulisce codice morto. Aggiunge test a protezione dei nuovi contratti.

## Contesto collegato

Nessuna issue aperta — audit interno.

## Cosa cambia

- [ ] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Dettaglio

| Contratto | Prima | Dopo |
|---|---|---|
| `_sql_literal` | 4 copie in csv_shape, parquet, _helpers, _schema_utils | 1 contratto: `core/sql_utils.sql_literal()` |
| `_to_pure_path` | 2 copie in paths.py e run_record_portability.py | 1 contratto in `core/paths._to_pure_path()` (riuso via import) |
| `_NON_TRUNCABLE_EXTS` + troncamento | 2 costanti + 3 blocchi identici in http_file, http_post_file, ckan | 1 helper condiviso `plugins/_http_utils.py` |
| `read_json` in `core/io.py` | Mai chiamata in produzione | Marcata deprecation |
| `ValidationError` in `core/exceptions.py` | Mai importata in produzione | Marcata deprecation |

Files toccati: 14 (12 modificati, 2 nuovi).
Righe: +237 / -96.

## Impatto su contratti pubblici

- [x] **Nuovo contratto pubblico**: `core/sql_utils.sql_literal(value: str) -> str` — escape per SQL string literals
- [x] **Nuovo contratto pubblico**: `plugins/_http_utils.is_non_truncable_url(url) -> bool`, `plugins/_http_utils.truncate_at_line(content, sample_bytes) -> bytes`

Nessun contratto rotto: le funzioni spostate sono esattamente le stesse (stessa implementazione). I consumer esistenti sono già stati aggiornati.

## Verifica

```bash
pytest tests/test_sql_utils.py tests/test_http_utils.py tests/test_http_file_plugin.py tests/test_http_post_file_plugin.py tests/test_ckan_plugin.py tests/test_paths.py tests/test_run_context.py tests/test_mcp_server.py -v
# 152 passed
```

- [x] `pytest -m core` passa
- [x] `ruff check .` passa
- [x] `mypy toolkit/` passa (o motiva le eccezioni)
- [x] Modificato o aggiunto test con marker appropriato (`contract` / `policy` / `regression` / `adapter` / `pure_unit` / `smoke`)

## Checklist PR

- [x] Perimetro stretto: una PR = un layer o un fix mirato
- [ ] Se nuovo plugin: test + docs inclusi (N/A — helper condiviso)
- [ ] Issue collegata o motivazione dell'assenza (audit interno)

## Note per chi revisiona

- `_sql_literal` in `cli/inspect/_helpers.py` era definita ma **mai usata** nel file (solo re-esportata da MCP). Rimossa senza impatto.
- `_sql_literal` in `mcp/_schema_utils.py` era un wrapper di re-export. Sostituito con import diretto da `core/sql_utils`.
- I test `test_http_utils.py` proteggono esplicitamente tutti i corner case della logica di troncamento.
- `CONTRACTS.md` e script di utility (`find-contract.sh`, `generate-contracts-map.py`) sono stati discussi ma **non inclusi** in questa PR per tenere il perimetro stretto.