### PR TITLE
feat(mcp): aggiungi tool aggregati toolkit_layer e toolkit_status

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -28,6 +28,8 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_dataset_info",
         "toolkit_clean_preview",
         "toolkit_raw_preview",
+        "toolkit_layer",
+        "toolkit_status",
         "toolkit_probe_url",
         "toolkit_probe_url_routed",
         "toolkit_infer_topic",

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -926,3 +926,141 @@ def test_list_candidates_stage_invalid(tmp_path: Path, monkeypatch: pytest.Monke
 
     with pytest.raises(ToolkitClientError, match="stage deve essere"):
         list_candidates(stage="bogus")
+
+
+# ---------------------------------------------------------------------------
+# Aggregated tools: layer_query e dataset_status
+# ---------------------------------------------------------------------------
+
+
+def _make_project_smoke(tmp_path: Path) -> tuple[Path, dict]:
+    """Crea project-example con output fittizi. Ritorna (config_path, paths_dict)."""
+    import duckdb
+
+    src = Path("project-example")
+    dst = tmp_path / "project-example"
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
+    config_path = dst / "dataset.yml"
+
+    # Crea output fittizi per clean e mart
+    root = dst / "_smoke_out"
+    slug = "project_example"
+    year = 2022
+    clean_dir = root / "data" / "clean" / slug / str(year)
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    clean_pq = clean_dir / f"{slug}_{year}_clean.parquet"
+    with duckdb.connect(":memory:") as conn:
+        conn.execute("CREATE TABLE t AS SELECT 'a' AS cat, 1 AS val")
+        conn.execute(f"COPY t TO '{clean_pq}' (FORMAT PARQUET)")
+
+    mart_dir = root / "data" / "mart" / slug / str(year)
+    mart_dir.mkdir(parents=True, exist_ok=True)
+    mart_pq = mart_dir / "rd_by_regione.parquet"
+    with duckdb.connect(":memory:") as conn:
+        conn.execute("CREATE TABLE t AS SELECT 'x' AS k, 10 AS v")
+        conn.execute(f"COPY t TO '{mart_pq}' (FORMAT PARQUET)")
+
+    return config_path, {"dataset": slug, "year": year}
+
+
+@pytest.mark.contract
+def test_layer_query_schema_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """layer_query mode=schema: restituisce schema."""
+    from toolkit.mcp.aggregate_ops import layer_query
+
+    config_path, info = _make_project_smoke(tmp_path)
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    result = layer_query(str(config_path), layer="clean", mode="schema")
+    assert result["layer"] == "clean"
+    assert result["column_count"] >= 1
+    assert "columns" in result
+
+
+@pytest.mark.contract
+def test_layer_query_preview_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """layer_query mode=preview: restituisce schema + righe."""
+    from toolkit.mcp.aggregate_ops import layer_query
+
+    config_path, info = _make_project_smoke(tmp_path)
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    result = layer_query(str(config_path), layer="clean", mode="preview", limit=5)
+    assert result["column_count"] >= 1
+    assert len(result.get("preview", [])) >= 1
+    assert result["row_count"] >= 1
+
+
+@pytest.mark.contract
+def test_layer_query_sql_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """layer_query mode=sql: esegue SQL arbitrario."""
+    from toolkit.mcp.aggregate_ops import layer_query
+
+    config_path, info = _make_project_smoke(tmp_path)
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    result = layer_query(
+        str(config_path),
+        layer="clean",
+        mode="sql",
+        sql="SELECT cat, SUM(val) AS tot FROM data GROUP BY cat",
+    )
+    assert result["mode"] == "sql"
+    assert result["column_count"] >= 2
+    assert result["sql"] is not None
+
+
+@pytest.mark.contract
+def test_layer_query_mart_preview(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """layer_query su layer=mart: funziona."""
+    from toolkit.mcp.aggregate_ops import layer_query
+
+    config_path, info = _make_project_smoke(tmp_path)
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    result = layer_query(str(config_path), layer="mart", mode="preview", limit=3)
+    assert result["layer"] == "mart"
+    assert result["column_count"] >= 1
+
+
+@pytest.mark.policy
+def test_layer_query_invalid_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """layer_query con mode non valido: errore."""
+    from toolkit.mcp.aggregate_ops import layer_query
+    from toolkit.mcp.errors import ToolkitClientError
+
+    config_path, info = _make_project_smoke(tmp_path)
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    with pytest.raises(ToolkitClientError, match="mode deve essere"):
+        layer_query(str(config_path), mode="invalid")
+
+
+@pytest.mark.policy
+def test_layer_query_profile_on_clean_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """layer_query mode=profile su layer=clean: errore."""
+    from toolkit.mcp.aggregate_ops import layer_query
+    from toolkit.mcp.errors import ToolkitClientError
+
+    config_path, info = _make_project_smoke(tmp_path)
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    with pytest.raises(ToolkitClientError, match="mode=profile"):
+        layer_query(str(config_path), layer="clean", mode="profile")
+
+
+@pytest.mark.contract
+def test_dataset_status_shape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """dataset_status: restituisce tutte le 5 sezioni."""
+    from toolkit.mcp.aggregate_ops import dataset_status
+
+    config_path, info = _make_project_smoke(tmp_path)
+    monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))
+
+    result = dataset_status(str(config_path))
+    assert "paths_info" in result
+    assert "summary" in result
+    assert "readiness" in result
+    assert "run_stats" in result
+    assert "info" in result
+    assert result["info"]["dataset"] == info["dataset"]

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -4,16 +4,27 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 
 ## Tool esposti
 
-### Ispezione pipeline
+### Tool aggregati (raccomandati)
+
+- `toolkit_layer(config_path, layer="clean", mode="schema", year=0, limit=20, sql=None, mart_index=0)` — query unificata RAW/CLEAN/MART. Mode: `schema` (colonne+tipi), `preview` (anteprima righe), `profile` (diagnostica raw), `sql` (SQL arbitrario su vista `data`)
+- `toolkit_status(config_path, year=0)` — stato completo dataset: paths + summary + readiness + run_stats + info in una chiamata
+
+### Tool granulari (ispezione pipeline)
 
 - `toolkit_inspect_paths(config_path, year=0)` — path contract + run metadata (run_file_count, years_seen, latest_run)
 - `toolkit_inspect_schema(config_path, layer="clean", year=0)`
+- `toolkit_inspect_profile(config_path, year=0)` — profilo raw (encoding, delim, colonne, missingness)
 - `toolkit_run_summary(config_path, year=0)` — statistiche aggregate (totali, successi, durata media)
 - `toolkit_summary(config_path, year=0)` — dashboard diagnostico (layer + run + warnings)
 - `toolkit_review_readiness(config_path, year=0)` — check di prontezza per review candidate
 - `toolkit_list_runs(config_path, year=0, since=None, until=None, status=None, limit=20, cross_year=False)`
+- `toolkit_list_candidates(stage="all", status_filter=None)` — elenca dataset disponibili in workspace
+- `toolkit_dataset_info(config_path)` — info base da dataset.yml
 - `toolkit_schema_diff(config_path)` — confronto segnali schema raw cross-year (encoding, colonne, ecc.)
 - `toolkit_csv_preview(csv_path, limit=20)` — schema + preview CSV via profiler pipeline
+- `toolkit_clean_preview(config_path, layer="clean", mart_index=0, year=0, limit=10)` — preview dati puliti
+- `toolkit_raw_preview(config_path, year=0, limit=20)` — preview raw file
+- `toolkit_validate_config(config_path)` — validazione dataset.yml
 
 ### Scout fonti
 

--- a/toolkit/mcp/aggregate_ops.py
+++ b/toolkit/mcp/aggregate_ops.py
@@ -1,0 +1,227 @@
+"""Consolidated MCP tools for layer query and dataset status.
+
+Questi tool aggregati delegano alle implementazioni esistenti (schema_ops,
+scout_ops, cli_adapter, discovery) — zero logica nuova, solo routing.
+
+Backward compat: i tool granulari esistenti (toolkit_inspect_schema,
+toolkit_clean_preview, toolkit_summary, ecc.) restano registrati.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from lab_connectors.mcp.errors import ErrorCode
+
+from toolkit.mcp.errors import ToolkitClientError
+from toolkit.mcp.path_safety import _load_cfg
+
+
+def _get_impls():
+    """Lazy import per evitare dipendenze circolari con server.py."""
+    from toolkit.mcp.cli_adapter import inspect_paths as _inspect_paths
+    from toolkit.mcp.schema_ops import (
+        clean_preview as _clean_preview,
+        dataset_info as _dataset_info,
+        raw_preview as _raw_preview,
+        raw_profile as _raw_profile,
+        review_readiness as _review_readiness,
+        run_summary as _run_summary,
+        show_schema as _show_schema,
+        summary as _summary,
+    )
+
+    return (
+        _inspect_paths, _clean_preview, _dataset_info,
+        _raw_preview, _raw_profile, _review_readiness,
+        _run_summary, _show_schema, _summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# toolkit_layer — layer query unificato
+# ---------------------------------------------------------------------------
+
+VALID_LAYERS = {"raw", "clean", "mart"}
+VALID_MODES = {"schema", "preview", "profile", "sql"}
+
+
+def layer_query(
+    config_path: str,
+    layer: str = "clean",
+    mode: str = "schema",
+    year: int | None = None,
+    limit: int = 20,
+    sql: str | None = None,
+    mart_index: int = 0,
+) -> dict[str, Any]:
+    """Query unificata su un layer (RAW/CLEAN/MART).
+
+    Args:
+        config_path: Path a dataset.yml o slug del dataset.
+        layer: ``"raw"``, ``"clean"`` (default) o ``"mart"``.
+        mode: Cosa restituire:
+            - ``"schema"`` (default): colonne + tipi.
+            - ``"preview"``: schema + prime N righe.
+            - ``"profile"``: profilo diagnostico RAW (solo layer=raw).
+            - ``"sql"``: SQL arbitrario sul parquet (solo clean/mart).
+        year: Anno del dataset. Se omesso usa l'ultimo anno configurato.
+        limit: Max righe in preview (default 20, solo mode=preview/sql).
+        sql: Query SQL. Il parquet e' disponibile come tabella ``data``.
+            (solo mode=sql).
+        mart_index: Indice della tabella mart (default 0, solo layer=mart).
+
+    Returns:
+        Dict con schema, preview o profilo a seconda del mode.
+
+    Raises:
+        ToolkitClientError: se layer/mode non validi, o file non trovato.
+    """
+    safe_layer = layer.strip().lower()
+    safe_mode = mode.strip().lower()
+
+    if safe_layer not in VALID_LAYERS:
+        raise ToolkitClientError(
+            f"layer deve essere uno tra: {', '.join(sorted(VALID_LAYERS))} (ricevuto: {layer})",
+            code=ErrorCode.INVALID_PARAMS,
+        )
+    if safe_mode not in VALID_MODES:
+        raise ToolkitClientError(
+            f"mode deve essere uno tra: {', '.join(sorted(VALID_MODES))} (ricevuto: {mode})",
+            code=ErrorCode.INVALID_PARAMS,
+        )
+    if safe_mode == "profile" and safe_layer != "raw":
+        raise ToolkitClientError(
+            f"mode=profile e' valido solo per layer=raw (ricevuto: layer={layer})",
+            code=ErrorCode.INVALID_PARAMS,
+        )
+    if safe_mode == "sql" and safe_layer == "raw":
+        raise ToolkitClientError(
+            "mode=sql non e' supportato per layer=raw (usa mode=schema o mode=preview)",
+            code=ErrorCode.INVALID_PARAMS,
+        )
+    if safe_mode == "sql" and not sql:
+        raise ToolkitClientError(
+            "mode=sql richiede il parametro sql (es. sql='SELECT * FROM data')",
+            code=ErrorCode.INVALID_PARAMS,
+        )
+
+    (
+        _inspect_paths, _clean_preview, _dataset_info,
+        _raw_preview, _raw_profile, _review_readiness,
+        _run_summary, _show_schema, _summary,
+    ) = _get_impls()
+
+    # Schema mode
+    if safe_mode == "schema":
+        return _show_schema(config_path, layer=safe_layer, year=year)
+
+    # Profile mode (raw only)
+    if safe_mode == "profile":
+        return _raw_profile(config_path, year=year)
+
+    # Preview mode
+    if safe_mode == "preview":
+        if safe_layer == "raw":
+            return _raw_preview(config_path, year=year, limit=limit)
+        return _clean_preview(config_path, layer=safe_layer, mart_index=mart_index, year=year, limit=limit)
+
+    # SQL mode
+    if safe_mode == "sql":
+        return _layer_sql(config_path, layer=safe_layer, year=year, limit=limit, sql=sql, mart_index=mart_index)
+
+    raise RuntimeError(f"mode non gestito: {safe_mode}")
+
+
+def _layer_sql(
+    config_path: str,
+    layer: str,
+    year: int | None,
+    limit: int,
+    sql: str,
+    mart_index: int,
+) -> dict[str, Any]:
+    """Esegue SQL arbitrario sul parquet risolto da config_path + layer.
+
+    Logica di risoluzione path identica a clean_preview/raw_preview.
+    """
+    config, cfg = _load_cfg(config_path)
+    from toolkit.mcp.cli_adapter import inspect_paths as _inspect_paths
+
+    paths = _inspect_paths(str(config), year)
+    resolved_year = paths.get("year", year)
+
+    if layer == "clean":
+        parquet_str = paths["paths"]["clean"].get("output")
+        if not parquet_str:
+            raise ToolkitClientError(
+                "Nessun output clean configurato", code=ErrorCode.PARQUET_NOT_FOUND
+            )
+        parquet_path = Path(parquet_str)
+    else:
+        outputs = paths["paths"]["mart"].get("outputs") or []
+        if not outputs:
+            raise ToolkitClientError(
+                "Nessun output mart configurato", code=ErrorCode.PARQUET_NOT_FOUND
+            )
+        if mart_index < 0 or mart_index >= len(outputs):
+            raise ToolkitClientError(
+                f"Indice mart {mart_index} non valido: {len(outputs)} output disponibili",
+                code=ErrorCode.INVALID_PARAMS,
+            )
+        parquet_path = Path(outputs[mart_index])
+
+    if not parquet_path.exists():
+        raise ToolkitClientError(
+            f"Parquet {layer} non trovato: {parquet_path}. "
+            f"Esegui 'toolkit run all -c {config_path}' per generarlo.",
+            code=ErrorCode.PARQUET_NOT_FOUND,
+        )
+
+    from toolkit.core.duckdb_shape import parquet_preview
+
+    result = parquet_preview(parquet_path, limit=limit, sql=sql)
+    result.update({
+        "dataset": paths.get("dataset"),
+        "year": resolved_year,
+        "layer": layer,
+        "config_path": str(config),
+        "mode": "sql",
+    })
+    return result
+
+
+# ---------------------------------------------------------------------------
+# toolkit_status — stato dataset unificato
+# ---------------------------------------------------------------------------
+
+
+def dataset_status(
+    config_path: str,
+    year: int | None = None,
+) -> dict[str, Any]:
+    """Stato completo di un dataset: percorso, run, validation, info.
+
+    Aggrega in una chiamata: paths_info + summary + readiness + run_stats + info.
+
+    Args:
+        config_path: Path a dataset.yml o slug del dataset.
+        year: Anno del dataset. Se omesso usa l'ultimo anno configurato.
+
+    Returns:
+        Dict con sezioni: paths_info, summary, readiness, run_stats, info.
+    """
+    (
+        _inspect_paths, _clean_preview, _dataset_info,
+        _raw_preview, _raw_profile, _review_readiness,
+        _run_summary, _show_schema, _summary,
+    ) = _get_impls()
+
+    return {
+        "paths_info": _inspect_paths(config_path, year=year),
+        "summary": _summary(config_path, year=year),
+        "readiness": _review_readiness(config_path, year=year),
+        "run_stats": _run_summary(config_path, year=year),
+        "info": _dataset_info(config_path),
+    }

--- a/toolkit/mcp/aggregate_ops.py
+++ b/toolkit/mcp/aggregate_ops.py
@@ -127,8 +127,9 @@ def layer_query(
             return _raw_preview(config_path, year=year, limit=limit)
         return _clean_preview(config_path, layer=safe_layer, mart_index=mart_index, year=year, limit=limit)
 
-    # SQL mode
+    # SQL mode — sql non puo' essere None qui (guardato sopra)
     if safe_mode == "sql":
+        assert sql is not None  # mypy narrowing
         return _layer_sql(config_path, layer=safe_layer, year=year, limit=limit, sql=sql, mart_index=mart_index)
 
     raise RuntimeError(f"mode non gestito: {safe_mode}")

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -1,11 +1,18 @@
 """Toolkit MCP server.
 
-Espone 13 tool read-only per ispezione della pipeline toolkit:
-- ispezione standard: inspect_paths, inspect_schema, inspect_profile, summary
-- diagnostica: review_readiness, schema_diff, run_summary
-- run history: list_runs
-- discovery: list_candidates, dataset_info
-- preview: csv_preview, clean_preview, raw_preview
+Espone tool read-only per ispezione della pipeline toolkit.
+Include sia tool granulari (backward compat) che tool aggregati.
+
+Tool aggregati:
+- toolkit_layer: schema/preview/profile/sql su RAW/CLEAN/MART in un tool
+- toolkit_status: paths + summary + readiness + run_stats + info in un tool
+
+Tool granulari (mantenuti per backward compat):
+- inspect_paths, inspect_schema, inspect_profile, summary
+- review_readiness, schema_diff, run_summary
+- list_runs, list_candidates, dataset_info
+- csv_preview, clean_preview, raw_preview
+- scout: probe_url, probe_url_routed, infer_topic, ckan, sparql, html, sdmx
 
 Usa ``lab_connectors.mcp`` per init standardizzato, error handling e logging.
 """
@@ -40,6 +47,11 @@ from .toolkit_client import (
     schema_diff as schema_diff_impl,
     summary as summary_impl,
     show_schema as show_schema_impl,
+)
+
+from .aggregate_ops import (
+    dataset_status as dataset_status_impl,
+    layer_query as layer_query_impl,
 )
 
 mcp = create_mcp_server(
@@ -184,6 +196,54 @@ def toolkit_list_runs(
 )
 def toolkit_csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
     return guard_timed(csv_preview_impl, "toolkit_csv_preview", csv_path, limit)
+
+
+# ---------------------------------------------------------------------------
+# Aggregated tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description="Query unificata su RAW/CLEAN/MART: schema, preview, profilo o SQL. "
+    "Sostituisce inspect_schema/clean_preview/raw_preview/inspect_profile/parquet_query "
+    "in un unico tool con parametro mode (schema|preview|profile|sql). "
+    "Esempi: mode=schema (colonne+tipi), mode=preview (anteprima righe), "
+    "mode=profile (diagnostica raw), mode=sql (SQL arbitrario su 'data').",
+    structured_output=True,
+)
+def toolkit_layer(
+    config_path: str,
+    layer: str = "clean",
+    mode: str = "schema",
+    year: int = 0,
+    limit: int = 20,
+    sql: str | None = None,
+    mart_index: int = 0,
+) -> dict[str, Any]:
+    return guard_timed(
+        layer_query_impl,
+        "toolkit_layer",
+        config_path,
+        layer=layer,
+        mode=mode,
+        year=year or None,
+        limit=limit,
+        sql=sql,
+        mart_index=mart_index,
+    )
+
+
+@mcp.tool(
+    description="Stato completo di un dataset: paths + summary + readiness + run_stats + info. "
+    "Aggrega inspect_paths, summary, review_readiness, run_summary e dataset_info "
+    "in una unica chiamata.",
+    structured_output=True,
+)
+def toolkit_status(
+    config_path: str,
+    year: int = 0,
+) -> dict[str, Any]:
+    return guard_timed(dataset_status_impl, "toolkit_status", config_path, year=year or None)
 
 
 # ---------------------------------------------------------------------------

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -5,7 +5,10 @@ This module is a thin facade. The actual implementation lives in dedicated sub-m
 - errors: ToolkitClientError
 - path_safety: _safe_path, _load_cfg
 - cli_adapter: inspect_paths (direct call, no subprocess)
-- schema_ops: list_runs, show_schema, raw_profile, run_state, summary, review_readiness
+- schema_ops: show_schema, raw_profile, run_state, summary, review_readiness, schema_diff, ...
+- aggregate_ops: layer_query (toolkit_layer), dataset_status (toolkit_status)
+- scout_ops: probe_url, infer_topic, ckan, sparql, html, sdmx
+- discovery: list_candidates
 
 Note: run_state is kept here for internal use (tests) but is no longer a registered MCP tool.
 Use inspect_paths (with run_file_count, years_seen) or summary (with latest_run_record) instead.
@@ -30,6 +33,10 @@ from toolkit.mcp.schema_ops import (
     schema_diff,
     show_schema,
     summary,
+)
+from toolkit.mcp.aggregate_ops import (
+    dataset_status,
+    layer_query,
 )
 from toolkit.mcp.scout_ops import (
     mcp_ckan_package_show,


### PR DESCRIPTION
## Sintesi

Due nuovi tool MCP aggregati che riducono da 22+ tool granulari a 2 tool di uso comune. Delegano tutti alle implementazioni esistenti — zero logica nuova.

## Cosa cambia

- [x] Nuova funzionalità del motore
- [ ] Refactor / performance
- [x] Documentazione

## Nuovi tool

### `toolkit_layer` — query unificata RAW/CLEAN/MART

Sostituisce in un tool: `inspect_schema` + `clean_preview` + `raw_preview` + `inspect_profile` + `parquet_query`.

```python
toolkit_layer(
    config_path,                    # dataset.yml o slug
    layer="clean",                  # raw | clean | mart
    mode="schema",                  # schema | preview | profile | sql
    year=0,                         # default: ultimo
    limit=20,                       # righe in preview / sql
    sql=None,                       # SQL arbitrario (mode=sql)
    mart_index=0,                   # tabella mart (layer=mart)
)
```

### `toolkit_status` — stato completo dataset

Aggrega in una chiamata: `inspect_paths` + `summary` + `review_readiness` + `run_summary` + `dataset_info`.

```python
toolkit_status(config_path, year=0)
# → { paths_info, summary, readiness, run_stats, info }
```

## Backward compat

Tutti i 22 tool granulari esistenti restano registrati.

## Verifica

```bash
pytest -m "core or contract" -x  → 437 passed
ruff check .
```

## Checklist PR

- [x] Perimetro stretto: due tool MCP + test + docs
- [x] Tool vecchi mantenuti (backward compat)
