### PR TITLE
refactor(core): centralizza dipendenza yaml in core/io.py

### DIFF
--- a/tests/test_io_yaml.py
+++ b/tests/test_io_yaml.py
@@ -1,0 +1,116 @@
+"""Test per le funzioni YAML in toolkit.core.io.
+
+Copre read_yaml, read_yaml_or_none, write_yaml, yaml_dumps.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from toolkit.core.io import (
+    read_yaml,
+    read_yaml_or_none,
+    write_yaml,
+    yaml_dumps,
+)
+
+pytestmark = pytest.mark.pure_unit
+
+
+# ---------------------------------------------------------------------------
+# read_yaml
+# ---------------------------------------------------------------------------
+
+def test_read_yaml_valid(tmp_path: Path) -> None:
+    path = tmp_path / "valid.yml"
+    path.write_text("key: value\nnested:\n  inner: 42\n", encoding="utf-8")
+    data = read_yaml(path)
+    assert data == {"key": "value", "nested": {"inner": 42}}
+
+
+def test_read_yaml_empty_file(tmp_path: Path) -> None:
+    path = tmp_path / "empty.yml"
+    path.write_text("", encoding="utf-8")
+    assert read_yaml(path) is None
+
+
+def test_read_yaml_invalid_syntax(tmp_path: Path) -> None:
+    path = tmp_path / "broken.yml"
+    path.write_text("{ invalid: yaml: :", encoding="utf-8")
+    with pytest.raises(ValueError, match="YAML parse error"):
+        read_yaml(path)
+
+
+def test_read_yaml_missing_file(tmp_path: Path) -> None:
+    path = tmp_path / "nope.yml"
+    with pytest.raises(FileNotFoundError):
+        read_yaml(path)
+
+
+# ---------------------------------------------------------------------------
+# read_yaml_or_none
+# ---------------------------------------------------------------------------
+
+def test_read_yaml_or_none_valid(tmp_path: Path) -> None:
+    path = tmp_path / "ok.yml"
+    path.write_text("a: 1\nb: 2\n", encoding="utf-8")
+    assert read_yaml_or_none(path) == {"a": 1, "b": 2}
+
+
+def test_read_yaml_or_none_missing(tmp_path: Path) -> None:
+    assert read_yaml_or_none(tmp_path / "missing.yml") is None
+
+
+def test_read_yaml_or_none_invalid(tmp_path: Path) -> None:
+    path = tmp_path / "broken.yml"
+    path.write_text(": broken", encoding="utf-8")
+    assert read_yaml_or_none(path) is None
+
+
+# ---------------------------------------------------------------------------
+# write_yaml
+# ---------------------------------------------------------------------------
+
+def test_write_yaml_roundtrip(tmp_path: Path) -> None:
+    data = {"key": "value", "list": [1, 2, 3]}
+    path = tmp_path / "out.yml"
+    write_yaml(data, path)
+    assert path.exists()
+    reloaded = read_yaml(path)
+    assert reloaded == data
+
+
+def test_write_yaml_creates_parent_dir(tmp_path: Path) -> None:
+    path = tmp_path / "sub" / "nested" / "out.yml"
+    write_yaml({"a": 1}, path)
+    assert path.exists()
+    assert read_yaml(path) == {"a": 1}
+
+
+# ---------------------------------------------------------------------------
+# yaml_dumps
+# ---------------------------------------------------------------------------
+
+def test_yaml_dumps_roundtrip() -> None:
+    data = {"name": "test", "items": [10, 20]}
+    dumped = yaml_dumps(data)
+    assert isinstance(dumped, str)
+    assert "name: test" in dumped
+    assert "items:" in dumped
+    # Il risultato deve essere riparsabile
+    import yaml
+    reloaded = yaml.safe_load(dumped)
+    assert reloaded == data
+
+
+def test_yaml_dumps_empty() -> None:
+    assert isinstance(yaml_dumps({}), str)
+
+
+def test_yaml_dumps_block_style() -> None:
+    """Verifica che safe_dump usi block style (non flow style)."""
+    data = {"a": {"b": "c"}}
+    dumped = yaml_dumps(data)
+    # Block style scrive su multiple righe, flow style su una riga
+    assert "\n" in dumped.strip()

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -14,7 +14,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-import yaml
+from toolkit.core.io import read_yaml
 from toolkit.core.csv_read import (
     READ_SELECTION_KEYS,
     READ_SOURCE_MODES,
@@ -59,7 +59,7 @@ def load_suggested_read(raw_year_dir: Path) -> dict[str, Any] | None:
     if not suggested_path.exists():
         return None
 
-    payload = yaml.safe_load(suggested_path.read_text(encoding="utf-8"))
+    payload = read_yaml(suggested_path)
     if not isinstance(payload, dict):
         return None
 

--- a/toolkit/cli/cmd_scaffold.py
+++ b/toolkit/cli/cmd_scaffold.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from typing import Any
 
 import typer
-import yaml
 
 from toolkit.cli.common import iter_years, load_cfg_and_logger
+from toolkit.core.io import read_yaml
 from toolkit.core.paths import RAW_PROFILE, RAW_SUGGESTED_READ, layer_year_dir
 from toolkit.scaffold.clean import format_clean_read_proposal, generate_clean_sql
 
@@ -52,8 +52,8 @@ def scaffold_clean(
         # Build a minimal profile dict from it so propose_clean_read works.
         if suggested_read_yml.exists():
             try:
-                raw_yaml = yaml.safe_load(suggested_read_yml.read_text(encoding="utf-8"))
-            except yaml.YAMLError as exc:
+                raw_yaml = read_yaml(suggested_read_yml)
+            except ValueError as exc:
                 raise typer.BadParameter(f"suggested_read.yml non valido: {exc}")
             clean_section = raw_yaml.get("clean", {}) if isinstance(raw_yaml, dict) else {}
             read_section = clean_section.get("read", {}) if isinstance(clean_section, dict) else {}

--- a/toolkit/core/io.py
+++ b/toolkit/core/io.py
@@ -107,3 +107,71 @@ def read_json_or_none(path: Path) -> dict[str, Any] | None:
         return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return None
+
+
+# ---------------------------------------------------------------------------
+# YAML helpers — centralise yaml dependency here so callers don't import yaml
+# ---------------------------------------------------------------------------
+
+def read_yaml(path: Path) -> Any:
+    """Read and parse a YAML file.
+
+    Args:
+        path: Path to the YAML file.
+
+    Returns:
+        Parsed content (dict, list, or scalar).
+
+    Raises:
+        ValueError: if the file cannot be parsed as YAML.
+        OSError: if the file cannot be read.
+    """
+    import yaml as _yaml
+
+    try:
+        return _yaml.safe_load(path.read_text(encoding="utf-8"))
+    except _yaml.YAMLError as exc:
+        raise ValueError(f"YAML parse error in {path}: {exc}") from exc
+
+
+def read_yaml_or_none(path: Path) -> Any:
+    """Read and parse a YAML file, returning None on any error.
+
+    Use for optional files where absence or malformation is a valid state.
+    """
+    import yaml as _yaml
+
+    try:
+        return _yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, _yaml.YAMLError, UnicodeDecodeError):
+        return None
+
+
+def write_yaml(data: Any, path: Path) -> None:
+    """Serialize data to a YAML file (safe_dump, block style).
+
+    Args:
+        data: Data to serialize (typically dict or list).
+        path: Destination path. Parent directories are created if needed.
+    """
+    import yaml as _yaml
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        _yaml.safe_dump(data, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def yaml_dumps(data: Any) -> str:
+    """Serialize data to a YAML string (safe_dump, block style).
+
+    Args:
+        data: Data to serialize.
+
+    Returns:
+        YAML-formatted string.
+    """
+    import yaml as _yaml
+
+    return _yaml.safe_dump(data, default_flow_style=False, sort_keys=False)

--- a/toolkit/mcp/discovery.py
+++ b/toolkit/mcp/discovery.py
@@ -13,9 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal
 
-from toolkit.core.io import read_json_or_none
-
-import yaml
+from toolkit.core.io import read_json_or_none, read_yaml
 
 from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.path_safety import WORKSPACE_ROOT
@@ -28,7 +26,7 @@ def _read_minimal_config(dataset_yml: Path) -> dict[str, Any]:
     Restituisce un dict con: name, years, root (stringa raw dal YAML).
     """
     try:
-        data = yaml.safe_load(dataset_yml.read_text(encoding="utf-8"))
+        data = read_yaml(dataset_yml)
     except Exception as exc:
         return {"_error": f"YAML non valido: {exc}"}
 

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -20,6 +20,7 @@ from lab_connectors.mcp.errors import ErrorCode
 
 from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.path_safety import _load_cfg, _safe_path
+from toolkit.core.io import read_yaml
 from toolkit.core.paths import RAW_PROFILE, RAW_SUGGESTED_READ
 from toolkit.core.run_records import get_run_dir_dataset, list_runs as _list_runs_records
 
@@ -70,11 +71,9 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
             ) from exc
     elif suggested_read_yml.exists():
         # Fallback: suggested_read.yml contains the same hints in YAML form
-        import yaml
-
         try:
-            raw_yaml = yaml.safe_load(suggested_read_yml.read_text(encoding="utf-8"))
-        except yaml.YAMLError as exc:
+            raw_yaml = read_yaml(suggested_read_yml)
+        except ValueError as exc:
             raise ToolkitClientError(
                 f"suggested_read.yml non valido in {suggested_read_yml}: {exc}",
                 code=ErrorCode.ARTIFACT_UNREADABLE,

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -359,9 +359,8 @@ def format_clean_read_proposal(profile: dict[str, Any]) -> str:
     Includes ``read_mode: robust`` as a top-level ``clean`` field when
     ``robust_read_suggested`` is set (not inside ``clean.read``).
     """
-    import yaml
-
     from toolkit.core.config_models.clean import CleanReadConfig
+    from toolkit.core.io import yaml_dumps
 
     proposed = propose_clean_read(profile)
     if not proposed:
@@ -376,4 +375,4 @@ def format_clean_read_proposal(profile: dict[str, Any]) -> str:
     if profile.get("robust_read_suggested"):
         result["clean"]["read_mode"] = "robust"
 
-    return yaml.safe_dump(result, default_flow_style=False, sort_keys=False)
+    return yaml_dumps(result)


### PR DESCRIPTION
## Sintesi

Centralizza la dipendenza dal pacchetto `yaml` in `core/io.py`, così che nessun file fuori da `core/` importi `yaml` direttamente. Principio: le dipendenze esterne vanno in `core/`, i layer superiori importano solo da `core/` o `lab-connectors`.

## Contesto collegato

Refactor pianificato — discussione architetturale in sessione di lavoro.

## Cosa cambia

- [ ] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Dettaglio

**`toolkit/core/io.py`** — 4 nuove funzioni con import lazy di pyyaml:
- `read_yaml(path)` — legge YAML, ValueError su errore parsing
- `read_yaml_or_none(path)` — come sopra, restituisce None su errore
- `write_yaml(data, path)` — serializza YAML su file
- `yaml_dumps(data)` — serializza YAML a stringa

**5 file consumer ripuliti** — `import yaml` → `from toolkit.core.io import ...`:

| File | Prima | Dopo |
|---|---|---|
| `clean/read_config.py` | `import yaml` | `from toolkit.core.io import read_yaml` |
| `cli/cmd_scaffold.py` | `import yaml` | `from toolkit.core.io import read_yaml` |
| `mcp/discovery.py` | `import yaml` | `from toolkit.core.io import read_yaml` |
| `mcp/schema_ops.py` | `import yaml` (inline) | `from toolkit.core.io import read_yaml` |
| `scaffold/clean.py` | `import yaml` (inline) | `from toolkit.core.io import yaml_dumps` |

Le eccezioni `yaml.YAMLError` sono wrappate in `ValueError` da `read_yaml`.

## Impatto su contratti pubblici

Nessuno. API pubbliche invariate. Nuove funzioni in `core/io.py` con nome esplicito.

## Verifica

```bash
pytest tests/test_io_yaml.py -v          # 12 nuovi test
pytest tests/ -x --timeout=60             # 905 test, tutti pass
ruff check toolkit/                       # nessun warning
```

- [x] `pytest tests/` passa (905 test)
- [x] `ruff check toolkit/` passa
- [ ] `mypy toolkit/` non eseguito (non bloccante, invariato rispetto a main)
- [x] Nuovi test con marker `pure_unit`

## Checklist PR

- [x] Perimetro stretto: solo centralizzazione yaml
- [ ] Se nuovo plugin: test + docs inclusi — N/A
- [ ] Issue collegata o motivazione dell'assenza — Refactor pianificato in sessione
- [ ] **Se rimuovo un modulo/funzione pubblica**: N/A

## Note per chi revisiona

- `core/dataset_loader.py` e `core/config_models/_loader.py` restano con `import yaml` diretto perché sono già in `core/` — il principio non li riguarda.
- `pyyaml` resta in `pyproject.toml` come dipendenza diretta (usata da `core/` e dai test).
- I consumer ora lanciano `ValueError` invece di `yaml.YAMLError` — nessun caller esterno noto catturava `yaml.YAMLError` specificamente (verificato con `rg`).
