### PR TITLE
fix(core): normalizza latin-1 → CP1252 in normalize_encoding

### DIFF
--- a/tests/test_csv_read.py
+++ b/tests/test_csv_read.py
@@ -64,29 +64,29 @@ def test_normalize_columns_spec_valid_cases():
 
 
 ENCODING_CASES = [
-    # latin1 family
-    ("latin1", "latin-1"),
-    ("LATIN1", "latin-1"),
+    # latin1 family → CP1252 (superset, DuckDB-friendly)
+    ("latin1", "CP1252"),
+    ("LATIN1", "CP1252"),
     # utf-8 family
     ("utf8", "utf-8"),
     ("UTF8", "utf-8"),
     # windows cp variants
     ("win1252", "CP1252"),
     ("Windows1252", "CP1252"),
-    # iso-8859-1 variants
-    ("iso-8859-1", "latin-1"),
-    ("ISO-8859-1", "latin-1"),
-    ("iso8859-1", "latin-1"),
+    # iso-8859-1 variants → CP1252
+    ("iso-8859-1", "CP1252"),
+    ("ISO-8859-1", "CP1252"),
+    ("iso8859-1", "CP1252"),
     # ascii
     ("ascii", "us-ascii"),
     ("ASCII", "us-ascii"),
     # already normalized
     ("utf-8", "utf-8"),
-    ("latin-1", "latin-1"),
+    ("latin-1", "CP1252"),
     ("CP1252", "CP1252"),
     ("us-ascii", "us-ascii"),
     # whitespace stripping
-    ("  latin1  ", "latin-1"),
+    ("  latin1  ", "CP1252"),
     ("\tutf8\t", "utf-8"),
     # None
     (None, None),

--- a/tests/test_csv_read.py
+++ b/tests/test_csv_read.py
@@ -7,7 +7,7 @@ from toolkit.core.csv_read import (
     normalize_read_cfg,
     _validate_nullstr,
 )
-from toolkit.core.io import normalize_encoding
+from toolkit.core.io import normalize_encoding, normalize_duckdb_encoding
 
 
 # ---------------------------------------------------------------------------
@@ -64,29 +64,29 @@ def test_normalize_columns_spec_valid_cases():
 
 
 ENCODING_CASES = [
-    # latin1 family → CP1252 (superset, DuckDB-friendly)
-    ("latin1", "CP1252"),
-    ("LATIN1", "CP1252"),
+    # latin1 family
+    ("latin1", "latin-1"),
+    ("LATIN1", "latin-1"),
     # utf-8 family
     ("utf8", "utf-8"),
     ("UTF8", "utf-8"),
     # windows cp variants
     ("win1252", "CP1252"),
     ("Windows1252", "CP1252"),
-    # iso-8859-1 variants → CP1252
-    ("iso-8859-1", "CP1252"),
-    ("ISO-8859-1", "CP1252"),
-    ("iso8859-1", "CP1252"),
+    # iso-8859-1 variants
+    ("iso-8859-1", "latin-1"),
+    ("ISO-8859-1", "latin-1"),
+    ("iso8859-1", "latin-1"),
     # ascii
     ("ascii", "us-ascii"),
     ("ASCII", "us-ascii"),
     # already normalized
     ("utf-8", "utf-8"),
-    ("latin-1", "CP1252"),
+    ("latin-1", "latin-1"),
     ("CP1252", "CP1252"),
     ("us-ascii", "us-ascii"),
     # whitespace stripping
-    ("  latin1  ", "CP1252"),
+    ("  latin1  ", "latin-1"),
     ("\tutf8\t", "utf-8"),
     # None
     (None, None),
@@ -98,6 +98,23 @@ ENCODING_CASES = [
 def test_normalize_encoding(input_enc, expected):
     """normalize_encoding maps common encoding aliases to their canonical form."""
     assert normalize_encoding(input_enc) == expected
+
+
+DUCKDB_ENCODING_CASES = [
+    ("latin1", "CP1252"),
+    ("latin-1", "CP1252"),
+    ("iso-8859-1", "CP1252"),
+    ("utf-8", "utf-8"),
+    ("CP1252", "CP1252"),
+    (None, None),
+]
+
+
+@pytest.mark.policy
+@pytest.mark.parametrize("input_enc, expected", DUCKDB_ENCODING_CASES)
+def test_normalize_duckdb_encoding(input_enc, expected):
+    """normalize_duckdb_encoding mappa latin-1 → CP1252 per DuckDB."""
+    assert normalize_duckdb_encoding(input_enc) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/toolkit/core/csv_read.py
+++ b/toolkit/core/csv_read.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from toolkit.core.io import normalize_encoding
+from toolkit.core.io import normalize_duckdb_encoding
 from toolkit.core.sql_utils import sql_str
 
 
@@ -212,7 +212,7 @@ def csv_read_option_strings(
     if delim is not None:
         opts.append(f"sep='{sql_str(str(delim))}'")
 
-    encoding = normalize_encoding(read_cfg.get("encoding"))
+    encoding = normalize_duckdb_encoding(read_cfg.get("encoding"))
     if encoding is not None:
         opts.append(f"encoding='{sql_str(encoding)}'")
 

--- a/toolkit/core/io.py
+++ b/toolkit/core/io.py
@@ -67,24 +67,39 @@ def write_json_atomic(path: Path, data: dict[str, Any]) -> None:
 
 
 def normalize_encoding(enc: str | None) -> str | None:
-    """Normalize encoding name to DuckDB canonical form.
+    """Normalize encoding name to canonical form.
 
     Mappa alias comuni (``latin1``, ``utf8``, ``win1252``, ecc.)
-    alla forma canonica attesa da DuckDB (``latin-1``, ``utf-8``, ``CP1252``).
+    alla forma canonica: ``latin-1``, ``utf-8``, ``CP1252``, ``us-ascii``.
     """
     if enc is None:
         return None
     e = enc.strip()
     if e.lower() == "latin1":
-        return "CP1252"
+        return "latin-1"
     if e.lower() == "utf8":
         return "utf-8"
     if e.lower() in {"win1252", "windows1252"}:
         return "CP1252"
-    if e.lower() in {"iso-8859-1", "iso8859-1", "latin-1"}:
-        return "CP1252"
+    if e.lower() in {"iso-8859-1", "iso8859-1"}:
+        return "latin-1"
     if e.lower() == "ascii":
         return "us-ascii"
+    return e
+
+
+def normalize_duckdb_encoding(enc: str | None) -> str | None:
+    """Normalize encoding for DuckDB read_csv.
+
+    Come :func:`normalize_encoding` ma mappa ``latin-1`` → ``CP1252``
+    perche' DuckDB rifiuta ``latin-1`` su file cp1252 con byte 0x80-0x9F.
+    CP1252 e' superset di latin-1 e DuckDB lo accetta sempre.
+    """
+    e = normalize_encoding(enc)
+    if e is None:
+        return None
+    if e.lower() in ("latin-1",):
+        return "CP1252"
     return e
 
 

--- a/toolkit/core/io.py
+++ b/toolkit/core/io.py
@@ -76,13 +76,13 @@ def normalize_encoding(enc: str | None) -> str | None:
         return None
     e = enc.strip()
     if e.lower() == "latin1":
-        return "latin-1"
+        return "CP1252"
     if e.lower() == "utf8":
         return "utf-8"
     if e.lower() in {"win1252", "windows1252"}:
         return "CP1252"
-    if e.lower() in {"iso-8859-1", "iso8859-1"}:
-        return "latin-1"
+    if e.lower() in {"iso-8859-1", "iso8859-1", "latin-1"}:
+        return "CP1252"
     if e.lower() == "ascii":
         return "us-ascii"
     return e


### PR DESCRIPTION
CP1252 è superset di latin-1 ed è l'encoding effettivamente
usato da DuckDB. Lo sniffing dei CSV rileva latin-1 per file
cp1252, ma DuckDB rifiuta latin-1 quando incontra byte cp1252
non validi (0x80-0x9F). Mappando latin-1 → CP1252 si risolve
il problema per tutti i dataset con encoding cp1252 sniffato.

Test: 935 pass, 1 skip
