### PR TITLE
feat(core): espone dateformat, timestampformat, rejects_table in clean.read

### DIFF
--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -494,3 +494,63 @@ def test_read_raw_to_relation_with_thousands_separator(tmp_path: Path):
     rows = con.execute("SELECT id, val FROM raw_input ORDER BY id").fetchall()
     assert rows == [(1, 1234.56), (2, 7890.12)], f"got {rows}"
     con.close()
+
+
+@pytest.mark.policy
+def test_dateformat_parses_italian_dates(tmp_path: Path):
+    """dateformat='%d/%m/%Y' deve parsare date in formato italiano."""
+    input_file = tmp_path / "date.csv"
+    input_file.write_text("data;valore\n01/02/2023;100\n15/08/2024;200\n", encoding="utf-8")
+
+    con = duckdb.connect(":memory:")
+    logger = logging.getLogger("tests.clean.duckdb_read.dateformat")
+
+    info = duckdb_read.read_raw_to_relation(
+        con,
+        [input_file],
+        {"delim": ";", "encoding": "utf-8", "header": True,
+         "dateformat": "%d/%m/%Y"},
+        "strict",
+        logger,
+    )
+
+    assert info.params_used["dateformat"] == "%d/%m/%Y"
+    # DuckDB should parse the dates correctly
+    rows = con.execute("SELECT data, valore FROM raw_input ORDER BY valore").fetchall()
+    assert len(rows) == 2
+    # Data types may vary (could be DATE or VARCHAR depending on DuckDB version)
+    # Check at least the year is correct
+    assert str(rows[0][0]).endswith("2023") or "2023" in str(rows[0][0])
+    assert str(rows[1][0]).endswith("2024") or "2024" in str(rows[1][0])
+    con.close()
+
+
+@pytest.mark.policy
+def test_rejects_table_captures_malformed_rows(tmp_path: Path):
+    """rejects_table deve catturare righe malformate senza bloccare la lettura."""
+    input_file = tmp_path / "mixed.csv"
+    # Row 2 ha 3 colonne invece di 2 — deve finire nella rejects_table
+    input_file.write_text("a;b\n1;2\n3;4;5\n6;7\n", encoding="utf-8")
+
+    con = duckdb.connect(":memory:")
+    logger = logging.getLogger("tests.clean.duckdb_read.rejects")
+
+    info = duckdb_read.read_raw_to_relation(
+        con,
+        [input_file],
+        {"delim": ";", "encoding": "utf-8", "header": True,
+         "ignore_errors": True, "rejects_table": "err_rows",
+         "rejects_scan": "err_scan"},
+        "strict",
+        logger,
+    )
+
+    assert "rejects_table" in info.params_used
+    assert info.params_used["rejects_table"] == "err_rows"
+    # Le righe valide devono essere state lette
+    rows = con.execute("SELECT a, b FROM raw_input ORDER BY a").fetchall()
+    assert rows == [(1, 2), (6, 7)], f"got {rows}"
+    # La riga malformata deve essere nella rejects_table
+    rejects = con.execute("SELECT * FROM err_rows").fetchall()
+    assert len(rejects) >= 1
+    con.close()

--- a/tests/test_csv_read_option_strings.py
+++ b/tests/test_csv_read_option_strings.py
@@ -105,6 +105,29 @@ class TestCsvReadOptionStrings:
         assert result[1].startswith("encoding=")
         assert result[-1].startswith("columns=")
 
+    def test_dateformat(self):
+        assert csv_read_option_strings({"dateformat": "%d/%m/%Y"}) == ["dateformat='%d/%m/%Y'"]
+
+    def test_timestampformat(self):
+        assert csv_read_option_strings({"timestampformat": "%Y-%m-%dT%H:%M:%S"}) == [
+            "timestampformat='%Y-%m-%dT%H:%M:%S'"
+        ]
+
+    def test_rejects_table(self):
+        assert csv_read_option_strings({"rejects_table": "my_rejects"}) == [
+            "rejects_table='my_rejects'"
+        ]
+
+    def test_rejects_scan(self):
+        assert csv_read_option_strings({"rejects_scan": "my_scan"}) == [
+            "rejects_scan='my_scan'"
+        ]
+
+    def test_rejects_sql_injection(self):
+        """Single quotes in rejects_table are escaped."""
+        result = csv_read_option_strings({"rejects_table": "bad'name"})
+        assert "''" in result[0]
+
     def test_full_cfg(self):
         """All supported keys together."""
         cfg = {
@@ -112,10 +135,14 @@ class TestCsvReadOptionStrings:
             "encoding": "utf-8",
             "decimal": ",",
             "thousands": ".",
+            "dateformat": "%d/%m/%Y",
+            "timestampformat": "%H:%M:%S",
             "nullstr": ["", "NA"],
             "auto_detect": False,
             "strict_mode": False,
             "ignore_errors": True,
+            "rejects_table": "err_rows",
+            "rejects_scan": "err_scan",
             "null_padding": True,
             "parallel": True,
             "quote": '"',
@@ -125,7 +152,13 @@ class TestCsvReadOptionStrings:
             "columns": {"id": "VARCHAR", "val": "DOUBLE"},
         }
         result = csv_read_option_strings(cfg)
-        # sep, encoding, decimal, thousands, nullstr, auto_detect, strict_mode,
-        # ignore_errors, null_padding, parallel, quote, escape, comment,
-        # max_line_size, columns = 15
-        assert len(result) == 15
+        # sep, encoding, decimal, thousands, dateformat, timestampformat,
+        # nullstr, auto_detect, strict_mode,
+        # ignore_errors, rejects_table, rejects_scan,
+        # null_padding, parallel, quote, escape, comment,
+        # max_line_size, columns = 19
+        assert len(result) == 19
+        assert "dateformat='%d/%m/%Y'" in result
+        assert "timestampformat='%H:%M:%S'" in result
+        assert "rejects_table='err_rows'" in result
+        assert "rejects_scan='err_scan'" in result

--- a/toolkit/core/config_models/clean.py
+++ b/toolkit/core/config_models/clean.py
@@ -25,12 +25,16 @@ class CleanReadConfig(BaseModel):
     encoding: str | None = None
     decimal: str | None = None
     thousands: str | None = None
+    dateformat: str | None = None
+    timestampformat: str | None = None
     skip: int | None = None
     auto_detect: bool | None = None
     quote: str | None = None
     escape: str | None = None
     comment: str | None = None
     ignore_errors: bool | None = None
+    rejects_table: str | None = None
+    rejects_scan: str | None = None
     strict_mode: bool | None = None
     null_padding: bool | None = None
     parallel: bool | None = None

--- a/toolkit/core/csv_read.py
+++ b/toolkit/core/csv_read.py
@@ -35,6 +35,10 @@ ALLOWED_READ_CSV_KEYS = {
     "trim_whitespace",
     "sample_size",
     "sheet_name",
+    "dateformat",
+    "timestampformat",
+    "rejects_table",
+    "rejects_scan",
 }
 FORMAT_HINT_KEYS = {
     "delim",
@@ -52,6 +56,8 @@ FORMAT_HINT_KEYS = {
     "normalize_rows_to_columns",
     "align_by_header",
     "trim_whitespace",
+    "dateformat",
+    "timestampformat",
 }
 READ_SELECTION_KEYS = {"mode", "glob", "prefer_from_raw_run", "allow_ambiguous", "include"}
 READ_SOURCE_MODES = {"auto", "config_only"}
@@ -197,8 +203,10 @@ def csv_read_option_strings(
     ``union_by_name=true``) and append caller-specific ones (e.g. columns).
 
     Supported keys:
-    ``delim``, ``sep``, ``encoding``, ``decimal``, ``thousands``, ``nullstr``,
-    ``auto_detect``, ``strict_mode``, ``ignore_errors``, ``null_padding``,
+    ``delim``, ``sep``, ``encoding``, ``decimal``, ``thousands``,
+    ``dateformat``, ``timestampformat``, ``nullstr``,
+    ``auto_detect``, ``strict_mode``, ``ignore_errors``, ``rejects_table``,
+    ``rejects_scan``, ``null_padding``,
     ``parallel``, ``quote``, ``escape``, ``comment``, ``max_line_size``,
     ``columns``.
 
@@ -226,6 +234,14 @@ def csv_read_option_strings(
     if thousands is not None:
         opts.append(f"thousands='{sql_str(str(thousands))}'")
 
+    dateformat = read_cfg.get("dateformat")
+    if dateformat is not None:
+        opts.append(f"dateformat='{sql_str(str(dateformat))}'")
+
+    timestampformat = read_cfg.get("timestampformat")
+    if timestampformat is not None:
+        opts.append(f"timestampformat='{sql_str(str(timestampformat))}'")
+
     nullstr = read_cfg.get("nullstr")
     if nullstr is not None:
         if isinstance(nullstr, list):
@@ -245,6 +261,14 @@ def csv_read_option_strings(
     ignore_errors = read_cfg.get("ignore_errors")
     if ignore_errors is not None:
         opts.append(f"ignore_errors={'true' if bool(ignore_errors) else 'false'}")
+
+    rejects_table = read_cfg.get("rejects_table")
+    if rejects_table is not None:
+        opts.append(f"rejects_table='{sql_str(str(rejects_table))}'")
+
+    rejects_scan = read_cfg.get("rejects_scan")
+    if rejects_scan is not None:
+        opts.append(f"rejects_scan='{sql_str(str(rejects_scan))}'")
 
     null_padding = read_cfg.get("null_padding")
     if null_padding is not None:

--- a/toolkit/core/duckdb_read.py
+++ b/toolkit/core/duckdb_read.py
@@ -81,7 +81,11 @@ def _csv_read_options(
 
     # Build the shared option strings, then prepend union_by_name and
     # append header/skip (which are layer-specific).
-    opts = ["union_by_name=true"] + csv_read_option_strings(read_cfg)
+    # NOTE: rejects_table è incompatibile con union_by_name in DuckDB.
+    # Quando rejects_table è attivo, union_by_name viene omesso perché
+    # l'utente sta debugghing un singolo file CSV, non un multi-file merge.
+    use_union = read_cfg.get("rejects_table") is None
+    opts = (["union_by_name=true"] if use_union else []) + csv_read_option_strings(read_cfg)
     opts.append(f"header={'true' if parser_header else 'false'}")
     if parser_skip is not None:
         opts.append(f"skip={parser_skip}")
@@ -94,10 +98,14 @@ def _csv_read_options(
         "encoding",
         "decimal",
         "thousands",
+        "dateformat",
+        "timestampformat",
         "nullstr",
         "auto_detect",
         "strict_mode",
         "ignore_errors",
+        "rejects_table",
+        "rejects_scan",
         "null_padding",
         "parallel",
         "quote",


### PR DESCRIPTION
## Sintesi

Aggiunge i parametri DuckDB `read_csv` ad alta priorità mancanti in `clean.read`:
`dateformat`, `timestampformat`, `rejects_table`, `rejects_scan`.

Closes #332

## Cosa cambia

- [ ] Bug fix
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Dettaglio

### `dateformat` / `timestampformat`
Parsing date direttamente in `read_csv`, senza necessità di `strptime()` in clean.sql.
Utile per: dataset ISTAT, INPS, OpenCoesione — formati data italiani (`dd/mm/AAAA`).

```yaml
read:
  dateformat: "%d/%m/%Y"
```

### `rejects_table` / `rejects_scan`
Salvataggio righe scartate da DuckDB per debugging. Molto utile quando la lettura strict
fallisce e non si capisce perché (es. colonne in più/meno del previsto, encoding mismatch).

```yaml
read:
  ignore_errors: true
  rejects_table: err_rows
  rejects_scan: err_scan
```

### File toccati

| File | Cosa |
|---|---|
| `core/csv_read.py` | Chiavi in `ALLOWED_READ_CSV_KEYS` + `FORMAT_HINT_KEYS`, option string generation |
| `core/config_models/clean.py` | Campi `CleanReadConfig` |
| `core/duckdb_read.py` | Tracking `params_used` + gestione incompatibilità `union_by_name` vs `rejects_table` |
| `tests/test_csv_read_option_strings.py` | 5 nuovi test unitari |
| `tests/test_clean_duckdb_read.py` | 2 test integrazione DuckDB reale |

## Impatto su contratti pubblici

Nessun cambio di contratti esistenti. Solo nuovi campi opzionali in `clean.read`.

- [ ] Struttura `dataset.yml` — nuovi campi opzionali, nessun obbligo
- [ ] Path output — invariato
- [ ] Schema parquet — invariato
- [ ] CLI o MCP tool — invariato
- [ ] API pubblica del toolkit — nuove funzioni interne (`csv_read_option_strings` supporta nuove chiavi)

## Verifica

```bash
pytest tests/test_csv_read_option_strings.py -v    # 23 test, 5 nuovi
pytest tests/test_clean_duckdb_read.py -v           # 18 test, 2 nuovi
pytest tests/ -x --timeout=60                        # 924 test, tutti pass
```

- [x] `pytest tests/` passa (924 test)
- [x] `ruff check toolkit/` passa
- [x] Nuovi test con marker `pure_unit` e `policy`

## Checklist PR

- [x] Perimetro stretto: solo i 4 parametri ad alta priorità della #332
- [ ] Issue collegata: #332
- [ ] **Se rimuovo un modulo/funzione pubblica**: N/A

## Note per chi revisiona

- `rejects_table` è incompatibile con `union_by_name=true` in DuckDB. Quando `rejects_table` è specificato, `union_by_name` viene omesso automaticamente — l'assunzione è che l'utente stia debugghing un singolo file CSV, non un multi-file merge.
- `dateformat` e `timestampformat` sono in `FORMAT_HINT_KEYS` (possono essere suggeriti da `suggested_read.yml`). `rejects_table` e `rejects_scan` no — sono parametri di controllo errore, non hint di formato.
