### PR TITLE
fix: downstream bypass - safe_connect e sql_path in CLI, core, mart

### DIFF
--- a/toolkit/cli/inspect/profile_ops.py
+++ b/toolkit/cli/inspect/profile_ops.py
@@ -12,8 +12,9 @@ from logging import Logger
 from pathlib import Path
 from typing import Any
 
-import duckdb
 import typer
+
+from lab_connectors.duckdb import safe_connect
 
 from toolkit.cli.common import dump_cfg_section, iter_selected_years, load_cfg_and_logger
 from toolkit.core.artifacts import should_write
@@ -69,7 +70,7 @@ def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
     read_opts = csv_read_option_strings(preview_cfg, include_header_skip=True)
     opt_sql = f"union_by_name=true, {', '.join(read_opts)}"
 
-    with duckdb.connect(database=":memory:") as conn:
+    with safe_connect() as conn:
         conn.execute("PRAGMA disable_progress_bar")
         conn.execute(
             f"CREATE VIEW csv_preview AS SELECT * FROM read_csv("

--- a/toolkit/core/layer_profile.py
+++ b/toolkit/core/layer_profile.py
@@ -6,7 +6,7 @@ from typing import Any
 import duckdb
 from lab_connectors.duckdb import safe_connect
 
-from toolkit.core.sql_utils import q_ident
+from toolkit.core.sql_utils import q_ident, sql_path
 
 
 def profile_relation(con: duckdb.DuckDBPyConnection, relation_name: str) -> dict[str, Any]:
@@ -27,10 +27,10 @@ def profile_parquet_files(files: list[Path]) -> dict[str, Any]:
     with safe_connect() as con:
         if len(files) == 1:
             con.execute(
-                f"CREATE VIEW profiled_input AS SELECT * FROM read_parquet('{files[0].as_posix()}')"
+                f"CREATE VIEW profiled_input AS SELECT * FROM read_parquet('{sql_path(files[0])}')"
             )
         else:
-            paths = ",".join(f"'{path.as_posix()}'" for path in files)
+            paths = ",".join(f"'{sql_path(p)}'" for p in files)
             con.execute(
                 f"CREATE VIEW profiled_input AS SELECT * FROM read_parquet([{paths}])"
             )

--- a/toolkit/core/multi_year_source.py
+++ b/toolkit/core/multi_year_source.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from toolkit.core.paths import layer_year_dir
+from toolkit.core.sql_utils import sql_path
 
 
 def collect_multi_year_files(
@@ -74,9 +75,9 @@ def bind_multi_year_view(con, files: list[Path], *, source_layer: str = "clean")
         source_layer: ``"clean"`` (default) or ``"mart"``.
     """
     if len(files) == 1:
-        source_expr = f"read_parquet('{files[0].as_posix()}')"
+        source_expr = f"read_parquet('{sql_path(files[0])}')"
     else:
-        paths = ",".join(f"'{p.as_posix()}'" for p in files)
+        paths = ",".join(f"'{sql_path(p)}'" for p in files)
         source_expr = f"read_parquet([{paths}])"
 
     # Views universali (sempre disponibili)

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -12,6 +12,7 @@ from toolkit.core.layer_profile import compare_layer_profiles, profile_relation,
 from toolkit.core.metadata import config_hash_for_year, file_record, merge_layer_manifest, write_metadata
 from toolkit.core.multi_year_source import bind_multi_year_view, collect_multi_year_files
 from toolkit.core.paths import MART_VALIDATION, layer_dataset_dir, layer_year_dir, resolve_root, resolve_sql_path, serialize_metadata_path
+from toolkit.core.sql_utils import sql_path as _sql_path_quote
 from toolkit.core.support import flatten_support_template_ctx, resolve_support_payloads
 from toolkit.core.template import build_runtime_template_ctx, public_template_ctx, render_template
 
@@ -326,9 +327,9 @@ def run_mart(
         if clean_files:
             # clean_input view
             if len(clean_files) == 1:
-                con.execute(f"CREATE VIEW clean_input AS SELECT * FROM read_parquet('{clean_files[0]}')")
+                con.execute(f"CREATE VIEW clean_input AS SELECT * FROM read_parquet('{_sql_path_quote(clean_files[0])}')")
             else:
-                paths = ",".join([f"'{p}'" for p in clean_files])
+                paths = ",".join([f"'{_sql_path_quote(p)}'" for p in clean_files])
                 con.execute(f"CREATE VIEW clean_input AS SELECT * FROM read_parquet([{paths}])")
 
             # alias for backward-compatible SQL (old templates may reference "clean")


### PR DESCRIPTION
## Sintesi

Fissa gli ultimi 5 bypass reali emersi dall'audit downstream. Nessuna logica cambiata.

## Cosa cambia

| File | Cosa | Motivo |
|---|---|---|
| `cli/inspect/profile_ops.py` | `duckdb.connect()` → `safe_connect()` | Usa il wrapper condiviso di lab-connectors |
| `core/layer_profile.py` | `files[0].as_posix()` → `sql_path(files[0])` | Path quoting corretto per SQL |
| `core/multi_year_source.py` | `files[0].as_posix()` → `sql_path(files[0])` | Path quoting corretto per SQL |
| `mart/run.py` | `clean_files[0]` → `_sql_path_quote(clean_files[0])` | Path quoting corretto per SQL (alias per conflitto nome con sql_path locale) |

## Verifica

```bash
pytest -m core -q
# 197 passed
ruff check .
# All checks passed
```