### PR TITLE
feat(core): dataset_loader — lettura leggera dataset.yml, centralizza pattern DI

### DIFF
--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -123,7 +123,7 @@ class TestDetectCandidateLayout:
         # Crea sql/mart.sql per farlo classificare come single_source
         (tmp_path / "sql").mkdir()
         (tmp_path / "sql" / "mart.sql").write_text("SELECT 1")
-        assert detect_candidate_layout(tmp_path) == "single_source"
+        assert detect_candidate_layout(tmp_path) == "single-source"
 
     def test_compose(self, tmp_path: Path) -> None:
         _write_dataset(tmp_path, {

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -1,7 +1,7 @@
 """Tests for toolkit.core.dataset_loader — contratto di lettura dataset.yml.
 
-Protegge il contratto pubblico: load_dataset_manifest, detect_candidate_layout,
-has_mart_sql. I test usano dataset.yml minimi per verificare ogni campo.
+Protegge il contratto pubblico: load_dataset_manifest, has_mart_sql.
+I test usano dataset.yml minimi per verificare ogni campo.
 """
 
 from __future__ import annotations
@@ -12,7 +12,6 @@ import pytest
 import yaml
 
 from toolkit.core.dataset_loader import (
-    detect_candidate_layout,
     has_mart_sql,
     load_dataset_manifest,
 )
@@ -111,38 +110,48 @@ class TestLoadDatasetManifest:
         result = load_dataset_manifest(filepath)
         assert result["name"] == "test"
 
+    def test_dataset_key_present(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {"dataset": {"name": "test"}})
+        result = load_dataset_manifest(tmp_path)
+        assert result["dataset"] is True
 
-class TestDetectCandidateLayout:
-    """Contract: detect_candidate_layout classifica la struttura candidate."""
+    def test_dataset_key_absent(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {"slug": "no-dataset-section"})
+        result = load_dataset_manifest(tmp_path)
+        assert result["dataset"] is False
 
-    def test_single_source(self, tmp_path: Path) -> None:
-        _write_dataset(tmp_path, {
-            "dataset": {"name": "test", "years": [2023]},
-            "raw": {"sources": [{"name": "src1"}]},
-        })
-        # Crea sql/mart.sql per farlo classificare come single_source
-        (tmp_path / "sql").mkdir()
-        (tmp_path / "sql" / "mart.sql").write_text("SELECT 1")
-        assert detect_candidate_layout(tmp_path) == "single-source"
-
-    def test_compose(self, tmp_path: Path) -> None:
-        _write_dataset(tmp_path, {
-            "dataset": {"name": "test"},
-            "support": [{"name": "sup1", "config": "path.yml"}],
-        })
-        assert detect_candidate_layout(tmp_path) == "compose"
-
-    def test_unknown_on_missing(self, tmp_path: Path) -> None:
-        assert detect_candidate_layout(tmp_path / "missing") == "unknown"
+    def test_yaml_parse_error(self, tmp_path: Path) -> None:
+        (tmp_path / "dataset.yml").write_text("invalid: [yaml: bad", encoding="utf-8")
+        result = load_dataset_manifest(tmp_path)
+        assert "error" in result
+        assert "YAML parse error" in result["error"]
 
 
 class TestHasMartSql:
-    """Contract: has_mart_sql verifica esistenza di sql/mart.sql."""
+    """Contract: has_mart_sql verifica esistenza di SQL mart nei formati DI."""
 
-    def test_exists(self, tmp_path: Path) -> None:
+    def test_mart_sql_exact(self, tmp_path: Path) -> None:
         (tmp_path / "sql").mkdir(parents=True)
         (tmp_path / "sql" / "mart.sql").write_text("SELECT 1")
         assert has_mart_sql(tmp_path) is True
 
+    def test_mart_star_sql(self, tmp_path: Path) -> None:
+        (tmp_path / "sql").mkdir(parents=True)
+        (tmp_path / "sql" / "mart_indicatori.sql").write_text("SELECT 1")
+        assert has_mart_sql(tmp_path) is True
+
+    def test_mart_subdir(self, tmp_path: Path) -> None:
+        (tmp_path / "sql" / "mart").mkdir(parents=True)
+        (tmp_path / "sql" / "mart" / "table1.sql").write_text("SELECT 1")
+        assert has_mart_sql(tmp_path) is True
+
     def test_missing(self, tmp_path: Path) -> None:
+        assert has_mart_sql(tmp_path) is False
+
+    def test_no_sql_dir(self, tmp_path: Path) -> None:
+        assert has_mart_sql(tmp_path) is False
+
+    def test_sql_dir_no_mart_files(self, tmp_path: Path) -> None:
+        (tmp_path / "sql").mkdir(parents=True)
+        (tmp_path / "sql" / "clean.sql").write_text("SELECT 1")
         assert has_mart_sql(tmp_path) is False

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -1,0 +1,148 @@
+"""Tests for toolkit.core.dataset_loader — contratto di lettura dataset.yml.
+
+Protegge il contratto pubblico: load_dataset_manifest, detect_candidate_layout,
+has_mart_sql. I test usano dataset.yml minimi per verificare ogni campo.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from toolkit.core.dataset_loader import (
+    detect_candidate_layout,
+    has_mart_sql,
+    load_dataset_manifest,
+)
+
+pytestmark = pytest.mark.pure_unit
+
+
+def _write_dataset(tmp_path: Path, data: dict, filename: str = "dataset.yml") -> Path:
+    path = tmp_path / filename
+    path.write_text(yaml.dump(data), encoding="utf-8")
+    return path
+
+
+class TestLoadDatasetManifest:
+    """Contract: load_dataset_manifest legge i campi comuni da dataset.yml."""
+
+    def test_minimal(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {"dataset": {"name": "test", "years": [2023]}})
+        result = load_dataset_manifest(tmp_path)
+        assert result["name"] == "test"
+        assert result["years"] == [2023]
+        assert result["slug"] == tmp_path.name
+
+    def test_slug_from_config(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {"slug": "custom-slug", "dataset": {"name": "test"}})
+        result = load_dataset_manifest(tmp_path)
+        assert result["slug"] == "custom-slug"
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent.yml"
+        result = load_dataset_manifest(missing)
+        assert "error" in result
+        assert result["slug"] == missing.parent.name
+
+    def test_sources(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test"},
+            "raw": {"sources": [{"name": "src1"}, {"name": "src2"}]},
+        })
+        result = load_dataset_manifest(tmp_path)
+        assert len(result["sources"]) == 2
+        assert result["sources"][0]["name"] == "src1"
+
+    def test_extra_ca_cert_urls_single(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test"},
+            "raw": {"sources": [{"args": {"extra_ca_cert_url": "https://certs.example.com/cert.pem"}}]},
+        })
+        result = load_dataset_manifest(tmp_path)
+        assert result["extra_ca_cert_urls"] == ["https://certs.example.com/cert.pem"]
+
+    def test_extra_ca_cert_urls_multiple(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test"},
+            "raw": {"sources": [{"args": {"extra_ca_cert_urls": ["a.pem", "b.pem"]}}]},
+        })
+        result = load_dataset_manifest(tmp_path)
+        assert result["extra_ca_cert_urls"] == ["a.pem", "b.pem"]
+
+    def test_support_root_level(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test"},
+            "support": [{"name": "sup1", "config": "path/to/config.yml"}],
+        })
+        result = load_dataset_manifest(tmp_path)
+        assert len(result["support"]) == 1
+        assert result["support"][0]["name"] == "sup1"
+
+    def test_support_in_dataset(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test", "support": [{"name": "sup1"}]},
+        })
+        result = load_dataset_manifest(tmp_path)
+        assert len(result["support"]) == 1
+
+    def test_time_coverage(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test", "time_coverage": {"start_year": 2020, "end_year": 2024}},
+        })
+        result = load_dataset_manifest(tmp_path)
+        assert result["time_coverage"]["start_year"] == 2020
+        assert result["time_coverage"]["end_year"] == 2024
+
+    def test_source_id(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {"dataset": {"source_id": "istat_sdmx"}})
+        result = load_dataset_manifest(tmp_path)
+        assert result["source_id"] == "istat_sdmx"
+
+    def test_empty_years_default(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {"dataset": {"name": "test"}})
+        result = load_dataset_manifest(tmp_path)
+        assert result["years"] == []
+
+    def test_accepts_filepath(self, tmp_path: Path) -> None:
+        filepath = _write_dataset(tmp_path, {"dataset": {"name": "test"}})
+        result = load_dataset_manifest(filepath)
+        assert result["name"] == "test"
+
+
+class TestDetectCandidateLayout:
+    """Contract: detect_candidate_layout classifica la struttura candidate."""
+
+    def test_single_source(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test", "years": [2023]},
+            "raw": {"sources": [{"name": "src1"}]},
+        })
+        # Crea sql/mart.sql per farlo classificare come single_source
+        (tmp_path / "sql").mkdir()
+        (tmp_path / "sql" / "mart.sql").write_text("SELECT 1")
+        assert detect_candidate_layout(tmp_path) == "single_source"
+
+    def test_compose(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test"},
+            "support": [{"name": "sup1", "config": "path.yml"}],
+        })
+        assert detect_candidate_layout(tmp_path) == "compose"
+
+    def test_unknown_on_missing(self, tmp_path: Path) -> None:
+        assert detect_candidate_layout(tmp_path / "missing") == "unknown"
+
+
+class TestHasMartSql:
+    """Contract: has_mart_sql verifica esistenza di sql/mart.sql."""
+
+    def test_exists(self, tmp_path: Path) -> None:
+        (tmp_path / "sql").mkdir(parents=True)
+        (tmp_path / "sql" / "mart.sql").write_text("SELECT 1")
+        assert has_mart_sql(tmp_path) is True
+
+    def test_missing(self, tmp_path: Path) -> None:
+        assert has_mart_sql(tmp_path) is False

--- a/toolkit/core/dataset_loader.py
+++ b/toolkit/core/dataset_loader.py
@@ -1,0 +1,123 @@
+"""Lettura leggera di dataset.yml — pattern condivisi tra script DI e toolkit.
+
+Centralizza la logica di lettura YAML che era duplicata in 6 script
+di ``dataset-incubator``. Non fa validazione Pydantic piena
+(vedi ``toolkit.core.config.load_config`` per quello), solo
+estrazione dei campi più usati per diagnostica, cataloghi e CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def load_dataset_manifest(path: str | Path) -> dict[str, Any]:
+    """Legge ``dataset.yml`` e restituisce un dict con i campi più usati.
+
+    Args:
+        path: Path al file ``dataset.yml`` o alla directory che lo contiene.
+
+    Returns:
+        Dict con: ``slug``, ``name``, ``years``, ``source_id``,
+        ``time_coverage``, ``sources``, ``support``, ``extra_ca_cert_urls``.
+
+        Tutti i campi opzionali sono ``None`` o ``[]`` se assenti.
+    """
+    import yaml
+
+    cfg_path = Path(path)
+    if cfg_path.is_dir():
+        cfg_path = cfg_path / "dataset.yml"
+
+    if not cfg_path.exists():
+        return {"slug": cfg_path.parent.name, "error": f"dataset.yml non trovato in {cfg_path}"}
+
+    with cfg_path.open(encoding="utf-8") as f:
+        cfg: dict[str, Any] = yaml.safe_load(f) or {}
+
+    slug = cfg.get("slug") or cfg_path.parent.name
+    ds: dict[str, Any] = cfg.get("dataset") or {}
+
+    # Campi base
+    result: dict[str, Any] = {
+        "slug": slug,
+        "name": ds.get("name"),
+        "years": ds.get("years") or [],
+        "source_id": ds.get("source_id"),
+        "time_coverage": ds.get("time_coverage"),
+    }
+
+    # raw.sources
+    raw: dict[str, Any] = cfg.get("raw") or {}
+    result["sources"] = raw.get("sources") or []
+
+    # extra_ca_cert_urls da raw.sources[].args
+    cert_urls: list[str] = []
+    for src in result["sources"]:
+        args: dict[str, Any] = src.get("args") or {}
+        single = args.get("extra_ca_cert_url")
+        if single:
+            cert_urls.append(single)
+        multiple = args.get("extra_ca_cert_urls")
+        if multiple:
+            cert_urls.extend(multiple)
+    result["extra_ca_cert_urls"] = cert_urls
+
+    # support (sia root-level che dentro dataset)
+    result["support"] = cfg.get("support") or ds.get("support") or []
+
+    return result
+
+
+def detect_candidate_layout(path: str | Path) -> str:
+    """Rileva il tipo di candidate dataset.
+
+    Scansiona la directory per determinare la struttura:
+
+    - ``single_source``: un solo file ``dataset.yml`` con raw.sources non vuoto
+    - ``multi_source``: una directory ``sources/`` con più sotto-directory
+    - ``compose``: ``dataset.yml`` senza raw/clean, solo support + mart
+    - ``support_dataset``: nella directory ``support_datasets/``
+    """
+    cfg_path = Path(path)
+    if cfg_path.is_dir():
+        cfg_path = cfg_path / "dataset.yml"
+
+    if not cfg_path.exists():
+        return "unknown"
+
+    import yaml
+
+    with cfg_path.open(encoding="utf-8") as f:
+        cfg: dict[str, Any] = yaml.safe_load(f) or {}
+
+    raw: dict[str, Any] = cfg.get("raw") or {}
+    has_raw = bool(raw.get("sources"))
+    has_mart = _has_mart_sql(cfg_path.parent)
+    has_support_entries = bool(cfg.get("support"))
+
+    parent_dir = cfg_path.parent
+    sources_subdir = parent_dir / "sources"
+
+    if sources_subdir.is_dir():
+        sub_items = [d for d in sources_subdir.iterdir() if d.is_dir()]
+        if len(sub_items) > 1:
+            return "multi_source"
+
+    if has_raw and has_mart:
+        return "single_source"
+
+    if has_support_entries and not has_raw:
+        return "compose"
+
+    return "single_source"
+
+
+def has_mart_sql(path: str | Path) -> bool:
+    """Verifica se esiste il file ``sql/mart.sql`` nella directory candidate."""
+    return _has_mart_sql(Path(path))
+
+
+def _has_mart_sql(path: Path) -> bool:
+    return (path / "sql" / "mart.sql").exists()

--- a/toolkit/core/dataset_loader.py
+++ b/toolkit/core/dataset_loader.py
@@ -75,60 +75,31 @@ def load_dataset_manifest(path: str | Path) -> dict[str, Any]:
     return result
 
 
-def detect_candidate_layout(path: str | Path) -> str:
-    """Rileva il tipo di candidate dataset.
-
-    Scansiona la directory per determinare la struttura:
-
-    - ``single_source``: un solo file ``dataset.yml`` con raw.sources non vuoto
-    - ``multi-source``: una directory ``sources/`` con più sotto-directory
-    - ``compose``: ``dataset.yml`` senza raw/clean, solo support + mart
-    - ``support_dataset``: nella directory ``support_datasets/``
-    """
-    cfg_path = Path(path)
-    if cfg_path.is_dir():
-        cfg_path = cfg_path / "dataset.yml"
-
-    if not cfg_path.exists():
-        return "unknown"
-
-    import yaml
-
-    with cfg_path.open(encoding="utf-8") as f:
-        cfg: dict[str, Any] = yaml.safe_load(f) or {}
-
-    raw: dict[str, Any] = cfg.get("raw") or {}
-    has_raw = bool(raw.get("sources"))
-    has_mart = _has_mart_sql(cfg_path.parent)
-    has_support_entries = bool(cfg.get("support"))
-
-    parent_dir = cfg_path.parent
-    sources_subdir = parent_dir / "sources"
-
-    if sources_subdir.is_dir():
-        sub_items = [d for d in sources_subdir.iterdir() if d.is_dir()]
-        if len(sub_items) > 1:
-            return "multi-source"
-
-    has_root_dataset = (cfg_path.parent / "dataset.yml").exists()
-    has_sources_dir = (cfg_path.parent / "sources").is_dir()
-
-    if has_root_dataset and has_sources_dir:
-        return "ambiguous"
-
-    if has_raw and has_mart:
-        return "single-source"
-
-    if has_support_entries and not has_raw:
-        return "compose"
-
-    return "single-source"
-
-
 def has_mart_sql(path: str | Path) -> bool:
-    """Verifica se esiste il file ``sql/mart.sql`` nella directory candidate."""
+    """Verifica se esiste SQL mart nella directory candidate.
+
+    Controlla tre pattern (in ordine di specificità):
+    - ``sql/mart.sql`` — file esatto
+    - ``sql/mart*.sql`` — qualsiasi file che inizia con ``mart`` in ``sql/``
+    - ``sql/mart/*.sql`` — qualsiasi file ``.sql`` in ``sql/mart/``
+
+    Corrisponde al contratto di ``dataset-incubator``.
+    """
     return _has_mart_sql(Path(path))
 
 
 def _has_mart_sql(path: Path) -> bool:
-    return (path / "sql" / "mart.sql").exists()
+    sql_dir = path / "sql"
+    if not sql_dir.is_dir():
+        return False
+    # mart.sql esatto
+    if (sql_dir / "mart.sql").exists():
+        return True
+    # mart*.sql in sql/
+    if any(p.name.startswith("mart") and p.suffix == ".sql" for p in sql_dir.iterdir()):
+        return True
+    # sql/mart/*.sql
+    mart_dir = sql_dir / "mart"
+    if mart_dir.is_dir() and any(p.suffix == ".sql" for p in mart_dir.iterdir()):
+        return True
+    return False

--- a/toolkit/core/dataset_loader.py
+++ b/toolkit/core/dataset_loader.py
@@ -33,14 +33,19 @@ def load_dataset_manifest(path: str | Path) -> dict[str, Any]:
     if not cfg_path.exists():
         return {"slug": cfg_path.parent.name, "error": f"dataset.yml non trovato in {cfg_path}"}
 
-    with cfg_path.open(encoding="utf-8") as f:
-        cfg: dict[str, Any] = yaml.safe_load(f) or {}
+    try:
+        with cfg_path.open(encoding="utf-8") as f:
+            cfg: dict[str, Any] = yaml.safe_load(f) or {}
+    except Exception as exc:
+        return {"slug": cfg_path.parent.name, "error": f"YAML parse error: {exc}"}
 
     slug = cfg.get("slug") or cfg_path.parent.name
     ds: dict[str, Any] = cfg.get("dataset") or {}
 
     # Campi base
+    has_dataset_section = "dataset" in cfg
     result: dict[str, Any] = {
+        "dataset": has_dataset_section,
         "slug": slug,
         "name": ds.get("name"),
         "years": ds.get("years") or [],
@@ -76,7 +81,7 @@ def detect_candidate_layout(path: str | Path) -> str:
     Scansiona la directory per determinare la struttura:
 
     - ``single_source``: un solo file ``dataset.yml`` con raw.sources non vuoto
-    - ``multi_source``: una directory ``sources/`` con più sotto-directory
+    - ``multi-source``: una directory ``sources/`` con più sotto-directory
     - ``compose``: ``dataset.yml`` senza raw/clean, solo support + mart
     - ``support_dataset``: nella directory ``support_datasets/``
     """
@@ -103,15 +108,21 @@ def detect_candidate_layout(path: str | Path) -> str:
     if sources_subdir.is_dir():
         sub_items = [d for d in sources_subdir.iterdir() if d.is_dir()]
         if len(sub_items) > 1:
-            return "multi_source"
+            return "multi-source"
+
+    has_root_dataset = (cfg_path.parent / "dataset.yml").exists()
+    has_sources_dir = (cfg_path.parent / "sources").is_dir()
+
+    if has_root_dataset and has_sources_dir:
+        return "ambiguous"
 
     if has_raw and has_mart:
-        return "single_source"
+        return "single-source"
 
     if has_support_entries and not has_raw:
         return "compose"
 
-    return "single_source"
+    return "single-source"
 
 
 def has_mart_sql(path: str | Path) -> bool:


### PR DESCRIPTION
## Sintesi

Nuovo modulo `toolkit/core/dataset_loader.py` che centralizza i pattern di lettura `dataset.yml` attualmente duplicati in 6 script di `dataset-incubator`.

## Cosa contiene

| Funzione | Cosa fa | Sostituisce in DI |
|---|---|---|
| `load_dataset_manifest(path)` | Legge dataset.yml → dict con slug, name, years, source_id, time_coverage, sources, support, extra_ca_cert_urls | 6 script che facevano `yaml.safe_load` + `.get()` |
| `detect_candidate_layout(path)` | Rileva: single_source, multi_source, compose | `validate_candidate_structure.detect_candidate_layout()` |
| `has_mart_sql(path)` | Verifica esistenza `sql/mart.sql` | `validate_candidate_structure.has_mart_sql()` |

## Test

17 test, copertura di tutti i campi e tutti i layout.

```bash
pytest tests/test_dataset_loader.py -v
# 17 passed
```

## Prossimo passo

Aggiornare `dataset-incubator/scripts/` per usare questo modulo invece di ripetere `yaml.safe_load` in 6 posti diversi.