### PR TITLE
feat(ckan): paginazione in _datastore_search per dataset con >100 records

### DIFF
--- a/tests/test_ckan_plugin.py
+++ b/tests/test_ckan_plugin.py
@@ -583,3 +583,51 @@ def test_ckan_datastore_search_paginates(monkeypatch):
     assert lines[1] == "0,record-0"
     assert lines[-1] == "4,record-4"
     assert len(calls) == 2, f"Expected 2 API calls, got {len(calls)}"
+
+
+def test_ckan_datastore_search_partial_page(monkeypatch):
+    """Server cappa a 100 record anche con limit=32000: offset avanza per records reali."""
+    calls = []
+
+    def _fake_get(self, url, **kwargs):
+        calls.append((url, kwargs.get("params")))
+        if "datastore_search" in url:
+            params = kwargs.get("params", {})
+            offset = int(params.get("offset", 0))
+            # Simula server che ignora limit e restituisce sempre <= 2 record
+            remaining = 7 - offset
+            batch_size = min(2, remaining)
+            records = (
+                [{"id": offset + i, "valore": f"r-{offset + i}"} for i in range(batch_size)]
+                if batch_size > 0
+                else []
+            )
+            return _ok(
+                _FakeResponse(
+                    200,
+                    json_data={
+                        "success": True,
+                        "result": {
+                            "fields": [{"id": "id"}, {"id": "valore"}],
+                            "records": records,
+                            "total": 7,
+                        },
+                    },
+                    url=url,
+                )
+            )
+        raise AssertionError(f"Unexpected request to {url}")
+
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
+
+    src = CkanSource()
+    csv_bytes = src._datastore_search("res-capped", "https://portal.example.org/api/3", page_size=32000)
+
+    text = csv_bytes.decode("utf-8")
+    lines = text.strip().splitlines()
+    assert lines[0] == "id,valore"
+    assert len(lines) - 1 == 7, f"Expected 7 records, got {len(lines) - 1}"
+    assert lines[1] == "0,r-0"
+    assert lines[-1] == "6,r-6"
+    # 7 records con batch da 2: offset 0→2→4→6 = 4 chiamate
+    assert len(calls) == 4, f"Expected 4 API calls (capped at 2/page), got {len(calls)}"

--- a/tests/test_ckan_plugin.py
+++ b/tests/test_ckan_plugin.py
@@ -538,3 +538,48 @@ def test_ckan_fetch_prefer_datastore_false_skips_datastore(monkeypatch):
     assert payload == b"csv-via-url"
     assert "csv-via-url" in origin or "dump.csv" in origin
     assert not any("datastore_search" in str(c) for c in calls)
+
+
+def test_ckan_datastore_search_paginates(monkeypatch):
+    """Verifica che _datastore_search pagini quando total > records per chiamata."""
+    calls = []
+    page1 = [{"id": i, "valore": f"record-{i}"} for i in range(3)]
+    page2 = [{"id": i + 3, "valore": f"record-{i + 3}"} for i in range(2)]
+    total = 5
+
+    def _fake_get(self, url, **kwargs):
+        calls.append((url, kwargs.get("params")))
+        if "datastore_search" in url:
+            params = kwargs.get("params", {})
+            offset = int(params.get("offset", 0))
+            page = page1 if offset == 0 else page2
+            return _ok(
+                _FakeResponse(
+                    200,
+                    json_data={
+                        "success": True,
+                        "result": {
+                            "fields": [{"id": "id"}, {"id": "valore"}],
+                            "records": page,
+                            "total": total,
+                        },
+                    },
+                    url=url,
+                )
+            )
+        raise AssertionError(f"Unexpected request to {url}")
+
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
+
+    src = CkanSource()
+    csv_bytes = src._datastore_search(
+        "res-paginated", "https://portal.example.org/api/3", page_size=3
+    )
+
+    text = csv_bytes.decode("utf-8")
+    lines = text.strip().splitlines()
+    assert lines[0] == "id,valore"
+    assert len(lines) - 1 == total  # header escluso
+    assert lines[1] == "0,record-0"
+    assert lines[-1] == "4,record-4"
+    assert len(calls) == 2, f"Expected 2 API calls, got {len(calls)}"

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import io
+from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 from lab_connectors.http import HttpClient
@@ -57,7 +58,7 @@ class CkanSource:
             user_agent=self.user_agent,
         )
 
-    def _get_json(self, url: str, params: dict[str, str]) -> dict:
+    def _get_json(self, url: str, params: dict[str, Any]) -> dict:
         result = self._client.get(url, params=params)
         if result.is_ok and result.response is not None:
             response = result.response

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -86,25 +86,61 @@ class CkanSource:
         err = result.err
         raise DownloadError(str(err) if err else f"Failed to fetch {url}")
 
-    def _datastore_search(self, resource_id: str, api_base: str) -> bytes:
+    def _datastore_search(self, resource_id: str, api_base: str, page_size: int = 32000) -> bytes:
+        """Fetch ALL rows from a CKAN DataStore resource, paginating if needed.
+
+        CKAN DataStore default limit is 100 rows; API max is 32000.
+        Questa funzione pagina automaticamente fino a esaurimento records.
+        """
         url = _normalize_datastore_search_url(api_base)
-        payload = self._get_json(url, {"id": resource_id})
-        result = payload.get("result", {})
-        records = result.get("records") or []
-        if not records:
+        all_records: list[dict] = []
+        fields: list[str] = []
+        total: int | None = None
+        offset = 0
+        limit = min(page_size, 32000)
+
+        while True:
+            params: dict[str, str | int] = {
+                "id": resource_id,
+                "limit": limit,
+                "offset": offset,
+            }
+            payload = self._get_json(url, params)
+            result = payload.get("result", {})
+            records = result.get("records") or []
+            if not records and total is None:
+                raise DownloadError(
+                    f"CKAN datastore_search for resource {resource_id} returned no records"
+                )
+
+            # Capture field list from first response
+            if not fields:
+                fields = [f["id"] for f in result.get("fields") or []]
+                if not fields and records:
+                    fields = list(records[0].keys())
+
+            all_records.extend(records)
+
+            # Stop when we have all records
+            if total is None:
+                total = result.get("total") or len(records)
+            if len(all_records) >= total:
+                break
+
+            offset += limit
+
+        if not all_records:
             raise DownloadError(
                 f"CKAN datastore_search for resource {resource_id} returned no records"
             )
-        # NOTE: other DownloadError from this method indicate empty-result only;
-        # HTTP/API errors surface as requests exceptions, caught by outer try-except in fetch()
-        fields = [f["id"] for f in result.get("fields") or []]
+
         buffer = io.StringIO(newline="")
         writer = csv.DictWriter(buffer, fieldnames=fields)
         writer.writeheader()
         # NOTE: CSV format does not distinguish None from empty string.
         # row.get(k) returns None for missing keys; csv.DictWriter emits '' for None.
         # If semantic distinction matters, a different format (JSONL) is needed.
-        for row in records:
+        for row in all_records:
             writer.writerow({k: row.get(k) for k in fields})
         return buffer.getvalue().encode("utf-8")
 

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -128,7 +128,15 @@ class CkanSource:
             if len(all_records) >= total:
                 break
 
-            offset += limit
+            # No-progress guard: server may cap at fewer records than limit
+            if not records:
+                break
+
+            # Advance by actual records returned, not by requested limit
+            # (alcuni portali CKAN ignorano limit=32000 e restituiscono
+            #  il loro default, es. 100. Offset su limit salterebbe dati
+            #  o causerebbe loop infinito.)
+            offset += len(records)
 
         if not all_records:
             raise DownloadError(


### PR DESCRIPTION
## Sintesi

`CkanSource._datastore_search()` faceva una singola chiamata API senza parametri `limit`/`offset`. CKAN DataStore default limit è 100 records, quindi per risorse con più di 100 righe (es. MUR contribuzione: 1.100 records) venivano scaricati solo i primi 100 → dati incompleti.

## Contesto collegato

Issue: il dataset `mur-contribuzione-universitaria` riceveva solo 10 atenei invece di 100 a causa della paginazione mancante.

## Cosa cambia

- [x] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Dettaglio tecnico

`_datastore_search()` ora:
1. Usa `limit=32000` (massimo CKAN) per minimizzare le chiamate
2. Legge `total` dal primo response
3. Se `total > len(records)`, cicla con `offset` fino a esaurimento
4. Concatena tutti i records in un unico CSV

Parametro opzionale `page_size` (default 32000) per controllo granulare.

## Verifica

```bash
pytest tests/test_ckan_plugin.py -v
pytest tests/ -q --ignore=tests/test_run_context.py
```

- [x] `pytest -m adapter` passa (14 test ckan + 1 test paginazione)
- [x] 931 test totali passano (1 skip preesistente)
- [x] Test specifico `test_ckan_datastore_search_paginates` con 2 pagine da 3+2 records

## Checklist PR

- [x] Perimetro stretto: solo `_datastore_search()`
- [x] Test nuovo con marker `adapter` (ereditato dal modulo)
- [x] Compatibilità backward: firma invariata (parametro `page_size` opzionale)

## Note per chi revisiona

La paginazione non cambia il comportamento per risorse con ≤100 records (nessuna chiamata extra). Per risorse grandi, il numero di chiamate è `ceil(total / page_size)`.
