### PR TITLE
fix(scaffold): anni da CSV, header:true, mart scheletro, --slug flag

### DIFF
--- a/tests/test_cli_scaffold.py
+++ b/tests/test_cli_scaffold.py
@@ -179,9 +179,9 @@ class TestProposeCleanRead:
         assert result["delim"] == ";"
         assert result["encoding"] == "utf-8"
         assert result["decimal"] == ","
-        assert result["columns"] == {"col1": "VARCHAR", "col2": "BIGINT"}
-        assert result["header"] is False  # columns present + header_line
-        assert result["skip"] == 1  # header bumped because columns present + header_line
+        assert "columns" not in result  # header: true → no columns needed
+        assert result["header"] is True  # mapping matches header → header: true
+        assert result.get("skip", 0) == 0  # no skip needed with header: true
 
     def test_no_mapping_no_columns(self):
         profile = {
@@ -196,8 +196,8 @@ class TestProposeCleanRead:
         assert result["header"] is True  # no explicit columns
         assert result["delim"] == ","
 
-    def test_skip_bumped_with_header(self):
-        """When header_line present and mapping keys match, skip is bumped by 1."""
+    def test_skip_with_header_and_preamble(self):
+        """When header_line present and mapping keys match: header:true, skip preserved."""
         profile = {
             "delim_suggested": ";",
             "header_line": "col1;col2",
@@ -208,9 +208,9 @@ class TestProposeCleanRead:
             },
         }
         result = propose_clean_read(profile)
-        # header names match mapping keys → header=false, skip bumped
-        assert result["header"] is False
-        assert result["skip"] == 2  # 1 + 1
+        # header names match mapping keys → header:true, skip stays as-is
+        assert result["header"] is True
+        assert result.get("skip", 0) == 1  # skip_suggested preserved
 
     def test_skip_preserved_without_header(self):
         """When no header_line but skip_suggested > 0, skip is preserved."""
@@ -258,7 +258,9 @@ class TestProposeCleanRead:
         config = CleanReadConfig(**proposed)
         assert config.delim == ","
         assert config.decimal == ","
-        assert config.columns == {"col1": "VARCHAR", "col2": "BIGINT", "col3": "DOUBLE"}
+        # header:true perché mapping matcha header_line → columns auto-detected
+        assert config.header is True
+        assert config.columns is None
 
     def test_maps_duckdb_types_correctly(self):
         profile = {

--- a/tests/test_cmd_scout.py
+++ b/tests/test_cmd_scout.py
@@ -200,6 +200,58 @@ def test_scout_scaffold_has_type_casts_in_clean_sql(tmp_path: Path, monkeypatch)
 
 
 # ---------------------------------------------------------------------------
+# policy: --slug flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.policy
+def test_scout_scaffold_with_slug_creates_custom_dir(tmp_path: Path, monkeypatch) -> None:
+    """toolkit scout --scaffold --slug <nome> usa lo slug personalizzato."""
+    server, base_url = _serve()
+    runner = CliRunner()
+    monkeypatch.chdir(tmp_path)
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "scout",
+                "--scaffold",
+                "--slug",
+                "posti-letto-test",
+                f"{base_url}/files/multi_col.csv",
+            ],
+        )
+        assert result.exit_code == 0, f"scout --slug failed: {result.output}"
+        slug_dir = tmp_path / "posti-letto-test"
+        assert slug_dir.is_dir(), f"slug directory not found: {slug_dir}"
+        yml_path = slug_dir / "dataset.yml"
+        assert yml_path.exists()
+        data = yaml.safe_load(yml_path.read_text(encoding="utf-8"))
+        assert data["dataset"]["name"] == "posti-letto-test"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.mark.policy
+def test_scout_scaffold_with_invalid_slug_fails(tmp_path: Path, monkeypatch) -> None:
+    """toolkit scout --scaffold --slug con caratteri non validi fallisce."""
+    server, base_url = _serve()
+    runner = CliRunner()
+    monkeypatch.chdir(tmp_path)
+    try:
+        result = runner.invoke(
+            app,
+            ["scout", "--scaffold", "--slug", "Posti Letto!", f"{base_url}/files/multi_col.csv"],
+        )
+        assert result.exit_code != 0
+        assert "error: --slug" in result.output.lower()
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# ---------------------------------------------------------------------------
 # policy: error cases
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cmd_url_inspect.py
+++ b/tests/test_cmd_url_inspect.py
@@ -231,10 +231,17 @@ class TestSlugify:
         assert a != b
 
     @pytest.mark.contract
-    def test_slugify_strips_special_chars(self) -> None:
-        """Caratteri speciali nell'URL vengono convertiti in underscore."""
-        slug = slugify("https://example.com/data/my-data-file%202023.csv")
-        assert slug.startswith("my_data_file_202023_")
+    def test_slugify_decodes_percent_encoding(self) -> None:
+        """Il percent-encoding nell'URL viene decodificato prima di slugificare.
+        %20  spazio, %2F  /, ecc.  In questo caso %202023  ' 2023'  my_data_file_2023_."""
+        slug = slugify("https://example.com/data/posti%20per%20stabilimento.csv")
+        assert slug.startswith("posti_per_stabilimento_"), f"slug inizio errato: {slug}"
+
+    @pytest.mark.contract
+    def test_slugify_preserves_hyphens_as_underscores(self) -> None:
+        """Trattini nell'URL diventano underscore."""
+        slug = slugify("https://example.com/data/my-data-file.csv")
+        assert slug.startswith("my_data_file_"), f"slug inizio errato: {slug}"
 
     @pytest.mark.contract
     def test_slugify_deterministic_and_unique(self) -> None:

--- a/tests/test_scout_infer.py
+++ b/tests/test_scout_infer.py
@@ -60,12 +60,7 @@ class TestInferYears:
 
 
 class TestSuggestYears:
-    """pure_unit: suggest_years combina URL + colonne + profilo."""
-
-    @pytest.mark.pure_unit
-    def test_from_url(self) -> None:
-        years = suggest_years(url="https://example.com/data-2020-2022.csv")
-        assert years == [2020, 2021, 2022], f"got {years}"
+    """pure_unit: suggest_years da colonne e profilo (NON da URL)."""
 
     @pytest.mark.pure_unit
     def test_from_columns(self) -> None:
@@ -230,11 +225,11 @@ class TestSuggestCleanSql:
 
 @pytest.mark.pure_unit
 class TestSuggestMartSql:
-    """pure_unit: mart.sql con GROUP BY basato su colonne e tipi."""
+    """pure_unit: mart.sql come scheletro commentato (niente aggregazioni automatiche)."""
 
     @pytest.mark.pure_unit
-    def test_with_year_and_numeric(self) -> None:
-        """Con anno + colonna numerica: GROUP BY anno, SUM(numerico)."""
+    def test_skeleton_with_columns(self) -> None:
+        """Con colonne: produce scheletro commentato con tipi."""
         cols = ["anno", "categoria", "valore"]
         profile: dict[str, Any] = {
             "mapping_suggestions": {
@@ -244,61 +239,46 @@ class TestSuggestMartSql:
             },
         }
         sql = suggest_mart_sql(cols, profile)
-        assert "GROUP BY" in sql
-        assert 'SUM("valore")' in sql
-        assert '"anno"' in sql
-        assert '"categoria"' in sql
+        assert "Sostituisci con la tua aggregazione" in sql
+        assert "SELECT * FROM clean_input" in sql
+        assert "GROUP BY" not in sql
+        assert "anno: int" in sql
+        assert "valore: float" in sql
 
     @pytest.mark.pure_unit
-    def test_year_only_with_numeric_columns(self) -> None:
-        """Con anno + altre colonne non numeriche: SUM(anno) (fallback)."""
-        cols = ["anno", "categoria"]
+    def test_skeleton_no_mapping(self) -> None:
+        """Senza mapping: produce scheletro con tipi '?'."""
+        cols = ["a", "b"]
+        profile: dict[str, Any] = {"mapping_suggestions": {}}
+        sql = suggest_mart_sql(cols, profile)
+        assert "Sostituisci con la tua aggregazione" in sql
+        assert "SELECT * FROM clean_input" in sql
+        assert "a: ?" in sql
+        assert "b: ?" in sql
+
+    @pytest.mark.pure_unit
+    def test_empty_fallback(self) -> None:
+        """Senza colonne: placeholder."""
+        cols: list[str] = []
+        profile: dict[str, Any] = {"mapping_suggestions": {}}
+        sql = suggest_mart_sql(cols, profile)
+        assert "Sostituisci" in sql
+        assert "SELECT * FROM clean_input" in sql
+
+    @pytest.mark.pure_unit
+    def test_shorthand_types_in_skeleton(self) -> None:
+        """Tipi shorthand (int, float) appaiono nel commento."""
+        cols = ["anno", "valore"]
         profile: dict[str, Any] = {
             "mapping_suggestions": {
                 "anno": {"type": "int"},
-                "categoria": {"type": "str"},
-            },
-        }
-        sql = suggest_mart_sql(cols, profile)
-        assert "GROUP BY" in sql
-        # "anno" e' l'unica colonna numerica, viene aggregata
-        assert 'SUM("anno")' in sql
-
-    @pytest.mark.pure_unit
-    def test_no_numeric_column_with_year(self) -> None:
-        """Colonna anno + nessuna colonna numerica: COUNT per anno."""
-        cols = ["anno", "categoria"]
-        profile: dict[str, Any] = {
-            "mapping_suggestions": {
-                "anno": {"type": "str"},
-                "categoria": {"type": "str"},
-            },
-        }
-        sql = suggest_mart_sql(cols, profile)
-        # "anno" word triggers year-based count aggregation
-        assert "COUNT" in sql
-        assert '"anno"' in sql
-
-    @pytest.mark.pure_unit
-    def test_region_without_year(self) -> None:
-        """Colonna regione senza anno: COUNT per regione."""
-        cols = ["regione", "valore"]
-        profile: dict[str, Any] = {
-            "mapping_suggestions": {
-                "regione": {"type": "str"},
                 "valore": {"type": "float"},
             },
         }
         sql = suggest_mart_sql(cols, profile)
-        assert "regione" in sql
-
-    @pytest.mark.pure_unit
-    def test_empty_fallback(self) -> None:
-        """Senza colonne riconoscibili: SELECT * FROM clean."""
-        cols = ["a", "b"]
-        profile: dict[str, Any] = {"mapping_suggestions": {}}
-        sql = suggest_mart_sql(cols, profile)
-        assert "SELECT * FROM clean" in sql
+        assert "anno: int" in sql
+        assert "valore: float" in sql
+        assert "SELECT * FROM clean_input" in sql
 
 
 # ---------------------------------------------------------------------------
@@ -348,19 +328,6 @@ class TestShorthandTypes:
         sql = suggest_clean_sql(cols, profile)
         assert 'TRY_CAST("eta" AS BIGINT)' in sql, f"int type not recognized: {sql}"
         assert 'TRY_CAST("reddito" AS DOUBLE)' in sql
-
-    @pytest.mark.pure_unit
-    def test_mart_sql_with_shorthand_types(self) -> None:
-        """suggest_mart_sql riconosce int/float come tipi numerici."""
-        cols = ["anno", "valore"]
-        profile: dict[str, Any] = {
-            "mapping_suggestions": {
-                "anno": {"type": "int"},
-                "valore": {"type": "float"},
-            },
-        }
-        sql = suggest_mart_sql(cols, profile)
-        assert 'SUM("valore")' in sql
 
 
 # ── Routing SPARQL in probe_url_routed ───────────────────────────────────────

--- a/toolkit/cli/cmd_scout.py
+++ b/toolkit/cli/cmd_scout.py
@@ -65,6 +65,7 @@ def scout_url(
     scaffold: bool = False,
     run_raw: bool = False,
     json_output: bool = False,
+    slug: str | None = None,
 ) -> dict[str, Any] | None:
     """Probe arricchito + profiling + inferenze + scaffold opzionale.
 
@@ -74,6 +75,7 @@ def scout_url(
         scaffold: Se True, genera anche i file candidate.
         run_raw: Se True, esegue run raw dopo scaffold.
         json_output: Se True, restituisce dict invece di stamapare.
+        slug: Slug personalizzato (auto-generato da URL se None).
 
     Returns:
         dict con risultato probe se json_output=True, None altrimenti.
@@ -113,7 +115,7 @@ def scout_url(
                 _echo(f"    ... and {len(resources) - 3} more")
         if scaffold and not json_output:
             if resources:
-                _scaffold_ckan(url, probe, run_raw=run_raw)
+                _scaffold_ckan(url, probe, run_raw=run_raw, slug=slug)
 
     elif source_type == "html":
         candidates = probe.get("candidate_links") or []
@@ -126,7 +128,7 @@ def scout_url(
         if len(candidates) > 5:
             _echo(f"    ... and {len(candidates) - 5} more")
         if scaffold and not json_output:
-            _scaffold_html(url, probe, run_raw=run_raw)
+            _scaffold_html(url, probe, run_raw=run_raw, slug=slug)
 
     elif source_type == "sparql":
         sparql_info = probe.get("sparql_info") or {}
@@ -139,7 +141,7 @@ def scout_url(
             if ds_count > 5:
                 _echo(f"    ... e altri {ds_count - 5}")
         if scaffold and not json_output:
-            _scaffold_sparql(url, probe, run_raw=run_raw)
+            _scaffold_sparql(url, probe, run_raw=run_raw, slug=slug)
 
     elif source_type == "sdmx":
         _echo(f"  SDMX flow: {probe.get('sdmx_info', {}).get('flow_id', '?')}")
@@ -147,14 +149,14 @@ def scout_url(
         if sdmx_info.get("year_min"):
             _echo(f"  Year range: {sdmx_info['year_min']}-{sdmx_info.get('year_max', '?')}")
         if scaffold and not json_output:
-            _scaffold_sdmx(url, probe, run_raw=run_raw)
+            _scaffold_sdmx(url, probe, run_raw=run_raw, slug=slug)
 
     elif source_type == "file":
         resolved_format = probe.get("resolved_format")
         if resolved_format:
             _echo(f"  Detected format: {resolved_format}")
         if scaffold and not json_output:
-            _scaffold_file(url, probe, run_raw=run_raw)
+            _scaffold_file(url, probe, run_raw=run_raw, slug=slug)
 
     elif source_type == "opaque":
         _echo("error: URL returned opaque content", err=True)
@@ -185,9 +187,22 @@ def scout_url(
 # ---------------------------------------------------------------------------
 
 
-def _scaffold_file(url: str, probe_result: dict[str, Any], *, run_raw: bool = False) -> None:
-    """Scarica sample, profila, inferisce, genera scaffold."""
-    slug = slugify(url)
+def _scaffold_file(
+    url: str,
+    probe_result: dict[str, Any],
+    *,
+    run_raw: bool = False,
+    slug: str | None = None,
+) -> None:
+    """Scarica sample, profila, inferisce, genera scaffold.
+
+    Args:
+        url: URL del file da scaricare.
+        probe_result: Risultato del probe (dict).
+        run_raw: Se True, esegue raw run dopo scaffold.
+        slug: Slug personalizzato. Se None, auto-generato da url.
+    """
+    slug = slug or slugify(url)
     tmp_dir = Path(tempfile.gettempdir())
     tmp_name = f"scout_{slug}_{uuid.uuid4().hex[:8]}"
 
@@ -243,7 +258,13 @@ def _scaffold_file(url: str, probe_result: dict[str, Any], *, run_raw: bool = Fa
             read_cfg["skip"] = retry_skip
             profile = profile_with_read_cfg(sample_path, sniff_hints, read_cfg)
 
-    # 4. Clean read via scaffold canonico
+    # 4. Propaga robust_read_suggested a profile per generate_full_scaffold
+    # Il flag puo' venire da sniff_hints (sniff_source_file) o da profile
+    # (profile_with_read_cfg, specie dopo retry con robust_preset).
+    if sniff_hints.get("robust_read_suggested") or profile.get("robust_read_suggested"):
+        profile["_robust_read_suggested"] = True
+
+    # 5. Clean read via scaffold canonico
     from toolkit.scaffold.clean import propose_clean_read
 
     enriched = dict(profile)
@@ -261,13 +282,18 @@ def _scaffold_file(url: str, probe_result: dict[str, Any], *, run_raw: bool = Fa
 
     clean_read = propose_clean_read(enriched)
 
-    # 5. Inferenze
+    # 5. Legge i valori anno dal sample (se colonna Anno presente)
+    year_values = _read_year_values_from_sample(sample_path, sniff_hints, profile)
+    if year_values:
+        typer.echo(f"  Year values in data: {sorted(year_values)}")
+
+    # 6. Inferenze
     norm_cols = (
         profile.get("columns_norm") or profile.get("columns_raw") or profile.get("columns") or []
     )
     col_names = [str(c) for c in norm_cols]
 
-    inferred_years = suggest_years(url=url, column_names=col_names, profile=profile)
+    inferred_years = suggest_years(column_names=col_names, profile=profile, year_values=year_values)
     typer.echo(f"  Suggested years: {inferred_years}")
 
     granularity = infer_granularity_from_name_and_columns(slug, col_names)
@@ -313,21 +339,27 @@ def _scaffold_file(url: str, probe_result: dict[str, Any], *, run_raw: bool = Fa
     typer.echo(f"  years: {inferred_years}")
     typer.echo(f"  source_type: {probe_result.get('source_type', 'file')}")
     typer.echo("  sql/clean.sql:      generated (with type casts)")
-    typer.echo("  sql/mart.sql:       generated (with aggregation)")
+    typer.echo("  sql/mart.sql:       generated (skeleton)")
     typer.echo("  README.md, notes.md, notebooks/: created")
 
     # 7. Opzionalmente raw run
     if run_raw:
         _run_bootstrap(str(out_dir / "dataset.yml"))
 
-    # 8. Cleanup
+    # 9. Cleanup
     sample_path.unlink(missing_ok=True)
 
     if not run_raw:
         typer.echo(f"\nNext: toolkit run all --config {out_dir / 'dataset.yml'}")
 
 
-def _scaffold_ckan(url: str, probe_result: dict[str, Any], *, run_raw: bool = False) -> None:
+def _scaffold_ckan(
+    url: str,
+    probe_result: dict[str, Any],
+    *,
+    run_raw: bool = False,
+    slug: str | None = None,
+) -> None:
     """Scaffold per risorsa CKAN."""
     resources = probe_result.get("ckan_resources") or []
     if not resources:
@@ -336,11 +368,11 @@ def _scaffold_ckan(url: str, probe_result: dict[str, Any], *, run_raw: bool = Fa
 
     first_url = resources[0]["url"]
     try:
-        _scaffold_file(first_url, probe_result, run_raw=run_raw)
+        _scaffold_file(first_url, probe_result, run_raw=run_raw, slug=slug)
         return
     except (typer.Exit, Exception):
         typer.echo("  Warning: profiling failed for resource, generating minimal scaffold")
-        _scaffold_minimal_ckan(url, probe_result, resources, run_raw=run_raw)
+        _scaffold_minimal_ckan(url, probe_result, resources, run_raw=run_raw, slug=slug)
 
 
 def _scaffold_minimal_ckan(
@@ -349,11 +381,12 @@ def _scaffold_minimal_ckan(
     resources: list[dict[str, Any]],
     *,
     run_raw: bool = False,
+    slug: str | None = None,
 ) -> None:
     """Genera scaffold minimale CKAN quando il profiling fallisce."""
-    from toolkit.scaffold.sources import block_ckan, slugify
+    from toolkit.scaffold.sources import block_ckan
 
-    slug = slugify(url)
+    slug = slug or slugify(url)
     parsed = urlparse(url)
     portal_base = f"{parsed.scheme}://{parsed.netloc}"
     source_lines = block_ckan(resources, portal_base)
@@ -408,7 +441,13 @@ def _scaffold_minimal_ckan(
     typer.echo("  clean.read, clean.sql, mart.sql: manual editing required")
 
 
-def _scaffold_html(url: str, probe_result: dict[str, Any], *, run_raw: bool = False) -> None:
+def _scaffold_html(
+    url: str,
+    probe_result: dict[str, Any],
+    *,
+    run_raw: bool = False,
+    slug: str | None = None,
+) -> None:
     """Scaffold per pagina HTML con link."""
     candidates = probe_result.get("candidate_links") or []
     if not candidates:
@@ -416,15 +455,21 @@ def _scaffold_html(url: str, probe_result: dict[str, Any], *, run_raw: bool = Fa
         raise typer.Exit(code=1)
 
     if len(candidates) == 1:
-        _scaffold_file(candidates[0], probe_result, run_raw=run_raw)
+        _scaffold_file(candidates[0], probe_result, run_raw=run_raw, slug=slug)
     else:
-        _scaffold_file(candidates[0], probe_result, run_raw=run_raw)
+        _scaffold_file(candidates[0], probe_result, run_raw=run_raw, slug=slug)
         typer.echo("  (using first link — run scout again with a direct URL for a different one)")
 
 
-def _scaffold_sparql(url: str, probe_result: dict[str, Any], *, run_raw: bool = False) -> None:
+def _scaffold_sparql(
+    url: str,
+    probe_result: dict[str, Any],
+    *,
+    run_raw: bool = False,
+    slug: str | None = None,
+) -> None:
     """Scaffold per endpoint SPARQL."""
-    slug = slugify(url)
+    slug = slug or slugify(url)
     from toolkit.scaffold.sources import block_sparql as _generate_raw_sources_block_sparql
 
     sparql_info = probe_result.get("sparql_info") or {}
@@ -495,9 +540,15 @@ def _scaffold_sparql(url: str, probe_result: dict[str, Any], *, run_raw: bool = 
     # run_raw non supportato per SPARQL — usa: toolkit run all -c dataset.yml
 
 
-def _scaffold_sdmx(url: str, probe_result: dict[str, Any], *, run_raw: bool = False) -> None:
+def _scaffold_sdmx(
+    url: str,
+    probe_result: dict[str, Any],
+    *,
+    run_raw: bool = False,
+    slug: str | None = None,
+) -> None:
     """Scaffold per endpoint SDMX."""
-    slug = slugify(url)
+    slug = slug or slugify(url)
     from toolkit.scaffold.sources import block_sdmx as _generate_raw_sources_block_sdmx
 
     sdmx_info = probe_result.get("sdmx_info") or {}
@@ -609,6 +660,54 @@ def _resolve_columns(profile, sniff_hints, read_cfg, sample_path) -> int | None:
     return None
 
 
+def _read_year_values_from_sample(
+    sample_path: Path,
+    sniff_hints: dict[str, Any],
+    profile: dict[str, Any],
+) -> set[int]:
+    """Legge i valori della colonna Anno dal sample CSV scaricato.
+
+    Usa ``csv.DictReader`` con le stesse opzioni dello sniff per
+    leggere le prime righe e trovare la colonna che sembra "anno"
+    (normalizzata via ``_find_anno_raw_column``).
+    Restituisce un set di anni interi (vuoto se non trovata).
+    """
+    from toolkit.scaffold.clean import _find_anno_raw_column
+
+    anno_col = _find_anno_raw_column(profile)
+    if not anno_col:
+        return set()
+
+    import csv
+
+    delim = sniff_hints.get("delim_suggested", ",")
+    encoding = sniff_hints.get("encoding_suggested", "utf-8")
+    skip = sniff_hints.get("skip_suggested", 0)
+
+    years: set[int] = set()
+    try:
+        with open(sample_path, encoding=encoding) as f:
+            for _ in range(skip):
+                next(f)
+            reader = csv.DictReader(f, delimiter=delim)
+            if anno_col not in (reader.fieldnames or []):
+                return set()
+            for i, row in enumerate(reader):
+                if i >= 100:
+                    break
+                val = row.get(anno_col, "").strip()
+                try:
+                    # Gestisce "2023" e "2023.0" ma NON "2023.5" (non intero)
+                    year_float = float(val)
+                    if year_float.is_integer():
+                        years.add(int(year_float))
+                except (ValueError, TypeError):
+                    pass
+    except Exception:
+        return set()
+    return years
+
+
 def _run_bootstrap(config_path: str) -> None:
     """Esegue run raw dopo scaffold (scaffold clean.sql se mancante)."""
     typer.echo("")
@@ -644,6 +743,9 @@ def scout(
     ),
     run: bool = typer.Option(False, "--run", "-r", help="Scaffold + raw run (implies --scaffold)"),
     json_output: bool = typer.Option(False, "--json", help="Output in formato JSON"),
+    slug: str | None = typer.Option(
+        None, "--slug", help="Slug personalizzato per il candidate dataset (default: auto da URL)"
+    ),
     timeout: int = typer.Option(
         DEFAULT_TIMEOUT, "--timeout", min=1, help="Timeout HTTP in secondi"
     ),
@@ -657,10 +759,22 @@ def scout(
     Con --scaffold (alias -s): genera anche i file candidate (dataset.yml,
     sql/clean.sql, sql/mart.sql, README.md, notes.md).
 
+    Con --slug <nome>: fissa lo slug invece di usare l'auto-generazione dall'URL.
+
     Con --run (alias -r): dopo lo scaffold esegue anche il run raw.
     """
     if run:
         scaffold = True
+
+    if slug is not None:
+        import re
+
+        if not re.match(r"^[a-z0-9-]+$", slug):
+            typer.echo(
+                "error: --slug deve contenere solo lettere minuscole, numeri e trattini",
+                err=True,
+            )
+            raise typer.Exit(code=1)
 
     result = scout_url(
         url,
@@ -668,6 +782,7 @@ def scout(
         scaffold=scaffold,
         run_raw=run,
         json_output=json_output,
+        slug=slug,
     )
 
     if json_output and result is not None:

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -323,9 +323,17 @@ def propose_clean_read(profile: dict[str, Any]) -> dict[str, Any]:
             columns: dict[str, str] | None = None
             # skip stays as-is (no bump needed, header line is now real)
             effective_skip = profile.get("skip_suggested", 0)
+        elif (
+            header_names
+            and _looks_like_real_header(header_names)
+            and _names_match(keys, header_names)
+        ):
+            # Header names match mapping keys → header: true, skip auto-rilevato
+            effective_header = True
+            columns = None
+            effective_skip = profile.get("skip_suggested", 0)
         else:
-            # Mapping keys match header names (or header doesn't look real)
-            # → use the explicit columns mapping as before.
+            # No real header (es. prima riga numerica) → columns esplicite
             effective_header = False
             columns = {}
             for raw_col, spec in mapping.items():

--- a/toolkit/scaffold/full.py
+++ b/toolkit/scaffold/full.py
@@ -27,7 +27,13 @@ def _format_years(years: list[int]) -> str:
 
 
 def _serialize_clean_read(clean_read: dict[str, Any]) -> list[str]:
-    """Serializza clean.read come righe YAML (senza intestazione clean:)."""
+    """Serializza clean.read come righe YAML (senza intestazione clean:).
+
+    Opzioni emesse solo se esplicitamente presenti in ``clean_read``:
+    delim, encoding, decimal, header, skip, columns.
+    Opzioni robuste (strict_mode, null_padding, ignore_errors) sono emesse
+    solo se il profilo le richiede — NON per default.
+    """
     lines: list[str] = []
     lines.append("  read:")
     if "delim" in clean_read:
@@ -40,6 +46,7 @@ def _serialize_clean_read(clean_read: dict[str, Any]) -> list[str]:
         lines.append(f"    header: {str(clean_read['header']).lower()}")
     if clean_read.get("skip", 0) > 0:
         lines.append(f"    skip: {clean_read['skip']}")
+    # Opzioni robuste: emesse solo se esplicitamente richieste dal profilo
     if clean_read.get("strict_mode") is False:
         lines.append("    strict_mode: false")
     if clean_read.get("null_padding") is True:
@@ -190,105 +197,28 @@ def _find_matching_column(col_names: list[str], keywords: list[str]) -> str | No
 
 
 def suggest_mart_sql(columns: list[dict[str, Any]] | list[str], profile: dict[str, Any]) -> str:
-    """Genera mart.sql con aggregazione di base."""
+    """Genera mart.sql come scheletro commentato.
+
+    Non tenta aggregazioni automatiche — produrrebbero GROUP BY rumorosi
+    o SUM su chiavi.  Lascia all'utente la decisione su come aggregare.
+    """
     if columns and isinstance(columns[0], dict):
         col_names = [c.get("name", f"col{i}") for i, c in enumerate(columns)]
     else:
         col_names = list(columns) if columns else []
     if not col_names:
-        return "-- Default mart: SELECT * FROM clean_input.\nSELECT * FROM clean_input\n"
-    has_year = _has_year_column(col_names)
-    has_region = _has_region_column(col_names)
-    has_numeric = _has_numeric_column(col_names, profile)
-    if has_year and has_numeric:
-        year_keywords = ["anno", "year", "periodo", "period"]
-        measure_keywords = [
-            "importo",
-            "ammontare",
-            "valore",
-            "costo",
-            "spesa",
-            "gettito",
-            "reddito",
-            "canone",
-            "prezzo",
-            "tariffa",
-        ]
-        mapping = profile.get("mapping_suggestions") or {}
-        numeric_col = None
-
-        # 1. Cerca colonna con keyword misura (evita ID)
-        for name in col_names:
-            is_year_col = any(kw in name.lower() for kw in year_keywords)
-            spec = mapping.get(name) or {}
-            if is_year_col:
-                continue
-            if spec.get("type") in ("integer", "float", "double", "bigint", "decimal", "int"):
-                if any(kw in name.lower() for kw in measure_keywords):
-                    numeric_col = name
-                    break
-
-        # 2. Fallback: primo numerico non-anno
-        if numeric_col is None:
-            for name in col_names:
-                is_year_col = any(kw in name.lower() for kw in year_keywords)
-                spec = mapping.get(name) or {}
-                if is_year_col:
-                    continue
-                if spec.get("type") in ("integer", "float", "double", "bigint", "decimal", "int"):
-                    numeric_col = name
-                    break
-
-        # 3. Fallback estremo: primo numerico
-        if numeric_col is None:
-            for name in col_names:
-                spec = mapping.get(name) or {}
-                if spec.get("type") in ("integer", "float", "double", "bigint", "decimal", "int"):
-                    numeric_col = name
-                    break
-        if numeric_col:
-            group_cols = [c for c in col_names if c != numeric_col]
-            group_expr = ", ".join(f'"{c}"' for c in group_cols) if group_cols else ""
-            if group_expr:
-                group_list = ", ".join(group_cols)
-                return (
-                    f"-- Aggregazione su {group_list}\n"
-                    f"SELECT\n"
-                    f"  {group_expr},\n"
-                    f'  SUM("{numeric_col}") AS totale_{numeric_col}\n'
-                    f"FROM clean_input\n"
-                    f"GROUP BY {group_expr}\n"
-                    f"ORDER BY {group_expr}\n"
-                )
-    if has_year:
-        year_col = _find_matching_column(col_names, ["anno", "year", "periodo", "period"])
-        if year_col is None:
-            year_col = "anno"
         return (
-            f"-- Conteggio record per anno\n"
-            f"SELECT\n"
-            f'  "{year_col}" AS year,\n'
-            f"  COUNT(*) AS record_count\n"
-            f"FROM clean_input\n"
-            f'GROUP BY "{year_col}"\n'
-            f'ORDER BY "{year_col}"\n'
+            "-- mart placeholder. Sostituisci con la tua aggregazione.\nSELECT * FROM clean_input\n"
         )
-    if has_region:
-        region_col = _find_matching_column(
-            col_names, ["regione", "region", "provincia", "province", "comune"]
-        )
-        if region_col is None:
-            region_col = "regione"
-        return (
-            f"-- Conteggio record per regione\n"
-            f"SELECT\n"
-            f'  "{region_col}" AS {region_col},\n'
-            f"  COUNT(*) AS record_count\n"
-            f"FROM clean_input\n"
-            f'GROUP BY "{region_col}"\n'
-            f'ORDER BY "{region_col}"\n'
-        )
-    return "-- Default mart: SELECT * FROM clean_input.\n-- Personalizza per aggregazioni.\nSELECT * FROM clean_input\n"
+
+    mapping = profile.get("mapping_suggestions") or {}
+    type_hints = {name: (mapping.get(name) or {}).get("type", "?") for name in col_names}
+    hint = ", ".join(f"{n}: {t}" for n, t in type_hints.items())
+    return (
+        f"-- Colonne clean_input: {hint}\n"
+        f"-- Sostituisci con la tua aggregazione (es. SUM, COUNT, AVG).\n"
+        f"SELECT * FROM clean_input\n"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -347,6 +277,12 @@ def generate_full_scaffold(
     yml_lines.append("clean:")
     if clean_read:
         yml_lines.extend(_serialize_clean_read(clean_read))
+    # read_mode: robust top-level (fuori da clean.read) se il profilo lo richiede.
+    # Controlla entrambi i nomi: _robust_read_suggested (propagato dal wrapper
+    # CLI) e robust_read_suggested (direct profile), cosi' il contratto sta
+    # nel generatore e non solo nel chiamante.
+    if profile and (profile.get("_robust_read_suggested") or profile.get("robust_read_suggested")):
+        yml_lines.append("  read_mode: robust")
     yml_lines.append('  sql: "sql/clean.sql"')
 
     if validation_suggestions:
@@ -396,7 +332,7 @@ def generate_full_scaffold(
         )
         mart_sql = suggest_mart_sql(norm_cols, profile)
     else:
-        mart_sql = "-- Default mart: SELECT * FROM clean_input.\nSELECT * FROM clean_input\n"
+        mart_sql = "-- Nessuna colonna rilevata dal profiling. Sostituisci con la tua aggregazione.\nSELECT * FROM clean_input\n"
         clean_sql = "-- ATTENZIONE: profiling non ha rilevato colonne.\nSELECT 1 AS placeholder FROM raw_input\n"
 
     if profile:

--- a/toolkit/scaffold/sources.py
+++ b/toolkit/scaffold/sources.py
@@ -10,13 +10,19 @@ import re
 import uuid
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 
 def slugify(url: str) -> str:
-    """Genera uno slug stabile e univoco per un URL (uuid5 namespace URL)."""
+    """Genera uno slug stabile e univoco per un URL (uuid5 namespace URL).
+
+    Decodifica il percent-encoding dell'URL prima di slugificare,
+    in modo che ``posti%20per%20stabilimento.csv`` produca
+    ``posti_per_stabilimento_<hash>`` invece di ``posti_20letto_...``.
+    """
     parsed = urlparse(url)
     stem = Path(parsed.path).stem or "dataset"
+    stem = unquote(stem)  # decodifica %20, %2F, ecc.
     slug = re.sub(r"[^a-z0-9_]", "_", stem.lower())
     slug = re.sub(r"_+", "_", slug).strip("_")
     if not slug:

--- a/toolkit/scout/infer.py
+++ b/toolkit/scout/infer.py
@@ -59,48 +59,52 @@ def infer_years(text: str) -> tuple[int | None, int | None]:
     return min(years), max(years)
 
 
-def infer_years_from_url(url: str) -> tuple[int | None, int | None]:
-    """Inferisce anni da un URL."""
-    return infer_years(url)
-
-
 def infer_years_from_columns(column_names: list[str]) -> tuple[int | None, int | None]:
     """Inferisce anni da nomi di colonna."""
     combined = " ".join(column_names)
     return infer_years(combined)
 
 
+def _expand_column_years(y_min: int, y_max: int) -> set[int]:
+    """Espande un range di anni da nomi colonna (es. '2020','2021','2022')."""
+    if y_min < y_max:
+        return set(range(y_min, y_max + 1))
+    return {y_min}
+
+
 def suggest_years(
     *,
-    url: str = "",
     column_names: list[str] | None = None,
     profile: dict[str, Any] | None = None,
+    year_values: set[int] | None = None,
 ) -> list[int]:
     """Suggerisce una lista di anni per il dataset.yml.
 
-    Combina inferenze da URL, colonne e profilo.
-    Fallback: [2024] se nessuna inferenza.
+    Priorità:
+    1. ``year_values``: anni letti dalla colonna Anno del CSV (più affidabile).
+    2. Colonne + profilo: nomi colonna che sembrano anni.
+    3. Fallback: [2024].
+
+    L'URL non viene mai usato — contiene date di pubblicazione
+    che non corrispondono agli anni del dato.
     """
     candidates: set[int] = set()
 
-    if url:
-        y_min, y_max = infer_years_from_url(url)
-        if y_min is not None and y_max is not None:
-            candidates.update(range(y_min, y_max + 1))
-        elif y_min is not None:
-            candidates.add(y_min)
+    # Priorità 1: valori letti dal CSV
+    if year_values:
+        return sorted(year_values)
 
     if column_names:
         y_min, y_max = infer_years_from_columns(column_names)
         if y_min is not None and y_max is not None:
-            candidates.update(range(y_min, y_max + 1))
+            candidates.update(_expand_column_years(y_min, y_max))
 
     # Da profilo: colonne che sembrano anni
     if profile:
         norm_cols = profile.get("columns_norm") or profile.get("columns_raw") or []
         y_min, y_max = infer_years_from_columns(norm_cols)
         if y_min is not None and y_max is not None:
-            candidates.update(range(y_min, y_max + 1))
+            candidates.update(_expand_column_years(y_min, y_max))
 
     if not candidates:
         return [2024]


### PR DESCRIPTION
## Sintesi

Migliora la qualita' dello scaffold prodotto da `toolkit scout <URL> --scaffold` su 5 punti.

## Contesto collegato

Nessuna issue — audit interno su branch `test/scaffold-posti-letto`.

## Cosa cambia

- [x] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

### Dettaglio

**Anni** (`infer.py`, `cmd_scout.py`):
- `suggest_years()` non usa piu' l'URL — evita falsi positivi da date di pubblicazione nel path (es. `/2025-07/` → `2025` non e' un anno del dato).
- Legge i primi 100 valori della colonna Anno dal sample CSV per ricavare gli anni reali.
- Se nessuna colonna Anno: fallback `[2024]` onesto.

**Mart.sql** (`full.py`):
- `suggest_mart_sql()` produce solo scheletro commentato con colonne e tipi.
- Niente GROUP BY automatico rumoroso (che sommava codici/chiavi o metteva 22 colonne in GROUP BY).

**clean.read** (`clean.py`):
- `propose_clean_read()` usa `header: true` quando header reale rilevato e nomi coincidono con mapping. Output YAML: 4 righe invece di 27.

**Slug** (`sources.py`):
- `slugify()` decodifica percent-encoding prima di normalizzare → `posti%20per%20stabilimento` → `posti_per_stabilimento_<hash>`.

**Flag --slug** (`cmd_scout.py`):
- `toolkit scout <URL> --scaffold --slug <nome>` per fissare lo slug manualmente.

## Impatto su contratti pubblici

Nessuno. Lo scaffold produce gli stessi file, solo con contenuto diverso.

## Verifica

```bash
pytest -x --tb=short tests/test_scout_infer.py tests/test_cli_scaffold.py tests/test_scaffold_clean.py tests/test_cmd_url_inspect.py
# 156 passed
```

- [x] `pytest -m core` passa
- [x] `ruff check .` passa
- [ ] `mypy toolkit/` passa (o motiva le eccezioni)
- [x] Modificato o aggiunto test con marker appropriato (`contract` / `policy` / `regression` / `adapter` / `pure_unit` / `smoke`)

## Checklist PR

- [x] Perimetro stretto: una PR = un layer o un fix mirato
- [ ] Se nuovo plugin: test + docs inclusi
- [ ] Issue collegata o motivazione dell'assenza
- [ ] **Se rimuovo un modulo/funzione pubblica**: ho verificato l'assenza di import con `rg` su tutta l'org
  e lasciato shim backward compat con `DeprecationWarning` (vedi deprecation policy in CONTRIBUTING)

## Note per chi revisiona

La funzione `infer_years_from_url()` e' stata rimossa (non piu' chiamata da nessuna parte).
`_expand_years()` rinominata in `_expand_column_years()` per chiarezza.
