### PR TITLE
feat: aggiunge parametro thousands a clean.read (DuckDB CSV)

### DIFF
--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -465,3 +465,32 @@ def test_filter_suggested_read_excludes_robustness_keys(tmp_path: Path):
     assert "null_padding" not in relation_cfg
     assert "strict_mode" not in relation_cfg
     assert "sample_size" not in relation_cfg
+
+
+@pytest.mark.policy
+def test_read_raw_to_relation_with_thousands_separator(tmp_path: Path):
+    """DuckDB read_csv respects decimal=',' + thousands='.'.
+
+    CSV con separatore migliaia "." e decimale ",".
+    1.234,56 deve essere letto come 1234.56 (non 1.234).
+    """
+    input_file = tmp_path / "thousands.csv"
+    input_file.write_text("id;val\n1;1.234,56\n2;7.890,12\n", encoding="utf-8")
+
+    con = duckdb.connect(":memory:")
+    logger = logging.getLogger("tests.clean.duckdb_read.thousands")
+
+    info = duckdb_read.read_raw_to_relation(
+        con,
+        [input_file],
+        {"delim": ";", "encoding": "utf-8", "header": True,
+         "decimal": ",", "thousands": "."},
+        "strict",
+        logger,
+    )
+
+    assert info.params_used["decimal"] == ","
+    assert info.params_used["thousands"] == "."
+    rows = con.execute("SELECT id, val FROM raw_input ORDER BY id").fetchall()
+    assert rows == [(1, 1234.56), (2, 7890.12)], f"got {rows}"
+    con.close()

--- a/tests/test_csv_read_option_strings.py
+++ b/tests/test_csv_read_option_strings.py
@@ -35,6 +35,9 @@ class TestCsvReadOptionStrings:
     def test_decimal(self):
         assert csv_read_option_strings({"decimal": ","}) == ["decimal_separator=','"]
 
+    def test_thousands(self):
+        assert csv_read_option_strings({"thousands": "."}) == ["thousands='.'"]
+
     def test_nullstr_scalar(self):
         assert csv_read_option_strings({"nullstr": ""}) == ["nullstr=''"]
 
@@ -108,6 +111,7 @@ class TestCsvReadOptionStrings:
             "delim": ";",
             "encoding": "utf-8",
             "decimal": ",",
+            "thousands": ".",
             "nullstr": ["", "NA"],
             "auto_detect": False,
             "strict_mode": False,
@@ -121,7 +125,7 @@ class TestCsvReadOptionStrings:
             "columns": {"id": "VARCHAR", "val": "DOUBLE"},
         }
         result = csv_read_option_strings(cfg)
-        # sep, encoding, decimal, nullstr, auto_detect, strict_mode,
+        # sep, encoding, decimal, thousands, nullstr, auto_detect, strict_mode,
         # ignore_errors, null_padding, parallel, quote, escape, comment,
-        # max_line_size, columns = 14
-        assert len(result) == 14
+        # max_line_size, columns = 15
+        assert len(result) == 15

--- a/toolkit/cli/inspect/probe_ops.py
+++ b/toolkit/cli/inspect/probe_ops.py
@@ -1,4 +1,4 @@
-"""inspect probe command — probe SPARQL endpoints for schema and statistics."""
+"""inspect sparql command — query SPARQL endpoints for schema and statistics."""
 
 from __future__ import annotations
 

--- a/toolkit/core/config_models/clean.py
+++ b/toolkit/core/config_models/clean.py
@@ -24,6 +24,7 @@ class CleanReadConfig(BaseModel):
     header: bool = True
     encoding: str | None = None
     decimal: str | None = None
+    thousands: str | None = None
     skip: int | None = None
     auto_detect: bool | None = None
     quote: str | None = None

--- a/toolkit/core/csv_read.py
+++ b/toolkit/core/csv_read.py
@@ -13,6 +13,7 @@ ALLOWED_READ_CSV_KEYS = {
     "header",
     "encoding",
     "decimal",
+    "thousands",
     "skip",
     "auto_detect",
     "quote",
@@ -39,6 +40,7 @@ FORMAT_HINT_KEYS = {
     "header",
     "encoding",
     "decimal",
+    "thousands",
     "skip",
     "quote",
     "escape",
@@ -193,7 +195,7 @@ def csv_read_option_strings(
     ``union_by_name=true``) and append caller-specific ones (e.g. columns).
 
     Supported keys:
-    ``delim``, ``sep``, ``encoding``, ``decimal``, ``nullstr``,
+    ``delim``, ``sep``, ``encoding``, ``decimal``, ``thousands``, ``nullstr``,
     ``auto_detect``, ``strict_mode``, ``ignore_errors``, ``null_padding``,
     ``parallel``, ``quote``, ``escape``, ``comment``, ``max_line_size``,
     ``columns``.
@@ -217,6 +219,10 @@ def csv_read_option_strings(
     decimal = read_cfg.get("decimal")
     if decimal is not None:
         opts.append(f"decimal_separator='{sql_str(str(decimal))}'")
+
+    thousands = read_cfg.get("thousands")
+    if thousands is not None:
+        opts.append(f"thousands='{sql_str(str(thousands))}'")
 
     nullstr = read_cfg.get("nullstr")
     if nullstr is not None:

--- a/toolkit/core/duckdb_read.py
+++ b/toolkit/core/duckdb_read.py
@@ -93,6 +93,7 @@ def _csv_read_options(
         "sep",
         "encoding",
         "decimal",
+        "thousands",
         "nullstr",
         "auto_detect",
         "strict_mode",


### PR DESCRIPTION
## Sintesi

Aggiunge il parametro `thousands` alla configurazione `clean.read` per la lettura CSV con DuckDB. I CSV italiani usano spesso `.` come separatore delle migliaia; finora andava gestito manualmente nel clean.sql via `REPLACE`.

## Contesto

Necessario per `dataset-incubator` PR #460 — il dataset `strutture-ricovero-asl` ha colonne numeriche con `.` separatore migliaia.

**Prima**: `source: config_only` con tutte colonne VARCHAR + `REPLACE` nel clean.sql — falliva in CI.
**Dopo**: `source: auto` + `decimal: ","` + `thousands: "."` — DuckDB parsers numbers correttamente.

## Cosa cambia

- [x] Nuova funzionalità del motore
- [ ] Modifica contratto pubblico

## Impatto su contratti pubblici

- [x] Struttura `dataset.yml` (nuovo campo `thousands`)

> `dataset-incubator` PR #460 già aggiornata per usare il nuovo campo.

## Verifica

```bash
python3 -c "
from toolkit.core.config_models.clean import CleanReadConfig
cfg = CleanReadConfig(thousands='.', decimal=',')
assert cfg.thousands == '.'
assert cfg.decimal == ','
print('OK')
"
```

- [x] Testato localmente con `toolkit run full` su `strutture-ricovero-asl`
- [x] `pytest -m core` da eseguire in CI
- [ ] `ruff check .` da eseguire in CI
- [ ] `mypy toolkit/` da eseguire in CI

## Note

Il mapping è esattamente come `decimal`: il valore YAML `thousands: "."` viene passato a DuckDB come `thousands='.'`. Supportato da DuckDB >= 0.10.0.