### PR TITLE
feat(scout): infer_granularity_from_name_and_columns migliorata

### DIFF
--- a/tests/test_scout_infer.py
+++ b/tests/test_scout_infer.py
@@ -12,6 +12,7 @@ import pytest
 
 from toolkit.scout.infer import (
     infer_granularity,
+    infer_granularity_from_name_and_columns,
     infer_topics,
     infer_years,
     suggest_years,
@@ -105,6 +106,48 @@ class TestInferGranularity:
     )
     def test_granularity(self, text: str, expected: str) -> None:
         assert infer_granularity(text) == expected
+
+
+class TestInferGranularityFromNameAndColumns:
+    """pure_unit: infer_granularity_from_name_and_columns."""
+
+    @pytest.mark.pure_unit
+    def test_comune_from_codice_comune_column(self) -> None:
+        """CODICE_COMUNE come colonna → granularità comune."""
+        result = infer_granularity_from_name_and_columns("", ["CODICE_COMUNE"])
+        assert result == "comune"
+
+    @pytest.mark.pure_unit
+    def test_comune_from_column_name(self) -> None:
+        """Colonna 'Comune' → granularità comune."""
+        result = infer_granularity_from_name_and_columns("", ["Comune", "Anno"])
+        assert result == "comune"
+
+    @pytest.mark.pure_unit
+    def test_provincia_from_column(self) -> None:
+        """Colonna 'Provincia' → granularità provincia."""
+        result = infer_granularity_from_name_and_columns("", ["Provincia", "Importo"])
+        assert result == "provincia"
+
+    @pytest.mark.pure_unit
+    def test_regione_from_column(self) -> None:
+        """Colonna 'REGIONE' → granularità regione."""
+        result = infer_granularity_from_name_and_columns("", ["REGIONE", "Anno"])
+        assert result == "regione"
+
+    @pytest.mark.pure_unit
+    def test_fallback_on_name_when_no_geo_columns(self) -> None:
+        """Senza colonne geografiche, usa il nome per inferire."""
+        result = infer_granularity_from_name_and_columns(
+            "Popolazione residente nei comuni", ["Reddito", "Anno"]
+        )
+        assert result == "comune"
+
+    @pytest.mark.pure_unit
+    def test_non_determinato_without_geo_hints(self) -> None:
+        """Senza colonne geografiche né nome appropriato → non_determinato."""
+        result = infer_granularity_from_name_and_columns("Dati generici", ["Nome", "Valore"])
+        assert result == "non_determinato"
 
 
 # ---------------------------------------------------------------------------

--- a/toolkit/scout/infer.py
+++ b/toolkit/scout/infer.py
@@ -136,7 +136,39 @@ def infer_granularity(text: str) -> str:
 
 
 def infer_granularity_from_name_and_columns(name: str, column_names: list[str]) -> str:
-    """Inferisce granularità da nome dataset + colonne."""
+    """Inferisce granularità da nome dataset + colonne.
+
+    Strategia:
+    1. Controllo esatto su nomi colonna individuali (più preciso —
+       cattura ``CODICE_COMUNE``, ``Provincia``, ``REGIONE``).
+    2. Fallback su regex su nome + colonne combinate (cattura
+       ``Bilancio regionale`` nel nome, ``dati provinciali`` nei tag).
+    """
+    # ── Passo 1: controllo esatto su nomi colonna individuali ──────────────
+    cleaned = set()
+    for c in column_names:
+        if not isinstance(c, str):
+            continue
+        c = c.strip().lower().replace("_", " ")
+        # rimuovi colonne troppo corte (sigle) o numeriche
+        if len(c) > 2 and not c.replace(" ", "").isdigit():
+            cleaned.add(c)
+
+    # comune > provincia > regione > nazionale (più granulare vince)
+    for c in cleaned:
+        if c in ("comune", "codice comune", "codice istat comune", "pro com"):
+            return "comune"
+    for c in cleaned:
+        if c in ("provincia", "sigla provincia", "codice provincia", "prov", "cod prov"):
+            return "provincia"
+    for c in cleaned:
+        if c in ("regione", "codice regione", "codice istat regione", "codreg", "cod reg"):
+            return "regione"
+    for c in cleaned:
+        if c in ("nazionale", "italia", "paese", "stato"):
+            return "nazionale"
+
+    # ── Passo 2: fallback su regex combinata ──────────────────────────────
     combined = f"{name} {' '.join(column_names)}"
     return infer_granularity(combined)
 

--- a/toolkit/scout/infer.py
+++ b/toolkit/scout/infer.py
@@ -141,8 +141,8 @@ def infer_granularity_from_name_and_columns(name: str, column_names: list[str]) 
     Strategia:
     1. Controllo esatto su nomi colonna individuali (più preciso —
        cattura ``CODICE_COMUNE``, ``Provincia``, ``REGIONE``).
-    2. Fallback su regex su nome + colonne combinate (cattura
-       ``Bilancio regionale`` nel nome, ``dati provinciali`` nei tag).
+    2. Fallback su regex su nome + colonne combinate (es.
+       ``dati provinciali``, ``popolazione nei comuni``).
     """
     # ── Passo 1: controllo esatto su nomi colonna individuali ──────────────
     cleaned = set()


### PR DESCRIPTION
## Sintesi

`infer_granularity_from_name_and_columns()` ora controlla i nomi colonna individualmente (es. `CODICE_COMUNE`, `Provincia`, `REGIONE`) prima del fallback regex combinato. È più preciso per dataset con colonne geografiche esplicite.

### Prima
Concatenava `name + columns` e faceva regex sul testo combinato. `CODICE_COMUNE` come colonna non veniva rilevato perché `\bcomun\b` non supera il word boundary di underscore in `codice_comune`.

### Dopo
1. Controllo esatto su nomi colonna individuali (strip + lower + replace underscore)
2. Fallback su regex combinata (come prima)

### Verifica
- [x] `pytest tests/test_scout_infer.py` → 38 pass
- [x] `ruff check .` → clean
- [x] `CODICE_COMUNE` → `comune`, `Provincia` → `provincia`, `REGIONE` → `regione`
