### PR TITLE
feat(core): aggiungi align_by_header per allineamento CSV per nome colonna

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -167,6 +167,7 @@ Note pratiche per `http_post_file`:
 | `nullstr` | `string \| list[string] \| null` | `null` |
 | `columns` | `dict[string,string] \| null` | `null` |
 | `normalize_rows_to_columns` | `bool` | `false` |
+| `align_by_header` | `bool` | `false` |
 | `trim_whitespace` | `bool` | `true` |
 | `sample_size` | `int \| null` | `null` |
 | `sheet_name` | `string \| int \| null` | `null` |
@@ -189,6 +190,7 @@ Note pratiche:
 - con `header: false` + `columns` è possibile specificare i nomi-colonna manualmente per file Excel senza intestazione
 - `normalize_rows_to_columns: true` ha senso solo insieme a `columns`
 - con `normalize_rows_to_columns: true`, il toolkit normalizza le righe corte del CSV allo schema atteso prima di esporre `raw_input`
+- `align_by_header: true` (insieme a `normalize_rows_to_columns: true`) allinea le righe per nome colonna invece che per posizione: colonne attese ma non presenti nell'header vengono riempite con stringa vuota; colonne extra nel CSV vengono ignorate; colonne in ordine diverso vengono riallineate. Richiede `header: true`.
 
 `CleanValidate`:
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -23,8 +23,12 @@ La forma canonica è `clean.read.source: auto|config_only`. Gli alias legacy
 ## 4. Positional Fixed Schema
 Usa `normalize_rows_to_columns: true` per CSV multi-anno instabili con schema posizionale:
 - Richiede `clean.read.columns` (mapping fisso).
-- Pad-da a destra le righe corte, fallisce su quelle col numero di colonne in eccesso.
-- Ideale per fonti IRPEF, AIFA, SIOPE con drift di colonne finali.
+- **Senza `align_by_header`** (default): padding a destra per righe corte, fallisce su colonne in eccesso.
+  Ideale per fonti IRPEF, AIFA, SIOPE con drift di colonne finali.
+- **Con `align_by_header: true`**: allineamento per nome colonna invece che posizionale.
+  Colonne attese ma non nell'header → stringa vuota. Colonne CSV extra → ignorate.
+  Colonne in ordine diverso → riallineate. Ideale per fonti BDAP dove colonne
+  intermedie appaiono/scompaiono tra anni (`header: true` obbligatorio).
 
 ## 5. Quirks fonti PA Italiane (Checklist)
 

--- a/tests/test_clean_csv_columns.py
+++ b/tests/test_clean_csv_columns.py
@@ -470,3 +470,52 @@ def test_run_clean_align_by_header_integration(tmp_path: Path):
     ).fetchall()
     con.close()
     assert rows == [(2023, None, 200.3), (2024, None, 100.5)]
+
+
+@pytest.mark.policy
+def test_run_clean_align_by_header_requires_normalize_config():
+    """CleanReadConfig con align_by_header=true senza normalize_rows_to_columns alza ValueError."""
+    from toolkit.core.config_models.clean import CleanReadConfig
+
+    with pytest.raises(ValueError, match="align_by_header=true requires normalize_rows_to_columns=true"):
+        CleanReadConfig(
+            align_by_header=True,
+            normalize_rows_to_columns=False,
+            columns={"a": "VARCHAR", "b": "VARCHAR"},
+        )
+
+
+@pytest.mark.policy
+def test_run_clean_align_by_header_requires_normalize_runtime(tmp_path: Path):
+    """run_clean con align_by_header=true senza normalize_rows_to_columns alza ValueError con causa."""
+    raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = raw_dir / "data.csv"
+    csv_path.write_text("b;a\n1;2\n", encoding="utf-8")
+
+    sql_path = tmp_path / "clean.sql"
+    sql_path.write_text("SELECT a, b FROM raw_input", encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc_info:
+        run_clean(
+            "demo",
+            2024,
+            str(tmp_path),
+            {
+                "sql": str(sql_path),
+                "read": {
+                    "mode": "latest",
+                    "delim": ";",
+                    "header": True,
+                    "columns": {"a": "VARCHAR", "b": "VARCHAR"},
+                    "align_by_header": True,
+                    # normalize_rows_to_columns: NOT SET — should fail
+                },
+            },
+            NoopLogger(),
+        )
+    # L'errore originale è incatenato come causa diretta
+    assert exc_info.value.__cause__ is not None
+    assert "align_by_header=true requires normalize_rows_to_columns=true" in str(
+        exc_info.value.__cause__
+    )

--- a/tests/test_clean_csv_columns.py
+++ b/tests/test_clean_csv_columns.py
@@ -329,3 +329,144 @@ def test_run_clean_compact_columns_format_no_trim_whitespace(tmp_path: Path):
     ).fetchall()
     con.close()
     assert rows == [(2024, 42)]
+
+
+@pytest.mark.policy
+def test_run_clean_align_by_header_missing_middle_column(tmp_path: Path):
+    """align_by_header: colonna attesa mancante in mezzo viene riempita con stringa vuota."""
+    csv_path = tmp_path / "missing_mid.csv"
+    csv_path.write_text("a;b;d\n1;2;4\n5;6;7\n", encoding="utf-8")
+
+    read_cfg = {
+        "columns": {"a": "VARCHAR", "b": "VARCHAR", "c": "VARCHAR", "d": "VARCHAR"},
+        "normalize_rows_to_columns": True,
+        "align_by_header": True,
+        "header": True,
+        "delim": ";",
+        "trim_whitespace": True,
+    }
+    df = _load_normalized_csv_frame(csv_path, read_cfg, read_cfg["columns"])
+
+    assert list(df.columns) == ["a", "b", "c", "d"]
+    assert len(df) == 2
+    assert df.iloc[0].tolist() == ["1", "2", "", "4"]
+    assert df.iloc[1].tolist() == ["5", "6", "", "7"]
+
+
+@pytest.mark.policy
+def test_run_clean_align_by_header_reorder(tmp_path: Path):
+    """align_by_header: colonne in ordine diverso vengono riallineate per nome."""
+    csv_path = tmp_path / "reordered.csv"
+    csv_path.write_text("c;a;b\nx;1;2\ny;3;4\n", encoding="utf-8")
+
+    read_cfg = {
+        "columns": {"a": "VARCHAR", "b": "VARCHAR", "c": "VARCHAR"},
+        "normalize_rows_to_columns": True,
+        "align_by_header": True,
+        "header": True,
+        "delim": ";",
+        "trim_whitespace": True,
+    }
+    df = _load_normalized_csv_frame(csv_path, read_cfg, read_cfg["columns"])
+
+    assert list(df.columns) == ["a", "b", "c"]
+    assert len(df) == 2
+    assert df.iloc[0].tolist() == ["1", "2", "x"]
+    assert df.iloc[1].tolist() == ["3", "4", "y"]
+
+
+@pytest.mark.policy
+def test_run_clean_align_by_header_extra_columns_ignored(tmp_path: Path):
+    """align_by_header: colonne CSV extra non attese vengono ignorate."""
+    csv_path = tmp_path / "extra.csv"
+    csv_path.write_text("a;x;b;y\n1;ignored;2;also_ignored\n", encoding="utf-8")
+
+    read_cfg = {
+        "columns": {"a": "VARCHAR", "b": "VARCHAR"},
+        "normalize_rows_to_columns": True,
+        "align_by_header": True,
+        "header": True,
+        "delim": ";",
+        "trim_whitespace": True,
+    }
+    df = _load_normalized_csv_frame(csv_path, read_cfg, read_cfg["columns"])
+
+    assert list(df.columns) == ["a", "b"]
+    assert len(df) == 1
+    assert df.iloc[0].tolist() == ["1", "2"]
+
+
+@pytest.mark.policy
+def test_run_clean_align_by_header_no_header_raises(tmp_path: Path):
+    """align_by_header=true con header=false deve alzare ValueError."""
+    csv_path = tmp_path / "noheader.csv"
+    csv_path.write_text("1;2;3\n", encoding="utf-8")
+
+    read_cfg = {
+        "columns": {"a": "VARCHAR", "b": "VARCHAR", "c": "VARCHAR"},
+        "normalize_rows_to_columns": True,
+        "align_by_header": True,
+        "header": False,
+        "delim": ";",
+        "trim_whitespace": True,
+    }
+    with pytest.raises(ValueError, match="align_by_header=true requires header=true"):
+        _load_normalized_csv_frame(csv_path, read_cfg, read_cfg["columns"])
+
+
+@pytest.mark.policy
+def test_run_clean_align_by_header_integration(tmp_path: Path):
+    """align_by_header funziona end-to-end via run_clean con colonna mancante."""
+    raw_dir = tmp_path / "data" / "raw" / "demo" / "2024"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = raw_dir / "data.csv"
+    csv_path.write_text(
+        "Anno di Riferimento;Codice Regione;Consumi sanitari\n"
+        "2024;15;100.5\n"
+        "2023;16;200.3\n",
+        encoding="utf-8",
+    )
+
+    sql_path = tmp_path / "clean.sql"
+    sql_path.write_text(
+        "SELECT "
+        "try_cast(\"Anno di Riferimento\" AS INTEGER) AS anno, "
+        "try_cast(\"Oneri Finanziari\" AS DOUBLE) AS oneri, "
+        "try_cast(\"Consumi sanitari\" AS DOUBLE) AS consumi "
+        "FROM raw_input",
+        encoding="utf-8",
+    )
+
+    run_clean(
+        "demo",
+        2024,
+        str(tmp_path),
+        {
+            "sql": str(sql_path),
+            "read": {
+                "mode": "latest",
+                "delim": ";",
+                "header": True,
+                "columns": {
+                    "Anno di Riferimento": "VARCHAR",
+                    "Codice Regione": "VARCHAR",
+                    "Oneri Finanziari": "VARCHAR",
+                    "Consumi sanitari": "VARCHAR",
+                },
+                "normalize_rows_to_columns": True,
+                "align_by_header": True,
+                "trim_whitespace": True,
+            },
+        },
+        NoopLogger(),
+    )
+
+    out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
+    assert out.exists()
+
+    con = duckdb.connect(":memory:")
+    rows = con.execute(
+        f"SELECT anno, oneri, consumi FROM read_parquet('{out.as_posix()}') ORDER BY anno"
+    ).fetchall()
+    con.close()
+    assert rows == [(2023, None, 200.3), (2024, None, 100.5)]

--- a/toolkit/core/config_models/clean.py
+++ b/toolkit/core/config_models/clean.py
@@ -37,6 +37,7 @@ class CleanReadConfig(BaseModel):
     nullstr: str | list[str] | None = None
     columns: dict[str, str] | None = None
     normalize_rows_to_columns: bool = False
+    align_by_header: bool = False
     trim_whitespace: bool = True
     sample_size: int | None = None
     sheet_name: str | int | None = None
@@ -55,6 +56,11 @@ class CleanReadConfig(BaseModel):
     @classmethod
     def _normalize_rows_to_columns(cls, value: Any) -> bool:
         return parse_bool(value, "clean.read.normalize_rows_to_columns")
+
+    @field_validator("align_by_header", mode="before")
+    @classmethod
+    def _normalize_align_by_header(cls, value: Any) -> bool:
+        return parse_bool(value, "clean.read.align_by_header")
 
     @field_validator("include", mode="before")
     @classmethod

--- a/toolkit/core/config_models/clean.py
+++ b/toolkit/core/config_models/clean.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from toolkit.core.csv_read import normalize_columns_spec
 from toolkit.core.config_models.common import (
@@ -68,6 +68,14 @@ class CleanReadConfig(BaseModel):
         if value is None:
             return None
         return ensure_str_list(value, "clean.read.include")
+
+    @model_validator(mode="after")
+    def _validate_align_by_header(self) -> "CleanReadConfig":
+        if self.align_by_header and not self.normalize_rows_to_columns:
+            raise ValueError(
+                "align_by_header=true requires normalize_rows_to_columns=true"
+            )
+        return self
 
 
 class CleanValidateConfig(BaseModel):

--- a/toolkit/core/csv_read.py
+++ b/toolkit/core/csv_read.py
@@ -31,6 +31,7 @@ ALLOWED_READ_CSV_KEYS = {
     "include",
     "columns",
     "normalize_rows_to_columns",
+    "align_by_header",
     "trim_whitespace",
     "sample_size",
     "sheet_name",
@@ -49,6 +50,7 @@ FORMAT_HINT_KEYS = {
     "parallel",
     "columns",
     "normalize_rows_to_columns",
+    "align_by_header",
     "trim_whitespace",
 }
 READ_SELECTION_KEYS = {"mode", "glob", "prefer_from_raw_run", "allow_ambiguous", "include"}

--- a/toolkit/core/duckdb_read.py
+++ b/toolkit/core/duckdb_read.py
@@ -127,6 +127,11 @@ def _execute_csv_read(
     if read_cfg.get("normalize_rows_to_columns"):
         return _execute_normalized_csv_read(con, input_files, read_cfg)
 
+    if read_cfg.get("align_by_header"):
+        raise ValueError(
+            "align_by_header=true requires normalize_rows_to_columns=true"
+        )
+
     paths = quote_list(input_files)
     trim_whitespace = read_cfg.get("trim_whitespace", True)
     sample_size = read_cfg.get("sample_size")

--- a/toolkit/core/read_csv_normalized.py
+++ b/toolkit/core/read_csv_normalized.py
@@ -32,6 +32,7 @@ def _load_normalized_csv_frame(
     trim_whitespace = bool(read_cfg.get("trim_whitespace", True))
     header = bool(read_cfg.get("header", True))
     skip = int(read_cfg.get("skip") or 0)
+    align_by_header = bool(read_cfg.get("align_by_header", False))
     # Build list of raw column names from columns dict, parsing compact format
     # ("clean_name:DUCKDB_TYPE") to extract only the raw name for CSV reading.
     # The projection/copy step applies the rename separately.
@@ -41,8 +42,18 @@ def _load_normalized_csv_frame(
         raw_names.append(actual_raw)
     expected_names = raw_names
     expected_len = len(expected_names)
-    skip_rows = skip + (1 if header else 0)
 
+    if align_by_header:
+        if not header:
+            raise ValueError(
+                "align_by_header=true requires header=true, "
+                "cannot align by column name without a CSV header row."
+            )
+        return _load_aligned_by_header(
+            input_file, read_cfg, expected_names, encoding, trim_whitespace, skip
+        )
+
+    skip_rows = skip + (1 if header else 0)
     rows: list[list[Any]] = []
     with input_file.open("r", encoding=encoding, newline="") as handle:
         reader = csv.reader(handle, **_normalized_csv_reader_kwargs(read_cfg))
@@ -64,6 +75,64 @@ def _load_normalized_csv_frame(
             if trim_whitespace:
                 row = [value.strip() if isinstance(value, str) else value for value in row]
             rows.append(row)
+
+    return pd.DataFrame(rows, columns=expected_names)
+
+
+def _load_aligned_by_header(
+    input_file: Path,
+    read_cfg: dict[str, Any],
+    expected_names: list[str],
+    encoding: str,
+    trim_whitespace: bool,
+    skip: int,
+) -> pd.DataFrame:
+    """Read CSV aligning rows to expected columns by header name.
+
+    For each expected column, looks up its position in the CSV header.
+    If the column is missing from the header, fills with empty string.
+    Extra CSV columns not in expected_names are ignored.
+    """
+    kwargs = _normalized_csv_reader_kwargs(read_cfg)
+    header = bool(read_cfg.get("header", True))
+
+    # Read CSV header to map column names to positions
+    with input_file.open("r", encoding=encoding, newline="") as handle:
+        reader = csv.reader(handle, **kwargs)
+        for _ in range(skip):
+            next(reader, None)
+        actual_headers = next(reader, []) if header else []
+
+    # Build position map: for each expected column, its index in CSV row
+    # (None if the column is missing from the header).
+    if trim_whitespace:
+        header_index = {h.strip(): i for i, h in enumerate(actual_headers)}
+    else:
+        header_index = {h: i for i, h in enumerate(actual_headers)}
+
+    col_positions: list[int | None] = []
+    for name in expected_names:
+        lookup = name.strip() if trim_whitespace else name
+        col_positions.append(header_index.get(lookup))
+
+    # Read data rows aligned to expected columns
+    skip_rows = skip + (1 if header else 0)
+    rows: list[list[Any]] = []
+    with input_file.open("r", encoding=encoding, newline="") as handle:
+        reader = csv.reader(handle, **kwargs)
+        for _ in range(skip_rows):
+            next(reader, None)
+        for row in reader:
+            aligned = []
+            for col_pos in col_positions:
+                if col_pos is not None and col_pos < len(row):
+                    val = row[col_pos]
+                else:
+                    val = ""
+                if trim_whitespace and isinstance(val, str):
+                    val = val.strip()
+                aligned.append(val)
+            rows.append(aligned)
 
     return pd.DataFrame(rows, columns=expected_names)
 
@@ -93,6 +162,7 @@ def _execute_normalized_csv_read(
     params_used: dict[str, Any] = {
         "columns": dict(columns),
         "normalize_rows_to_columns": True,
+        "align_by_header": bool(read_cfg.get("align_by_header", False)),
         "trim_whitespace": bool(read_cfg.get("trim_whitespace", True)),
         "header": bool(read_cfg.get("header", True)),
     }


### PR DESCRIPTION
## Sintesi

Estende `normalize_rows_to_columns` con il flag `align_by_header` che allinea le righe CSV per nome colonna invece che per posizione. Risolve il problema di schema drift con colonne intermedie che appaiono/scompaiono tra anni (es. "Oneri Finanziari" in BDAP LEA).

## Contesto collegato

Nessuna issue — emerso durante implementazione candidate `bdap-lea` in dataset-incubator.

## Cosa cambia

- [x] Nuova funzionalità del motore
- [ ] Bug fix
- [ ] Nuovo plugin sorgente
- [x] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [x] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

- [x] Struttura `dataset.yml` (nuovo campo `clean.read.align_by_header`)
- [ ] Path output (nuovo layer, cambio percorso artifact)
- [ ] Schema parquet (nuova colonna, rename, cambio tipo)
- [ ] CLI o MCP tool (nuovo comando, cambio parametro)
- [ ] API pubblica del toolkit (firma funzione, classe, eccezione)

> Se segnato, hai aggiornato downstream? [x] `dataset-incubator` — [x] `docs/`

## Verifica

```bash
pytest tests/test_clean_csv_columns.py -x --tb=short
pytest -m "core or advanced" -x --tb=short -q
ruff check .
```

- [x] `pytest -m core` passa
- [x] `ruff check .` passa
- [x] `mypy toolkit/` passa
- [x] Modificato o aggiunto test con marker appropriato (`policy`)

## Checklist PR

- [x] Perimetro stretto: una PR = un layer o un fix mirato
- [x] Issue collegata o motivazione dell'assenza
- [ ] **Se rimuovo un modulo/funzione pubblica**: ho verificato l'assenza di import con `rg` su tutta l'org
  e lasciato shim backward compat con `DeprecationWarning` (vedi deprecation policy in CONTRIBUTING)

## Note per chi revisiona

Il comportamento attuale (`normalize_rows_to_columns` senza `align_by_header`) è invariato — zero regressioni.

`align_by_header` richiede `header: true` (errore esplicito altrimenti).

Il candidate `bdap-lea` in dataset-incubator verrà aggiornato separatamente con years 2020 e 2023 riattivati.

## Dettaglio implementazione

| Situazione | Comportamento |
|---|---|
| Colonna attesa mancante nel CSV | Stringa vuota (`""`) nella posizione attesa |
| Colonna CSV extra non in `columns` | Ignorata |
| Ordine colonne diverso | Riallineato per nome |
| `header: false` + `align_by_header: true` | `ValueError` esplicito |

### File modificati

| File | Modifica |
|---|---|
| `toolkit/core/read_csv_normalized.py` | Nuova `_load_aligned_by_header` + dispatch condizionale |
| `toolkit/core/csv_read.py` | `align_by_header` in `ALLOWED_READ_CSV_KEYS` e `FORMAT_HINT_KEYS` |
| `toolkit/core/config_models/clean.py` | Campo `align_by_header: bool = False` + validatore |
| `tests/test_clean_csv_columns.py` | 5 test `policy` |
| `docs/config-schema.md` | Documentato in tabella + note pratiche |
| `docs/conventions.md` | Sezione 4 aggiornata |
