### PR TITLE
feat: supporto path s3:// in parquet_preview e toolkit query

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "requests>=2.33.1",
   "typer>=0.12.0",
   "rich>=13.0",
-  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.12.0"
+  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_duckdb_shape.py
+++ b/tests/test_duckdb_shape.py
@@ -126,36 +126,4 @@ def test_parquet_preview_invalid_sql_raises(tmp_path):
         parquet_preview(pq, sql="SELECT * FROM nonexistent_table")
 
 
-@pytest.mark.smoke
-def test_parquet_preview_s3_public_bucket():
-    """parquet_preview su bucket GCS pubblico via S3-compatible API.
 
-    Smoke test: richiede connettivita' esterna. Legge il catalog_inventory
-    parquet pubblico e verifica che abbia almeno 1 riga.
-    """
-    from pathlib import Path
-    from toolkit.core.duckdb_shape import parquet_preview, parquet_schema, parquet_row_count
-
-    url = "s3://dataciviclab-clean/catalog_inventory/catalog_inventory_latest.parquet"
-
-    # Schema
-    schema = parquet_schema(Path(url))
-    assert len(schema) > 0, "S3 schema vuoto"
-
-    # Row count
-    count = parquet_row_count(Path(url))
-    assert count is not None and count > 0, f"S3 count: {count}"
-
-    # Preview
-    result = parquet_preview(Path(url), limit=3)
-    assert result["column_count"] > 0
-    assert result["row_count"] == count
-    assert len(result["preview"]) == 3
-
-    # SQL
-    sql_result = parquet_preview(
-        Path(url),
-        sql="SELECT source_id, COUNT(*) AS n FROM data GROUP BY source_id ORDER BY n DESC LIMIT 3",
-    )
-    assert sql_result["column_count"] == 2
-    assert len(sql_result["preview"]) == 3

--- a/tests/test_duckdb_shape.py
+++ b/tests/test_duckdb_shape.py
@@ -124,3 +124,38 @@ def test_parquet_preview_invalid_sql_raises(tmp_path):
 
     with pytest.raises(Exception, match="nonexistent_table"):
         parquet_preview(pq, sql="SELECT * FROM nonexistent_table")
+
+
+@pytest.mark.smoke
+def test_parquet_preview_s3_public_bucket():
+    """parquet_preview su bucket GCS pubblico via S3-compatible API.
+
+    Smoke test: richiede connettivita' esterna. Legge il catalog_inventory
+    parquet pubblico e verifica che abbia almeno 1 riga.
+    """
+    from pathlib import Path
+    from toolkit.core.duckdb_shape import parquet_preview, parquet_schema, parquet_row_count
+
+    url = "s3://dataciviclab-clean/catalog_inventory/catalog_inventory_latest.parquet"
+
+    # Schema
+    schema = parquet_schema(Path(url))
+    assert len(schema) > 0, "S3 schema vuoto"
+
+    # Row count
+    count = parquet_row_count(Path(url))
+    assert count is not None and count > 0, f"S3 count: {count}"
+
+    # Preview
+    result = parquet_preview(Path(url), limit=3)
+    assert result["column_count"] > 0
+    assert result["row_count"] == count
+    assert len(result["preview"]) == 3
+
+    # SQL
+    sql_result = parquet_preview(
+        Path(url),
+        sql="SELECT source_id, COUNT(*) AS n FROM data GROUP BY source_id ORDER BY n DESC LIMIT 3",
+    )
+    assert sql_result["column_count"] == 2
+    assert len(sql_result["preview"]) == 3

--- a/tests/test_s3_parquet_smoke.py
+++ b/tests/test_s3_parquet_smoke.py
@@ -1,18 +1,25 @@
 """Smoke test: parquet_preview su bucket GCS pubblici via S3.
 
-Questo file NON e' in CORE_TESTS ne in ADVANCED_TESTS (conftest.py).
-Richiede connettivita' esterna. Eseguire esplicitamente:
+Richiede connettivita' esterna. Skippato di default.
+Eseguire esplicitamente con:
 
-    pytest tests/test_s3_parquet_smoke.py -v
+    RUN_S3_SMOKE=1 pytest tests/test_s3_parquet_smoke.py -v
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.smoke
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.skipif(
+        not os.environ.get("RUN_S3_SMOKE"),
+        reason="S3 smoke test: set RUN_S3_SMOKE=1 per eseguire",
+    ),
+]
 
 
 @pytest.mark.smoke

--- a/tests/test_s3_parquet_smoke.py
+++ b/tests/test_s3_parquet_smoke.py
@@ -1,0 +1,54 @@
+"""Smoke test: parquet_preview su bucket GCS pubblici via S3.
+
+Questo file NON e' in CORE_TESTS ne in ADVANCED_TESTS (conftest.py).
+Richiede connettivita' esterna. Eseguire esplicitamente:
+
+    pytest tests/test_s3_parquet_smoke.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.smoke
+def test_parquet_preview_s3_public_bucket() -> None:
+    """parquet_preview su bucket GCS pubblico: schema, count, preview, SQL."""
+    from toolkit.core.duckdb_shape import (
+        parquet_preview,
+        parquet_row_count,
+        parquet_schema,
+    )
+
+    url = "s3://dataciviclab-clean/catalog_inventory/catalog_inventory_latest.parquet"
+    p = Path(url)
+
+    # Schema
+    schema = parquet_schema(p)
+    assert len(schema) > 0, "S3 schema vuoto"
+
+    # Row count
+    count = parquet_row_count(p)
+    assert count is not None and count > 0, f"S3 count: {count}"
+
+    # Preview
+    result = parquet_preview(p, limit=3)
+    assert result["column_count"] > 0
+    assert result["row_count"] == count
+    assert len(result["preview"]) == 3
+
+    # SQL
+    sql_result = parquet_preview(
+        p,
+        sql="SELECT source_id, COUNT(*) AS n FROM data GROUP BY source_id ORDER BY n DESC LIMIT 3",
+    )
+    assert sql_result["column_count"] == 2
+    assert len(sql_result["preview"]) == 3
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/toolkit/cli/cmd_query.py
+++ b/toolkit/cli/cmd_query.py
@@ -152,10 +152,14 @@ def query(
             resolved_config = str(Path(config).resolve())
             parquet_path = _resolve_path_from_config(resolved_config, layer, year or None)
         elif path_arg:
-            parquet_path = Path(path_arg).resolve()
-            if not parquet_path.exists():
-                typer.echo(f"error: file non trovato: {parquet_path}", err=True)
-                raise typer.Exit(code=1)
+            if path_arg.startswith("s3://"):
+                # Path GCS: non esiste localmente, non usare Path.resolve()
+                parquet_path = Path(path_arg)
+            else:
+                parquet_path = Path(path_arg).resolve()
+                if not parquet_path.exists():
+                    typer.echo(f"error: file non trovato: {parquet_path}", err=True)
+                    raise typer.Exit(code=1)
         else:
             typer.echo("error: specificare un path parquet o --config", err=True)
             raise typer.Exit(code=1)

--- a/toolkit/core/duckdb_shape.py
+++ b/toolkit/core/duckdb_shape.py
@@ -10,6 +10,8 @@ Rinominato da ``core/parquet.py`` — ora in ``core/duckdb_shape.py``.
 
 from __future__ import annotations
 
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -19,8 +21,62 @@ from lab_connectors.duckdb import safe_connect
 from toolkit.core.sql_utils import sql_literal
 
 
+def _is_s3_path(path: str | Path) -> bool:
+    """True se il path inizia con ``s3://`` (path GCS via DuckDB httpfs).
+
+    Rileva anche ``s3:/`` (``Path()`` normalizza ``//`` in ``/``).
+
+    I bucket pubblici ``dataciviclab-clean`` e ``dataciviclab-mart``
+    sono accessibili in lettura anonima via S3-compatible API GCS.
+    """
+    s = str(path)
+    return s.startswith("s3://") or s.startswith("s3:/")
+
+
+def _s3_config() -> dict[str, str]:
+    """Config DuckDB per leggere bucket GCS pubblici via S3-compatible API."""
+    return {
+        "s3_endpoint": "storage.googleapis.com",
+        "s3_region": "auto",
+        "s3_access_key_id": "",
+        "s3_secret_access_key": "",
+        "s3_use_ssl": "true",
+    }
+
+
+@contextmanager
+def _parquet_connect(path: Path) -> Generator[Any, None, None]:
+    """Context manager DuckDB con supporto S3 se il path e' ``s3://``.
+
+    Per path locali usa ``safe_connect`` (backward compat).
+    Per path ``s3://`` apre connessione DuckDB con httpfs + S3 config.
+    """
+    path_str = str(path)
+    if _is_s3_path(path_str):
+        con = duckdb.connect(":memory:", config=_s3_config())
+        try:
+            con.execute("LOAD httpfs")
+            yield con
+        finally:
+            try:
+                con.close()
+            except Exception:
+                pass
+    else:
+        # safe_connect e' gia' un context manager decorato
+        with safe_connect() as con:
+            yield con
+
+
 def _rel(path: Path) -> str:
-    return f"read_parquet('{sql_literal(str(path))}')"
+    """Build ``read_parquet(...)`` reference.
+
+    Preserva il prefisso ``s3://`` — ``Path()`` normalizza ``//`` in ``/``.
+    """
+    path_str = str(path)
+    if path_str.startswith("s3:/") and not path_str.startswith("s3://"):
+        path_str = "s3://" + path_str[4:]
+    return f"read_parquet('{sql_literal(path_str)}')"
 
 
 # ---------------------------------------------------------------------------
@@ -67,14 +123,16 @@ def csv_quick_shape(csv_path: str | Path) -> dict[str, Any]:
 def parquet_schema(path: Path) -> list[dict[str, str]]:
     """Legge lo schema di un file Parquet (nomi colonne + tipo DuckDB).
 
+    Supporta path locali e ``s3://`` (bucket GCS pubblici).
+
     Returns:
         Lista di ``{"name": str, "type": str}``.
         Lista vuota se il file non esiste o non è leggibile.
     """
-    if not path.exists():
+    if not _is_s3_path(path) and not path.exists():
         return []
     try:
-        with safe_connect() as con:
+        with _parquet_connect(path) as con:
             con.execute("PRAGMA disable_progress_bar")
             rows = con.execute(f"DESCRIBE SELECT * FROM {_rel(path)}").fetchall()
             return [{"name": str(r[0]), "type": str(r[1])} for r in rows]
@@ -85,13 +143,15 @@ def parquet_schema(path: Path) -> list[dict[str, str]]:
 def parquet_row_count(path: Path) -> int | None:
     """Conta le righe di un file Parquet.
 
+    Supporta path locali e ``s3://`` (bucket GCS pubblici).
+
     Returns:
         Numero di righe, ``None`` se il file non esiste o non è leggibile.
     """
-    if not path.exists():
+    if not _is_s3_path(path) and not path.exists():
         return None
     try:
-        with safe_connect() as con:
+        with _parquet_connect(path) as con:
             con.execute("PRAGMA disable_progress_bar")
             result = con.execute(f"SELECT COUNT(*) FROM {_rel(path)}").fetchone()
             return int(result[0]) if result else None
@@ -131,14 +191,14 @@ def parquet_preview(
             è fornito; in modalità default graceful empty dict).
         RuntimeError: se la query SQL fallisce (solo con ``sql``).
     """
-    if not path.exists():
+    if not _is_s3_path(path) and not path.exists():
         if sql is not None:
             raise FileNotFoundError(f"Parquet non trovato: {path}")
         return {"path": str(path), "column_count": 0, "columns": [],
                 "row_count": None, "preview": [], "truncated": False, "sql": None}
 
     try:
-        with safe_connect() as con:
+        with _parquet_connect(path) as con:
             con.execute("PRAGMA disable_progress_bar")
 
             if sql is not None:

--- a/toolkit/core/duckdb_shape.py
+++ b/toolkit/core/duckdb_shape.py
@@ -48,24 +48,28 @@ def _s3_config() -> Mapping[str, Any]:
 def _parquet_connect(path: Path) -> Generator[Any, None, None]:
     """Context manager DuckDB con supporto S3 se il path e' ``s3://``.
 
-    Per path locali usa ``safe_connect`` (backward compat).
-    Per path ``s3://`` apre connessione DuckDB con httpfs + S3 config.
+    Per path locali usa ``safe_connect()`` (backward compat).
+    Per path ``s3://`` usa ``safe_connect(extensions=["httpfs"], config=...)``
+    (via ``lab_connectors.duckdb`` v0.13.0).
     """
-    path_str = str(path)
-    if _is_s3_path(path_str):
-        con = duckdb.connect(":memory:", config=_s3_config())  # type: ignore[arg-type]
-        try:
-            con.execute("LOAD httpfs")
+    if _is_s3_path(str(path)):
+        with safe_connect(extensions=["httpfs"], config=_s3_config()) as con:
             yield con
-        finally:
-            try:
-                con.close()
-            except Exception:
-                pass
     else:
-        # safe_connect e' gia' un context manager decorato
         with safe_connect() as con:
             yield con
+
+
+def _normalize_s3(path_str: str) -> str:
+    """Ripristina ``s3://`` se ``Path()`` l'ha normalizzato in ``s3:/``."""
+    if path_str.startswith("s3:/") and not path_str.startswith("s3://"):
+        return "s3://" + path_str[4:]
+    return path_str
+
+
+def _display_path(path: Path) -> str:
+    """Path come stringa, con ``s3://`` preservato."""
+    return _normalize_s3(str(path))
 
 
 def _rel(path: Path) -> str:
@@ -73,10 +77,7 @@ def _rel(path: Path) -> str:
 
     Preserva il prefisso ``s3://`` — ``Path()`` normalizza ``//`` in ``/``.
     """
-    path_str = str(path)
-    if path_str.startswith("s3:/") and not path_str.startswith("s3://"):
-        path_str = "s3://" + path_str[4:]
-    return f"read_parquet('{sql_literal(path_str)}')"
+    return f"read_parquet('{sql_literal(_display_path(path))}')"
 
 
 # ---------------------------------------------------------------------------
@@ -194,7 +195,7 @@ def parquet_preview(
     if not _is_s3_path(path) and not path.exists():
         if sql is not None:
             raise FileNotFoundError(f"Parquet non trovato: {path}")
-        return {"path": str(path), "column_count": 0, "columns": [],
+        return {"path": _display_path(path), "column_count": 0, "columns": [],
                 "row_count": None, "preview": [], "truncated": False, "sql": None}
 
     try:
@@ -222,7 +223,7 @@ def parquet_preview(
             preview_rows = [dict(zip(col_names, row)) for row in preview]
 
             return {
-                "path": str(path),
+                "path": _display_path(path),
                 "column_count": len(columns),
                 "columns": columns,
                 "row_count": row_count,
@@ -234,7 +235,7 @@ def parquet_preview(
         if sql is not None:
             # In modalità SQL esplicito, propaga l'errore
             raise
-        base = {"path": str(path), "column_count": 0, "columns": [],
+        base = {"path": _display_path(path), "column_count": 0, "columns": [],
                 "row_count": None, "preview": [], "truncated": False}
         base["sql"] = sql
         return base

--- a/toolkit/core/duckdb_shape.py
+++ b/toolkit/core/duckdb_shape.py
@@ -10,7 +10,7 @@ Rinominato da ``core/parquet.py`` — ora in ``core/duckdb_shape.py``.
 
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -33,7 +33,7 @@ def _is_s3_path(path: str | Path) -> bool:
     return s.startswith("s3://") or s.startswith("s3:/")
 
 
-def _s3_config() -> dict[str, str]:
+def _s3_config() -> Mapping[str, Any]:
     """Config DuckDB per leggere bucket GCS pubblici via S3-compatible API."""
     return {
         "s3_endpoint": "storage.googleapis.com",
@@ -53,7 +53,7 @@ def _parquet_connect(path: Path) -> Generator[Any, None, None]:
     """
     path_str = str(path)
     if _is_s3_path(path_str):
-        con = duckdb.connect(":memory:", config=_s3_config())
+        con = duckdb.connect(":memory:", config=_s3_config())  # type: ignore[arg-type]
         try:
             con.execute("LOAD httpfs")
             yield con


### PR DESCRIPTION
## Sintesi

`parquet_preview` e `toolkit query` ora supportano path `s3://` — query diretta su parquet GCS pubblici senza download locale.

## Cosa cambia

- **`core/duckdb_shape.py`**: rileva path `s3://` e carica automaticamente httpfs + S3 config per DuckDB
- **`cli/cmd_query.py`**: skippa `path.resolve()` e `path.exists()` per path S3
- **`tests/test_duckdb_shape.py`**: smoke test su bucket GCS pubblico

## Uso

```bash
# Preview direttamente da GCS
toolkit query 's3://dataciviclab-clean/catalog_inventory/catalog_inventory_latest.parquet' --limit 5

# SQL arbitrario
toolkit query 's3://dataciviclab-clean/catalog_inventory/source-check/source_check_results.parquet' \
  --sql 'SELECT source_id, COUNT(*) AS n FROM data GROUP BY source_id ORDER BY n DESC LIMIT 5'
```

## Impatto

- Nessun contratto rotto: `parquet_preview(sql=None)` backward compat
- Nuova feature: `parquet_preview` con `Path("s3://...")`
- DuckDB httpfs è core extension — zero nuove dipendenze
- I bucket `dataciviclab-clean` e `dataciviclab-mart` sono pubblici in lettura anonima

## Verifica

```bash
pytest -m "core or contract" -x  → 438 passed
ruff check .
```
