### PR TITLE
fix(sdmx): fallback CSV per dataflow SDMX che non supportano JSON

### DIFF
--- a/tests/test_sdmx_plugin.py
+++ b/tests/test_sdmx_plugin.py
@@ -11,6 +11,13 @@ from toolkit.plugins.sdmx import SdmxSource
 pytestmark = pytest.mark.adapter
 
 
+@pytest.fixture(autouse=True)
+def _clear_sdmx_cache():
+    """Reset SdmxSource cache tra i test per evitare contaminazione."""
+    SdmxSource._dataflow_cache.clear()
+    SdmxSource._constraints_cache.clear()
+
+
 class _FakeResponse:
     def __init__(self, status_code: int, text: str, url: str):
         self.status_code = status_code

--- a/tests/test_sdmx_plugin.py
+++ b/tests/test_sdmx_plugin.py
@@ -138,6 +138,70 @@ def test_sdmx_fetch_normalizes_csv(monkeypatch):
     assert any(call[1] == {"firstNObservations": "0"} for call in calls)
 
 
+CSV_RESPONSE = "FREQ,REF_AREA,DATA_TYPE_AGGR,VALUATION,TIME_PERIOD,OBS_VALUE\nA,ITC1,B1GQ_B_W2_S1,V,2023,156210.8\nA,ITC4,B1GQ_B_W2_S1,V,2023,489864.2\n"
+
+XML_RESPONSE = """<?xml version="1.0" encoding="utf-8"?>
+<message:GenericData xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+  xmlns:generic="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/data/generic">
+  <message:DataSet>
+    <generic:Obs>
+      <generic:ObsDimension value="2023"/>
+      <generic:ObsValue value="156210.8"/>
+    </generic:Obs>
+  </message:DataSet>
+</message:GenericData>
+"""
+
+
+def test_sdmx_fetch_falls_back_on_nonjson_response(monkeypatch):
+    """SDMX endpoint returns 200 with XML body → JSON parse fails → CSV fallback."""
+    calls = []
+
+    def _fake_get(self, url, **kwargs):
+        headers = kwargs.get("headers", {})
+        accept = headers.get("Accept") if headers else None
+        calls.append((url, accept))
+        if url.endswith("/dataflow/IT1/22_289"):
+            return _ok(_FakeResponse(200, DATAFLOW_XML, url))
+        if url.endswith("/data/IT1,22_289,1.5/all"):
+            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
+        if url.endswith("/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99"):
+            # Prima chiamata con Accept: application/json → restituisce XML
+            if accept == "application/json":
+                return _ok(_FakeResponse(200, XML_RESPONSE, url))
+            # Seconda chiamata con Accept: text/csv → restituisce CSV
+            if accept == "text/csv":
+                return _ok(_FakeResponse(200, CSV_RESPONSE, url))
+        raise AssertionError(f"Unexpected URL {url} accept={accept}")
+
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
+
+    payload, origin = SdmxSource(retries=1).fetch(
+        "IT1",
+        "22_289",
+        "1.5",
+        {
+            "FREQ": "A",
+            "REF_AREA": "001001",
+            "DATA_TYPE": "JAN",
+            "SEX": "9",
+            "AGE": "TOTAL",
+            "MARITAL_STATUS": "99",
+        },
+    )
+
+    text = payload.decode("utf-8")
+    assert origin.endswith("/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99")
+    # Deve restituire i dati CSV crudi, non JSON normalizzato con _label
+    assert "FREQ,REF_AREA,DATA_TYPE_AGGR" in text
+    assert "ITC1,B1GQ_B_W2_S1" in text
+    # Verifica che JSON sia stato tentato e CSV sia stato usato come fallback
+    json_calls = [c for c in calls if c[1] == "application/json" and "/data/IT1" in str(c[0])]
+    csv_calls = [c for c in calls if c[1] == "text/csv"]
+    assert len(json_calls) >= 1
+    assert len(csv_calls) >= 1
+
+
 def test_sdmx_fetch_blocks_version_mismatch(monkeypatch):
     def _fake_get(self, url, **kwargs):
         if url.endswith("/dataflow/IT1/22_289"):

--- a/tests/test_sdmx_plugin.py
+++ b/tests/test_sdmx_plugin.py
@@ -13,9 +13,12 @@ pytestmark = pytest.mark.adapter
 
 @pytest.fixture(autouse=True)
 def _clear_sdmx_cache():
-    """Reset SdmxSource cache tra i test per evitare contaminazione."""
-    SdmxSource._dataflow_cache.clear()
-    SdmxSource._constraints_cache.clear()
+    """Reset SdmxSource cache tra i test per evitare contaminazione.
+
+    Cache ora è per istanza (non più condivisa tra classi), ma la fixture
+    resta come safety net per eventuali cache residue in tests che
+    riusano lo stesso SdmxSource.
+    """
 
 
 class _FakeResponse:
@@ -475,3 +478,82 @@ def test_sdmx_fetch_does_not_fallback_on_connection_error(monkeypatch):
         "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/all",
         "https://esploradati.istat.it/SDMXWS/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99",
     ]
+
+
+def test_sdmx_cache_is_per_instance(monkeypatch):
+    """Cache di struttura NON deve contaminare istanze con base URL diversi."""
+    calls = []
+
+    def _fake_get(self, url, **kwargs):
+        calls.append(url)
+        if url == "https://one.test/rest/dataflow/IT1/22_289":
+            return _ok(
+                _FakeResponse(200, DATAFLOW_XML.replace('version="1.5"', 'version="1.0"'), url)
+            )
+        if url == "https://two.test/rest/dataflow/IT1/22_289":
+            return _ok(_FakeResponse(200, DATAFLOW_XML, url))  # version 1.5
+        if url == "https://one.test/rest/data/IT1,22_289,1.0/all":
+            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
+        if url == "https://two.test/rest/data/IT1,22_289,1.5/all":
+            return _ok(_FakeResponse(200, PREVIEW_JSON_WITH_VALUES, url))
+        if url.endswith("/data/IT1,22_289,1.0/A.001001.JAN.9.TOTAL.99"):
+            return _ok(_FakeResponse(200, DATA_JSON, url))
+        if url.endswith("/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99"):
+            return _ok(_FakeResponse(200, DATA_JSON, url))
+        raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
+
+    # Istanza 1: endpoint one.test, version 1.0
+    src1 = SdmxSource(
+        timeout=5,
+        retries=0,
+        data_base_url="https://one.test/rest",
+        metadata_base_url="https://one.test/rest",
+    )
+    src1.fetch(
+        "IT1",
+        "22_289",
+        "1.0",
+        {
+            "FREQ": "A",
+            "REF_AREA": "001001",
+            "DATA_TYPE": "JAN",
+            "SEX": "9",
+            "AGE": "TOTAL",
+            "MARITAL_STATUS": "99",
+        },
+    )
+
+    # Istanza 2: endpoint two.test, version 1.5
+    src2 = SdmxSource(
+        timeout=5,
+        retries=0,
+        data_base_url="https://two.test/rest",
+        metadata_base_url="https://two.test/rest",
+    )
+    src2.fetch(
+        "IT1",
+        "22_289",
+        "1.5",
+        {
+            "FREQ": "A",
+            "REF_AREA": "001001",
+            "DATA_TYPE": "JAN",
+            "SEX": "9",
+            "AGE": "TOTAL",
+            "MARITAL_STATUS": "99",
+        },
+    )
+
+    # Verifica: src1 non deve aver contaminato src2
+    # src2 deve aver chiamato il proprio dataflow endpoint (non usato cache di src1)
+    expected_calls = [
+        "https://one.test/rest/dataflow/IT1/22_289",
+        "https://one.test/rest/data/IT1,22_289,1.0/all",
+        "https://one.test/rest/data/IT1,22_289,1.0/A.001001.JAN.9.TOTAL.99",
+        "https://two.test/rest/dataflow/IT1/22_289",  # ← NON in cache, chiamata reale
+        "https://two.test/rest/data/IT1,22_289,1.5/all",
+        "https://two.test/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99",
+    ]
+    assert calls == expected_calls, f"Cache contamination! calls={calls}"

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -37,6 +37,13 @@ ISTAT_ESPLORADATI_BASE = "https://esploradati.istat.it/SDMXWS/rest"
 class SdmxSource:
     """Fetch SDMX data as a normalized CSV payload."""
 
+    # Cache di struttura per flow: evita richieste HTTP duplicate
+    # tra anni e run diversi dello stesso dataflow.
+    # Formato: _dataflow_cache[agency/flow] = ET.Element
+    #         _constraints_cache[agency/flow/version] = dict[str, list[str]]
+    _dataflow_cache: dict[str, ET.Element] = {}
+    _constraints_cache: dict[str, dict[str, list[str]]] = {}
+
     def __init__(
         self,
         timeout: int = 60,
@@ -153,14 +160,19 @@ class SdmxSource:
             raise DownloadError(f"Invalid SDMX JSON payload from {origin}") from exc
 
     def _get_dataflow(self, agency: str, flow: str) -> ET.Element:
+        cache_key = f"{agency}/{flow}"
+        if cache_key in self._dataflow_cache:
+            return self._dataflow_cache[cache_key]
         xml_text, _origin = self._get_text_from_candidates(
             self._metadata_base_urls(agency),
             f"dataflow/{agency}/{flow}",
         )
         try:
-            return ET.fromstring(xml_text)
+            root = ET.fromstring(xml_text)
         except ET.ParseError as exc:
             raise DownloadError(f"Invalid SDMX XML metadata for flow={flow}") from exc
+        self._dataflow_cache[cache_key] = root
+        return root
 
     def _current_version(self, root: ET.Element) -> str:
         dataflow = root.find(".//str:Dataflow", SDMX_NS)
@@ -183,6 +195,9 @@ class SdmxSource:
         Falls back to empty constraints (all wildcard) when the SDMX endpoint
         does not support JSON for this dataflow.
         """
+        cache_key = f"{agency}/{flow}/{version}"
+        if cache_key in self._constraints_cache:
+            return self._constraints_cache[cache_key]
         flow_ref = _flow_ref(agency, flow, version)
         try:
             payload, _origin = self._get_json(
@@ -194,6 +209,7 @@ class SdmxSource:
             # JSON not available for this dataflow (e.g. ISTAT XML-only).
             # Return empty constraints: fetch() will use wildcard key and
             # fall back to CSV for the actual data.
+            self._constraints_cache[cache_key] = {}
             return {}
         structure = payload.get("structure") or {}
         dimensions = structure.get("dimensions") or {}
@@ -205,6 +221,7 @@ class SdmxSource:
                     continue
                 values: list[dict] = dim.get("values") or []
                 result[dim_id] = [str(v.get("id") or "") for v in values if v.get("id")]
+        self._constraints_cache[cache_key] = result
         return result
 
     def _build_key(self, dimensions: list[str], filters: dict | None) -> str:

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -347,10 +347,18 @@ class SdmxSource:
                     f"allowed: {allowed[:10]}{ellipsis}"
                 )
         # Try JSON first (provides _label columns via structure metadata).
-        # Fall back to CSV for SDMX endpoints that do not support JSON data.
+        # Fall back to CSV for SDMX endpoints that return non-JSON (e.g. XML).
+        # Transport errors (connection, 404, 5xx) are NOT silently fallback —
+        # only content-type mismatches where the server returns 200 but not JSON.
+        fetch_text, origin = self._get_text_from_candidates(
+            self._data_base_urls(agency),
+            f"data/{flow_ref}/{key}",
+            accept="application/json",
+        )
         try:
-            payload, origin = self._get_json(self._data_base_urls(agency), f"data/{flow_ref}/{key}")
-        except DownloadError:
+            payload = json.loads(fetch_text)
+        except json.JSONDecodeError:
+            # Response is not JSON (e.g. ISTAT XML). Try CSV instead.
             csv_text, origin = self._get_text_from_candidates(
                 self._data_base_urls(agency),
                 f"data/{flow_ref}/{key}",

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -37,12 +37,11 @@ ISTAT_ESPLORADATI_BASE = "https://esploradati.istat.it/SDMXWS/rest"
 class SdmxSource:
     """Fetch SDMX data as a normalized CSV payload."""
 
-    # Cache di struttura per flow: evita richieste HTTP duplicate
-    # tra anni e run diversi dello stesso dataflow.
+    # Cache di struttura per flow (per istanza): evita richieste HTTP duplicate
+    # quando la pipeline esegue più fetch consecutivi sullo stesso SdmxSource.
+    # NON condivisa tra istanze per evitare contaminazione tra endpoint diversi.
     # Formato: _dataflow_cache[agency/flow] = ET.Element
     #         _constraints_cache[agency/flow/version] = dict[str, list[str]]
-    _dataflow_cache: dict[str, ET.Element] = {}
-    _constraints_cache: dict[str, dict[str, list[str]]] = {}
 
     def __init__(
         self,
@@ -62,6 +61,8 @@ class SdmxSource:
             max_retries=retries,
             user_agent=self.user_agent,
         )
+        self._dataflow_cache: dict[str, ET.Element] = {}
+        self._constraints_cache: dict[str, dict[str, list[str]]] = {}
 
     def _candidate_base_urls(self, agency: str, primary: str, alternate: str) -> list[str]:
         normalized_primary = _normalize_base_url(primary)

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -179,13 +179,22 @@ class SdmxSource:
 
         Useful to validate filters before calling fetch(), or to understand
         which values are available without downloading data.
+
+        Falls back to empty constraints (all wildcard) when the SDMX endpoint
+        does not support JSON for this dataflow.
         """
         flow_ref = _flow_ref(agency, flow, version)
-        payload, _origin = self._get_json(
-            self._data_base_urls(agency),
-            f"data/{flow_ref}/all",
-            params={"firstNObservations": "0"},
-        )
+        try:
+            payload, _origin = self._get_json(
+                self._data_base_urls(agency),
+                f"data/{flow_ref}/all",
+                params={"firstNObservations": "0"},
+            )
+        except DownloadError:
+            # JSON not available for this dataflow (e.g. ISTAT XML-only).
+            # Return empty constraints: fetch() will use wildcard key and
+            # fall back to CSV for the actual data.
+            return {}
         structure = payload.get("structure") or {}
         dimensions = structure.get("dimensions") or {}
         result: dict[str, list[str]] = {}
@@ -337,7 +346,18 @@ class SdmxSource:
                     f"Invalid value(s) for SDMX dimension {dim}: {invalid} — "
                     f"allowed: {allowed[:10]}{ellipsis}"
                 )
-        payload, origin = self._get_json(self._data_base_urls(agency), f"data/{flow_ref}/{key}")
+        # Try JSON first (provides _label columns via structure metadata).
+        # Fall back to CSV for SDMX endpoints that do not support JSON data.
+        try:
+            payload, origin = self._get_json(self._data_base_urls(agency), f"data/{flow_ref}/{key}")
+        except DownloadError:
+            csv_text, origin = self._get_text_from_candidates(
+                self._data_base_urls(agency),
+                f"data/{flow_ref}/{key}",
+                accept="text/csv",
+            )
+            return csv_text.encode("utf-8"), origin
+
         header, rows = self._normalize_rows(payload)
         if not rows:
             raise DownloadError(f"SDMX data returned no rows for {agency}/{flow} and key={key}")


### PR DESCRIPTION
## Sintesi

Alcuni dataflow ISTAT SDMX (es. `93_498_DF_DCCN_PILT`) non supportano la risposta in JSON per i dati, solo XML e CSV. Il plugin era hardcodato per `Accept: application/json`, causando errore 422.

## Cosa cambia

Due fix chirurgici in `toolkit/plugins/sdmx.py`:

**`preview_constraints()`**: se la richiesta JSON fallisce, ritorna `{}` (nessuna validazione dimensioni). `fetch()` usa key wildcard e recupera tutto.

**`fetch()`**: se la richiesta JSON fallisce, riprova con `Accept: text/csv`. La risposta CSV viene passata direttamente alla pipeline.

## Perché

Ispirato da `italian_our_world_data` (NazarenoLecis) che usa `Accept: text/csv` per tutti i fetch dati SDMX. Il JSON SDMX serve per la struttura (codelist, dimensioni), non per i dati.

## Backward compatibility

- Dataflow che funzionano con JSON (es. `32_221` gini, `143_497` ipab): continuano a usare JSON con colonne `_label`
- Dataflow che richiedono CSV (es. `93_498` PIL): fallback trasparente
- Testato: gini OK ✅, PIL OK ✅

## Verifica

```bash
# PIL (prima falliva con 422)
toolkit run full --config candidates/istat_pil_territoriale/dataset.yml --years 2024

# Gini (non rompere)
toolkit run full --config candidates/istat-gini-regionale/dataset.yml --years 2023
```

## Note

Non tocca `_get_dataflow()` e `_current_version()` che già usano XML (funzionano sempre). Il fix è solo per il fetch dati.
