### PR TITLE
feat(core): transitive support resolution — run full esegue support annidati

### DIFF
--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -8,6 +8,7 @@ import pytest
 from toolkit.core.support import (
     flatten_support_template_ctx,
     resolve_support_payloads,
+    resolve_transitive_supports,
     _support_expected_mart_outputs,
 )
 
@@ -322,3 +323,153 @@ class TestResolveAndFlatten:
         resolved = resolve_support_payloads(None, require_exists=True)
         ctx = flatten_support_template_ctx(resolved)
         assert ctx == {}
+
+
+# --- resolve_transitive_supports ---
+
+
+def _make_support_config(
+    tmp_path: Path,
+    name: str = "support_ds",
+    sub_supports: list[dict] | None = None,
+) -> tuple[Path, object]:
+    """Create a minimal support dataset with optional sub-supports.
+
+    Returns (config_path, config_object).
+    """
+
+    ds_dir = tmp_path / name
+    ds_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write a minimal dataset.yml so load_config() can read it
+    yml = f"root: {ds_dir}\ndataset:\n  name: {name}\n  years: [2024]\nmart:\n  tables:\n    - name: mart_result\n      sql: sql/mart.sql\n"
+    if sub_supports:
+        for s in sub_supports or []:
+            yml += f"support:\n  - name: {s['name']}\n    config: {s['config']}\n    years: [{s['years'][0]}]\n"
+
+    config_path = ds_dir / "dataset.yml"
+    config_path.write_text(yml, encoding="utf-8")
+
+    from toolkit.core.config import load_config
+
+    return config_path, load_config(str(config_path))
+
+
+def _make_sub_support(tmp_path: Path, name: str, grandchild: str | None = None) -> Path:
+    """Create a leaf support dataset (no sub-supports). Returns config path."""
+    return _make_support_config(tmp_path, name)[0]
+
+
+class TestResolveTransitiveSupports:
+    def test_empty_list(self):
+        """Lista vuota -> lista vuota."""
+        result = resolve_transitive_supports([])
+        assert result == []
+
+    def test_single_level_no_nesting(self, tmp_path: Path):
+        """Support singolo senza nesting -> stessa entry."""
+        cfg_path = _make_sub_support(tmp_path, "leaf")
+        entries = [{"name": "a", "config": str(cfg_path), "years": [2024]}]
+        from toolkit.core.config_models import SupportDatasetConfig
+
+        typed = [SupportDatasetConfig(**e) for e in entries]
+        result = resolve_transitive_supports(typed)
+
+        assert len(result) == 1
+        assert result[0].name == "a"
+
+    def test_multiple_siblings_no_nesting(self, tmp_path: Path):
+        """2 support senza nesting -> stesso ordine dichiarato."""
+        cfg_a = _make_sub_support(tmp_path, "alpha")
+        cfg_b = _make_sub_support(tmp_path, "beta")
+        from toolkit.core.config_models import SupportDatasetConfig
+
+        entries = [
+            SupportDatasetConfig(name="a", config=str(cfg_a), years=[2024]),
+            SupportDatasetConfig(name="b", config=str(cfg_b), years=[2024]),
+        ]
+        result = resolve_transitive_supports(entries)
+
+        assert len(result) == 2
+        assert result[0].name == "a"
+        assert result[1].name == "b"
+
+    def test_two_levels_deepest_first(self, tmp_path: Path):
+        """Compose -> support -> sub-support: sub-support deve apparire prima."""
+        # Crea sub-support (foglia)
+        sub_path = _make_sub_support(tmp_path, "sub")
+
+        # Crea support intermedio che ha sub come dipendenza
+        mid_dir = tmp_path / "mid"
+        mid_dir.mkdir(exist_ok=True)
+        mid_yml = (
+            f"root: {mid_dir}\n"
+            f"dataset:\n  name: mid\n  years: [2024]\n"
+            f"mart:\n  tables:\n    - name: mart_mid\n      sql: sql/mart.sql\n"
+            f"support:\n  - name: sub\n    config: {sub_path}\n    years: [2024]\n"
+        )
+        mid_path = mid_dir / "dataset.yml"
+        mid_path.write_text(mid_yml, encoding="utf-8")
+
+        # Top-level support che ha mid come dipendenza
+        from toolkit.core.config_models import SupportDatasetConfig
+
+        entries = [
+            SupportDatasetConfig(name="top", config=str(mid_path), years=[2024]),
+        ]
+        result = resolve_transitive_supports(entries)
+
+        # sub deve venire prima di mid (top non ha anni propri da runnare)
+        names = [e.name for e in result]
+        assert "sub" in names, f"sub non trovato in {names}"
+        assert "top" in names, f"mid/top non trovato in {names}"
+        # sub (foglia) deve stare prima di top
+        assert names.index("sub") < names.index("top"), f"Ordine sbagliato: {names}"
+
+    def test_dedup_same_config(self, tmp_path: Path):
+        """Stesso config path riferito da due entry diverse -> eseguito una volta sola."""
+        cfg_path = _make_sub_support(tmp_path, "shared")
+        from toolkit.core.config_models import SupportDatasetConfig
+
+        entries = [
+            SupportDatasetConfig(name="a", config=str(cfg_path), years=[2024]),
+            SupportDatasetConfig(name="b", config=str(cfg_path), years=[2024]),
+        ]
+        result = resolve_transitive_supports(entries)
+
+        # Deve apparire una volta sola (la prima entry)
+        assert len(result) == 1
+        assert result[0].name == "a"
+
+    def test_cycle_detection(self, tmp_path: Path):
+        """Ciclo A -> B -> A deve sollevare ValueError."""
+        cfg_a = tmp_path / "a" / "dataset.yml"
+        cfg_a.parent.mkdir(parents=True)
+        cfg_a.write_text(
+            f"root: {cfg_a.parent}\n"
+            f"dataset:\n  name: a\n  years: [2024]\n"
+            f"mart:\n  tables:\n    - name: m\n      sql: sql/m.sql\n"
+            f"support:\n  - name: b\n    config: {tmp_path}/b/dataset.yml\n    years: [2024]\n",
+            encoding="utf-8",
+        )
+
+        cfg_b = tmp_path / "b" / "dataset.yml"
+        cfg_b.parent.mkdir(parents=True)
+        cfg_b.write_text(
+            f"root: {cfg_b.parent}\n"
+            f"dataset:\n  name: b\n  years: [2024]\n"
+            f"mart:\n  tables:\n    - name: m\n      sql: sql/m.sql\n"
+            f"support:\n  - name: a\n    config: {cfg_a}\n    years: [2024]\n",
+            encoding="utf-8",
+        )
+
+        from toolkit.core.config_models import SupportDatasetConfig
+
+        # Il ciclo e' tra b (che punta ad a) e a (che punta a b).
+        # Il resolver parte dalla root che punta a b.
+        entries = [
+            SupportDatasetConfig(name="root_b", config=str(cfg_b), years=[2024]),
+        ]
+
+        with pytest.raises(ValueError, match="Circular support dependency"):
+            resolve_transitive_supports(entries)

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -13,6 +13,7 @@ from toolkit.clean.validate import run_clean_validation
 from toolkit.core.logging import bind_logger, get_logger
 from toolkit.core.paths import RAW_PROFILE, layer_dataset_dir, layer_year_dir
 from toolkit.core.run_context import RunContext
+from toolkit.core.support import resolve_transitive_supports
 from toolkit.mart.run import run_mart, run_mart_multi_year
 from toolkit.mart.validate import run_mart_validation
 from toolkit.raw.run import run_raw
@@ -721,13 +722,20 @@ def run_full(
     # per le query MART del candidate (placeholder {support.NAME.mart} ecc.).
     # In dry-run i support vengono solo annunciati (non eseguiti): la validazione
     # SQL del candidate usa require_exists=False e non richiede file reali.
-    support_entries = cfg.support or []
-    if support_entries:
+    #
+    # Nota: resolve_transitive_supports() appiattisce le dipendenze transitive
+    # (support che hanno a loro volta support:) in un unico DAG topologico,
+    # con le dipendenze più annidate eseguite per prime.
+    support_dag = resolve_transitive_supports(cfg.support or [])
+    if support_dag:
         logger.info(
-            "RUN FULL — processing %d support dataset(s) before candidate",
-            len(support_entries),
+            "RUN FULL — processing %d support dataset(s) "
+            "(%d direct, %d transitive) before candidate",
+            len(support_dag),
+            len(cfg.support or []),
+            len(support_dag) - len(cfg.support or []),
         )
-        for entry in support_entries:
+        for entry in support_dag:
             logger.info("Support: %s — %s", entry.name, entry.config)
 
             if dry_flag:

--- a/toolkit/core/support.py
+++ b/toolkit/core/support.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from toolkit.core.config import load_config
+from toolkit.core.config import SupportDatasetConfig, load_config
 from toolkit.core.paths import layer_year_dir
 
 
@@ -86,3 +86,69 @@ def flatten_support_template_ctx(payloads: list[dict[str, Any]]) -> dict[str, An
         ctx[f"support.{name}.outputs"] = payload["outputs"]
         ctx[f"support.{name}.mart"] = payload["mart"]
     return ctx
+
+
+def resolve_transitive_supports(
+    support_entries: list[SupportDatasetConfig],
+    *,
+    _visited: set[Path] | None = None,
+    _path: list[str] | None = None,
+) -> list[SupportDatasetConfig]:
+    """Resolve transitive support dipendenze in un flat DAG eseguibile.
+
+    Ordine topologico: le dipendenze più profonde (annidate) vengono prima.
+    Deduplica per config path risolto (stesso file YAML eseguito una volta sola).
+    Rileva cicli e solleva ValueError.
+
+    Returns:
+        Lista piatta di ``SupportDatasetConfig`` in ordine di esecuzione
+        (deepest-first). Include sia le entry dirette che quelle transitive.
+
+    Raises:
+        ValueError: se una config di supporto non è caricabile o viene rilevato
+        un ciclo nelle dipendenze.
+    """
+    if _visited is None:
+        _visited = set()
+    if _path is None:
+        _path = []
+
+    result: list[SupportDatasetConfig] = []
+
+    for entry in support_entries or []:
+        config_path = Path(str(entry.config)).resolve()
+
+        # Già processato (dedup — stesso file YAML)
+        if config_path in _visited:
+            continue
+
+        # Ciclo: questo config_path è già nello stack ricorsivo
+        path_str = str(config_path)
+        if path_str in _path:
+            cycle = " → ".join(_path + [path_str])
+            raise ValueError(
+                f"Circular support dependency detected: {cycle}. "
+                "Verifica support[].config references in dataset.yml."
+            )
+
+        # Carica config del support per controllare se ha nested support
+        try:
+            cfg = load_config(str(config_path))
+        except Exception as exc:
+            raise ValueError(
+                f"Cannot load support config '{entry.name}' ({entry.config}): {exc}"
+            ) from exc
+
+        # Ricorsione: nested support prima (deepest-first)
+        if cfg.support:
+            nested = resolve_transitive_supports(
+                cfg.support,
+                _visited=_visited,
+                _path=_path + [path_str],
+            )
+            result.extend(nested)
+
+        _visited.add(config_path)
+        result.append(entry)
+
+    return result


### PR DESCRIPTION
## Sintesi

Aggiunge `resolve_transitive_supports()` che appiattisce le dipendenze transitive dei support dataset in un DAG eseguibile. Con questa modifica, un compose (o qualsiasi dataset con `support:`) può dichiarare support che a loro volta hanno support — il toolkit li esegue tutti automaticamente in ordine topologico.

## Contesto collegato

Necessario per dataset-incubator PR [#???] (compose malasanita): il compose ha 3 candidate flat come support, ciascuno dei quali può avere propri support dataset.

## Cosa cambia

- [x] Nuova funzionalità del motore

## Impatto su contratti pubblici

Nessuno. Formato `dataset.yml` invariato, CLI invariata, placeholder `{support.*}` invariati.

## Verifica

```bash
pytest -x --tb=short -q
# 930 passed, 1 skipped
```

- [x] `pytest -m core` passa
- [x] `ruff check .` passa
- [x] `mypy toolkit/` passa

## Checklist PR

- [x] Perimetro stretto: una PR = un layer o un fix mirato
- [x] Test aggiunti con marker appropriato

## Dettaglio implementazione

1. **`toolkit/core/support.py`** — nuova funzione `resolve_transitive_supports()`:
   - Ricorsione depth-first con deduplica per config path risolto
   - Cycle detection (A→B→A → `ValueError` esplicito)
   - Deepest-first ordering (le dipendenze più annidate vengono eseguite prima)

2. **`toolkit/cli/cmd_run.py`** — `run_full()` usa il DAG invece di iterare `cfg.support` linearmente:
   ```python
   # Prima: solo 1 livello
   for entry in cfg.support: ...
   
   # Dopo: n livelli, topo-sorted
   support_dag = resolve_transitive_supports(cfg.support or [])
   for entry in support_dag: ...
   ```

3. **`tests/test_support.py`** — 6 nuovi test (27→33):
   - empty_list, single_level, multiple_siblings, deepest_first, dedup, cycle_detection

## Note

- Retrocompatibile: support semplici (senza nesting) funzionano identico a prima
- Il conteggio log: "X support (%d direct, %d transitive)" rende visibile il lavoro del resolver
- La PR DI complementare (compose malasanita) userà questa feature invece dello script workaround `run_compose_with_support.py`