### PR TITLE
feat(cli): aggiungi comando `toolkit query` per SQL su parquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Il toolkit non gestisce il deployment: scrive nella directory configurata via
 
 | Comando | Cosa fa |
 |---|---|
+| `toolkit query path/to/file.parquet [--sql "..."]` | Query SQL su parquet (via path o via dataset.yml + layer) |
 | `toolkit scout <URL>` | Esplora URL esterno (HTTP/CKAN/SDMX/HTML) — probe + routing + inferenze |
 | `toolkit scout <URL> --scaffold` | Probe + scaffold candidato completo (dataset.yml, SQL, README) |
 | `toolkit scout <URL> --run` | Probe + scaffold + raw run |
@@ -266,6 +267,7 @@ toolkit/
 | Problema | Soluzione |
 |---|---|
 | `toolkit: command not found` | Usa `python -m toolkit.cli.app` al posto di `toolkit` |
+| "fare una query SQL su un parquet?" | `toolkit query path/to/file.parquet --sql "SELECT * FROM data WHERE ..."` |
 | `run all` fallisce | `toolkit review-readiness --config dataset.yml` + controlla che la fonte sia raggiungibile |
 | "dove sono i parquet prodotti?" | `toolkit inspect paths --config dataset.yml --year <anno>` o cerca in `root/data/` |
 | "errore schema tra anni diversi" | `toolkit inspect schema-diff --config dataset.yml` per vedere il drift RAW |

--- a/docs/feature-stability.md
+++ b/docs/feature-stability.md
@@ -3,7 +3,9 @@
 Questa matrice serve a chiarire cosa il toolkit considera percorso canonico, cosa resta supportato ma secondario, e cosa non va trattato come parte del quickstart dei repo dataset clonati dal template.
 
 | Area | Stato | Uso raccomandato |
-|---|---|---|---|
+|---|---|---|---|---|
+| `query` | stable | query SQL su parquet (path o dataset.yml + layer) |
+| `parquet_preview(sql=...)` | stable | API core per SQL arbitrario su parquet |
 | `run all` | stable | percorso canonico |
 | `validate all` | stable | percorso canonico |
 | `status` | stable | percorso canonico |

--- a/docs/feature-stability.md
+++ b/docs/feature-stability.md
@@ -3,7 +3,7 @@
 Questa matrice serve a chiarire cosa il toolkit considera percorso canonico, cosa resta supportato ma secondario, e cosa non va trattato come parte del quickstart dei repo dataset clonati dal template.
 
 | Area | Stato | Uso raccomandato |
-|---|---|---|---|---|
+|---|---|---|
 | `query` | stable | query SQL su parquet (path o dataset.yml + layer) |
 | `parquet_preview(sql=...)` | stable | API core per SQL arbitrario su parquet |
 | `run all` | stable | percorso canonico |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ import pytest
 
 CORE_TESTS = {
     "test_cli_inspect_paths.py",
+    "test_cli_query.py",
+    "test_duckdb_shape.py",
     "test_cli_path_contract.py",
     "test_cli_resume.py",
     "test_cli_scout_url.py",

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -1,10 +1,15 @@
-"""Test per CLI toolkit query."""
+"""Test per CLI toolkit query.
+
+Contract: copre path diretto e modalita' --config (con e senza artifact).
+Policy: missing file, no args, --config senza artifact.
+"""
 
 from __future__ import annotations
 
 import json
 
 import pytest
+import yaml
 from typer.testing import CliRunner
 
 from tests.helpers import write_parquet
@@ -24,6 +29,47 @@ def sample_parquet(tmp_path):
                        "SELECT 'b', 20 UNION ALL "
                        "SELECT 'a', 30")
     return pq
+
+
+@pytest.fixture
+def dataset_with_clean_parquet(tmp_path):
+    """Crea un dataset.yml minimale con un parquet clean nel path atteso.
+
+    Crea la struttura:
+        {tmp_path}/_smoke_out/data/clean/mio_test/2024/mio_test_2024_clean.parquet
+        {tmp_path}/dataset.yml
+    """
+    root = tmp_path / "_smoke_out"
+    slug = "mio_test"
+    year = 2024
+    clean_dir = root / "data" / "clean" / slug / str(year)
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    pq = clean_dir / f"{slug}_{year}_clean.parquet"
+    write_parquet(pq, "CREATE TABLE t AS SELECT 1 AS id, 'x' AS val")
+
+    # dataset.yml
+    config = {
+        "root": str(root),
+        "dataset": {"name": slug, "years": [year]},
+        "raw": {"sources": [{"type": "local_file", "args": {"path": "dummy.csv"}}]},
+        "clean": {"sql": "sql/clean.sql"},
+        "mart": {"tables": []},
+    }
+    cfg_path = tmp_path / "dataset.yml"
+    cfg_path.write_text(yaml.dump(config), encoding="utf-8")
+
+    # sql stub (evita errori di validazione)
+    sql_dir = tmp_path / "sql"
+    sql_dir.mkdir(exist_ok=True)
+    (sql_dir / "clean.sql").write_text("SELECT 1", encoding="utf-8")
+
+    return {
+        "config_path": str(cfg_path),
+        "layer": "clean",
+        "year": year,
+        "slug": slug,
+        "parquet_path": pq,
+    }
 
 
 @pytest.mark.contract
@@ -98,3 +144,80 @@ def test_query_no_path_no_config(runner):
 
     result = runner.invoke(app, ["query"])
     assert result.exit_code != 0
+
+
+# --- Modalita' --config ---
+
+
+@pytest.mark.contract
+def test_query_config_with_artifact(runner, dataset_with_clean_parquet):
+    """query -c dataset.yml -l clean con artifact presente: successo."""
+    from toolkit.cli.app import app
+
+    info = dataset_with_clean_parquet
+    result = runner.invoke(app, [
+        "query",
+        "--config", info["config_path"],
+        "--layer", info["layer"],
+        "--year", str(info["year"]),
+    ])
+    assert result.exit_code == 0
+    assert "id" in result.stdout
+    assert "val" in result.stdout
+    assert "x" in result.stdout
+
+
+@pytest.mark.contract
+def test_query_config_json_output(runner, dataset_with_clean_parquet):
+    """query -c dataset.yml -l clean --json con artifact: JSON valido."""
+    from toolkit.cli.app import app
+
+    info = dataset_with_clean_parquet
+    result = runner.invoke(app, [
+        "query",
+        "--config", info["config_path"],
+        "--layer", info["layer"],
+        "--json",
+    ])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["column_count"] == 2
+    assert data["row_count"] == 1
+
+
+@pytest.mark.policy
+def test_query_config_missing_artifact(runner, tmp_path):
+    """query -c dataset.yml -l clean SENZA artifact: exit code 1.
+
+    Crea un dataset.yml ma non genera il parquet. Il comando deve fallire
+    con messaggio chiaro, non restituire preview vuota.
+    """
+    # dataset.yml senza parquet generato
+    root = tmp_path / "_smoke_out"
+    slug = "mai_run"
+    year = 2024
+    config = {
+        "root": str(root),
+        "dataset": {"name": slug, "years": [year]},
+        "raw": {"sources": [{"type": "local_file", "args": {"path": "dummy.csv"}}]},
+        "clean": {"sql": "sql/clean.sql"},
+        "mart": {"tables": []},
+    }
+    cfg_path = tmp_path / "dataset.yml"
+    cfg_path.write_text(yaml.dump(config), encoding="utf-8")
+
+    # sql stub
+    sql_dir = tmp_path / "sql"
+    sql_dir.mkdir(exist_ok=True)
+    (sql_dir / "clean.sql").write_text("SELECT 1", encoding="utf-8")
+
+    from toolkit.cli.app import app
+
+    result = runner.invoke(app, [
+        "query",
+        "--config", str(cfg_path),
+        "--layer", "clean",
+        "--year", str(year),
+    ])
+    assert result.exit_code == 1
+    assert "non trovato" in result.stdout or "non trovato" in result.stderr

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -1,0 +1,100 @@
+"""Test per CLI toolkit query."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from tests.helpers import write_parquet
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def sample_parquet(tmp_path):
+    """Crea un parquet di esempio per i test."""
+    pq = tmp_path / "data.parquet"
+    write_parquet(pq, "CREATE TABLE t AS "
+                       "SELECT 'a' AS cat, 10 AS val UNION ALL "
+                       "SELECT 'b', 20 UNION ALL "
+                       "SELECT 'a', 30")
+    return pq
+
+
+@pytest.mark.contract
+def test_query_default_no_sql(runner, sample_parquet):
+    """query senza --sql: SELECT * LIMIT 20 (default)."""
+    from toolkit.cli.app import app
+
+    result = runner.invoke(app, ["query", str(sample_parquet)])
+    assert result.exit_code == 0
+    assert "cat" in result.stdout
+    assert "val" in result.stdout
+
+
+@pytest.mark.contract
+def test_query_with_sql(runner, sample_parquet):
+    """query con --sql: esegue SQL arbitrario."""
+    from toolkit.cli.app import app
+
+    result = runner.invoke(app, [
+        "query", str(sample_parquet),
+        "--sql", "SELECT cat, SUM(val) AS total FROM data GROUP BY cat ORDER BY cat",
+    ])
+    assert result.exit_code == 0
+    assert "a" in result.stdout
+    assert "b" in result.stdout
+    assert "total" in result.stdout
+    assert "40" in result.stdout  # SUM(a: 10+30)
+    assert "20" in result.stdout
+
+
+@pytest.mark.contract
+def test_query_with_where(runner, sample_parquet):
+    """query con WHERE: filtra correttamente."""
+    from toolkit.cli.app import app
+
+    result = runner.invoke(app, [
+        "query", str(sample_parquet),
+        "--sql", "SELECT * FROM data WHERE cat = 'a'",
+    ])
+    assert result.exit_code == 0
+    assert result.stdout.count("a") >= 2  # header + 2 righe
+    assert "30" in result.stdout
+
+
+@pytest.mark.contract
+def test_query_json_output(runner, sample_parquet):
+    """query --json: output JSON valido."""
+    from toolkit.cli.app import app
+
+    result = runner.invoke(app, ["query", str(sample_parquet), "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["column_count"] == 2
+    assert data["row_count"] == 3
+    assert len(data["preview"]) == 3
+
+
+@pytest.mark.policy
+def test_query_missing_file(runner, tmp_path):
+    """query su file inesistente: exit code 1."""
+    from toolkit.cli.app import app
+
+    result = runner.invoke(app, ["query", str(tmp_path / "nonexistent.parquet")])
+    assert result.exit_code == 1
+    assert "error" in result.stdout.lower() or "error" in result.stderr.lower()
+
+
+@pytest.mark.policy
+def test_query_no_path_no_config(runner):
+    """query senza path ne --config: exit code 1."""
+    from toolkit.cli.app import app
+
+    result = runner.invoke(app, ["query"])
+    assert result.exit_code != 0

--- a/toolkit/cli/app.py
+++ b/toolkit/cli/app.py
@@ -10,6 +10,7 @@ from toolkit.cli.cmd_inspect import register as register_inspect
 from toolkit.cli.cmd_scaffold import register as register_scaffold
 from toolkit.cli.cmd_batch import register as register_batch
 from toolkit.cli.cmd_review_readiness import register as register_review_readiness
+from toolkit.cli.cmd_query import register as register_query
 from toolkit.cli.cmd_scout import register as register_scout
 from toolkit.version import __version__
 
@@ -35,6 +36,7 @@ register_inspect(app)
 register_scaffold(app)
 register_batch(app)
 register_review_readiness(app)
+register_query(app)
 register_scout(app)
 
 

--- a/toolkit/cli/cmd_query.py
+++ b/toolkit/cli/cmd_query.py
@@ -1,0 +1,166 @@
+"""CLI command: toolkit query
+
+Esegue query SQL su parquet. Due modalità:
+  - path diretto: toolkit query path/to/data.parquet [--sql "..."]
+  - da config:   toolkit query -c dataset.yml -l clean [--sql "..."] [--year 2023]
+
+Usage:
+    toolkit query path/to/file.parquet [--limit 20] [--json]
+    toolkit query path/to/file.parquet --sql "SELECT * FROM data WHERE anno > 2020"
+    toolkit query -c dataset.yml -l clean [--sql "..."] [--year 2023] [--limit 20] [--json]
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from toolkit.core.config import load_config
+from toolkit.core.duckdb_shape import parquet_preview
+
+
+def _resolve_path_from_config(config_path: str, layer: str, year: int | None) -> Path:
+    """Risolve il parquet clean o mart da dataset.yml + layer + year."""
+    from toolkit.cli.inspect._helpers import _payload_for_year
+
+    cfg = load_config(config_path)
+    if year is None:
+        year = max(cfg.years) if cfg.years else 0
+    paths = _payload_for_year(cfg, year)
+
+    if layer == "clean":
+        parquet_str = paths["paths"]["clean"].get("output")
+        if not parquet_str:
+            raise FileNotFoundError(f"Nessun output clean per {cfg.dataset}/{year}")
+        return Path(parquet_str)
+    elif layer == "mart":
+        outputs = paths["paths"]["mart"].get("outputs") or []
+        if not outputs:
+            raise FileNotFoundError(f"Nessun output mart per {cfg.dataset}/{year}")
+        return Path(outputs[0])
+    else:
+        raise ValueError(f"layer deve essere 'clean' o 'mart', non '{layer}'")
+
+
+def _render_human(result: dict[str, Any]) -> None:
+    """Stampa output query in formato leggibile."""
+    path_label = result.get("path", "")
+    row_count = result.get("row_count")
+    col_count = result.get("column_count", 0)
+    sql_used = result.get("sql")
+    preview = result.get("preview", [])
+    columns = result.get("columns", [])
+
+    # Header
+    dataset_label = result.get("dataset") or ""
+    year_label = result.get("year") or ""
+    parts = [f"path: {path_label}"]
+    if dataset_label:
+        parts.append(f"dataset: {dataset_label}")
+    if year_label:
+        parts.append(f"year: {year_label}")
+    typer.echo("  ".join(parts))
+    if sql_used:
+        typer.echo(f"sql: {sql_used[:120]}{'...' if len(sql_used) > 120 else ''}")
+
+    # Schema
+    typer.echo(f"colonne: {col_count}")
+    if row_count is not None:
+        typer.echo(f"righe: {row_count}")
+    else:
+        typer.echo("righe: ?")
+    typer.echo("")
+
+    for col in columns:
+        typer.echo(f"  {col.get('name', '?'):30s} {col.get('type', '?')}")
+
+    typer.echo("")
+    if not preview:
+        typer.echo("(nessuna riga)")
+        return
+
+    # Tabella: calcola larghezza colonne
+    col_names = [c["name"] for c in columns]
+    # Pre-calcola larghezze minime
+    widths = {name: len(name) for name in col_names}
+    for row in preview:
+        for name in col_names:
+            val = row.get(name)
+            str_val = str(val) if val is not None else ""
+            widths[name] = max(widths[name], len(str_val))
+
+    # Header row
+    header = "  ".join(f"{name:{widths[name]}s}" for name in col_names)
+    typer.echo(header)
+    typer.echo("-" * len(header))
+
+    # Data rows
+    for row in preview:
+        vals = []
+        for name in col_names:
+            val = row.get(name)
+            str_val = str(val) if val is not None else "NULL"
+            vals.append(f"{str_val:{widths[name]}s}")
+        typer.echo("  ".join(vals))
+
+    truncated = result.get("truncated", False)
+    if truncated:
+        typer.echo(f"\n(... mostra prime {len(preview)} righe su {row_count})")
+
+
+def query(
+    path_arg: str = typer.Argument("", metavar="PATH", help="Path al file parquet (posizionale)"),
+    config: str = typer.Option(None, "--config", "-c", help="Path a dataset.yml (alternativo a PATH)"),
+    layer: str = typer.Option("clean", "--layer", "-l", help="Layer: clean o mart (solo con -c)"),
+    year: int = typer.Option(0, "--year", "-y", help="Anno (default: ultimo del config, solo con -c)"),
+    sql: str = typer.Option(None, "--sql", help="SQL query (default: SELECT * LIMIT N)"),
+    limit: int = typer.Option(20, "--limit", help="Max righe in output"),
+    json_output: bool = typer.Option(False, "--json", help="Output JSON"),
+) -> None:
+    """Esegue una query SQL su un file parquet.
+
+    Il parquet puo' essere specificato come argomento posizionale (PATH)
+    o risolto da dataset.yml con --config / -c.
+
+    La query SQL (--sql) puo' referenziare il parquet come tabella 'data'.
+    Esempi: "SELECT * FROM data", "SELECT COUNT(*) FROM data WHERE ...".
+
+    Se --sql non e' fornito, mostra le prime N righe (equivalente a SELECT *).
+    """
+    # Risolvi il path del parquet
+    try:
+        if config:
+            # Da dataset.yml
+            resolved_config = str(Path(config).resolve())
+            parquet_path = _resolve_path_from_config(resolved_config, layer, year or None)
+        elif path_arg:
+            parquet_path = Path(path_arg).resolve()
+            if not parquet_path.exists():
+                typer.echo(f"error: file non trovato: {parquet_path}", err=True)
+                raise typer.Exit(code=1)
+        else:
+            typer.echo("error: specificare un path parquet o --config", err=True)
+            raise typer.Exit(code=1)
+    except (FileNotFoundError, ValueError) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    # Esegui query
+    try:
+        result = parquet_preview(parquet_path, limit=limit, sql=sql)
+    except Exception as exc:
+        typer.echo(f"error: {type(exc).__name__}: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    if json_output:
+        typer.echo(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+        return
+
+    _render_human(result)
+
+
+def register(app: typer.Typer) -> None:
+    app.command("query")(query)

--- a/toolkit/cli/cmd_query.py
+++ b/toolkit/cli/cmd_query.py
@@ -23,7 +23,15 @@ from toolkit.core.duckdb_shape import parquet_preview
 
 
 def _resolve_path_from_config(config_path: str, layer: str, year: int | None) -> Path:
-    """Risolve il parquet clean o mart da dataset.yml + layer + year."""
+    """Risolve il parquet clean o mart da dataset.yml + layer + year.
+
+    Returns:
+        Path al file parquet.
+
+    Raises:
+        FileNotFoundError: se il parquet non esiste su disco o non è configurato.
+        ValueError: se layer non è 'clean' o 'mart'.
+    """
     from toolkit.cli.inspect._helpers import _payload_for_year
 
     cfg = load_config(config_path)
@@ -34,15 +42,22 @@ def _resolve_path_from_config(config_path: str, layer: str, year: int | None) ->
     if layer == "clean":
         parquet_str = paths["paths"]["clean"].get("output")
         if not parquet_str:
-            raise FileNotFoundError(f"Nessun output clean per {cfg.dataset}/{year}")
-        return Path(parquet_str)
+            raise FileNotFoundError(f"Nessun output clean configurato per {cfg.dataset}/{year}")
+        parquet_path = Path(parquet_str)
     elif layer == "mart":
         outputs = paths["paths"]["mart"].get("outputs") or []
         if not outputs:
-            raise FileNotFoundError(f"Nessun output mart per {cfg.dataset}/{year}")
-        return Path(outputs[0])
+            raise FileNotFoundError(f"Nessun output mart configurato per {cfg.dataset}/{year}")
+        parquet_path = Path(outputs[0])
     else:
         raise ValueError(f"layer deve essere 'clean' o 'mart', non '{layer}'")
+
+    if not parquet_path.exists():
+        raise FileNotFoundError(
+            f"Parquet {layer} non trovato: {parquet_path}\n"
+            f"  Esegui 'toolkit run all -c {config_path}' per generarlo."
+        )
+    return parquet_path
 
 
 def _render_human(result: dict[str, Any]) -> None:


### PR DESCRIPTION
## Sintesi

Nuovo comando CLI `toolkit query` per eseguire query SQL su file parquet.
Si appoggia a `core.duckdb_shape.parquet_preview(sql=...)` aggiunto nella PR #333.

## Cosa cambia

- [ ] Bug fix
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [x] Documentazione
- [ ] Dipendenze o CI

## Uso

```bash
# Path diretto
toolkit query path/to/data.parquet
toolkit query path/to/data.parquet --sql "SELECT * FROM data WHERE anno > 2020" --limit 50
toolkit query path/to/data.parquet --json

# Da dataset config
toolkit query -c dataset.yml -l clean -y 2023
toolkit query -c dataset.yml -l mart --sql "SELECT regione, COUNT(*) FROM data GROUP BY regione"
```

La query SQL referenzia il parquet come tabella `data`.

## Impatto su contratti pubblici

- [x] CLI o MCP tool (nuovo comando `toolkit query`)

## Verifica

```bash
pytest -m core -x --tb=short  → 211 passed
ruff check .
```

- [x] `pytest -m core` passa
- [x] `ruff check .` passa
- [ ] `mypy toolkit/` passa (solo errori preesistenti)

## Checklist PR

- [x] Perimetro stretto: un comando CLI + test
- [ ] Se nuovo plugin: test + docs inclusi
- [ ] Issue collegata o motivazione dell'assenza

## Note per chi revisiona

Il comando delega a `core.duckdb_shape.parquet_preview` (zero logica nuova).
Dipende dal contratto `sql=` e vista `data` già mergiato nella PR #333.
