### PR TITLE
refactor: allineamento CLI↔MCP — schema_diff condiviso + sql= in parquet_preview

### DIFF
--- a/tests/test_duckdb_shape.py
+++ b/tests/test_duckdb_shape.py
@@ -1,0 +1,126 @@
+"""Test per core/duckdb_shape.py — parquet_preview con e senza sql=.
+
+Il marker ``contract`` protegge l'API pubblica di ``parquet_preview``.
+Il marker ``policy`` protegge regole non ovvie (es. eccezioni vs empty dict).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.helpers import write_parquet
+
+
+@pytest.mark.contract
+def test_parquet_preview_default_no_sql(tmp_path):
+    """parquet_preview senza sql=: SELECT * LIMIT N (backward compat)."""
+    from toolkit.core.duckdb_shape import parquet_preview
+
+    pq = tmp_path / "test.parquet"
+    write_parquet(pq, "CREATE TABLE t AS SELECT 1 AS x, 'a' AS y")
+
+    result = parquet_preview(pq, limit=5)
+    assert result["column_count"] == 2
+    assert result["row_count"] == 1
+    assert len(result["preview"]) == 1
+    assert result["preview"][0]["x"] == 1
+    assert result["preview"][0]["y"] == "a"
+    assert result["sql"] is None
+    assert result["truncated"] is False
+
+
+@pytest.mark.contract
+def test_parquet_preview_with_sql_select_star(tmp_path):
+    """parquet_preview con sql='SELECT * FROM data': funziona."""
+    from toolkit.core.duckdb_shape import parquet_preview
+
+    pq = tmp_path / "test.parquet"
+    write_parquet(pq, "CREATE TABLE t AS SELECT 1 AS x, 'a' AS y")
+
+    result = parquet_preview(pq, sql="SELECT * FROM data")
+    assert result["column_count"] == 2
+    assert result["row_count"] == 1
+    assert len(result["preview"]) == 1
+    assert result["sql"] == "SELECT * FROM data"
+
+
+@pytest.mark.contract
+def test_parquet_preview_with_where(tmp_path):
+    """parquet_preview con WHERE: filtra correttamente."""
+    from toolkit.core.duckdb_shape import parquet_preview
+
+    pq = tmp_path / "test.parquet"
+    write_parquet(pq, "CREATE TABLE t AS "
+                       "SELECT 1 AS id, 'a' AS val UNION ALL "
+                       "SELECT 2, 'b' UNION ALL "
+                       "SELECT 3, 'a'")
+
+    result = parquet_preview(pq, sql="SELECT * FROM data WHERE val = 'a'")
+    assert result["row_count"] == 2
+    assert len(result["preview"]) == 2
+    assert all(r["val"] == "a" for r in result["preview"])
+
+
+@pytest.mark.contract
+def test_parquet_preview_with_group_by(tmp_path):
+    """parquet_preview con GROUP BY: aggregazione corretta."""
+    from toolkit.core.duckdb_shape import parquet_preview
+
+    pq = tmp_path / "test.parquet"
+    write_parquet(pq, "CREATE TABLE t AS "
+                       "SELECT 'x' AS k, 10 AS v UNION ALL "
+                       "SELECT 'x', 20 UNION ALL "
+                       "SELECT 'y', 5")
+
+    result = parquet_preview(pq, sql="SELECT k, SUM(v) AS total FROM data GROUP BY k ORDER BY k")
+    assert result["column_count"] == 2
+    assert result["row_count"] == 2
+    rows = {r["k"]: r["total"] for r in result["preview"]}
+    assert rows["x"] == 30
+    assert rows["y"] == 5
+
+
+@pytest.mark.contract
+def test_parquet_preview_with_read_parquet_direct(tmp_path):
+    """parquet_preview con read_parquet() esplicito: funziona comunque."""
+    from toolkit.core.duckdb_shape import parquet_preview
+
+    pq = tmp_path / "test.parquet"
+    write_parquet(pq, "CREATE TABLE t AS SELECT 42 AS n")
+
+    # Usa read_parquet direttamente invece di 'data'
+    result = parquet_preview(pq, sql=f"SELECT n FROM read_parquet('{pq}') WHERE n = 42")
+    assert result["row_count"] == 1
+    assert result["preview"][0]["n"] == 42
+
+
+@pytest.mark.policy
+def test_parquet_preview_missing_file_no_sql_graceful(tmp_path):
+    """Senza sql=, file mancante → empty dict graceful."""
+    from toolkit.core.duckdb_shape import parquet_preview
+
+    result = parquet_preview(tmp_path / "nonexistent.parquet")
+    assert result["column_count"] == 0
+    assert result["row_count"] is None
+    assert result["preview"] == []
+
+
+@pytest.mark.policy
+def test_parquet_preview_missing_file_with_sql_raises(tmp_path):
+    """Con sql=, file mancante → FileNotFoundError."""
+    from toolkit.core.duckdb_shape import parquet_preview
+
+    with pytest.raises(FileNotFoundError, match="nonexistent"):
+        parquet_preview(tmp_path / "nonexistent.parquet", sql="SELECT 1")
+
+
+@pytest.mark.policy
+def test_parquet_preview_invalid_sql_raises(tmp_path):
+    """Con sql= invalido → eccezione propagata (non ingoiata)."""
+    from toolkit.core.duckdb_shape import parquet_preview
+
+    pq = tmp_path / "test.parquet"
+    write_parquet(pq, "CREATE TABLE t AS SELECT 1 AS x")
+
+    with pytest.raises(Exception, match="nonexistent_table"):
+        parquet_preview(pq, sql="SELECT * FROM nonexistent_table")

--- a/toolkit/cli/inspect/schema_diff_ops.py
+++ b/toolkit/cli/inspect/schema_diff_ops.py
@@ -1,8 +1,13 @@
-"""inspect schema-diff command — compare RAW schema signals across years."""
+"""inspect schema-diff command — compare RAW schema signals across years.
+
+Implementazione condivisa: sia CLI che MCP la chiamano.
+MCP wrappa le eccezioni in ToolkitClientError.
+"""
 
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import typer
 
@@ -12,6 +17,34 @@ from toolkit.core.config import load_config
 from ._helpers import _compare_schema_entries, _raw_schema_payload
 
 
+# --- Implementazione condivisa ---
+
+
+def schema_diff_payload(config_path: str) -> dict[str, Any]:
+    """Confronta i segnali di schema RAW tra gli anni configurati.
+
+    Args:
+        config_path: path al dataset.yml.
+
+    Returns:
+        Dict con entries per anno e comparazioni pairwise.
+    """
+    cfg = load_config(config_path)
+    years = iter_years(cfg, None)
+    entries = [_raw_schema_payload(cfg, selected_year) for selected_year in years]
+    comparisons = _compare_schema_entries(entries)
+    return {
+        "dataset": cfg.dataset,
+        "config_path": str(cfg.base_dir / "dataset.yml"),
+        "years": [entry["year"] for entry in entries],
+        "entries": entries,
+        "comparisons": comparisons,
+    }
+
+
+# --- CLI wrapper (Typer) ---
+
+
 def schema_diff(
     config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
     as_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
@@ -19,16 +52,9 @@ def schema_diff(
     """
     Confronta i principali segnali di schema RAW tra gli anni configurati.
     """
-    cfg = load_config(config)
-    entries = [_raw_schema_payload(cfg, selected_year) for selected_year in iter_years(cfg, None)]
-    comparisons = _compare_schema_entries(entries)
-    payload = {
-        "dataset": cfg.dataset,
-        "config_path": str(cfg.base_dir / "dataset.yml"),
-        "years": [entry["year"] for entry in entries],
-        "entries": entries,
-        "comparisons": comparisons,
-    }
+    payload = schema_diff_payload(config)
+    entries = payload["entries"]
+    comparisons = payload["comparisons"]
 
     if as_json:
         typer.echo(json.dumps(payload, indent=2, ensure_ascii=False))

--- a/toolkit/core/duckdb_shape.py
+++ b/toolkit/core/duckdb_shape.py
@@ -107,17 +107,33 @@ def parquet_preview(
     """Schema + conteggio + preview righe di un file Parquet.
 
     Args:
-        path: Path al file parquet (usato solo se ``sql`` è ``None``).
+        path: Path al file parquet.
         limit: Numero massimo di righe in preview (default 10).
-        sql: SQL arbitrario da eseguire sul parquet. Se ``None`` (default),
-            esegue ``SELECT * FROM file LIMIT {limit}`` (backward compat).
+        sql: SQL SELECT da eseguire sul parquet. Il parquet è disponibile
+            come vista ``data``. Esempi::
+
+                SELECT * FROM data WHERE anno > 2020
+                SELECT regione, COUNT(*) FROM data GROUP BY regione
+
+            Se ``None`` (default), esegue ``SELECT * FROM data LIMIT {limit}``
+            (backward compat).
+
+            Nota: solo SELECT singolo (DuckDB non supporta multi-statement
+            in una chiamata ``execute()``).
 
     Returns:
         ``{"path": str, "column_count": int, "columns": [...],
           "row_count": int | None, "preview": [...], "truncated": bool,
           "sql": str | None}``.
+
+    Raises:
+        FileNotFoundError: se il parquet non esiste (solo quando ``sql``
+            è fornito; in modalità default graceful empty dict).
+        RuntimeError: se la query SQL fallisce (solo con ``sql``).
     """
-    if not path.exists() and sql is None:
+    if not path.exists():
+        if sql is not None:
+            raise FileNotFoundError(f"Parquet non trovato: {path}")
         return {"path": str(path), "column_count": 0, "columns": [],
                 "row_count": None, "preview": [], "truncated": False, "sql": None}
 
@@ -126,7 +142,8 @@ def parquet_preview(
             con.execute("PRAGMA disable_progress_bar")
 
             if sql is not None:
-                # SQL arbitrario: lo esegue direttamente, con LIMIT finale
+                # Registra il parquet come vista 'data' per query naturali
+                con.execute(f"CREATE OR REPLACE VIEW data AS SELECT * FROM {_rel(path)}")
                 source = f"({sql})"
             else:
                 source = _rel(path)
@@ -154,6 +171,9 @@ def parquet_preview(
                 "sql": sql,
             }
     except Exception:
+        if sql is not None:
+            # In modalità SQL esplicito, propaga l'errore
+            raise
         base = {"path": str(path), "column_count": 0, "columns": [],
                 "row_count": None, "preview": [], "truncated": False}
         base["sql"] = sql

--- a/toolkit/core/duckdb_shape.py
+++ b/toolkit/core/duckdb_shape.py
@@ -102,32 +102,45 @@ def parquet_row_count(path: Path) -> int | None:
 def parquet_preview(
     path: Path,
     limit: int = 10,
+    sql: str | None = None,
 ) -> dict[str, Any]:
     """Schema + conteggio + preview righe di un file Parquet.
 
+    Args:
+        path: Path al file parquet (usato solo se ``sql`` è ``None``).
+        limit: Numero massimo di righe in preview (default 10).
+        sql: SQL arbitrario da eseguire sul parquet. Se ``None`` (default),
+            esegue ``SELECT * FROM file LIMIT {limit}`` (backward compat).
+
     Returns:
         ``{"path": str, "column_count": int, "columns": [...],
-          "row_count": int | None, "preview": [...], "truncated": bool}``.
+          "row_count": int | None, "preview": [...], "truncated": bool,
+          "sql": str | None}``.
     """
-    if not path.exists():
+    if not path.exists() and sql is None:
         return {"path": str(path), "column_count": 0, "columns": [],
-                "row_count": None, "preview": [], "truncated": False}
+                "row_count": None, "preview": [], "truncated": False, "sql": None}
 
     try:
         with safe_connect() as con:
             con.execute("PRAGMA disable_progress_bar")
-            rel = _rel(path)
+
+            if sql is not None:
+                # SQL arbitrario: lo esegue direttamente, con LIMIT finale
+                source = f"({sql})"
+            else:
+                source = _rel(path)
 
             # schema
-            describe = con.execute(f"DESCRIBE SELECT * FROM {rel}").fetchall()
+            describe = con.execute(f"DESCRIBE SELECT * FROM {source}").fetchall()
             columns = [{"name": str(r[0]), "type": str(r[1])} for r in describe]
 
             # row count
-            count_row = con.execute(f"SELECT COUNT(*) FROM {rel}").fetchone()
+            count_row = con.execute(f"SELECT COUNT(*) FROM {source}").fetchone()
             row_count = int(count_row[0]) if count_row else None
 
             # preview
-            preview = con.execute(f"SELECT * FROM {rel} LIMIT {int(limit)}").fetchall()
+            preview = con.execute(f"SELECT * FROM {source} LIMIT {int(limit)}").fetchall()
             col_names = [c["name"] for c in columns]
             preview_rows = [dict(zip(col_names, row)) for row in preview]
 
@@ -138,7 +151,10 @@ def parquet_preview(
                 "row_count": row_count,
                 "preview": preview_rows,
                 "truncated": bool(row_count and row_count > limit),
+                "sql": sql,
             }
     except Exception:
-        return {"path": str(path), "column_count": 0, "columns": [],
+        base = {"path": str(path), "column_count": 0, "columns": [],
                 "row_count": None, "preview": [], "truncated": False}
+        base["sql"] = sql
+        return base

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -31,19 +31,6 @@ def _inspect_paths(*args: Any, **kwargs: Any) -> Any:
     return _impl(*args, **kwargs)
 
 
-def _raw_schema_payload(*args: Any, **kwargs: Any) -> Any:
-    """Lazy import to avoid circular dependency with cli/inspect."""
-    from toolkit.cli.inspect._helpers import _raw_schema_payload as _impl
-
-    return _impl(*args, **kwargs)
-
-
-def _compare_schema_entries(*args: Any, **kwargs: Any) -> Any:
-    """Lazy import to avoid circular dependency with cli/inspect."""
-    from toolkit.cli.inspect._helpers import _compare_schema_entries as _impl
-
-    return _impl(*args, **kwargs)
-
 
 def show_schema(config_path: str, layer: str = "clean", year: int | None = None) -> dict[str, Any]:
     """Mostra lo schema (colonne + tipi) di raw, clean o mart.
@@ -373,24 +360,17 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
 def schema_diff(config_path: str) -> dict[str, Any]:
     """Compare RAW schema signals across the years configured for a dataset.
 
-    Returns entries per year (encoding, delim, columns, etc.) and pairwise
-    comparisons showing added/removed columns between consecutive years.
+    Thin wrapper MCP: delega a ``toolkit.cli.inspect.schema_diff_ops.schema_diff_payload``.
     """
-    config, cfg = _load_cfg(config_path)
+    from toolkit.cli.inspect.schema_diff_ops import schema_diff_payload as _payload
 
-    from toolkit.cli.common import iter_years
+    try:
+        return _payload(config_path)
+    except (ValueError, FileNotFoundError) as exc:
+        from toolkit.mcp.errors import ToolkitClientError
+        from lab_connectors.mcp.errors import ErrorCode
 
-    years = iter_years(cfg, None)
-    entries = [_raw_schema_payload(cfg, selected_year) for selected_year in years]
-    comparisons = _compare_schema_entries(entries)
-
-    return {
-        "dataset": cfg.dataset,
-        "config_path": str(config_path),
-        "years": [entry["year"] for entry in entries],
-        "entries": entries,
-        "comparisons": comparisons,
-    }
+        raise ToolkitClientError(str(exc), code=ErrorCode.INVALID_PARAMS) from exc
 
 
 def clean_preview(


### PR DESCRIPTION
## Sintesi

Allineamento iniziale CLI/MCP seguendo il pattern già esistente nel repo:
- **schema_diff**: unica implementazione condivisa (era duplicata tra CLI e MCP)
- **parquet_preview**: nuovo parametro `sql=` per query arbitraria (prepara il terreno per chiudere il gap del DuckDB MCP deprecato)

## Contesto collegato

Conversazione di design: allineamento superfici CLI/MCP con logica condivisa.

## Cosa cambia

- [ ] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

- [ ] Struttura `dataset.yml`
- [ ] Path output
- [ ] Schema parquet
- [ ] CLI o MCP tool
- [x] API pubblica del toolkit — `parquet_preview()` aggiunge campo `sql` nel dict di ritorno e parametro opzionale `sql=` (backward compat)

> Se segnato, hai aggiornato downstream? — [ ] `dataset-incubator` — [ ] `docs/`

## Verifica

```bash
pytest -m core -x --tb=short  # 197 pass
ruff check .
mypy toolkit/
```

- [x] `pytest -m core` passa
- [x] `ruff check .` passa
- [x] `mypy toolkit/` passa (solo errori preesistenti in read_excel.py e profile/raw.py)
- [ ] Modificato o aggiunto test con marker appropriato — _refactor di implementazione esistente, test core già coprono_

## Checklist PR

- [x] Perimetro stretto: una PR = un fix mirato (allineamento pattern)
- [ ] Se nuovo plugin: test + docs inclusi
- [ ] Issue collegata o motivazione dell'assenza — _design discussion, nessuna issue_
- [x] **Se rimuovo un modulo/funzione pubblica**: ho verificato l'assenza di import — `_raw_schema_payload` e `_compare_schema_entries` rimosse da `mcp/schema_ops.py` (erano funzioni private, non importate da test)

## Note per chi revisiona

Due commit separati, uno per逻辑:
1. **refactor**: schema_diff_payload() condivisa — segue pattern già usato da `show_schema` in `schema_ops.py`
2. **feat**: parametro `sql=` in `parquet_preview()` — aggiunta backward compat, prepara il terreno per i prossimi step (CLI `toolkit query`, MCP `toolkit_layer`)

Il branch è solo locale/pushato per review. Nessun merge automatico.
