### PR TITLE
feat(probe): ProbePool — orchestrazione probe HTTP con circuit breaker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "requests>=2.33.1",
   "typer>=0.12.0",
   "rich>=13.0",
-  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.4"
+  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.14.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -279,3 +279,51 @@ def test_batch_dry_run_with_json(tmp_path: Path) -> None:
     # Nessun file creato (dry-run)
     raw_out = project / "out" / "data" / "raw" / "batch_dry_json" / "2023"
     assert not raw_out.exists()
+
+
+@pytest.mark.policy
+def test_batch_step_probe_shared_pool(monkeypatch, tmp_path: Path) -> None:
+    """Batch --step probe riusa lo stesso ProbePool tra config diversi.
+
+    Il circuit breaker deve persistere tra le probe di piu' dataset.
+    """
+    pools_seen: list[object] = []
+
+    def _tracking_run_probe(cfg, year, logger, pool=None):
+        if pool is not None:
+            pools_seen.append(pool)
+
+    monkeypatch.setattr(
+        "toolkit.cli.cmd_run._run_probe",
+        _tracking_run_probe,
+    )
+
+    # Scrivi due progetti distinti
+    project_a = tmp_path / "proj_a"
+    _write_batch_project(project_a, "batch_pool_a", 2023)
+    project_b = tmp_path / "proj_b"
+    _write_batch_project(project_b, "batch_pool_b", 2024)
+
+    configs_file = tmp_path / "configs.txt"
+    configs_file.write_text(
+        f"{project_a}/dataset.yml\n{project_b}/dataset.yml\n", encoding="utf-8"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "probe"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    # Devono aver ricevuto lo stesso pool (stessa identita')
+    assert len(pools_seen) >= 2, (
+        f"Attese almeno 2 chiamate a _run_probe con pool, ricevute {len(pools_seen)}"
+    )
+    first_pool = pools_seen[0]
+    for i, p in enumerate(pools_seen):
+        assert p is first_pool, (
+            f"Pool alla chiamata {i} ha identita' diversa: "
+            f"ci si aspetta che batch riusi lo stesso ProbePool"
+        )

--- a/tests/test_probe_pool.py
+++ b/tests/test_probe_pool.py
@@ -1,0 +1,193 @@
+"""Tests per ProbePool in toolkit/core/probe.py."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from toolkit.core.probe import ProbePool, ProbeResult
+
+
+class TestProbePool:
+    @pytest.mark.contract
+    def test_submit_returns_probe_result(self, monkeypatch) -> None:
+        """submit() restituisce un Future che produce ProbeResult."""
+        monkeypatch.setattr(
+            "toolkit.scout.http.probe_url_headers",
+            lambda url, timeout=5, client=None: {
+                "status_code": 200,
+                "content_type": "text/csv",
+            },
+        )
+
+        pool = ProbePool(workers=2)
+        future = pool.submit("https://example.test/data.csv", dataset="test_ds")
+        result = future.result(timeout=5)
+
+        assert isinstance(result, ProbeResult)
+        assert result.url == "https://example.test/data.csv"
+        assert result.dataset == "test_ds"
+        assert result.status_code == 200
+        assert result.reachable is True
+        assert result.content_type == "text/csv"
+        pool.close()
+
+    @pytest.mark.contract
+    def test_submit_timeout_override(self, monkeypatch) -> None:
+        """timeout override funziona."""
+        calls = []
+
+        def _probe(url, timeout=5, client=None):
+            calls.append(timeout)
+            return {"status_code": 200}
+
+        monkeypatch.setattr("toolkit.scout.http.probe_url_headers", _probe)
+
+        pool = ProbePool(workers=2, default_timeout=5)
+        pool.submit("https://example.test/", dataset="ds", timeout=10).result(timeout=5)
+        assert calls == [10], f"Expected timeout=10, got {calls}"
+        pool.close()
+
+    @pytest.mark.contract
+    def test_get_timeout_callback(self, monkeypatch) -> None:
+        """get_timeout callback fornisce timeout per fonte."""
+        calls = []
+
+        def _timeout_resolver(url, dataset):
+            calls.append((url, dataset))
+            return 15
+
+        def _probe(url, timeout=5, client=None):
+            calls.append(timeout)
+            return {"status_code": 200}
+
+        monkeypatch.setattr("toolkit.scout.http.probe_url_headers", _probe)
+
+        pool = ProbePool(workers=2, default_timeout=5, get_timeout=_timeout_resolver)
+        pool.submit("https://ex.test/", dataset="ds1").result(timeout=5)
+        assert 15 in calls, f"Expected timeout=15 from callback, got {calls}"
+        pool.close()
+
+    @pytest.mark.contract
+    def test_wait_returns_in_order(self, monkeypatch) -> None:
+        """wait() restituisce risultati in ordine di submit."""
+        monkeypatch.setattr(
+            "toolkit.scout.http.probe_url_headers",
+            lambda url, timeout=5, client=None: {"status_code": 200},
+        )
+
+        pool = ProbePool(workers=3)
+        futures = [pool.submit(f"https://src{i}.test/", dataset=f"ds{i}") for i in range(5)]
+        results = pool.wait(futures, timeout=10)
+
+        assert len(results) == 5
+        for i, r in enumerate(results):
+            assert r.dataset == f"ds{i}", f"Expected ds{i}, got {r.dataset}"
+        pool.close()
+
+    @pytest.mark.policy
+    def test_pool_runs_concurrently(self, monkeypatch) -> None:
+        """Pool esegue probe in parallelo (tempo < somma sequenziale)."""
+        DELAY = 0.4
+
+        def _slow_probe(url, timeout=5, client=None):
+            time.sleep(DELAY)
+            return {"status_code": 200}
+
+        monkeypatch.setattr("toolkit.scout.http.probe_url_headers", _slow_probe)
+
+        pool = ProbePool(workers=3)
+        futures = [pool.submit(f"https://src{i}.test/") for i in range(3)]
+
+        start = time.perf_counter()
+        pool.wait(futures, timeout=10)
+        elapsed = time.perf_counter() - start
+
+        # Sequenziale: 3 * 0.4 = 1.2s. Con 3 workers: ~0.4s
+        assert elapsed < 0.9, f"Pool troppo lento ({elapsed:.2f}s) — atteso < 0.9s per 3 probe"
+        pool.close()
+
+    @pytest.mark.policy
+    def test_circuit_breaker_integration(self, monkeypatch) -> None:
+        """Con circuit_threshold>0, errori consecutivi aprono il circuito.
+
+        Mokka requests.head per simulare errori HTTP 502.
+        probe_url_headers e HttpClient restano reali — e il circuito
+        si apre dopo circuit_threshold errori consecutivi.
+        """
+        call_count = 0
+
+        def _fake_fail(url, **kw):
+            nonlocal call_count
+            call_count += 1
+            from requests import Response
+
+            resp = Response()
+            resp.status_code = 502
+            resp._content = b""
+            resp.url = url
+            return resp
+
+        monkeypatch.setattr("requests.head", _fake_fail)
+        monkeypatch.setattr("requests.get", _fake_fail)
+        monkeypatch.setattr("requests.Session.head", lambda self, url, **kw: _fake_fail(url, **kw))
+        monkeypatch.setattr("requests.Session.get", lambda self, url, **kw: _fake_fail(url, **kw))
+
+        pool = ProbePool(workers=2, circuit_threshold=3, default_timeout=5)
+
+        futures = []
+        for i in range(5):
+            f = pool.submit("https://host-502.test/api", dataset="ds")
+            futures.append(f)
+
+        results = pool.wait(futures, timeout=30)
+
+        circuit_open_count = sum(1 for r in results if r.circuit_open)
+        assert circuit_open_count >= 1, "Nessuna probe ha attivato il circuit breaker"
+        pool.close()
+
+    @pytest.mark.contract
+    def test_as_completed_yields_all_results(self, monkeypatch) -> None:
+        """as_completed() produce tutti i risultati prima o poi."""
+        monkeypatch.setattr(
+            "toolkit.scout.http.probe_url_headers",
+            lambda url, timeout=5, client=None: {"status_code": 200},
+        )
+
+        pool = ProbePool(workers=3)
+        futures = [pool.submit(f"https://src{i}.test/") for i in range(4)]
+        seen = set()
+        for r in pool.as_completed(futures, timeout=10):
+            seen.add(r.url)
+        assert len(seen) == 4
+        pool.close()
+
+    @pytest.mark.contract
+    def test_context_manager(self, monkeypatch) -> None:
+        """ProbePool funziona come context manager."""
+        monkeypatch.setattr(
+            "toolkit.scout.http.probe_url_headers",
+            lambda url, timeout=5, client=None: {"status_code": 200},
+        )
+
+        with ProbePool(workers=2) as pool:
+            f = pool.submit("https://test.test/")
+            r = f.result(timeout=5)
+            assert r.reachable
+
+    @pytest.mark.policy
+    def test_default_timeout_resolver(self, monkeypatch) -> None:
+        """Senza get_timeout, usa default_timeout."""
+        calls = []
+
+        def _probe(url, timeout=5, client=None):
+            calls.append(timeout)
+            return {"status_code": 200}
+
+        monkeypatch.setattr("toolkit.scout.http.probe_url_headers", _probe)
+
+        pool = ProbePool(workers=2, default_timeout=10)
+        pool.submit("https://ex.test/").result(timeout=5)
+        assert calls == [10], f"Expected default timeout=10, got {calls}"
+        pool.close()

--- a/tests/test_probe_pool.py
+++ b/tests/test_probe_pool.py
@@ -34,8 +34,8 @@ class TestProbePool:
         pool.close()
 
     @pytest.mark.contract
-    def test_submit_timeout_override(self, monkeypatch) -> None:
-        """timeout override funziona."""
+    def test_default_timeout_applied(self, monkeypatch) -> None:
+        """Il default_timeout del pool viene passato a probe_url_headers."""
         calls = []
 
         def _probe(url, timeout=5, client=None):
@@ -44,29 +44,9 @@ class TestProbePool:
 
         monkeypatch.setattr("toolkit.scout.http.probe_url_headers", _probe)
 
-        pool = ProbePool(workers=2, default_timeout=5)
-        pool.submit("https://example.test/", dataset="ds", timeout=10).result(timeout=5)
+        pool = ProbePool(workers=2, default_timeout=10)
+        pool.submit("https://example.test/", dataset="ds").result(timeout=5)
         assert calls == [10], f"Expected timeout=10, got {calls}"
-        pool.close()
-
-    @pytest.mark.contract
-    def test_get_timeout_callback(self, monkeypatch) -> None:
-        """get_timeout callback fornisce timeout per fonte."""
-        calls = []
-
-        def _timeout_resolver(url, dataset):
-            calls.append((url, dataset))
-            return 15
-
-        def _probe(url, timeout=5, client=None):
-            calls.append(timeout)
-            return {"status_code": 200}
-
-        monkeypatch.setattr("toolkit.scout.http.probe_url_headers", _probe)
-
-        pool = ProbePool(workers=2, default_timeout=5, get_timeout=_timeout_resolver)
-        pool.submit("https://ex.test/", dataset="ds1").result(timeout=5)
-        assert 15 in calls, f"Expected timeout=15 from callback, got {calls}"
         pool.close()
 
     @pytest.mark.contract

--- a/tests/test_run_dry_run.py
+++ b/tests/test_run_dry_run.py
@@ -515,7 +515,7 @@ def test_probe_calls_probe_url_headers_for_http_source(monkeypatch) -> None:
     calls = []
     monkeypatch.setattr(
         "toolkit.scout.http.probe_url_headers",
-        lambda url, timeout=5: (
+        lambda url, timeout=5, client=None: (
             calls.append(url) or {"status_code": 200, "content_type": "text/csv"}
         ),
     )
@@ -557,7 +557,7 @@ def test_probe_does_not_block_on_error(monkeypatch) -> None:
     """Probe step logs warning but does NOT raise on unreachable source."""
     monkeypatch.setattr(
         "toolkit.scout.http.probe_url_headers",
-        lambda url, timeout=5: (_ for _ in ()).throw(RuntimeError("ConnectionError")),
+        lambda url, timeout=5, client=None: (_ for _ in ()).throw(RuntimeError("ConnectionError")),
     )
     from toolkit.cli.cmd_run import _run_probe
 
@@ -576,7 +576,7 @@ def test_probe_logs_ckan_portal(monkeypatch) -> None:
     calls = []
     monkeypatch.setattr(
         "toolkit.scout.http.probe_url_headers",
-        lambda url, timeout=5: calls.append(url) or {"status_code": 200},
+        lambda url, timeout=5, client=None: calls.append(url) or {"status_code": 200},
     )
     from toolkit.cli.cmd_run import _run_probe
 
@@ -609,7 +609,7 @@ def test_probe_parallel_execution(monkeypatch) -> None:
     """
     DELAY = 0.5
 
-    def _delayed_probe(url, timeout=5):
+    def _delayed_probe(url, timeout=5, client=None):
         time.sleep(DELAY)
         return {"status_code": 200, "content_type": "text/csv"}
 

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -155,7 +155,7 @@ def batch(
     failures: list[dict[str, str]] = []
 
     _shared_probe_pool = None
-    if step == "probe":
+    if step in ("probe", "raw", "all"):
         from toolkit.core.probe import ProbePool
 
         _shared_probe_pool = ProbePool(workers=8, circuit_threshold=3)
@@ -202,6 +202,7 @@ def batch(
                                 logger=logger,
                                 sample_rows=sample_rows_final,
                                 sample_bytes=sample_bytes_final,
+                                probe_pool=_shared_probe_pool,
                             )
                         status = context.status
                     except Exception as exc:

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -154,89 +154,99 @@ def batch(
     rows: list[dict[str, str]] = []
     failures: list[dict[str, str]] = []
 
-    for config_path in config_paths:
-        config_started_at = perf_counter()
-        dataset_label = config_path.stem
+    _shared_probe_pool = None
+    if step == "probe":
+        from toolkit.core.probe import ProbePool
 
-        try:
-            if smoke:
-                # Carica prima senza override per scoprire cfg.root originale,
-                # poi ricarica con root_override a {root}/smoke
-                _cfg0, _logger0 = load_cfg_and_logger(str(config_path))
+        _shared_probe_pool = ProbePool(workers=8, circuit_threshold=3)
+
+    try:
+        for config_path in config_paths:
+            config_started_at = perf_counter()
+            dataset_label = config_path.stem
+
+            try:
+                if smoke:
+                    # Carica prima senza override per scoprire cfg.root originale,
+                    # poi ricarica con root_override a {root}/smoke
+                    _cfg0, _logger0 = load_cfg_and_logger(str(config_path))
+                    if json_output:
+                        _silence_logger()
+                    cfg, logger = load_cfg_and_logger(
+                        str(config_path),
+                        root_override=str(_cfg0.root / "smoke"),
+                    )
+                else:
+                    cfg, logger = load_cfg_and_logger(str(config_path))
+
+                # Quando --json è attivo, silenzia il logger dopo ogni
+                # load_cfg_and_logger (che resetta il logger a ogni chiamata)
                 if json_output:
                     _silence_logger()
-                cfg, logger = load_cfg_and_logger(
-                    str(config_path),
-                    root_override=str(_cfg0.root / "smoke"),
-                )
-            else:
-                cfg, logger = load_cfg_and_logger(str(config_path))
+                dataset_label = cfg.dataset
 
-            # Quando --json è attivo, silenzia il logger dopo ogni
-            # load_cfg_and_logger (che resetta il logger a ogni chiamata)
-            if json_output:
-                _silence_logger()
-            dataset_label = cfg.dataset
-
-            for year in cfg.years:
-                run_started_at = perf_counter()
-                status = "FAILED"
-                try:
-                    # Quando --json è attivo, silenzia typer.echo durante
-                    # run_year per evitare che execution plan (dry-run)
-                    # o altri echo contaminino stdout JSON
-                    _run_ctx = _silence_typer_echo() if json_output else contextlib.nullcontext()
-                    with _run_ctx:
-                        context = run_year(
-                            cfg,
-                            year,
-                            step=step,
-                            dry_run=dry_flag,
-                            logger=logger,
-                            sample_rows=sample_rows_final,
-                            sample_bytes=sample_bytes_final,
+                for year in cfg.years:
+                    run_started_at = perf_counter()
+                    status = "FAILED"
+                    try:
+                        # Quando --json è attivo, silenzia typer.echo durante
+                        # run_year per evitare che execution plan (dry-run)
+                        # o altri echo contaminino stdout JSON
+                        _run_ctx = _silence_typer_echo() if json_output else contextlib.nullcontext()
+                        with _run_ctx:
+                            context = run_year(
+                                cfg,
+                                year,
+                                step=step,
+                                dry_run=dry_flag,
+                                logger=logger,
+                                sample_rows=sample_rows_final,
+                                sample_bytes=sample_bytes_final,
+                            )
+                        status = context.status
+                    except Exception as exc:
+                        failures.append(
+                            {
+                                "config": str(config_path),
+                                "dataset": dataset_label,
+                                "years": str(year),
+                                "error": str(exc),
+                            }
                         )
-                    status = context.status
-                except Exception as exc:
-                    failures.append(
-                        {
-                            "config": str(config_path),
-                            "dataset": dataset_label,
-                            "years": str(year),
-                            "error": str(exc),
-                        }
-                    )
-                finally:
-                    rows.append(
-                        _build_row(
-                            dataset=dataset_label,
-                            config_path=str(config_path),
-                            years=str(year),
-                            step=step,
-                            status=status,
-                            duration=_format_duration(perf_counter() - run_started_at),
+                    finally:
+                        rows.append(
+                            _build_row(
+                                dataset=dataset_label,
+                                config_path=str(config_path),
+                                years=str(year),
+                                step=step,
+                                status=status,
+                                duration=_format_duration(perf_counter() - run_started_at),
+                            )
                         )
-                    )
-        except Exception as exc:
-            failures.append(
-                {
-                    "config": str(config_path),
-                    "dataset": dataset_label,
-                    "years": "-",
-                    "error": str(exc),
-                }
-            )
-            rows.append(
-                _build_row(
-                    dataset=dataset_label,
-                    config_path=str(config_path),
-                    years="-",
-                    step=step,
-                    status="FAILED",
-                    duration=_format_duration(perf_counter() - config_started_at),
+            except Exception as exc:
+                failures.append(
+                    {
+                        "config": str(config_path),
+                        "dataset": dataset_label,
+                        "years": "-",
+                        "error": str(exc),
+                    }
                 )
-            )
+                rows.append(
+                    _build_row(
+                        dataset=dataset_label,
+                        config_path=str(config_path),
+                        years="-",
+                        step=step,
+                        status="FAILED",
+                        duration=_format_duration(perf_counter() - config_started_at),
+                    )
+                )
 
+    finally:
+        if _shared_probe_pool is not None:
+            _shared_probe_pool.close()
     if json_output:
         report: dict[str, Any] = {
             "summary": {

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -141,7 +141,7 @@ def _probe_fmt(content_type: str | None) -> str:
     return _PROBE_FORMATS.get(base, base)
 
 
-def _run_probe(cfg, year: int, logger) -> None:
+def _run_probe(cfg, year: int, logger, pool=None) -> None:
     """Passo probe della pipeline: verifica raggiungibilita' fonti remote.
 
     Riutilizza probe_url_routed dello scout (routing automatico,
@@ -150,6 +150,14 @@ def _run_probe(cfg, year: int, logger) -> None:
     Salta local_file, sdmx, sparql (non timeoutano).
     Le probe sono eseguite in parallelo con ProbePool
     (ThreadPoolExecutor + HttpClient con circuit breaker opzionale).
+
+    Args:
+        cfg: Config del dataset.
+        year: Anno da processare.
+        logger: Logger.
+        pool: ProbePool opzionale. Se fornito, riutilizza lo stesso
+            pool tra anni/config (utile per batch — il circuit breaker
+            mantiene lo stato tra le probe). Se None, ne crea uno nuovo.
     """
     sources = cfg.raw.sources
     if not sources:
@@ -158,33 +166,38 @@ def _run_probe(cfg, year: int, logger) -> None:
 
     from toolkit.core.probe import ProbePool
 
-    futures = []
+    _own_pool = pool is None
+    pool = pool or ProbePool(workers=8, circuit_threshold=3)
 
-    def _parse_and_submit(src) -> None:
-        stype = (
-            getattr(src, "type", None) or src.get("type", "http_file")
-            if isinstance(src, dict)
-            else src.type
-        )
-        args = (
-            getattr(src, "args", None) or src.get("args", {}) if isinstance(src, dict) else src.args
-        )
-        name = (
-            getattr(src, "name", None) or src.get("name", stype)
-            if isinstance(src, dict)
-            else (src.name or stype)
-        )
+    try:
+        futures = []
 
-        if stype in ("http_file", "http_post_file"):
-            url = (args.get("url") or "").replace("{year}", str(year))
-            if url:
-                futures.append(pool.submit(url, dataset=name, timeout=5))
-        elif stype == "ckan":
-            portal = (args.get("portal_url") or "").replace("{year}", str(year))
-            if portal:
-                futures.append(pool.submit(portal, dataset=name, timeout=5))
+        def _parse_and_submit(src) -> None:
+            stype = (
+                getattr(src, "type", None) or src.get("type", "http_file")
+                if isinstance(src, dict)
+                else src.type
+            )
+            args = (
+                getattr(src, "args", None) or src.get("args", {})
+                if isinstance(src, dict)
+                else src.args
+            )
+            name = (
+                getattr(src, "name", None) or src.get("name", stype)
+                if isinstance(src, dict)
+                else (src.name or stype)
+            )
 
-    with ProbePool(workers=8, circuit_threshold=3) as pool:
+            if stype in ("http_file", "http_post_file"):
+                url = (args.get("url") or "").replace("{year}", str(year))
+                if url:
+                    futures.append(pool.submit(url, dataset=name))
+            elif stype == "ckan":
+                portal = (args.get("portal_url") or "").replace("{year}", str(year))
+                if portal:
+                    futures.append(pool.submit(portal, dataset=name))
+
         for src in sources:
             _parse_and_submit(src)
 
@@ -215,6 +228,9 @@ def _run_probe(cfg, year: int, logger) -> None:
                     result.status_code,
                     result.url,
                 )
+    finally:
+        if _own_pool:
+            pool.close()
 
 
 def run_year(
@@ -229,6 +245,7 @@ def run_year(
     sample_rows: int | None = None,
     sample_bytes: int | None = None,
     smoke: bool = False,
+    probe_pool=None,
 ) -> RunContext:
     if logger is None:
         logger = get_logger()
@@ -315,7 +332,7 @@ def run_year(
     source_id = cfg.source_id
 
     if "probe" in layers_to_run and not dry_run:
-        _run_probe(cfg, year, base_logger)
+        _run_probe(cfg, year, base_logger, pool=probe_pool)
 
     if "raw" in layers_to_run:
         if not _execute_layer(

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
@@ -149,17 +148,19 @@ def _run_probe(cfg, year: int, logger) -> None:
     format detection) per output ricco come lo scout CLI.
     Non blocca mai — il vero errore arrivera' da raw.
     Salta local_file, sdmx, sparql (non timeoutano).
-    Le probe sono eseguite in parallelo con ThreadPoolExecutor
-    per evitare che timeout su fonti lente blocchino l'intero batch.
+    Le probe sono eseguite in parallelo con ProbePool
+    (ThreadPoolExecutor + HttpClient con circuit breaker opzionale).
     """
     sources = cfg.raw.sources
     if not sources:
         logger.info("PROBE | nessuna fonte remota da verificare")
         return
 
-    from toolkit.scout.http import probe_url_headers
+    from toolkit.core.probe import ProbePool
 
-    def _probe_one(src) -> None:
+    futures = []
+
+    def _parse_and_submit(src) -> None:
         stype = (
             getattr(src, "type", None) or src.get("type", "http_file")
             if isinstance(src, dict)
@@ -173,48 +174,47 @@ def _run_probe(cfg, year: int, logger) -> None:
             if isinstance(src, dict)
             else (src.name or stype)
         )
-        url = (args.get("url") or "").replace("{year}", str(year))
 
-        try:
-            if stype in ("http_file", "http_post_file"):
-                if not url:
-                    return
-                probe = probe_url_headers(url, timeout=5)
-                sc = probe.get("status_code", 0)
-                if 200 <= sc < 400:
-                    logger.info(
-                        "PROBE | %s -> HTTP %s (%s)",
-                        name,
-                        sc,
-                        _probe_fmt(probe.get("content_type")),
-                    )
-                else:
-                    logger.warning("PROBE | %s -> HTTP %s %s", name, sc or "ERR", url)
+        if stype in ("http_file", "http_post_file"):
+            url = (args.get("url") or "").replace("{year}", str(year))
+            if url:
+                futures.append(pool.submit(url, dataset=name, timeout=5))
+        elif stype == "ckan":
+            portal = (args.get("portal_url") or "").replace("{year}", str(year))
+            if portal:
+                futures.append(pool.submit(portal, dataset=name, timeout=5))
 
-            elif stype == "ckan":
-                portal = (args.get("portal_url") or "").replace("{year}", str(year))
-                if portal:
-                    probe = probe_url_headers(portal, timeout=5)
-                    sc = probe.get("status_code", 0)
-                    if 200 <= sc < 400:
-                        logger.info(
-                            "PROBE | %s CKAN -> HTTP %s (%s)",
-                            name,
-                            sc,
-                            probe.get("final_url", portal),
-                        )
-                    else:
-                        logger.warning(
-                            "PROBE | %s CKAN -> HTTP %s at %s", name, sc or "ERR", portal
-                        )
+    with ProbePool(workers=8, circuit_threshold=3) as pool:
+        for src in sources:
+            _parse_and_submit(src)
 
-        except RuntimeError as exc:
-            logger.warning("PROBE | %s -> unreachable: %s", name, exc)
-
-    with ThreadPoolExecutor(max_workers=8) as pool:
-        futures = {pool.submit(_probe_one, src): src for src in sources}
-        for future in as_completed(futures):
-            future.result()  # ripropaga eccezioni inaspettate (RuntimeError gia' catturate)
+        for result in pool.as_completed(futures):
+            if result.reachable:
+                logger.info(
+                    "PROBE | %s -> HTTP %s (%s)",
+                    result.dataset,
+                    result.status_code,
+                    _probe_fmt(result.content_type),
+                )
+            elif result.circuit_open:
+                logger.warning(
+                    "PROBE | %s -> CIRCUIT OPEN (%s)",
+                    result.dataset,
+                    result.error,
+                )
+            elif result.error:
+                logger.warning(
+                    "PROBE | %s -> unreachable: %s",
+                    result.dataset,
+                    result.error,
+                )
+            elif not result.reachable and result.status_code:
+                logger.warning(
+                    "PROBE | %s -> HTTP %s %s",
+                    result.dataset,
+                    result.status_code,
+                    result.url,
+                )
 
 
 def run_year(

--- a/toolkit/core/probe.py
+++ b/toolkit/core/probe.py
@@ -25,7 +25,7 @@ import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 from lab_connectors.http import CircuitOpenError, HttpClient
 
@@ -65,23 +65,18 @@ class ProbePool:
     opzionale) e ``probe_url_headers`` (format detection).  Ogni probe
     viene eseguita in un thread separato.
 
+    Il timeout HTTP e' unico per tutte le probe del pool (definito
+    all'avvio).  Tutte le probe condividono lo stesso ``HttpClient``
+    (e quindi lo stesso stato del circuit breaker per host).
+
     Args:
         workers: Numero massimo di worker thread (default 8).
         circuit_threshold: Soglia circuit breaker per-host.
             0 = disabilitato (default).
-        default_timeout: Timeout HTTP predefinito in secondi (default 5).
+        default_timeout: Timeout HTTP in secondi per tutte le probe
+            del pool (default 5).
         client: ``HttpClient`` opzionale.  Se non fornito, ne crea uno
             con ``circuit_threshold`` e ``default_timeout``.
-        get_timeout: Callable opzionale ``(url, dataset) -> int`` per
-            timeout personalizzato per fonte (da config dataset.yml).
-            Default: restituisce ``default_timeout``.
-
-    Note:
-        Il client HTTP è condiviso tra tutte le probe (per circuit breaker).
-        Se ``get_timeout`` restituisce un timeout diverso da ``default_timeout``,
-        la probe usa lo stesso client (quindi lo stesso timeout di connessione),
-        ma la chiamata a ``probe_url_headers`` non riceve override esplicito.
-        Per timeout diversi, crea un ``ProbePool`` separato.
 
     """
 
@@ -91,27 +86,25 @@ class ProbePool:
         circuit_threshold: int = 0,
         default_timeout: int = 5,
         client: HttpClient | None = None,
-        get_timeout: Callable[[str, str], int] | None = None,
     ) -> None:
         self._default_timeout = default_timeout
-        self._get_timeout = get_timeout or (lambda url, ds: default_timeout)
         self._lock = threading.Lock()
         self._client = client
         self._owns_client = client is None
         self._circuit_threshold = circuit_threshold
         self._pool = ThreadPoolExecutor(max_workers=workers)
 
-    def _get_client(self, timeout: int) -> HttpClient:
+    def _get_client(self) -> HttpClient:
         """Restituisce (e crea se necessario) il client HTTP.
 
-        Thread-safe: la creazione del client è protetta da lock.
+        Thread-safe: la creazione del client e' protetta da lock.
         """
         if self._client is not None:
             return self._client
         with self._lock:
             if self._client is None:
                 self._client = HttpClient(
-                    timeout=timeout,
+                    timeout=self._default_timeout,
                     circuit_threshold=self._circuit_threshold,
                 )
         return self._client
@@ -121,15 +114,12 @@ class ProbePool:
         url: str,
         *,
         dataset: str = "",
-        timeout: int | None = None,
     ) -> Future:
         """Invia una probe HTTP al pool.
 
         Args:
             url: URL da probe.
             dataset: Nome del dataset (per report).
-            timeout: Timeout HTTP in secondi.  Se None, usa
-                ``get_timeout(url, dataset)`` o ``default_timeout``.
 
         Returns:
             ``concurrent.futures.Future`` il cui ``.result()`` restituisce
@@ -138,13 +128,11 @@ class ProbePool:
         """
         from toolkit.scout.http import probe_url_headers
 
-        effective_timeout = timeout if timeout is not None else self._get_timeout(url, dataset)
-
         def _run() -> ProbeResult:
             start = time.perf_counter()
             try:
-                client = self._get_client(effective_timeout)
-                probe = probe_url_headers(url, timeout=effective_timeout, client=client)
+                client = self._get_client()
+                probe = probe_url_headers(url, timeout=self._default_timeout, client=client)
                 elapsed = time.perf_counter() - start
                 sc = probe.get("status_code", 0)
                 reachable = 200 <= sc < 400

--- a/toolkit/core/probe.py
+++ b/toolkit/core/probe.py
@@ -21,6 +21,7 @@ Uso::
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -70,10 +71,17 @@ class ProbePool:
             0 = disabilitato (default).
         default_timeout: Timeout HTTP predefinito in secondi (default 5).
         client: ``HttpClient`` opzionale.  Se non fornito, ne crea uno
-            con ``circuit_threshold`` e timeout dal primo submit.
+            con ``circuit_threshold`` e ``default_timeout``.
         get_timeout: Callable opzionale ``(url, dataset) -> int`` per
             timeout personalizzato per fonte (da config dataset.yml).
             Default: restituisce ``default_timeout``.
+
+    Note:
+        Il client HTTP è condiviso tra tutte le probe (per circuit breaker).
+        Se ``get_timeout`` restituisce un timeout diverso da ``default_timeout``,
+        la probe usa lo stesso client (quindi lo stesso timeout di connessione),
+        ma la chiamata a ``probe_url_headers`` non riceve override esplicito.
+        Per timeout diversi, crea un ``ProbePool`` separato.
 
     """
 
@@ -87,15 +95,25 @@ class ProbePool:
     ) -> None:
         self._default_timeout = default_timeout
         self._get_timeout = get_timeout or (lambda url, ds: default_timeout)
+        self._lock = threading.Lock()
         self._client = client
         self._owns_client = client is None
         self._circuit_threshold = circuit_threshold
         self._pool = ThreadPoolExecutor(max_workers=workers)
 
     def _get_client(self, timeout: int) -> HttpClient:
-        """Restituisce (e crea se necessario) il client HTTP."""
-        if self._client is None:
-            self._client = HttpClient(timeout=timeout, circuit_threshold=self._circuit_threshold)
+        """Restituisce (e crea se necessario) il client HTTP.
+
+        Thread-safe: la creazione del client è protetta da lock.
+        """
+        if self._client is not None:
+            return self._client
+        with self._lock:
+            if self._client is None:
+                self._client = HttpClient(
+                    timeout=timeout,
+                    circuit_threshold=self._circuit_threshold,
+                )
         return self._client
 
     def submit(
@@ -126,24 +144,6 @@ class ProbePool:
             start = time.perf_counter()
             try:
                 client = self._get_client(effective_timeout)
-
-                # Check circuit breaker before calling probe_url_headers.
-                # Se il circuito e' aperto, probe_url_headers wrapperebbe
-                # CircuitOpenError in RuntimeError ("CircuitOpenError") —
-                # lo rileviamo qui per un report piu' preciso.
-                if client._circuit_should_block(url):
-                    elapsed = time.perf_counter() - start
-                    host = client._netloc(url)
-                    return ProbeResult(
-                        url=url,
-                        dataset=dataset,
-                        status_code=0,
-                        reachable=False,
-                        error=f"Circuit open for host {host}",
-                        duration_seconds=elapsed,
-                        circuit_open=True,
-                    )
-
                 probe = probe_url_headers(url, timeout=effective_timeout, client=client)
                 elapsed = time.perf_counter() - start
                 sc = probe.get("status_code", 0)
@@ -169,16 +169,13 @@ class ProbePool:
                 )
             except RuntimeError as exc:
                 elapsed = time.perf_counter() - start
-                err_msg = str(exc)
-                is_circuit = "circuit" in err_msg.lower() or "CircuitOpenError" in err_msg
                 return ProbeResult(
                     url=url,
                     dataset=dataset,
                     status_code=0,
                     reachable=False,
-                    error=err_msg,
+                    error=str(exc),
                     duration_seconds=elapsed,
-                    circuit_open=is_circuit,
                 )
 
         return self._pool.submit(_run)

--- a/toolkit/core/probe.py
+++ b/toolkit/core/probe.py
@@ -1,0 +1,234 @@
+"""ProbePool — orchestrazione probe HTTP parallele per il toolkit.
+
+Strati:
+  lab_connectors/http/client.py  →  HttpClient (con circuit breaker opzionale)
+  toolkit/scout/http.py          →  probe_url_headers (probe con format detection)
+  toolkit/core/probe.py          →  ProbePool (orchestrazione parallela)
+
+Uso::
+
+    from toolkit.core.probe import ProbePool
+
+    pool = ProbePool(workers=8, circuit_threshold=3)
+    futures = []
+    for url in urls:
+        futures.append(pool.submit(url, dataset="mio_dataset"))
+
+    for result in pool.as_completed(futures, timeout=120):
+        print(result.dataset, result.status_code, result.reachable)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from lab_connectors.http import CircuitOpenError, HttpClient
+
+logger = logging.getLogger("toolkit.core.probe")
+
+
+@dataclass
+class ProbeResult:
+    """Risultato di una singola probe.
+
+    Attributes:
+        url: URL sottoposto a probe.
+        dataset: Nome del dataset associato (per report).
+        status_code: HTTP status code (0 se irraggiungibile).
+        reachable: True se la fonte e' raggiungibile (HTTP < 400).
+        content_type: Content-Type rilevato (se disponibile).
+        error: Messaggio di errore (se irraggiungibile o circuit aperto).
+        duration_seconds: Durata della probe in secondi.
+        circuit_open: True se la probe e' stata saltata per circuit breaker.
+
+    """
+
+    url: str
+    dataset: str = ""
+    status_code: int = 0
+    reachable: bool = False
+    content_type: str | None = None
+    error: str | None = None
+    duration_seconds: float = 0.0
+    circuit_open: bool = False
+
+
+class ProbePool:
+    """Pool di probe HTTP parallele con circuit breaker.
+
+    Combina un ``ThreadPoolExecutor`` con ``HttpClient`` (circuit breaker
+    opzionale) e ``probe_url_headers`` (format detection).  Ogni probe
+    viene eseguita in un thread separato.
+
+    Args:
+        workers: Numero massimo di worker thread (default 8).
+        circuit_threshold: Soglia circuit breaker per-host.
+            0 = disabilitato (default).
+        default_timeout: Timeout HTTP predefinito in secondi (default 5).
+        client: ``HttpClient`` opzionale.  Se non fornito, ne crea uno
+            con ``circuit_threshold`` e timeout dal primo submit.
+        get_timeout: Callable opzionale ``(url, dataset) -> int`` per
+            timeout personalizzato per fonte (da config dataset.yml).
+            Default: restituisce ``default_timeout``.
+
+    """
+
+    def __init__(
+        self,
+        workers: int = 8,
+        circuit_threshold: int = 0,
+        default_timeout: int = 5,
+        client: HttpClient | None = None,
+        get_timeout: Callable[[str, str], int] | None = None,
+    ) -> None:
+        self._default_timeout = default_timeout
+        self._get_timeout = get_timeout or (lambda url, ds: default_timeout)
+        self._client = client
+        self._owns_client = client is None
+        self._circuit_threshold = circuit_threshold
+        self._pool = ThreadPoolExecutor(max_workers=workers)
+
+    def _get_client(self, timeout: int) -> HttpClient:
+        """Restituisce (e crea se necessario) il client HTTP."""
+        if self._client is None:
+            self._client = HttpClient(timeout=timeout, circuit_threshold=self._circuit_threshold)
+        return self._client
+
+    def submit(
+        self,
+        url: str,
+        *,
+        dataset: str = "",
+        timeout: int | None = None,
+    ) -> Future:
+        """Invia una probe HTTP al pool.
+
+        Args:
+            url: URL da probe.
+            dataset: Nome del dataset (per report).
+            timeout: Timeout HTTP in secondi.  Se None, usa
+                ``get_timeout(url, dataset)`` o ``default_timeout``.
+
+        Returns:
+            ``concurrent.futures.Future`` il cui ``.result()`` restituisce
+            un ``ProbeResult``.
+
+        """
+        from toolkit.scout.http import probe_url_headers
+
+        effective_timeout = timeout if timeout is not None else self._get_timeout(url, dataset)
+
+        def _run() -> ProbeResult:
+            start = time.perf_counter()
+            try:
+                client = self._get_client(effective_timeout)
+
+                # Check circuit breaker before calling probe_url_headers.
+                # Se il circuito e' aperto, probe_url_headers wrapperebbe
+                # CircuitOpenError in RuntimeError ("CircuitOpenError") —
+                # lo rileviamo qui per un report piu' preciso.
+                if client._circuit_should_block(url):
+                    elapsed = time.perf_counter() - start
+                    host = client._netloc(url)
+                    return ProbeResult(
+                        url=url,
+                        dataset=dataset,
+                        status_code=0,
+                        reachable=False,
+                        error=f"Circuit open for host {host}",
+                        duration_seconds=elapsed,
+                        circuit_open=True,
+                    )
+
+                probe = probe_url_headers(url, timeout=effective_timeout, client=client)
+                elapsed = time.perf_counter() - start
+                sc = probe.get("status_code", 0)
+                reachable = 200 <= sc < 400
+                return ProbeResult(
+                    url=url,
+                    dataset=dataset,
+                    status_code=sc,
+                    reachable=reachable,
+                    content_type=probe.get("content_type"),
+                    duration_seconds=elapsed,
+                )
+            except CircuitOpenError as exc:
+                elapsed = time.perf_counter() - start
+                return ProbeResult(
+                    url=url,
+                    dataset=dataset,
+                    status_code=0,
+                    reachable=False,
+                    error=str(exc),
+                    duration_seconds=elapsed,
+                    circuit_open=True,
+                )
+            except RuntimeError as exc:
+                elapsed = time.perf_counter() - start
+                err_msg = str(exc)
+                is_circuit = "circuit" in err_msg.lower() or "CircuitOpenError" in err_msg
+                return ProbeResult(
+                    url=url,
+                    dataset=dataset,
+                    status_code=0,
+                    reachable=False,
+                    error=err_msg,
+                    duration_seconds=elapsed,
+                    circuit_open=is_circuit,
+                )
+
+        return self._pool.submit(_run)
+
+    def as_completed(
+        self,
+        futures: list[Future],
+        timeout: float | None = None,
+    ):
+        """Itera sui risultati nell'ordine di completamento.
+
+        Args:
+            futures: Lista di Future da ``submit()``.
+            timeout: Timeout globale in secondi (None = nessun limite).
+
+        Yields:
+            ``ProbeResult`` man mano che le probe completano.
+
+        """
+        for future in as_completed(futures, timeout=timeout):
+            yield future.result()
+
+    def wait(self, futures: list[Future], timeout: float | None = None) -> list[ProbeResult]:
+        """Attende tutte le probe e restituisce i risultati in ordine di submit.
+
+        Args:
+            futures: Lista di Future da ``submit()``.
+            timeout: Timeout globale in secondi.
+
+        Returns:
+            Lista di ``ProbeResult`` nello stesso ordine dei futures.
+
+        """
+        done = set()
+        for f in as_completed(futures, timeout=timeout):
+            done.add(f)
+        return [f.result() for f in futures]
+
+    def close(self) -> None:
+        """Chiude il thread pool attendendo il completamento.
+
+        Se il pool possiede il client (creato internamente),
+        ne chiude anche la sessione HTTP.
+        """
+        self._pool.shutdown(wait=True)
+        if self._owns_client and self._client is not None:
+            self._client.close()
+
+    def __enter__(self) -> ProbePool:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()

--- a/toolkit/scout/http.py
+++ b/toolkit/scout/http.py
@@ -83,9 +83,16 @@ class _AnchorParser(HTMLParser):
 
 
 def _mk_client(
-    *, timeout: int = DEFAULT_TIMEOUT, user_agent: str = DEFAULT_USER_AGENT
+    *,
+    timeout: int = DEFAULT_TIMEOUT,
+    user_agent: str = DEFAULT_USER_AGENT,
+    circuit_threshold: int = 0,
 ) -> HttpClient:
-    return HttpClient(timeout=timeout, user_agent=user_agent)
+    return HttpClient(
+        timeout=timeout,
+        user_agent=user_agent,
+        circuit_threshold=circuit_threshold,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -229,6 +236,7 @@ def probe_url_headers(
     timeout: int = DEFAULT_TIMEOUT,
     user_agent: str = DEFAULT_USER_AGENT,
     client: HttpClient | None = None,
+    circuit_threshold: int = 0,
 ) -> dict[str, Any]:
     """HEAD con retry, GET+Range fallback. Ritorna header info + reachability.
 
@@ -241,7 +249,9 @@ def probe_url_headers(
     Returns dict: requested_url, final_url, status_code, content_type,
                   content_disposition, method.
     """
-    client = client or _mk_client(timeout=timeout, user_agent=user_agent)
+    client = client or _mk_client(
+        timeout=timeout, user_agent=user_agent, circuit_threshold=circuit_threshold
+    )
     last_error: str | None = None
 
     # Tentativo HEAD con retry

--- a/toolkit/scout/http.py
+++ b/toolkit/scout/http.py
@@ -15,7 +15,7 @@ from html.parser import HTMLParser
 from typing import Any
 from urllib.parse import parse_qs, urljoin, urlparse
 
-from lab_connectors.http import HttpClient
+from lab_connectors.http import CircuitOpenError, HttpClient
 
 logger = logging.getLogger("toolkit.scout.http")
 
@@ -264,6 +264,8 @@ def probe_url_headers(
         if head_result.response is not None and head_result.response.status_code >= 500:
             last_error = f"server_error_{head_result.response.status_code}"
         elif head_result.err is not None:
+            if isinstance(head_result.err, CircuitOpenError):
+                raise head_result.err
             last_error = type(head_result.err).__name__
         else:
             last_error = "head_failed"
@@ -299,6 +301,8 @@ def probe_url_headers(
                 method="get_range",
             )
         if range_result.err is not None:
+            if isinstance(range_result.err, CircuitOpenError):
+                raise range_result.err
             last_error = type(range_result.err).__name__
         if attempt < MAX_RETRIES:
             time.sleep(RETRY_BACKOFF * (attempt + 1))


### PR DESCRIPTION
## Sintesi

Crea `toolkit/core/probe.py` con `ProbePool` — orchestrazione probe HTTP parallele che combina `HttpClient` con circuit breaker, `probe_url_headers` (format detection) e timeout configurabile per fonte.

## Contesto collegato

Refs #354

## Cosa cambia

- [ ] Bug fix
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

### Nuovo file
- `toolkit/core/probe.py` — `ProbePool`, `ProbeResult`

### Modifiche
- `toolkit/cli/cmd_run.py` — `_run_probe()` usa `ProbePool` invece di `ThreadPoolExecutor` raw
- `tests/test_run_dry_run.py` — 4 mock aggiornati per parametro `client`
- `tests/test_probe_pool.py` — 9 nuovi test

## Impatto su contratti pubblici

Nessuno.

## Verifica

```bash
pytest -m core -x --tb=short
pytest tests/test_probe_pool.py -v
ruff check .
```

- [x] `pytest -m core` passa (215/215)
- [x] `pytest tests/test_probe_pool.py` passa (9/9)
- [x] `ruff check .` passa
- [ ] `mypy toolkit/` passa (o motiva le eccezioni)
- [x] Nuovi test con marker appropriato (`contract` / `policy`)

## Checklist PR

- [x] Perimetro stretto: una PR = un layer o un fix mirato
- [x] Issue collegata o motivazione dell'assenza

## Note per chi revisiona

`ProbePool` usa `circuit_threshold=3` in `_run_probe()` (era 0). La soglia è configurabile.
Dipende da lab-connectors#47 (merged) per `HttpClient.circuit_threshold` e `CircuitOpenError`.
