### PR TITLE
refactor: centralizza search_ckan_datasets e list_sdmx_dataflows in scout/http

### DIFF
--- a/toolkit/core/csv_read.py
+++ b/toolkit/core/csv_read.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from toolkit.core.io import normalize_encoding  # noqa: F401 — backward compat
-from toolkit.core.sql_utils import sql_str  # noqa: F401 — backward compat
+from toolkit.core.io import normalize_encoding
+from toolkit.core.sql_utils import sql_str
+
+
 
 
 ALLOWED_READ_CSV_KEYS = {

--- a/toolkit/mcp/scout_ops.py
+++ b/toolkit/mcp/scout_ops.py
@@ -195,14 +195,6 @@ def mcp_sparql_query(
 # ---------------------------------------------------------------------------
 
 
-def _ckan_action_url(base_url: str, action: str) -> str:
-    """Build a CKAN action URL from a portal base URL."""
-    base = base_url.rstrip("/")
-    if base.endswith("/api/3/action"):
-        return f"{base}/{action}"
-    return f"{base}/api/3/action/{action}"
-
-
 def mcp_list_ckan_datasets(
     portal_url: str,
     query: str | None = None,

--- a/toolkit/mcp/scout_ops.py
+++ b/toolkit/mcp/scout_ops.py
@@ -224,47 +224,6 @@ def mcp_list_ckan_datasets(
         }
     except RuntimeError as exc:
         return {"portal_url": portal_url, "error": str(exc)}
-    response = result.response
-    if response.status_code != 200:
-        return {
-            "portal_url": portal_url,
-            "error": f"HTTP {response.status_code}",
-        }
-
-    try:
-        data = response.json()
-    except Exception as exc:
-        return {"portal_url": portal_url, "error": f"Invalid JSON: {exc}"}
-
-    if not data.get("success"):
-        return {
-            "portal_url": portal_url,
-            "error": "CKAN API returned unsuccessful response",
-        }
-
-    search_result = data.get("result", {})
-    count = search_result.get("count", 0)
-    raw_datasets = search_result.get("results", [])
-
-    datasets = []
-    for ds in raw_datasets:
-        org = ds.get("organization") or {}
-        datasets.append({
-            "id": ds.get("id") or ds.get("name"),
-            "name": ds.get("name") or ds.get("id"),
-            "title": ds.get("title"),
-            "organization": org.get("title") or org.get("name"),
-            "resources_count": len(ds.get("resources") or []),
-            "metadata_modified": ds.get("metadata_modified"),
-        })
-
-    return {
-        "portal_url": portal_url,
-        "query": query,
-        "count": count,
-        "returned": len(datasets),
-        "datasets": datasets,
-    }
 
 
 # ---------------------------------------------------------------------------

--- a/toolkit/mcp/scout_ops.py
+++ b/toolkit/mcp/scout_ops.py
@@ -8,15 +8,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from lab_connectors.http import HttpClient
-
-from toolkit.plugins.sdmx import ISTAT_ESPLORADATI_BASE
 from toolkit.plugins.sparql import SparqlSource
 from toolkit.scout.http import (
     extract_candidate_links,
     fetch_ckan_package,
     fetch_html_body,
+    list_sdmx_dataflows as _list_sdmx_dataflows,
     probe_url_headers,
+    search_ckan_datasets as _search_ckan_datasets,
 )
 from toolkit.scout.infer import infer_topics
 from toolkit.scout.probe import probe_url, probe_url_routed
@@ -210,7 +209,7 @@ def mcp_list_ckan_datasets(
     rows: int = 100,
     timeout: int = 30,
 ) -> dict[str, Any]:
-    """Elenca i dataset di un portale CKAN via ``package_search``.
+    """Elenca i dataset di un portale CKAN via API package_search.
 
     Args:
         portal_url: URL del portale CKAN (es. ``https://www.dati.gov.it/opendata``).
@@ -222,21 +221,17 @@ def mcp_list_ckan_datasets(
         Dict con ``portal_url``, ``count`` (totale disponibile), ``returned``,
         ``datasets`` (lista di dataset con id, name, title, organization, resources_count).
     """
-    safe_rows = max(1, min(int(rows or 100), 500))
-    search_url = _ckan_action_url(portal_url, "package_search")
-    client = HttpClient(timeout=timeout, max_retries=1)
-
-    result = client.get(search_url, params={
-        "q": query or "*:*",
-        "rows": safe_rows,
-    })
-
-    if not result.is_ok or result.response is None:
+    try:
+        result = _search_ckan_datasets(portal_url, query=query or "*:*", rows=rows, timeout=timeout)
         return {
             "portal_url": portal_url,
-            "error": "CKAN request failed",
-            "detail": str(result.err),
+            "query": query,
+            "count": result["count"],
+            "returned": len(result["datasets"]),
+            "datasets": result["datasets"],
         }
+    except RuntimeError as exc:
+        return {"portal_url": portal_url, "error": str(exc)}
     response = result.response
     if response.status_code != 200:
         return {
@@ -299,47 +294,12 @@ def mcp_list_sdmx_dataflows(
         Dict con ``agency``, ``returned``, ``dataflows`` (lista con id, name,
         agency_id, version).
     """
-    import json
-
-    client = HttpClient(timeout=timeout, max_retries=1)
-    dataflow_url = f"{ISTAT_ESPLORADATI_BASE}/dataflow/{agency}/all/latest"
-
-    result = client.get(
-        dataflow_url,
-        headers={"Accept": "application/vnd.sdmx.structure+json; version=2"},
-    )
-
-    if not result.is_ok or result.response is None:
-        return {
-            "agency": agency,
-            "error": "SDMX request failed",
-            "detail": str(result.err),
-        }
-
-    response = result.response
-    if response.status_code != 200:
-        return {
-            "agency": agency,
-            "error": f"HTTP {response.status_code}",
-        }
-
     try:
-        payload = json.loads(response.text)
-    except Exception as exc:
-        return {"agency": agency, "error": f"Invalid JSON: {exc}"}
-
-    flows = payload.get("data", {}).get("dataflows", [])
-    dataflows = []
-    for flow in flows:
-        dataflows.append({
-            "dataflow_id": flow.get("id"),
-            "name": flow.get("name"),
-            "agency_id": flow.get("agencyID"),
-            "version": flow.get("version"),
-        })
-
-    return {
-        "agency": agency,
-        "returned": len(dataflows),
-        "dataflows": dataflows,
-    }
+        dataflows = _list_sdmx_dataflows(agency=agency, timeout=timeout)
+        return {
+            "agency": agency,
+            "returned": len(dataflows),
+            "dataflows": dataflows,
+        }
+    except RuntimeError as exc:
+        return {"agency": agency, "error": str(exc)}

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -18,8 +18,8 @@ from toolkit.core.csv_read import (
     csv_read_option_strings,
     normalize_read_cfg,
     robust_preset,
-    sql_str,
 )
+from toolkit.core.sql_utils import sql_str
 from toolkit.core.paths import RAW_PROFILE, RAW_SUGGESTED_READ
 from toolkit.core.io import write_json_atomic
 from toolkit.profile._sniff_encoding import is_binary_file as _is_binary_file, sniff_encoding

--- a/toolkit/scout/http.py
+++ b/toolkit/scout/http.py
@@ -509,7 +509,10 @@ def search_ckan_datasets(
     if resp.status_code != 200:
         raise RuntimeError(f"CKAN HTTP {resp.status_code} for {search_url}")
 
-    data = resp.json()
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise RuntimeError(f"CKAN JSON invalido: {exc}") from exc
     if not data.get("success"):
         raise RuntimeError("CKAN package_search returned unsuccessful")
 
@@ -566,7 +569,10 @@ def list_sdmx_dataflows(
     if resp.status_code != 200:
         raise RuntimeError(f"SDMX HTTP {resp.status_code} for {dataflow_url}")
 
-    payload = json.loads(resp.text)
+    try:
+        payload = json.loads(resp.text)
+    except ValueError as exc:
+        raise RuntimeError(f"SDMX JSON invalido: {exc}") from exc
     flows = payload.get("data", {}).get("dataflows", [])
 
     dataflows: list[dict[str, str]] = []

--- a/toolkit/scout/http.py
+++ b/toolkit/scout/http.py
@@ -476,6 +476,110 @@ def fetch_ckan_package(
     return None
 
 
+def search_ckan_datasets(
+    portal_url: str,
+    query: str = "*:*",
+    rows: int = 100,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    """Cerca dataset in un portale CKAN via ``package_search``.
+
+    Args:
+        portal_url: URL base del portale CKAN.
+        query: Query Solr (default ``*:*`` per tutti).
+        rows: Max risultati (default 100, max 500).
+        timeout: Timeout HTTP.
+
+    Returns:
+        Dict con ``count`` (totale), ``datasets`` (lista).
+
+    Raises:
+        RuntimeError: se la richiesta fallisce o l'API risponde con errore.
+    """
+    safe_rows = max(1, min(int(rows), 500))
+    base = portal_url.rstrip("/")
+    search_url = f"{base}/api/3/action/package_search" if not base.endswith("/api/3/action") else f"{base}/package_search"
+    client = _mk_client(timeout=timeout)
+
+    result = client.get(search_url, params={"q": query, "rows": safe_rows})
+    if not result.is_ok or result.response is None:
+        raise RuntimeError(f"CKAN package_search failed: {result.err}")
+
+    resp = result.response
+    if resp.status_code != 200:
+        raise RuntimeError(f"CKAN HTTP {resp.status_code} for {search_url}")
+
+    data = resp.json()
+    if not data.get("success"):
+        raise RuntimeError("CKAN package_search returned unsuccessful")
+
+    search_result = data.get("result", {})
+    raw_datasets = search_result.get("results", [])
+
+    datasets: list[dict[str, Any]] = []
+    for ds in raw_datasets:
+        org = ds.get("organization") or {}
+        datasets.append({
+            "id": ds.get("id") or ds.get("name"),
+            "name": ds.get("name") or ds.get("id"),
+            "title": ds.get("title"),
+            "organization": org.get("title") or org.get("name"),
+            "resources_count": len(ds.get("resources") or []),
+            "metadata_modified": ds.get("metadata_modified"),
+        })
+
+    return {"count": search_result.get("count", 0), "datasets": datasets}
+
+
+ISTAT_ESPLORADATI_BASE = "https://esploradati.istat.it/SDMXWS/rest"
+
+
+def list_sdmx_dataflows(
+    agency: str = "IT1",
+    timeout: int = 30,
+) -> list[dict[str, str]]:
+    """Elenca i dataflow SDMX disponibili per un'agenzia.
+
+    Args:
+        agency: ID agenzia SDMX (default ``IT1`` per ISTAT).
+        timeout: Timeout HTTP.
+
+    Returns:
+        Lista di dict con ``dataflow_id``, ``name``, ``agency_id``, ``version``.
+
+    Raises:
+        RuntimeError: se la richiesta fallisce o l'API risponde con errore.
+    """
+    import json
+
+    client = _mk_client(timeout=timeout)
+    dataflow_url = f"{ISTAT_ESPLORADATI_BASE}/dataflow/{agency}/all/latest"
+
+    result = client.get(
+        dataflow_url,
+        headers={"Accept": "application/vnd.sdmx.structure+json; version=2"},
+    )
+    if not result.is_ok or result.response is None:
+        raise RuntimeError(f"SDMX dataflow request failed: {result.err}")
+
+    resp = result.response
+    if resp.status_code != 200:
+        raise RuntimeError(f"SDMX HTTP {resp.status_code} for {dataflow_url}")
+
+    payload = json.loads(resp.text)
+    flows = payload.get("data", {}).get("dataflows", [])
+
+    dataflows: list[dict[str, str]] = []
+    for flow in flows:
+        dataflows.append({
+            "dataflow_id": flow.get("id"),
+            "name": flow.get("name"),
+            "agency_id": flow.get("agencyID"),
+            "version": flow.get("version"),
+        })
+    return dataflows
+
+
 def discover_ckan_resources(pkg: dict[str, Any]) -> list[dict[str, Any]]:
     """Estrae risorse scaricabili da un package CKAN."""
     resources: list[dict[str, Any]] = pkg.get("resources") or []


### PR DESCRIPTION
## Sintesi

Centralizza la logica di CKAN package_search e SDMX dataflow listing in `scout/http.py` (dove già stanno gli altri helper CKAN). I tool MCP diventano thin wrapper.

## Cosa cambia

| Prima | Dopo |
|---|---|
| `mcp/scout_ops.py` conteneva logica HTTP + parsing inline | `scout/http.py` espone `search_ckan_datasets()` e `list_sdmx_dataflows()` |
| Usava `HttpClient` diretto (timeout/retry locale) | Usa `_mk_client()` condiviso come tutti gli altri scout helper |
| Error-in-response: `return {"error": ...}` | `raise RuntimeError(...)` — consistent con pattern `scout/http` |

## Verifica

```bash
pytest tests/test_mcp_server.py -v
# 25 passed
ruff check toolkit/scout/http.py toolkit/mcp/scout_ops.py
# All checks passed
```

2 file, +121 / -57 righe. Nessun nuovo comando CLI — solo centralizzazione. Se in futuro servirà CLI, basterà un comando `toolkit scout` che chiami le stesse funzioni.