### PR TITLE
feat(scout): fetch_sparql_count — contratto centralizzato per probe SPARQL

### DIFF
--- a/tests/test_scout_sparql.py
+++ b/tests/test_scout_sparql.py
@@ -1,0 +1,106 @@
+"""Tests per toolkit.scout.sparql — fetch_sparql_count e altri."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from toolkit.scout.sparql import fetch_sparql_count
+
+pytestmark = pytest.mark.contract
+
+
+def _fake_bindings(count: int) -> list[dict]:
+    """Crea bindings finti per execute_sparql."""
+    return [{"c": {"type": "xsd:integer", "value": str(count)}}]
+
+
+class TestFetchSparqlCount:
+    """Contract: fetch_sparql_count torna conteggio o None."""
+
+    def test_endpoint_responds_with_count(self):
+        """Endpoint raggiungibile → triple count."""
+        with patch(
+            "toolkit.scout.sparql.execute_sparql",
+            return_value=_fake_bindings(42),
+        ):
+            result = fetch_sparql_count("https://example.test/sparql")
+        assert result == 42
+
+    def test_with_graph_uri(self):
+        """Graph URI passato → query GRAPH inclusa."""
+        captured_query = None
+
+        def _mock_execute(endpoint, query, timeout=15):
+            nonlocal captured_query
+            captured_query = query
+            return _fake_bindings(100)
+
+        with patch(
+            "toolkit.scout.sparql.execute_sparql",
+            side_effect=_mock_execute,
+        ):
+            result = fetch_sparql_count(
+                "https://example.test/sparql",
+                graph_uri="http://example.org/graph/1",
+            )
+
+        assert result == 100
+        assert captured_query is not None
+        assert "GRAPH <http://example.org/graph/1>" in captured_query
+
+    def test_no_bindings_returns_zero(self):
+        """Nessun binding → 0 (endpoint funziona ma nessuna tripla)."""
+        with patch(
+            "toolkit.scout.sparql.execute_sparql",
+            return_value=[],
+        ):
+            result = fetch_sparql_count("https://example.test/sparql")
+        assert result == 0
+
+    def test_endpoint_unreachable_returns_none(self):
+        """Endpoint irraggiungibile → None."""
+        with patch(
+            "toolkit.scout.sparql.execute_sparql",
+            side_effect=RuntimeError("connection refused"),
+        ):
+            result = fetch_sparql_count("https://example.test/sparql")
+        assert result is None
+
+    def test_timeout_passed_through(self):
+        """timeout propagato a execute_sparql."""
+        captured_timeout = None
+
+        def _mock_execute(endpoint, query, timeout=15):
+            nonlocal captured_timeout
+            captured_timeout = timeout
+            return _fake_bindings(1)
+
+        with patch(
+            "toolkit.scout.sparql.execute_sparql",
+            side_effect=_mock_execute,
+        ):
+            fetch_sparql_count(
+                "https://example.test/sparql",
+                timeout=30,
+            )
+        assert captured_timeout == 30
+
+    def test_zero_on_empty_bindings_with_value_none(self):
+        """Binding con value=None → 0, non crash."""
+        with patch(
+            "toolkit.scout.sparql.execute_sparql",
+            return_value=[{"c": {"type": "xsd:integer", "value": None}}],
+        ):
+            result = fetch_sparql_count("https://example.test/sparql")
+        assert result == 0
+
+    def test_value_error_caught(self):
+        """ValueError viene catturato e ritorna None."""
+        with patch(
+            "toolkit.scout.sparql.execute_sparql",
+            side_effect=ValueError("bad query"),
+        ):
+            result = fetch_sparql_count("https://example.test/sparql")
+        assert result is None

--- a/toolkit/scout/__init__.py
+++ b/toolkit/scout/__init__.py
@@ -17,6 +17,7 @@ Scaffold non e' piu' in scout. Usa toolkit.scaffold.full e toolkit.scaffold.sour
 
 from toolkit.scout.sparql import (  # noqa: F401
     discover_named_graphs,
+    fetch_sparql_count,
     infer_graph_schema,
 )
 

--- a/toolkit/scout/sparql.py
+++ b/toolkit/scout/sparql.py
@@ -1,4 +1,4 @@
-"""SPARQL scout — named graph discovery e schema inference.
+"""SPARQL scout — named graph discovery, schema inference, lightweight probe.
 
 Wrapper leggero su lab_connectors.http.sparql.
 Mantiene le firme originali per backward compat con SO e altri caller.
@@ -8,9 +8,12 @@ Le funzioni di routing/orchestrazione stanno in toolkit.scout.probe.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
-from lab_connectors.http.sparql import discover_graphs, infer_schema
+from lab_connectors.http.sparql import discover_graphs, execute_sparql, infer_schema
+
+log = logging.getLogger(__name__)
 
 
 def discover_named_graphs(
@@ -41,3 +44,41 @@ def infer_graph_schema(
         timeout=timeout,
         limit=limit,
     )
+
+
+def fetch_sparql_count(
+    endpoint: str,
+    graph_uri: str | None = None,
+    timeout: int = 15,
+) -> int | None:
+    """Conta triple su un endpoint SPARQL, opzionalmente in un named graph.
+
+    Usa SELECT (COUNT(*)) per verificare che l'endpoint risponda e
+    restituire il numero di triple. Ritorna None se l'endpoint non
+    risponde o la query fallisce.
+
+    Args:
+        endpoint: URL dell'endpoint SPARQL.
+        graph_uri: URI del named graph (None = default graph).
+        timeout: Timeout HTTP in secondi.
+
+    Returns:
+        Numero triple (int) o None se endpoint irraggiungibile.
+    """
+    if graph_uri:
+        query = f"SELECT (COUNT(*) AS ?c) WHERE {{ GRAPH <{graph_uri}> {{ ?s ?p ?o }} }}"
+    else:
+        query = "SELECT (COUNT(*) AS ?c) WHERE { ?s ?p ?o }"
+
+    try:
+        bindings = execute_sparql(endpoint, query, timeout=timeout)
+        if bindings and len(bindings) > 0:
+            val = bindings[0].get("c", {})
+            if isinstance(val, dict) and "value" in val:
+                raw = val["value"]
+                if raw is not None:
+                    return int(raw)
+        return 0
+    except (RuntimeError, ValueError, Exception) as exc:
+        log.debug("SPARQL count failed on %s: %s", endpoint, exc)
+        return None


### PR DESCRIPTION
## Sintesi

Aggiunge `fetch_sparql_count()` in `toolkit.scout.sparql`: una funzione leggera che esegue `SELECT COUNT(*)` su un endpoint SPARQL per verificare che risponda e contare le triple, opzionalmente in un named graph.

Serve come **contratto centralizzato** per il source-check SPARQL-aware di source-observatory (PR #341).

## Contesto collegato

Source-observatory [#340](https://github.com/dataciviclab/source-observatory/issues/340) — gap source-check SPARQL

## Cosa cambia

- [x] Nuova funzionalità del motore
- [ ] Modifica contratto pubblico
- [ ] Refactor / performance
- [x] Test

## Dettaglio

`fetch_sparql_count(endpoint, graph_uri=None, timeout=15) -> int | None`:
- endpoint raggiungibile → conta triple nel default graph (o in `graph_uri`)
- endpoint irraggiungibile o errore → `None`
- gestisce timeout, ValueError, RuntimeError senza sollevare eccezioni
- timeout default 15s (leggero, pensato per source-check bulk)

Esportata da `toolkit.scout.__init__`.

## Impatto su contratti pubblici

Nessuno. Aggiunge una funzione pubblica al modulo `toolkit.scout.sparql`.

- [ ] Struttura `dataset.yml` 
- [ ] Path output 
- [ ] Schema parquet 
- [x] API pubblica del toolkit (`fetch_sparql_count` in `toolkit.scout.sparql`)
- [ ] CLI o MCP tool 

## Verifica

```bash
pytest tests/test_scout_sparql.py -v
ruff check toolkit/scout/ tests/test_scout_sparql.py
```

- [x] `pytest -m core` passa (31 test SPARQL)
- [x] `ruff check .` passa
- [x] Test aggiunti: 7 contract su conteggio, graph_uri, errori, timeout

## Checklist PR

- [x] Perimetro stretto: una PR = `fetch_sparql_count` + test
- [x] Issue collegata (source-observatory#340)
- [x] Test con marker `contract`
