### PR TITLE
fix(http_file): curl fallback quando Python requests fallisce con SSL attraverso proxy

### DIFF
--- a/tests/test_http_file_plugin.py
+++ b/tests/test_http_file_plugin.py
@@ -7,13 +7,21 @@ logic lives in lab-connectors and is tested there.
 
 from __future__ import annotations
 
+import os
+from unittest import mock
+
 import pytest
 
-from lab_connectors.http import HttpResult
+from lab_connectors.http import HttpResult, HttpFallbackError
 from lab_connectors.testing import FakeHttpClient, fake_response
 
 from toolkit.core.exceptions import DownloadError
-from toolkit.plugins.http_file import HttpFileSource
+from toolkit.plugins.http_file import (
+    HttpFileSource,
+    _sanitize_proxy_url,
+    _parse_curl_status,
+    _strip_curl_status,
+)
 
 
 @pytest.mark.contract
@@ -160,3 +168,97 @@ class TestNonTruncableSampleBytes:
         else:
             # CSV/JSON: sample_bytes rispettato con troncamento locale
             assert len(payload) <= 5000
+
+
+# --- curl fallback helpers ---
+
+
+@pytest.mark.contract
+class TestSanitizeProxyUrl:
+    def test_no_credentials(self):
+        assert _sanitize_proxy_url("http://proxy.example:8888") == "http://proxy.example:8888"
+
+    def test_username_only(self):
+        result = _sanitize_proxy_url("http://user@proxy.example:8888")
+        assert "user@" in result
+        assert "***" not in result
+
+    def test_username_password(self):
+        result = _sanitize_proxy_url("http://user:pass@proxy.example:8888")
+        assert "user:***@" in result
+        assert "pass" not in result
+
+    def test_no_port(self):
+        assert _sanitize_proxy_url("http://proxy.example") == "http://proxy.example"
+
+
+@pytest.mark.contract
+class TestParseCurlStatus:
+    def test_status_at_end(self):
+        assert _parse_curl_status(b"body\n200", b"") == 200
+
+    def test_status_with_trailing_newline(self):
+        assert _parse_curl_status(b"body\n200\n", b"") == 200
+
+    def test_no_status_raises(self):
+        with pytest.raises(DownloadError, match="no HTTP status"):
+            _parse_curl_status(b"body\n", b"curl: (7) Failed to connect")
+
+
+@pytest.mark.contract
+class TestStripCurlStatus:
+    def test_strips_trailing_status(self):
+        assert _strip_curl_status(b"body\n200", 200) == b"body"
+
+    def test_noop_when_not_suffixed(self):
+        assert _strip_curl_status(b"body", 200) == b"body"
+
+
+@pytest.mark.contract
+class TestCurlFallbackIntegration:
+    """Quando is_ssl_fallback_failed=True e HTTPS_PROXY è impostato,
+    fetch deve chiamare _fetch_via_curl invece di lanciare DownloadError."""
+
+    def test_fallback_triggered_with_proxy(self):
+        """ssl_fallback_failed + proxy → curl fallback chiamato."""
+        err = HttpFallbackError(
+            primary_error=ConnectionError("SSL err"), fallback_error=ConnectionError("fallback err")
+        )
+        fake = FakeHttpClient()
+        fake.responses["https://example.test/data.csv"] = HttpResult(
+            response=None,
+            err=err,
+            ssl_fallback_used=False,
+        )
+
+        source = HttpFileSource(retries=1)
+        source._client = fake
+
+        with mock.patch.dict(os.environ, {"HTTPS_PROXY": "http://proxy:8888"}):
+            with mock.patch(
+                "toolkit.plugins.http_file._fetch_via_curl",
+                return_value=b"curl-data",
+            ) as mock_curl:
+                payload = source.fetch("https://example.test/data.csv")
+
+        assert payload == b"curl-data"
+        mock_curl.assert_called_once()
+
+    def test_no_fallback_without_proxy(self):
+        """ssl_fallback_failed ma senza proxy → DownloadError (no curl)."""
+        err = HttpFallbackError(
+            primary_error=ConnectionError("SSL err"), fallback_error=ConnectionError("fallback err")
+        )
+        fake = FakeHttpClient()
+        fake.responses["https://example.test/data.csv"] = HttpResult(
+            response=None,
+            err=err,
+            ssl_fallback_used=False,
+        )
+
+        source = HttpFileSource(retries=1)
+        source._client = fake
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(DownloadError, match="fallback failed"):
+                source.fetch("https://example.test/data.csv")

--- a/tests/test_http_file_plugin.py
+++ b/tests/test_http_file_plugin.py
@@ -173,52 +173,59 @@ class TestNonTruncableSampleBytes:
 # --- curl fallback helpers ---
 
 
-@pytest.mark.contract
 class TestSanitizeProxyUrl:
+    @pytest.mark.pure_unit
     def test_no_credentials(self):
         assert _sanitize_proxy_url("http://proxy.example:8888") == "http://proxy.example:8888"
 
+    @pytest.mark.pure_unit
     def test_username_only(self):
         result = _sanitize_proxy_url("http://user@proxy.example:8888")
         assert "user@" in result
         assert "***" not in result
 
+    @pytest.mark.pure_unit
     def test_username_password(self):
         result = _sanitize_proxy_url("http://user:pass@proxy.example:8888")
         assert "user:***@" in result
         assert "pass" not in result
 
+    @pytest.mark.pure_unit
     def test_no_port(self):
         assert _sanitize_proxy_url("http://proxy.example") == "http://proxy.example"
 
 
-@pytest.mark.contract
 class TestParseCurlStatus:
+    @pytest.mark.pure_unit
     def test_status_at_end(self):
         assert _parse_curl_status(b"body\n200", b"") == 200
 
+    @pytest.mark.pure_unit
     def test_status_with_trailing_newline(self):
         assert _parse_curl_status(b"body\n200\n", b"") == 200
 
+    @pytest.mark.pure_unit
     def test_no_status_raises(self):
         with pytest.raises(DownloadError, match="no HTTP status"):
             _parse_curl_status(b"body\n", b"curl: (7) Failed to connect")
 
 
-@pytest.mark.contract
+@pytest.mark.pure_unit
 class TestStripCurlStatus:
+    @pytest.mark.pure_unit
     def test_strips_trailing_status(self):
         assert _strip_curl_status(b"body\n200", 200) == b"body"
 
+    @pytest.mark.pure_unit
     def test_noop_when_not_suffixed(self):
         assert _strip_curl_status(b"body", 200) == b"body"
 
 
-@pytest.mark.contract
 class TestCurlFallbackIntegration:
     """Quando is_ssl_fallback_failed=True e HTTPS_PROXY è impostato,
     fetch deve chiamare _fetch_via_curl invece di lanciare DownloadError."""
 
+    @pytest.mark.contract
     def test_fallback_triggered_with_proxy(self):
         """ssl_fallback_failed + proxy → curl fallback chiamato."""
         err = HttpFallbackError(
@@ -244,6 +251,7 @@ class TestCurlFallbackIntegration:
         assert payload == b"curl-data"
         mock_curl.assert_called_once()
 
+    @pytest.mark.contract
     def test_no_fallback_without_proxy(self):
         """ssl_fallback_failed ma senza proxy → DownloadError (no curl)."""
         err = HttpFallbackError(

--- a/toolkit/plugins/http_file.py
+++ b/toolkit/plugins/http_file.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+from urllib.parse import urlparse, urlunparse
 
 from lab_connectors.http import HttpClient
 
@@ -57,14 +58,33 @@ class HttpFileSource:
             proxy = _get_proxy_from_env()
             if proxy:
                 logger.warning(
-                    "SSL fallback failed for %s — riprovo con curl via proxy %s",
+                    "SSL fallback failed for %s — riprovo con curl via proxy",
                     url,
-                    proxy,
                 )
                 return _fetch_via_curl(url, proxy, self.timeout, self.user_agent, sample_bytes)
 
         err = result.err
         raise DownloadError(str(err) if err else f"Failed to fetch {url}")
+
+
+def _sanitize_proxy_url(proxy: str) -> str:
+    """Rimuove credenziali da URL proxy per log sicuri."""
+    parsed = urlparse(proxy)
+    if parsed.password:
+        return urlunparse(
+            parsed._replace(
+                netloc=f"{parsed.username}:***@{parsed.hostname}"
+                f"{':' + str(parsed.port) if parsed.port else ''}"
+            )
+        )
+    if parsed.username:
+        return urlunparse(
+            parsed._replace(
+                netloc=f"{parsed.username}@{parsed.hostname}"
+                f"{':' + str(parsed.port) if parsed.port else ''}"
+            )
+        )
+    return proxy
 
 
 def _get_proxy_from_env() -> str | None:
@@ -83,17 +103,22 @@ def _fetch_via_curl(
 
     Fallback usato quando Python requests fallisce con SSLError attraverso
     un proxy HTTP (es. GitHub Actions + tinyproxy vs dati.salute.gov.it).
+    Equivalente semantico di requests: segue redirect, controlla HTTP 200/206.
     """
+    # Usa --write-out per catturare lo HTTP status code (ultima riga stdout)
     cmd = [
         "curl",
-        "-s",  # silent
-        "-S",  # show errors
+        "-sS",  # silent, show errors
+        "-L",  # follow redirects
+        "--fail-with-body",  # exit non-zero su HTTP 400+, body preservato
         "--max-time",
         str(timeout),
         "-x",
         proxy,
         "-A",
         user_agent,
+        "-w",
+        "\n%{http_code}",
     ]
     if sample_bytes is not None:
         cmd += ["-r", f"0-{sample_bytes - 1}"]
@@ -102,16 +127,40 @@ def _fetch_via_curl(
     try:
         r = subprocess.run(cmd, capture_output=True, timeout=timeout + 5)
     except subprocess.TimeoutExpired:
-        raise DownloadError(f"curl timeout after {timeout}s for {url} (proxy: {proxy})")
+        raise DownloadError(f"curl timeout after {timeout}s for {url}")
 
-    if r.returncode != 0:
+    # Estrai HTTP status code dall'ultima riga di stdout
+    stdout = r.stdout
+    status_code = _parse_curl_status(stdout, r.stderr)
+    body = _strip_curl_status(stdout, status_code)
+
+    # --fail-with-body + exit 0 garantisce 2xx, ma verifichiamo 200/206
+    if status_code not in (200, 206):
         stderr = r.stderr.decode("utf-8", errors="replace").strip()
-        raise DownloadError(
-            f"curl exit={r.returncode} per {url} (proxy: {proxy}): {stderr or 'unknown error'}"
-        )
+        raise DownloadError(f"curl HTTP {status_code} per {url}: {stderr or 'unexpected status'}")
 
-    content = r.stdout
+    content = body
     if sample_bytes is not None:
         content = truncate_at_line(content, sample_bytes)
-    logger.info("curl fallback OK — %d bytes da %s (via %s)", len(content), url, proxy)
+    logger.info("curl fallback OK — %d bytes da %s", len(content), url)
     return content
+
+
+def _parse_curl_status(stdout: bytes, stderr: bytes) -> int:
+    """Estrae HTTP status dall'ultima riga di stdout di curl."""
+    lines = stdout.split(b"\n")
+    for candidate in reversed(lines):
+        candidate = candidate.strip()
+        if candidate.isdigit():
+            return int(candidate)
+    # Se non trovato, curl non ha prodotto output (startup error)
+    err_text = stderr.decode("utf-8", errors="replace").strip()
+    raise DownloadError(f"curl: no HTTP status in output: {err_text or 'empty response'}")
+
+
+def _strip_curl_status(stdout: bytes, status_code: int) -> bytes:
+    """Rimuove la riga di status_code aggiunta da -w."""
+    suffix = f"\n{status_code}".encode()
+    if stdout.endswith(suffix):
+        return stdout[: -len(suffix)]
+    return stdout

--- a/toolkit/plugins/http_file.py
+++ b/toolkit/plugins/http_file.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import subprocess
 
 from lab_connectors.http import HttpClient
 
@@ -47,5 +49,69 @@ class HttpFileSource:
             if sample_bytes is not None:
                 content = truncate_at_line(content, sample_bytes)
             return content
+
+        # Fallback a curl via proxy quando Python requests fallisce con SSL
+        # (noto: GitHub Actions + tinyproxy da SSLV3_ALERT_HANDSHAKE_FAILURE
+        #  con dati.salute.gov.it — curl invece funziona)
+        if result.is_ssl_fallback_failed:
+            proxy = _get_proxy_from_env()
+            if proxy:
+                logger.warning(
+                    "SSL fallback failed for %s — riprovo con curl via proxy %s",
+                    url,
+                    proxy,
+                )
+                return _fetch_via_curl(url, proxy, self.timeout, self.user_agent, sample_bytes)
+
         err = result.err
         raise DownloadError(str(err) if err else f"Failed to fetch {url}")
+
+
+def _get_proxy_from_env() -> str | None:
+    """Legge HTTPS_PROXY dall'ambiente (lowercase/uppercase)."""
+    return os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy")
+
+
+def _fetch_via_curl(
+    url: str,
+    proxy: str,
+    timeout: int,
+    user_agent: str,
+    sample_bytes: int | None = None,
+) -> bytes:
+    """Scarica URL tramite curl con proxy.
+
+    Fallback usato quando Python requests fallisce con SSLError attraverso
+    un proxy HTTP (es. GitHub Actions + tinyproxy vs dati.salute.gov.it).
+    """
+    cmd = [
+        "curl",
+        "-s",  # silent
+        "-S",  # show errors
+        "--max-time",
+        str(timeout),
+        "-x",
+        proxy,
+        "-A",
+        user_agent,
+    ]
+    if sample_bytes is not None:
+        cmd += ["-r", f"0-{sample_bytes - 1}"]
+    cmd += [url]
+
+    try:
+        r = subprocess.run(cmd, capture_output=True, timeout=timeout + 5)
+    except subprocess.TimeoutExpired:
+        raise DownloadError(f"curl timeout after {timeout}s for {url} (proxy: {proxy})")
+
+    if r.returncode != 0:
+        stderr = r.stderr.decode("utf-8", errors="replace").strip()
+        raise DownloadError(
+            f"curl exit={r.returncode} per {url} (proxy: {proxy}): {stderr or 'unknown error'}"
+        )
+
+    content = r.stdout
+    if sample_bytes is not None:
+        content = truncate_at_line(content, sample_bytes)
+    logger.info("curl fallback OK — %d bytes da %s (via %s)", len(content), url, proxy)
+    return content

--- a/toolkit/plugins/http_file.py
+++ b/toolkit/plugins/http_file.py
@@ -129,12 +129,18 @@ def _fetch_via_curl(
     except subprocess.TimeoutExpired:
         raise DownloadError(f"curl timeout after {timeout}s for {url}")
 
+    # Curl exit status: errori di rete, I/O, write failure, trasferimento
+    # parziale ecc. --fail-with-body copre solo HTTP 4xx/5xx, non tutto.
+    if r.returncode != 0:
+        stderr = r.stderr.decode("utf-8", errors="replace").strip()
+        raise DownloadError(f"curl exit={r.returncode} per {url}: {stderr or 'unknown error'}")
+
     # Estrai HTTP status code dall'ultima riga di stdout
     stdout = r.stdout
     status_code = _parse_curl_status(stdout, r.stderr)
     body = _strip_curl_status(stdout, status_code)
 
-    # --fail-with-body + exit 0 garantisce 2xx, ma verifichiamo 200/206
+    # Verifichiamo 200/206 (--fail-with-body già blocca 4xx/5xx ma teniamo il check)
     if status_code not in (200, 206):
         stderr = r.stderr.decode("utf-8", errors="replace").strip()
         raise DownloadError(f"curl HTTP {status_code} per {url}: {stderr or 'unexpected status'}")


### PR DESCRIPTION
## Sintesi

Quando Python `requests` fallisce con SSLError attraverso un proxy HTTPS (es. GitHub Actions + tinyproxy vs `dati.salute.gov.it`), il plugin `http_file.py` riprova con `curl` via subprocess.

Il problema era `SSLV3_ALERT_HANDSHAKE_FAILURE` — un errore TLS che si verifica solo dalla combinazione Python + GH Actions runner + tinyproxy. `curl` invece negozia TLS diversamente e funziona sempre.

## Condizioni di attivazione

1. `result.is_ssl_fallback_failed == True` (entrambi i tentativi SSL falliti)
2. `HTTPS_PROXY` o `https_proxy` impostato nellambiente