### PR TITLE
fix(probe): parallelizza _run_probe con ThreadPoolExecutor

### DIFF
--- a/tests/test_run_dry_run.py
+++ b/tests/test_run_dry_run.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from pathlib import Path
 
 import duckdb
@@ -596,4 +597,40 @@ def test_probe_logs_ckan_portal(monkeypatch) -> None:
     assert len(calls) == 1
     assert "ckan.test/api/3/action" in calls[0], (
         "should probe the full portal_url, not just scheme://host"
+    )
+
+
+@pytest.mark.policy
+def test_probe_parallel_execution(monkeypatch) -> None:
+    """Probe step esegue fonti multiple in parallelo, non in serie.
+
+    Con 3 fonti che impiegano 0.5s ciascuna, il tempo totale deve
+    essere minore di 3 * 0.5 = 1.5s (prova di parallelismo).
+    """
+    DELAY = 0.5
+
+    def _delayed_probe(url, timeout=5):
+        time.sleep(DELAY)
+        return {"status_code": 200, "content_type": "text/csv"}
+
+    monkeypatch.setattr(
+        "toolkit.scout.http.probe_url_headers",
+        _delayed_probe,
+    )
+    from toolkit.cli.cmd_run import _run_probe
+
+    sources = [
+        {"name": "s1", "type": "http_file", "args": {"url": f"https://src{i}.test/data.csv"}}
+        for i in range(3)
+    ]
+
+    start = time.perf_counter()
+    _run_probe(_FakeCfg(sources), 2024, logging.getLogger("t"))
+    elapsed = time.perf_counter() - start
+
+    # Se fosse seriale: 3 * 0.5 = 1.5s + overhead
+    # Con parallelismo: ~0.5s + overhead
+    assert elapsed < 1.2, (
+        f"Troppo lento ({elapsed:.2f}s): le probe sembrano sequenziali. "
+        f"Atteso < 1.2s per 3 fonti da {DELAY}s ciascuna."
     )

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
@@ -148,6 +149,8 @@ def _run_probe(cfg, year: int, logger) -> None:
     format detection) per output ricco come lo scout CLI.
     Non blocca mai — il vero errore arrivera' da raw.
     Salta local_file, sdmx, sparql (non timeoutano).
+    Le probe sono eseguite in parallelo con ThreadPoolExecutor
+    per evitare che timeout su fonti lente blocchino l'intero batch.
     """
     sources = cfg.raw.sources
     if not sources:
@@ -156,7 +159,7 @@ def _run_probe(cfg, year: int, logger) -> None:
 
     from toolkit.scout.http import probe_url_headers
 
-    for src in sources:
+    def _probe_one(src) -> None:
         stype = (
             getattr(src, "type", None) or src.get("type", "http_file")
             if isinstance(src, dict)
@@ -175,7 +178,7 @@ def _run_probe(cfg, year: int, logger) -> None:
         try:
             if stype in ("http_file", "http_post_file"):
                 if not url:
-                    continue
+                    return
                 probe = probe_url_headers(url, timeout=5)
                 sc = probe.get("status_code", 0)
                 if 200 <= sc < 400:
@@ -207,6 +210,11 @@ def _run_probe(cfg, year: int, logger) -> None:
 
         except RuntimeError as exc:
             logger.warning("PROBE | %s -> unreachable: %s", name, exc)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = {pool.submit(_probe_one, src): src for src in sources}
+        for future in as_completed(futures):
+            future.result()  # ripropaga eccezioni inaspettate (RuntimeError gia' catturate)
 
 
 def run_year(


### PR DESCRIPTION
## Sintesi

Il loop sequenziale in `_run_probe()` faceva impiegare 66 minuti al weekly probe. Con `ThreadPoolExecutor(max_workers=8)` le probe HTTP partono in parallelo. Stima: da 66 min a ~5 min.

## Contesto collegato

Closes #354

## Cosa cambia

- [ ] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

Nessuno.

## Verifica

```bash
pytest -m core -x --tb=short
pytest tests/test_run_dry_run.py -k "probe" -v
ruff check .
```

- [x] `pytest -m core` passa (215/215)
- [x] `ruff check .` passa
- [ ] `mypy toolkit/` passa (o motiva le eccezioni)
- [x] Modificato o aggiunto test con marker appropriato (`policy`)

## Checklist PR

- [x] Perimetro stretto: una PR = un layer o un fix mirato
- [x] Se nuovo plugin: test + docs inclusi
- [x] Issue collegata o motivazione dell'assenza
- [ ] **Se rimuovo un modulo/funzione pubblica**: ho verificato l'assenza di import con `rg` su tutta l'org
  e lasciato shim backward compat con `DeprecationWarning` (vedi deprecation policy in CONTRIBUTING)

## Note per chi revisiona

Rischio principale: `RuntimeError` viene catturato dentro `_probe_one()`, quindi `future.result()` non dovrebbe mai ricevere errori previsti. Eccezioni inaspettate vengono ripropagate — comportamento identico al codice originale (dove uscivano dal loop).
