### PR TITLE
fix(core): blocco A — ripristina profile_parse_error, usa sql_path per read_parquet

### DIFF
--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -10,6 +10,8 @@ from typing import Any
 from lab_connectors.duckdb import safe_connect
 from toolkit.core.io import read_json_or_none
 
+from toolkit.core.sql_utils import sql_path
+
 from toolkit.core.column_rules import (
     check_max_null_pct,
     check_not_null,
@@ -108,7 +110,9 @@ def validate_clean(
         )
 
     with safe_connect() as con:
-        con.execute(f"CREATE VIEW t AS SELECT * FROM read_parquet('{p.as_posix()}')")
+        con.execute(
+            f"CREATE VIEW t AS SELECT * FROM read_parquet('{sql_path(p)}')"
+        )
 
         cols = [r[0] for r in con.execute("DESCRIBE t").fetchall()]
 

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -352,12 +352,9 @@ def run_clean_validation(cfg, year: int, logger, *, sample_mode: bool = False) -
             try:
                 with safe_connect() as _con:
                     if _raw_file.suffix == ".parquet":
-                        _query = f'DESCRIBE SELECT * FROM read_parquet("{_raw_file.as_posix()}")'
+                        _query = f"DESCRIBE SELECT * FROM read_parquet('{sql_path(_raw_file)}')"
                     else:
-                        _csv_path = _raw_file.as_posix()
-                        _query = (
-                            f"DESCRIBE SELECT * FROM read_csv(\"{_csv_path}\", auto_detect=true)"
-                        )
+                        _query = f"DESCRIBE SELECT * FROM read_csv('{sql_path(_raw_file)}', auto_detect=true)"
                         raw_probe_source = "legacy_autodetect"
                         if raw_probe_reason:
                             merged_warnings.append(

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -301,24 +301,25 @@ def run_clean_validation(cfg, year: int, logger, *, sample_mode: bool = False) -
     profile_path = _profile_dir / RAW_PROFILE
     profile_parse_error: bool = False
     trusted_raw_cols: list[str] = []
-    raw_profile = read_json_or_none(profile_path) if profile_path.exists() else None
-    if raw_profile is not None:
-        def _to_snake(n: str) -> str:
-            s = _re.sub(r"([a-z])([A-Z])", r"\1_\2", n.strip())
-            s = _re.sub(r"[^a-zA-Z0-9]+", "_", s)
-            return _re.sub(r"_+", "_", s).lower().strip("_") or "col"
+    if profile_path.exists():
+        raw_profile = read_json_or_none(profile_path)
+        if raw_profile is not None:
+            def _to_snake(n: str) -> str:
+                s = _re.sub(r"([a-z])([A-Z])", r"\1_\2", n.strip())
+                s = _re.sub(r"[^a-zA-Z0-9]+", "_", s)
+                return _re.sub(r"_+", "_", s).lower().strip("_") or "col"
 
-        trusted_raw_cols = raw_profile.get("columns_raw") or []
-        scaffold_cols = {_to_snake(c) for c in trusted_raw_cols}
-        clean_cols_set = set(clean_cols)
-        unmapped = sorted(scaffold_cols - clean_cols_set)
-        if unmapped:
-            merged_warnings.append(
-                f"[scaffold] {len(unmapped)} colonne raw non mappate nel clean "
-                f"(drop senza -- DROP: <motivo>?): {unmapped}"
-            )
-    else:
-        profile_parse_error = True
+            trusted_raw_cols = raw_profile.get("columns_raw") or []
+            scaffold_cols = {_to_snake(c) for c in trusted_raw_cols}
+            clean_cols_set = set(clean_cols)
+            unmapped = sorted(scaffold_cols - clean_cols_set)
+            if unmapped:
+                merged_warnings.append(
+                    f"[scaffold] {len(unmapped)} colonne raw non mappate nel clean "
+                    f"(drop senza -- DROP: <motivo>?): {unmapped}"
+                )
+        else:
+            profile_parse_error = True
 
     actual_raw_col_count: int | None = len(trusted_raw_cols) if trusted_raw_cols else None
     raw_missing_columns: list[str] = []

--- a/toolkit/mart/validate.py
+++ b/toolkit/mart/validate.py
@@ -15,6 +15,7 @@ from toolkit.core.column_rules import (
 from toolkit.core.config_models import MartTableRuleConfig, MartValidationSpec
 from toolkit.core.metadata import merge_layer_manifest
 from toolkit.core.paths import MART_VALIDATION, METADATA, layer_year_dir, to_root_relative
+from toolkit.core.sql_utils import sql_path
 from toolkit.core.validation import (
     ValidationResult,
     build_validation_summary,
@@ -92,7 +93,7 @@ def validate_mart(
             name = p.stem
 
             try:
-                rc = int(con.execute(f"SELECT COUNT(*) FROM read_parquet('{p.as_posix()}')").fetchone()[0])
+                rc = int(con.execute(f"SELECT COUNT(*) FROM read_parquet('{sql_path(p)}')").fetchone()[0])
                 row_counts[name] = rc
             except Exception as e:
                 warnings.append(f"Could not count rows for {p.name}: {e}")
@@ -106,7 +107,9 @@ def validate_mart(
             if min_rows is not None and rc < min_rows:
                 errors.append(f"[{name}] row_count too small: {rc} < {min_rows}")
 
-            con.execute(f"CREATE OR REPLACE VIEW t AS SELECT * FROM read_parquet('{p.as_posix()}')")
+            con.execute(
+                f"CREATE OR REPLACE VIEW t AS SELECT * FROM read_parquet('{sql_path(p)}')"
+            )
             cols = [r[0] for r in con.execute("DESCRIBE t").fetchall()]
 
             # required columns

--- a/toolkit/mcp/discovery.py
+++ b/toolkit/mcp/discovery.py
@@ -72,7 +72,10 @@ def _find_latest_run_status(slug: str, runs_root: Path | None = None) -> str | N
         if not year_dir.is_dir() or not year_dir.name.isdigit():
             continue
         for run_file in year_dir.glob("*.json"):
-            mtime = run_file.stat().st_mtime
+            try:
+                mtime = run_file.stat().st_mtime
+            except OSError:
+                continue
             if mtime > latest_mtime:
                 data = read_json_or_none(run_file)
                 if isinstance(data, dict):


### PR DESCRIPTION
## Blocco A — Fix bypass core

Unica PR che raggruppa:
1. **Fix post-merge #318** da review (validate.py + discovery.py)
2. **Path quoting** in `clean/validate.py` e `mart/validate.py`: `read_parquet('{p.as_posix()}')` → `read_parquet('{sql_path(p)}')`

## Cosa cambia

| File | Cosa |
|---|---|
| `clean/validate.py` | Distingue "file non esistente" da "parse fallito" per `profile_parse_error` + usa `sql_path()` per path quoting |
| `mart/validate.py` | Usa `sql_path()` per path quoting in `read_parquet()` |
| `mcp/discovery.py` | Ripristina try/except per `run_file.stat()` (tolleranza I/O) |

## Dettaglio review fix

- **validate.py:304**: prima ogni file non parsabile O inesistente settava `profile_parse_error=True`, rendendo irraggiungibile `no_profile_found`. Ora l'`if profile_path.exists()` separa i due casi.
- **discovery.py:75**: `stat()` era fuori dal try/except — se un file sparisce tra glob e stat, falliva.

## Verifica

```bash
pytest tests/test_validate_rules.py tests/test_mart_hierarchy.py tests/test_cli_status.py tests/test_mcp_server.py -v
# 42 passed
ruff check toolkit/clean/validate.py toolkit/mart/validate.py toolkit/mcp/discovery.py
# All checks passed
```

3 file, +33 / -22 righe.

## Prossimi blocchi

- B: Script (audit-imports.py, find-contract.sh, generate-contracts-map.py)
- C: Audit downstream