### PR TITLE
feat: validate config — validazione leggera dataset.yml + CLI + MCP

### DIFF
--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -6,10 +6,14 @@ I test usano dataset.yml minimi per verificare ogni campo.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 import yaml
+from typer.testing import CliRunner
+
+from toolkit.cli.app import app
 
 from toolkit.core.dataset_loader import (
     has_mart_sql,
@@ -223,6 +227,55 @@ class TestValidateConfig:
         result = validate_config(tmp_path)
         assert result["ok"] is False
         assert any("YAML" in e for e in result["errors"])
-        (tmp_path / "sql").mkdir(parents=True)
-        (tmp_path / "sql" / "clean.sql").write_text("SELECT 1")
-        assert has_mart_sql(tmp_path) is False
+
+
+class TestValidateConfigCLI:
+    """Contract CLI: toolkit validate config."""
+
+    def test_valid_json(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test", "years": [2023]},
+            "raw": {"sources": [{"name": "src"}]},
+        })
+        cfg = tmp_path / "dataset.yml"
+        runner = CliRunner()
+        result = runner.invoke(app, ["validate", "config", "-c", str(cfg), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert data["slug"] == tmp_path.name
+
+    def test_valid_human(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test", "years": [2023]},
+            "raw": {"sources": [{"name": "src"}]},
+        })
+        cfg = tmp_path / "dataset.yml"
+        runner = CliRunner()
+        result = runner.invoke(app, ["validate", "config", "-c", str(cfg)])
+        assert result.exit_code == 0
+        assert "configurazione valida" in result.output
+
+    def test_invalid_exit_code(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {"slug": "no-dataset"})
+        cfg = tmp_path / "dataset.yml"
+        runner = CliRunner()
+        result = runner.invoke(app, ["validate", "config", "-c", str(cfg)])
+        assert result.exit_code != 0
+        assert "Sezione 'dataset' mancante" in result.output
+
+    def test_invalid_json(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {"slug": "no-dataset"})
+        cfg = tmp_path / "dataset.yml"
+        runner = CliRunner()
+        result = runner.invoke(app, ["validate", "config", "-c", str(cfg), "--json"])
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["ok"] is False
+
+    def test_missing_config_file(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "nonexistent.yml"
+        runner = CliRunner()
+        result = runner.invoke(app, ["validate", "config", "-c", str(cfg)])
+        assert result.exit_code != 0
+        assert "non trovato" in result.output

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -14,6 +14,7 @@ import yaml
 from toolkit.core.dataset_loader import (
     has_mart_sql,
     load_dataset_manifest,
+    validate_config,
 )
 
 pytestmark = pytest.mark.pure_unit
@@ -152,6 +153,76 @@ class TestHasMartSql:
         assert has_mart_sql(tmp_path) is False
 
     def test_sql_dir_no_mart_files(self, tmp_path: Path) -> None:
+        (tmp_path / "sql").mkdir(parents=True)
+        (tmp_path / "sql" / "clean.sql").write_text("SELECT 1")
+        assert has_mart_sql(tmp_path) is False
+
+
+class TestValidateConfig:
+    """Contract: validate_config controlla campi obbligatori dataset.yml."""
+
+    def test_valid(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test", "years": [2023]},
+            "raw": {"sources": [{"name": "src1"}]},
+        })
+        result = validate_config(tmp_path)
+        assert result["ok"] is True
+        assert result["errors"] == []
+
+    def test_missing_dataset_section(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {"raw": {"sources": [{"name": "src"}]}})
+        result = validate_config(tmp_path)
+        assert result["ok"] is False
+        assert any("dataset" in e for e in result["errors"])
+
+    def test_missing_name(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"years": [2023]},
+            "raw": {"sources": [{"name": "src"}]},
+        })
+        result = validate_config(tmp_path)
+        assert result["ok"] is False
+        assert any("name" in e for e in result["errors"])
+
+    def test_missing_years(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test"},
+            "raw": {"sources": [{"name": "src"}]},
+        })
+        result = validate_config(tmp_path)
+        assert result["ok"] is False
+        assert any("years" in e for e in result["errors"])
+
+    def test_years_not_list(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test", "years": "2023"},
+            "raw": {"sources": [{"name": "src"}]},
+        })
+        result = validate_config(tmp_path)
+        assert result["ok"] is False
+        assert any("interi" in e for e in result["errors"])
+
+    def test_no_sources_no_support(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {"dataset": {"name": "test", "years": [2023]}})
+        result = validate_config(tmp_path)
+        assert result["ok"] is False
+        assert any("fetchare" in e for e in result["errors"])
+
+    def test_warns_missing_source_id(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {
+            "dataset": {"name": "test", "years": [2023]},
+            "raw": {"sources": [{"name": "src1"}]},
+        })
+        result = validate_config(tmp_path)
+        assert result["ok"] is True
+        assert any("source_id" in w for w in result["warnings"])
+
+    def test_invalid_yaml(self, tmp_path: Path) -> None:
+        (tmp_path / "dataset.yml").write_text("invalid: [")
+        result = validate_config(tmp_path)
+        assert result["ok"] is False
+        assert any("YAML" in e for e in result["errors"])
         (tmp_path / "sql").mkdir(parents=True)
         (tmp_path / "sql" / "clean.sql").write_text("SELECT 1")
         assert has_mart_sql(tmp_path) is False

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -36,6 +36,7 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_list_ckan_datasets",
         "toolkit_list_sdmx_dataflows",
         "toolkit_sparql_query",
+        "toolkit_validate_config",
     }
 
 

--- a/toolkit/cli/cmd_validate.py
+++ b/toolkit/cli/cmd_validate.py
@@ -37,7 +37,7 @@ def _validate_config_cmd(config_arg: str, as_json: bool) -> None:
 
 def validate(
     step: str = typer.Argument(..., help="raw | clean | mart | all | config"),
-    config_path: str = typer.Option("", "--config", "-c", help="Path to dataset.yml"),
+    config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
     year: int | None = typer.Option(None, "--year", "-y", help="Single dataset year"),
     years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
     as_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
@@ -50,11 +50,10 @@ def validate(
     - ``all``: raw + clean + mart
     """
     if step == "config":
-        cfg_path = config_path or "dataset.yml"
-        _validate_config_cmd(cfg_path, as_json)
+        _validate_config_cmd(config, as_json)
         return
 
-    cfg, logger = load_cfg_and_logger(config_path)
+    cfg, logger = load_cfg_and_logger(config)
     years_arg = years if isinstance(years, str) else None
     year_arg = year if isinstance(year, int) else None
     selected_years = iter_selected_years(cfg, year_arg=year_arg, years_arg=years_arg)

--- a/toolkit/cli/cmd_validate.py
+++ b/toolkit/cli/cmd_validate.py
@@ -6,6 +6,7 @@ import typer
 
 from toolkit.cli.common import iter_selected_years, load_cfg_and_logger
 from toolkit.clean.validate import run_clean_validation
+from toolkit.core.dataset_loader import validate_config
 from toolkit.mart.validate import run_mart_validation
 from toolkit.raw.validate import run_raw_validation
 
@@ -16,20 +17,44 @@ _VALIDATORS = {
 }
 
 
+def _validate_config_cmd(config_arg: str, as_json: bool) -> None:
+    """Valida dataset.yml — cammini obbligatori, coerenza campi."""
+    result = validate_config(config_arg)
+    if as_json:
+        typer.echo(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        slug = result["slug"]
+        if result["errors"]:
+            for e in result["errors"]:
+                typer.echo(f"🔴 {slug}: {e}")
+        for w in result["warnings"]:
+            typer.echo(f"🟡 {slug}: {w}")
+        if result["ok"]:
+            typer.echo(f"✅ {slug}: configurazione valida")
+    if not result["ok"]:
+        raise typer.Exit(code=1)
+
+
 def validate(
-    step: str = typer.Argument(..., help="raw | clean | mart | all"),
-    config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
+    step: str = typer.Argument(..., help="raw | clean | mart | all | config"),
+    config_path: str = typer.Option("", "--config", "-c", help="Path to dataset.yml"),
     year: int | None = typer.Option(None, "--year", "-y", help="Single dataset year"),
     years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
     as_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
 ):
     """
-    Quality gate per RAW, CLEAN (include cross-layer raw→clean) e MART.
-    Usa regole opzionali in dataset.yml:
-      clean.validate.*
-      mart.validate.table_rules.*
+    Quality gate per dataset.yml, RAW, CLEAN e MART.
+
+    - ``config``: valida il file dataset.yml (campi obbligatori, coerenza)
+    - ``raw/clean/mart``: valida output della pipeline
+    - ``all``: raw + clean + mart
     """
-    cfg, logger = load_cfg_and_logger(config)
+    if step == "config":
+        cfg_path = config_path or "dataset.yml"
+        _validate_config_cmd(cfg_path, as_json)
+        return
+
+    cfg, logger = load_cfg_and_logger(config_path)
     years_arg = years if isinstance(years, str) else None
     year_arg = year if isinstance(year, int) else None
     selected_years = iter_selected_years(cfg, year_arg=year_arg, years_arg=years_arg)

--- a/toolkit/core/dataset_loader.py
+++ b/toolkit/core/dataset_loader.py
@@ -75,6 +75,64 @@ def load_dataset_manifest(path: str | Path) -> dict[str, Any]:
     return result
 
 
+def validate_config(path: str | Path) -> dict[str, Any]:
+    """Validazione leggera di un file ``dataset.yml``.
+
+    Controlli:
+    - ``dataset`` section presente
+    - ``dataset.name`` presente
+    - ``dataset.years`` presente e non vuoto
+    - Almeno una ``raw.sources`` o sezione ``support``
+    - Opzionale: ``source_id`` se ci sono sources
+
+    Args:
+        path: Path al file ``dataset.yml`` o directory.
+
+    Returns:
+        Dict con ``ok`` (bool), ``errors`` (list),
+        ``warnings`` (list), ``slug`` (str).
+    """
+    from toolkit.core.dataset_loader import load_dataset_manifest
+
+    manifest = load_dataset_manifest(path)
+    if "error" in manifest:
+        return {"ok": False, "errors": [manifest["error"]], "warnings": [], "slug": manifest.get("slug", "?")}
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    slug = manifest["slug"]
+
+    if not manifest.get("dataset"):
+        errors.append("Sezione 'dataset' mancante")
+
+    name = manifest.get("name")
+    if not name:
+        errors.append("'dataset.name' mancante o vuoto")
+
+    years = manifest.get("years", [])
+    if not years:
+        errors.append("'dataset.years' mancante o vuoto")
+    elif not all(isinstance(y, int) for y in years):
+        errors.append("'dataset.years' deve essere una lista di interi")
+
+    sources = manifest.get("sources", [])
+    support = manifest.get("support", [])
+
+    if not sources and not support:
+        errors.append("Nessuna 'raw.sources' né sezione 'support' — niente da fetchare")
+
+    if sources and not manifest.get("source_id"):
+        warnings.append("'dataset.source_id' non impostato (utile per catalogazione)")
+
+    return {
+        "ok": len(errors) == 0,
+        "errors": errors,
+        "warnings": warnings,
+        "slug": slug,
+    }
+
+
 def has_mart_sql(path: str | Path) -> bool:
     """Verifica se esiste SQL mart nella directory candidate.
 

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -16,6 +16,8 @@ from typing import Any
 
 from lab_connectors.mcp import create_mcp_server, guard_timed
 
+from toolkit.core.dataset_loader import validate_config as _validate_config_impl
+
 from .toolkit_client import (
     clean_preview as clean_preview_impl,
     csv_preview as csv_preview_impl,
@@ -182,6 +184,19 @@ def toolkit_list_runs(
 )
 def toolkit_csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
     return guard_timed(csv_preview_impl, "toolkit_csv_preview", csv_path, limit)
+
+
+# ---------------------------------------------------------------------------
+# Validate config
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description="Validazione leggera dataset.yml: campi obbligatori, coerenza.",
+    structured_output=True,
+)
+def toolkit_validate_config(config_path: str) -> dict[str, Any]:
+    return guard_timed(_validate_config_impl, "toolkit_validate_config", config_path)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Sintesi

Nuovo comando `toolkit validate config` per validazione leggera del file `dataset.yml`, con MCP tool corrispondente.

## Cosa controlla

- Sezione `dataset` presente
- `dataset.name` presente
- `dataset.years` presente e non vuoto
- Almeno `raw.sources` o sezione `support`
- `dataset.source_id` raccomandato (warning se assente)

## Cosa cambia

| Dove | Cosa |
|---|---|
| `core/dataset_loader.py` | Nuova funzione `validate_config(path) → dict` |
| `cli/cmd_validate.py` | Nuovo step `config` per `validate` comando |
| `mcp/server.py` | Nuovo tool `toolkit_validate_config` |

## Esempi

```bash
# Validazione base
toolkit validate config -c project-example/dataset.yml
# → ✅ project-example: configurazione valida

# JSON output
toolkit validate config -c project-example/dataset.yml --json

# Config mancante
toolkit validate config
# → errore: dataset.yml non trovato
```

Il pattern è core → CLI wrapper → MCP wrapper, come da architettura dei layer.