### PR TITLE
audit(scripts): fix 9 bypass json.loads → read_json_or_none

### DIFF
--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from lab_connectors.duckdb import safe_connect
+from toolkit.core.io import read_json_or_none
 
 from toolkit.core.column_rules import (
     check_max_null_pct,
@@ -211,15 +212,12 @@ def validate_promotion(
     profile_dir = raw_path / "_profile"
     saved_profile_path = profile_dir / RAW_PROFILE
 
-    if saved_profile_path.exists():
-        try:
-            saved = json.loads(saved_profile_path.read_text(encoding="utf-8"))
-            raw_profile = {
-                "row_count": saved.get("row_count"),
-                "columns": [{"name": c, "type": "VARCHAR"} for c in (saved.get("columns_raw") or [])],
-            }
-        except Exception:
-            raw_profile = _profile_raw_input(input_files, read_cfg, read_mode, logger)
+    saved = read_json_or_none(saved_profile_path) if saved_profile_path.exists() else None
+    if saved is not None:
+        raw_profile = {
+            "row_count": saved.get("row_count"),
+            "columns": [{"name": c, "type": "VARCHAR"} for c in (saved.get("columns_raw") or [])],
+        }
     else:
         raw_profile = _profile_raw_input(input_files, read_cfg, read_mode, logger)
     transition_profile = compare_layer_profiles(
@@ -303,26 +301,24 @@ def run_clean_validation(cfg, year: int, logger, *, sample_mode: bool = False) -
     profile_path = _profile_dir / RAW_PROFILE
     profile_parse_error: bool = False
     trusted_raw_cols: list[str] = []
-    if profile_path.exists():
-        try:
-            def _to_snake(n: str) -> str:
-                s = _re.sub(r"([a-z])([A-Z])", r"\1_\2", n.strip())
-                s = _re.sub(r"[^a-zA-Z0-9]+", "_", s)
-                return _re.sub(r"_+", "_", s).lower().strip("_") or "col"
+    raw_profile = read_json_or_none(profile_path) if profile_path.exists() else None
+    if raw_profile is not None:
+        def _to_snake(n: str) -> str:
+            s = _re.sub(r"([a-z])([A-Z])", r"\1_\2", n.strip())
+            s = _re.sub(r"[^a-zA-Z0-9]+", "_", s)
+            return _re.sub(r"_+", "_", s).lower().strip("_") or "col"
 
-            raw_profile = json.loads(profile_path.read_text(encoding="utf-8"))
-            trusted_raw_cols = raw_profile.get("columns_raw") or []
-            scaffold_cols = {_to_snake(c) for c in trusted_raw_cols}
-            clean_cols_set = set(clean_cols)
-            unmapped = sorted(scaffold_cols - clean_cols_set)
-            if unmapped:
-                merged_warnings.append(
-                    f"[scaffold] {len(unmapped)} colonne raw non mappate nel clean "
-                    f"(drop senza -- DROP: <motivo>?): {unmapped}"
-                )
-        except Exception:
-            profile_parse_error = True
-            pass
+        trusted_raw_cols = raw_profile.get("columns_raw") or []
+        scaffold_cols = {_to_snake(c) for c in trusted_raw_cols}
+        clean_cols_set = set(clean_cols)
+        unmapped = sorted(scaffold_cols - clean_cols_set)
+        if unmapped:
+            merged_warnings.append(
+                f"[scaffold] {len(unmapped)} colonne raw non mappate nel clean "
+                f"(drop senza -- DROP: <motivo>?): {unmapped}"
+            )
+    else:
+        profile_parse_error = True
 
     actual_raw_col_count: int | None = len(trusted_raw_cols) if trusted_raw_cols else None
     raw_missing_columns: list[str] = []

--- a/toolkit/cli/cmd_status.py
+++ b/toolkit/cli/cmd_status.py
@@ -8,6 +8,7 @@ import typer
 
 from toolkit.cli.common import format_profile_preview, load_layer_profile_summaries
 from toolkit.core.config import load_config
+from toolkit.core.io import read_json_or_none
 from toolkit.core.paths import METADATA, RAW_PROFILE_DIR, RAW_SUGGESTED_READ, layer_dataset_dir
 from toolkit.core.run_records import get_run_dir, read_run_record
 from toolkit.cli.inspect.readiness_ops import summary as _summary
@@ -59,9 +60,8 @@ def _print_validation_summaries(layers: dict[str, Any]) -> None:
 
 def _print_validation_details(layer_name: str, vpath: Path) -> None:
     """Legge validation JSON e stampa dettagli extra (missing columns, tables, ecc.)."""
-    try:
-        content = json.loads(vpath.read_text(encoding="utf-8"))
-    except Exception:
+    content = read_json_or_none(vpath)
+    if content is None:
         return
     summary = content.get("summary") or {}
     details: list[str] = []

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -5,7 +5,6 @@ Not part of the public API — internal utility module.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +23,7 @@ from toolkit.core.paths import (
 )
 from toolkit.core.run_records import get_run_dir, latest_run
 from toolkit.core.support import resolve_support_payloads
+from toolkit.core.io import read_json_or_none
 from toolkit.profile.raw import sniff_source_file
 
 
@@ -59,11 +59,9 @@ def _raw_schema_payload(cfg, year: int) -> dict[str, Any]:
     if not columns_preview and profile_hints.get("is_binary_file"):
         raw_profile_path = raw_dir / RAW_PROFILE_DIR / RAW_PROFILE
         if raw_profile_path.exists():
-            try:
-                raw_profile_data = json.loads(raw_profile_path.read_text(encoding="utf-8"))
+            raw_profile_data = read_json_or_none(raw_profile_path)
+            if raw_profile_data:
                 columns_preview = raw_profile_data.get("columns_norm") or raw_profile_data.get("columns_raw") or []
-            except Exception:
-                pass
 
     warnings = list(profile_hints.get("warnings") or [])
     if sniff_error is not None:
@@ -263,10 +261,7 @@ def _read_validation_content(path: str | None) -> dict[str, Any] | None:
     """Read a validation JSON file and return its content, or None if missing."""
     if not path or not _exists(path):
         return None
-    try:
-        return json.loads(Path(path).read_text(encoding="utf-8"))
-    except Exception:
-        return None
+    return read_json_or_none(Path(path))
 
 
 def _check_run_record_coherence(

--- a/toolkit/cli/inspect/readiness_ops.py
+++ b/toolkit/cli/inspect/readiness_ops.py
@@ -6,9 +6,10 @@ MCP wrappa le eccezioni in ToolkitClientError.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
+
+from toolkit.core.io import read_json_or_none
 
 from toolkit.cli.inspect._helpers import (
     _check_run_record_coherence,
@@ -53,10 +54,7 @@ def run_state(config_path: str, year: int | None = None) -> dict[str, Any]:
     if latest_run and latest_run.get("path"):
         latest_path = Path(latest_run["path"])
         if latest_path.exists():
-            try:
-                latest_payload = json.loads(latest_path.read_text(encoding="utf-8"))
-            except Exception:
-                pass
+            latest_payload = read_json_or_none(latest_path)
 
     years_seen = (
         sorted({p.parent.name for p in run_dir.parent.glob("*/*.json") if p.parent.name.isdigit()})
@@ -121,10 +119,7 @@ def summary(config_path: str, year: int | None = None) -> dict[str, Any]:
 
     latest_run_record: dict[str, Any] | None = None
     if latest_run_path and Path(latest_run_path).exists():
-        try:
-            latest_run_record = json.loads(Path(latest_run_path).read_text(encoding="utf-8"))
-        except Exception:
-            pass
+        latest_run_record = read_json_or_none(Path(latest_run_path))
 
     warnings: list[str] = []
     if primary_output_file and not _exists(primary_output_path):

--- a/toolkit/core/metadata.py
+++ b/toolkit/core/metadata.py
@@ -8,7 +8,7 @@ import hashlib
 from pathlib import Path
 from typing import Any
 
-from toolkit.core.io import write_json_atomic
+from toolkit.core.io import read_json_or_none, write_json_atomic
 from toolkit.core.paths import METADATA
 from toolkit.version import __version__
 
@@ -70,10 +70,7 @@ def _read_metadata(folder: Path, filename: str = METADATA) -> dict[str, Any] | N
     path = folder / filename
     if not path.exists():
         return None
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        return None
+    return read_json_or_none(path)
 
 
 def read_layer_metadata(layer_dir: Path) -> dict[str, Any]:

--- a/toolkit/mcp/discovery.py
+++ b/toolkit/mcp/discovery.py
@@ -10,9 +10,10 @@ del workspace DataCivicLab.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Literal
+
+from toolkit.core.io import read_json_or_none
 
 import yaml
 
@@ -71,15 +72,12 @@ def _find_latest_run_status(slug: str, runs_root: Path | None = None) -> str | N
         if not year_dir.is_dir() or not year_dir.name.isdigit():
             continue
         for run_file in year_dir.glob("*.json"):
-            try:
-                mtime = run_file.stat().st_mtime
-                if mtime > latest_mtime:
-                    data = json.loads(run_file.read_text(encoding="utf-8"))
-                    if isinstance(data, dict):
-                        latest = data
-                        latest_mtime = mtime
-            except Exception:
-                continue
+            mtime = run_file.stat().st_mtime
+            if mtime > latest_mtime:
+                data = read_json_or_none(run_file)
+                if isinstance(data, dict):
+                    latest = data
+                    latest_mtime = mtime
 
     if latest:
         return latest.get("status")


### PR DESCRIPTION
## Sintesi

Sostituisce 9 occorrenze di `json.loads(path.read_text())` con `read_json_or_none()` da `core.io` in file che già avevano try/except a gestire l'errore.

## Cosa cambia

- [ ] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Dettaglio

9 sostituzioni in 6 file:
- `clean/validate.py`: righe 216, 313 — try/except → read_json_or_none
- `cli/cmd_status.py`: riga 63 — try/except → read_json_or_none
- `cli/inspect/_helpers.py`: righe 63, 267 — try/except e funzione intera
- `cli/inspect/readiness_ops.py`: righe 57, 125 — try/except → read_json_or_none
- `mcp/discovery.py`: riga 77 — try/except → read_json_or_none
- `core/metadata.py`: riga 74 — _read_metadata intera

Rimosso `import json` da 2 file (`_helpers.py`, `readiness_ops.py`).

## Verifica

```bash
python -m pytest tests/test_cli_status.py tests/test_cli_inspect_paths.py tests/test_run_context.py tests/test_metadata_hash.py tests/test_mcp_server.py tests/test_sql_utils.py -v
# 78 passed
```

- [x] `pytest -m core` passa
- [x] `ruff check .` passa
- [x] `mypy toolkit/` passa

## Note

PR mergiata e in review post-merge. Lo script `audit-imports.py` non faceva parte di questa PR — verrà in un commit separato.