### PR TITLE
feat(profile): preview_url — HEAD + Range GET + sniff + DuckDB profile + infer (solo CSV/TSV)

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -38,6 +38,7 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_list_ckan_datasets",
         "toolkit_list_sdmx_dataflows",
         "toolkit_sparql_query",
+        "toolkit_preview_url",
         "toolkit_validate_config",
     }
 

--- a/tests/test_profile_preview.py
+++ b/tests/test_profile_preview.py
@@ -1,0 +1,218 @@
+"""Tests per preview_url: probe + download sniff profile infer."""
+
+from __future__ import annotations
+
+
+import pytest
+
+from toolkit.profile.preview import (
+    _download_preview_chunk,
+    _extract_year_values_from_sample,
+    preview_url,
+)
+
+
+def _mock_probe(monkeypatch, result: dict | None = None):
+    """Mock probe_url_headers per non fare HTTP reale."""
+    default = {
+        "requested_url": "https://example.test/data.csv",
+        "final_url": "https://example.test/data.csv",
+        "status_code": 200,
+        "content_type": "text/csv",
+        "content_disposition": None,
+        "method": "head",
+        "content_length": "500",
+    }
+    mock_result = {**default, **(result or {})}
+
+    import toolkit.profile.preview as _preview_mod
+
+    monkeypatch.setattr(
+        _preview_mod,
+        "probe_url_headers",
+        lambda url, **kw: mock_result,
+    )
+
+
+def _mock_download(monkeypatch, content: bytes = b"", status: int = 200):
+    """Mock HttpClient.get per non fare HTTP reale."""
+    from lab_connectors.http import HttpResult
+    from lab_connectors.testing import fake_response
+
+    def fake_get(self, url, **kw):
+        return HttpResult(
+            response=fake_response(
+                status,
+                text=content.decode("utf-8", errors="replace"),
+                headers={
+                    "Content-Type": "text/csv",
+                    "Content-Length": str(len(content)),
+                },
+            ),
+            err=None,
+        )
+
+    monkeypatch.setattr("lab_connectors.http.HttpClient.get", fake_get)
+
+
+class TestPreviewUrl:
+    @pytest.mark.smoke
+    def test_csv_preview_produces_columns(self, monkeypatch):
+        """Preview CSV: deve restituire colonne e tipi."""
+        csv_content = b"col1,col2,col3\n1,2,3\n4,5,6\n7,8,9\n"
+        _mock_probe(monkeypatch, {"status_code": 200, "content_type": "text/csv"})
+        _mock_download(monkeypatch, csv_content)
+
+        result = preview_url("https://example.test/data.csv")
+
+        assert result["reachable"] is True
+        assert result["resource_format"] == "CSV"
+        assert result["columns"] == ["col1", "col2", "col3"]
+        assert isinstance(result["col_types"], dict)
+        assert set(result["col_types"].keys()) == {"col1", "col2", "col3"}
+        assert result["preview_row_count"] == 3
+        assert result["enrich_method"] == "csv_preview"
+
+    @pytest.mark.smoke
+    def test_csv_preview_reachable_false_on_probe_fail(self, monkeypatch):
+        """HEAD fallimento → reachable=False."""
+        import toolkit.profile.preview as _preview_mod
+
+        def _fail_probe(url, **kw):
+            raise RuntimeError("timeout")
+
+        monkeypatch.setattr(_preview_mod, "probe_url_headers", _fail_probe)
+
+        result = preview_url("https://example.test/timeout.csv")
+        assert result["reachable"] is False
+        assert result["enrich_method"] == "probe_failed"
+
+    @pytest.mark.smoke
+    def test_csv_with_known_params_skips_sniff(self, monkeypatch):
+        """known_encoding + known_delim → sniff saltato."""
+        csv_content = b"a;b;c\n1;2;3\n"
+        _mock_probe(monkeypatch, {"status_code": 200, "content_type": "text/csv"})
+
+        def _fake_get(self, url, **kw):
+            from lab_connectors.http import HttpResult
+            from lab_connectors.testing import fake_response
+
+            return HttpResult(
+                response=fake_response(
+                    200,
+                    text=csv_content.decode(),
+                    headers={"Content-Type": "text/csv", "Content-Length": str(len(csv_content))},
+                ),
+                err=None,
+            )
+
+        monkeypatch.setattr("lab_connectors.http.HttpClient.get", _fake_get)
+
+        result = preview_url(
+            "https://example.test/data.csv",
+            known_encoding="utf-8",
+            known_delim=";",
+        )
+
+        assert result["columns"] == ["a", "b", "c"]
+        assert result["encoding_suggested"] == "utf-8"
+        assert result["delim_suggested"] == ";"
+        # sniff saltato → decimal e skip rimangono default
+        assert result["skip_suggested"] == 0
+
+    @pytest.mark.contract
+    def test_preview_returns_granularity(self, monkeypatch):
+        """Preview deve inferire granularità da nomi colonna."""
+        csv_content = b"Comune,Popolazione,Anno\nRoma,1000000,2023\nMilano,500000,2023\n"
+        _mock_probe(monkeypatch, {"status_code": 200, "content_type": "text/csv"})
+
+        def _fake_get(self, url, **kw):
+            from lab_connectors.http import HttpResult
+            from lab_connectors.testing import fake_response
+
+            return HttpResult(
+                response=fake_response(
+                    200,
+                    text=csv_content.decode(),
+                    headers={"Content-Type": "text/csv", "Content-Length": str(len(csv_content))},
+                ),
+                err=None,
+            )
+
+        monkeypatch.setattr("lab_connectors.http.HttpClient.get", _fake_get)
+
+        result = preview_url("https://example.test/comuni.csv")
+        assert result["granularity"] != "non_determinato"
+        assert result["granularity"] is not None
+
+
+class TestExtractYearValues:
+    @pytest.mark.contract
+    def test_multiple_years_in_column(self):
+        sample = [
+            {"Anno": 2020, "Regione": "Lombardia", "Valore": 100},
+            {"Anno": 2021, "Regione": "Lombardia", "Valore": 110},
+            {"Anno": 2022, "Regione": "Lombardia", "Valore": 120},
+        ]
+        columns = ["Anno", "Regione", "Valore"]
+        result = _extract_year_values_from_sample(sample, columns)
+        assert result == [2020, 2021, 2022]
+
+    @pytest.mark.contract
+    def test_no_year_values(self):
+        sample = [{"nome": "Mario", "eta": 30}]
+        assert _extract_year_values_from_sample(sample, ["nome", "eta"]) == []
+
+    @pytest.mark.contract
+    def test_nan_values_in_sample(self):
+        sample = [
+            {"Anno": float("nan"), "Regione": "Lombardia", "Valore": 100},
+            {"Anno": 2021.0, "Regione": "Lombardia", "Valore": 110},
+        ]
+        columns = ["Anno", "Regione", "Valore"]
+        result = _extract_year_values_from_sample(sample, columns)
+        assert result == [2021]
+
+
+class TestDownloadPreviewChunk:
+    @pytest.mark.contract
+    def test_download_csv_chunk(self, monkeypatch):
+        """Range GET → bytes + file_size."""
+        from lab_connectors.http import HttpResult
+        from lab_connectors.testing import fake_response
+
+        def fake_get(self, url, **kw):
+            return HttpResult(
+                response=fake_response(
+                    200,
+                    text="a,b,c\n1,2,3\n",
+                    headers={"Content-Type": "text/csv", "Content-Length": "10"},
+                ),
+                err=None,
+            )
+
+        monkeypatch.setattr("lab_connectors.http.HttpClient.get", fake_get)
+
+        content, file_size = _download_preview_chunk("https://example.test/data.csv", "csv")
+        assert content is not None
+        assert file_size == 10
+
+    @pytest.mark.contract
+    def test_download_4xx_returns_none(self, monkeypatch):
+        """Range GET 4xx → None."""
+        from lab_connectors.http import HttpResult
+        from lab_connectors.testing import fake_response
+
+        def fake_get(self, url, **kw):
+            return HttpResult(
+                response=fake_response(404, text="not found"),
+                err=None,
+            )
+
+        monkeypatch.setattr("lab_connectors.http.HttpClient.get", fake_get)
+
+        content, file_size = _download_preview_chunk("https://example.test/missing.csv", "csv")
+        assert content is None
+
+
+pytestmark = pytest.mark.contract

--- a/tests/test_profile_preview.py
+++ b/tests/test_profile_preview.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
-
 import pytest
 
 from toolkit.profile.preview import (
-    _download_preview_chunk,
-    _extract_year_values_from_sample,
+    PreviewResult,
+    extract_year_values_from_sample,
     preview_url,
 )
 
 
-def _mock_probe(monkeypatch, result: dict | None = None):
+def _mock_probe(monkeypatch, result: dict | None = None, error: bool = False):
     """Mock probe_url_headers per non fare HTTP reale."""
     default = {
         "requested_url": "https://example.test/data.csv",
@@ -23,36 +22,46 @@ def _mock_probe(monkeypatch, result: dict | None = None):
         "method": "head",
         "content_length": "500",
     }
-    mock_result = {**default, **(result or {})}
 
-    import toolkit.profile.preview as _preview_mod
+    import toolkit.profile.preview as mod
 
-    monkeypatch.setattr(
-        _preview_mod,
-        "probe_url_headers",
-        lambda url, **kw: mock_result,
-    )
+    if error:
 
+        def _fail(url, **kw):
+            raise RuntimeError("timeout")
 
-def _mock_download(monkeypatch, content: bytes = b"", status: int = 200):
-    """Mock HttpClient.get per non fare HTTP reale."""
-    from lab_connectors.http import HttpResult
-    from lab_connectors.testing import fake_response
-
-    def fake_get(self, url, **kw):
-        return HttpResult(
-            response=fake_response(
-                status,
-                text=content.decode("utf-8", errors="replace"),
-                headers={
-                    "Content-Type": "text/csv",
-                    "Content-Length": str(len(content)),
-                },
-            ),
-            err=None,
+        monkeypatch.setattr(mod, "probe_url_headers", _fail)
+    else:
+        mock_result = {**default, **(result or {})}
+        monkeypatch.setattr(
+            mod,
+            "probe_url_headers",
+            lambda url, **kw: mock_result,
         )
 
-    monkeypatch.setattr("lab_connectors.http.HttpClient.get", fake_get)
+
+def _mock_fetch(monkeypatch, content: bytes = b"", error: bool = False):
+    """Mock fetch_content per non fare HTTP reale."""
+    import toolkit.profile.preview as mod
+
+    if error:
+
+        def _fail(url, **kw):
+            raise RuntimeError("fetch failed")
+
+        monkeypatch.setattr(mod, "fetch_content", _fail)
+    else:
+        monkeypatch.setattr(
+            mod,
+            "fetch_content",
+            lambda url, **kw: {
+                "content": content,
+                "content_type": "text/csv",
+                "status_code": 200,
+                "final_url": url,
+                "method": "range",
+            },
+        )
 
 
 class TestPreviewUrl:
@@ -60,53 +69,42 @@ class TestPreviewUrl:
     def test_csv_preview_produces_columns(self, monkeypatch):
         """Preview CSV: deve restituire colonne e tipi."""
         csv_content = b"col1,col2,col3\n1,2,3\n4,5,6\n7,8,9\n"
-        _mock_probe(monkeypatch, {"status_code": 200, "content_type": "text/csv"})
-        _mock_download(monkeypatch, csv_content)
+        _mock_probe(monkeypatch)
+        _mock_fetch(monkeypatch, csv_content)
 
         result = preview_url("https://example.test/data.csv")
 
-        assert result["reachable"] is True
-        assert result["resource_format"] == "CSV"
-        assert result["columns"] == ["col1", "col2", "col3"]
-        assert isinstance(result["col_types"], dict)
-        assert set(result["col_types"].keys()) == {"col1", "col2", "col3"}
-        assert result["preview_row_count"] == 3
-        assert result["enrich_method"] == "csv_preview"
+        assert result.status == "success"
+        assert result.reachable is True
+        assert result.resource_format == "CSV"
+        assert result.columns == ["col1", "col2", "col3"]
+        assert isinstance(result.col_types, dict)
+        assert set(result.col_types.keys()) == {"col1", "col2", "col3"}
+        assert result.preview_row_count == 3
 
     @pytest.mark.smoke
-    def test_csv_preview_reachable_false_on_probe_fail(self, monkeypatch):
-        """HEAD fallimento → reachable=False."""
-        import toolkit.profile.preview as _preview_mod
-
-        def _fail_probe(url, **kw):
-            raise RuntimeError("timeout")
-
-        monkeypatch.setattr(_preview_mod, "probe_url_headers", _fail_probe)
+    def test_probe_failure_returns_error_status(self, monkeypatch):
+        """HEAD fallimento → status=probe_failed."""
+        _mock_probe(monkeypatch, error=True)
 
         result = preview_url("https://example.test/timeout.csv")
-        assert result["reachable"] is False
-        assert result["enrich_method"] == "probe_failed"
+        assert result.status == "probe_failed"
+        assert result.reachable is False
+
+    @pytest.mark.smoke
+    def test_unsupported_format_returns_error(self, monkeypatch):
+        """Formato non supportato → status=unsupported_format."""
+        _mock_probe(monkeypatch, {"content_type": "application/pdf"})
+
+        result = preview_url("https://example.test/report.pdf")
+        assert result.status == "unsupported_format"
 
     @pytest.mark.smoke
     def test_csv_with_known_params_skips_sniff(self, monkeypatch):
         """known_encoding + known_delim → sniff saltato."""
         csv_content = b"a;b;c\n1;2;3\n"
-        _mock_probe(monkeypatch, {"status_code": 200, "content_type": "text/csv"})
-
-        def _fake_get(self, url, **kw):
-            from lab_connectors.http import HttpResult
-            from lab_connectors.testing import fake_response
-
-            return HttpResult(
-                response=fake_response(
-                    200,
-                    text=csv_content.decode(),
-                    headers={"Content-Type": "text/csv", "Content-Length": str(len(csv_content))},
-                ),
-                err=None,
-            )
-
-        monkeypatch.setattr("lab_connectors.http.HttpClient.get", _fake_get)
+        _mock_probe(monkeypatch, {"content_type": "text/csv"})
+        _mock_fetch(monkeypatch, csv_content)
 
         result = preview_url(
             "https://example.test/data.csv",
@@ -114,36 +112,46 @@ class TestPreviewUrl:
             known_delim=";",
         )
 
-        assert result["columns"] == ["a", "b", "c"]
-        assert result["encoding_suggested"] == "utf-8"
-        assert result["delim_suggested"] == ";"
-        # sniff saltato → decimal e skip rimangono default
-        assert result["skip_suggested"] == 0
+        assert result.columns == ["a", "b", "c"]
+        assert result.encoding_suggested == "utf-8"
+        assert result.delim_suggested == ";"
+        assert result.skip_suggested == 0
 
     @pytest.mark.contract
-    def test_preview_returns_granularity(self, monkeypatch):
+    def test_preview_infers_granularity(self, monkeypatch):
         """Preview deve inferire granularità da nomi colonna."""
         csv_content = b"Comune,Popolazione,Anno\nRoma,1000000,2023\nMilano,500000,2023\n"
-        _mock_probe(monkeypatch, {"status_code": 200, "content_type": "text/csv"})
+        _mock_probe(monkeypatch, {"content_type": "text/csv"})
 
-        def _fake_get(self, url, **kw):
-            from lab_connectors.http import HttpResult
-            from lab_connectors.testing import fake_response
+        def _fake_fetch(url, **kw):
+            return {
+                "content": csv_content,
+                "content_type": "text/csv",
+                "status_code": 200,
+                "final_url": url,
+                "method": "range",
+            }
 
-            return HttpResult(
-                response=fake_response(
-                    200,
-                    text=csv_content.decode(),
-                    headers={"Content-Type": "text/csv", "Content-Length": str(len(csv_content))},
-                ),
-                err=None,
-            )
+        import toolkit.profile.preview as mod
 
-        monkeypatch.setattr("lab_connectors.http.HttpClient.get", _fake_get)
+        monkeypatch.setattr(mod, "fetch_content", _fake_fetch)
 
         result = preview_url("https://example.test/comuni.csv")
-        assert result["granularity"] != "non_determinato"
-        assert result["granularity"] is not None
+        assert result.status == "success"
+        assert result.granularity is not None
+        assert result.granularity != "non_determinato"
+
+    @pytest.mark.regression
+    def test_no_internal_fields_in_result(self, monkeypatch):
+        """PreviewResult non deve contenere campi interni."""
+        csv_content = b"a,b,c\n1,2,3\n"
+        _mock_probe(monkeypatch)
+        _mock_fetch(monkeypatch, csv_content)
+
+        result = preview_url("https://example.test/data.csv")
+        assert isinstance(result, PreviewResult)
+        # Verifica che non ci siano attributi non definiti nel dataclass
+        assert not hasattr(result, "_sample_rows")
 
 
 class TestExtractYearValues:
@@ -155,13 +163,13 @@ class TestExtractYearValues:
             {"Anno": 2022, "Regione": "Lombardia", "Valore": 120},
         ]
         columns = ["Anno", "Regione", "Valore"]
-        result = _extract_year_values_from_sample(sample, columns)
+        result = extract_year_values_from_sample(sample, columns)
         assert result == [2020, 2021, 2022]
 
     @pytest.mark.contract
     def test_no_year_values(self):
         sample = [{"nome": "Mario", "eta": 30}]
-        assert _extract_year_values_from_sample(sample, ["nome", "eta"]) == []
+        assert extract_year_values_from_sample(sample, ["nome", "eta"]) == []
 
     @pytest.mark.contract
     def test_nan_values_in_sample(self):
@@ -170,49 +178,47 @@ class TestExtractYearValues:
             {"Anno": 2021.0, "Regione": "Lombardia", "Valore": 110},
         ]
         columns = ["Anno", "Regione", "Valore"]
-        result = _extract_year_values_from_sample(sample, columns)
+        result = extract_year_values_from_sample(sample, columns)
         assert result == [2021]
 
-
-class TestDownloadPreviewChunk:
-    @pytest.mark.contract
-    def test_download_csv_chunk(self, monkeypatch):
-        """Range GET → bytes + file_size."""
-        from lab_connectors.http import HttpResult
-        from lab_connectors.testing import fake_response
-
-        def fake_get(self, url, **kw):
-            return HttpResult(
-                response=fake_response(
-                    200,
-                    text="a,b,c\n1,2,3\n",
-                    headers={"Content-Type": "text/csv", "Content-Length": "10"},
-                ),
-                err=None,
-            )
-
-        monkeypatch.setattr("lab_connectors.http.HttpClient.get", fake_get)
-
-        content, file_size = _download_preview_chunk("https://example.test/data.csv", "csv")
-        assert content is not None
-        assert file_size == 10
+    @pytest.mark.regression
+    def test_empty_sample(self):
+        assert extract_year_values_from_sample([], ["A"]) == []
 
     @pytest.mark.contract
-    def test_download_4xx_returns_none(self, monkeypatch):
-        """Range GET 4xx → None."""
-        from lab_connectors.http import HttpResult
-        from lab_connectors.testing import fake_response
+    def test_single_year_with_hint_column(self):
+        """Un solo anno in colonna hint deve matchare."""
+        sample = [
+            {"anno": 2020, "valore": 100},
+        ]
+        result = extract_year_values_from_sample(sample, ["anno", "valore"])
+        assert result == [2020]
 
-        def fake_get(self, url, **kw):
-            return HttpResult(
-                response=fake_response(404, text="not found"),
-                err=None,
-            )
 
-        monkeypatch.setattr("lab_connectors.http.HttpClient.get", fake_get)
+class TestPreviewResultDataclass:
+    @pytest.mark.contract
+    def test_default_values(self):
+        """PreviewResult con default deve avere stato probe_failed."""
+        r = PreviewResult(url="https://test.test/", status="probe_failed")
+        assert r.url == "https://test.test/"
+        assert r.status == "probe_failed"
+        assert r.reachable is False
+        assert r.columns is None
+        assert r.granularity == "non_determinato"
+        assert r.skip_suggested == 0
 
-        content, file_size = _download_preview_chunk("https://example.test/missing.csv", "csv")
-        assert content is None
+    @pytest.mark.contract
+    def test_success_has_columns(self):
+        """Success deve poter avere colonne."""
+        r = PreviewResult(
+            url="https://test.test/data.csv",
+            status="success",
+            reachable=True,
+            columns=["a", "b"],
+            col_types={"a": "BIGINT", "b": "VARCHAR"},
+        )
+        assert len(r.columns) == 2
+        assert r.col_types["a"] == "BIGINT"
 
 
 pytestmark = pytest.mark.contract

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -7,7 +7,6 @@ import toolkit.raw as raw_pkg
 from toolkit.clean import run_clean, run_clean_validation, validate_clean
 from toolkit.plugins import CkanSource, HttpFileSource, LocalFileSource, SdmxSource, SparqlSource
 from toolkit.profile import (
-    PreviewResult,
     RawProfile,
     build_suggested_read_cfg,
     profile_excel,

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -7,6 +7,7 @@ import toolkit.raw as raw_pkg
 from toolkit.clean import run_clean, run_clean_validation, validate_clean
 from toolkit.plugins import CkanSource, HttpFileSource, LocalFileSource, SdmxSource, SparqlSource
 from toolkit.profile import (
+    PreviewResult,
     RawProfile,
     build_suggested_read_cfg,
     profile_excel,
@@ -59,8 +60,10 @@ def test_plugins_exports() -> None:
 
 def test_profile_exports() -> None:
     assert profile_pkg.__all__ == [
+        "PreviewResult",
         "RawProfile",
         "build_suggested_read_cfg",
+        "preview_url",
         "profile_excel",
         "profile_raw",
         "profile_with_read_cfg",
@@ -69,6 +72,8 @@ def test_profile_exports() -> None:
         "write_suggested_read_yml",
     ]
     assert RawProfile.__name__ == "RawProfile"
+    assert profile_pkg.PreviewResult.__name__ == "PreviewResult"
+    assert callable(profile_pkg.preview_url)
     assert callable(profile_raw)
     assert callable(profile_with_read_cfg)
     assert callable(profile_excel)

--- a/toolkit/cli/cmd_scout.py
+++ b/toolkit/cli/cmd_scout.py
@@ -801,38 +801,38 @@ def preview(
     known_delim: str | None = typer.Option(None, "--delim", help="Delimiter noto (salta sniff)"),
 ):
     """
-    Preview remoto di un URL dati: scarica un chunk, profila con DuckDB,
+    Preview remoto di un URL CSV/TSV: scarica un chunk, profila con DuckDB,
     e restituisce colonne, tipi, granularità e intervallo anni.
 
-    A differenza di ``toolkit scout`` (che fa probe + routing + scaffold),
-    questo comando fa HEAD + Range GET + sniff + DuckDB profile + infer
-    in un colpo solo. Utile per quality assessment pre-intake.
+    Solo CSV/TSV per ora. Usa ``toolkit scout <URL>`` per probe generico.
     """
+    from dataclasses import asdict
+
     from toolkit.profile.preview import preview_url as _preview_url
 
     result = _preview_url(url, known_encoding=known_encoding, known_delim=known_delim)
 
     if json_output:
-        typer.echo(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+        typer.echo(json.dumps(asdict(result), indent=2, ensure_ascii=False, default=str))
         return
 
     typer.echo(f"URL: {url}")
-    typer.echo(f"  Reachable:       {result.get('reachable')}")
-    typer.echo(f"  HTTP status:     {result.get('http_status')}")
-    typer.echo(f"  File size:       {result.get('file_size')}")
-    typer.echo(f"  Format:          {result.get('resource_format')}")
-    typer.echo(f"  Encoding:        {result.get('encoding_suggested')}")
-    typer.echo(f"  Delimiter:       {result.get('delim_suggested')}")
-    typer.echo(f"  Skip rows:       {result.get('skip_suggested')}")
-    typer.echo(f"  Granularity:     {result.get('granularity')}")
-    typer.echo(f"  Year range:      {result.get('year_min')} - {result.get('year_max')}")
-    typer.echo(f"  Row count:       {result.get('preview_row_count')}")
-    columns = result.get("columns")
-    if columns:
-        typer.echo(f"  Columns ({len(columns)}): {', '.join(str(c) for c in columns[:20])}")
-        if len(columns) > 20:
-            typer.echo(f"    ... and {len(columns) - 20} more")
-    typer.echo(f"  Enrich method:   {result.get('enrich_method')}")
+    typer.echo(f"  Status:          {result.status}")
+    typer.echo(f"  Reachable:       {result.reachable}")
+    typer.echo(f"  HTTP status:     {result.http_status}")
+    typer.echo(f"  File size:       {result.file_size}")
+    typer.echo(f"  Format:          {result.resource_format}")
+    typer.echo(f"  Encoding:        {result.encoding_suggested}")
+    typer.echo(f"  Delimiter:       {result.delim_suggested}")
+    typer.echo(f"  Skip rows:       {result.skip_suggested}")
+    typer.echo(f"  Granularity:     {result.granularity}")
+    typer.echo(f"  Year range:      {result.year_min} - {result.year_max}")
+    typer.echo(f"  Row count:       {result.preview_row_count}")
+    if result.columns:
+        cols = result.columns
+        typer.echo(f"  Columns ({len(cols)}): {', '.join(str(c) for c in cols[:20])}")
+        if len(cols) > 20:
+            typer.echo(f"    ... and {len(cols) - 20} more")
 
 
 def register(app: typer.Typer) -> None:

--- a/toolkit/cli/cmd_scout.py
+++ b/toolkit/cli/cmd_scout.py
@@ -789,5 +789,52 @@ def scout(
         typer.echo(json.dumps(result, indent=2, ensure_ascii=False))
 
 
+# ── preview subcommand ──────────────────────────────────────────────────────
+
+
+def preview(
+    url: str = typer.Argument(..., help="URL del file dati remoto da profilare"),
+    json_output: bool = typer.Option(False, "--json", help="Output in formato JSON"),
+    known_encoding: str | None = typer.Option(
+        None, "--encoding", help="Encoding noto (salta sniff)"
+    ),
+    known_delim: str | None = typer.Option(None, "--delim", help="Delimiter noto (salta sniff)"),
+):
+    """
+    Preview remoto di un URL dati: scarica un chunk, profila con DuckDB,
+    e restituisce colonne, tipi, granularità e intervallo anni.
+
+    A differenza di ``toolkit scout`` (che fa probe + routing + scaffold),
+    questo comando fa HEAD + Range GET + sniff + DuckDB profile + infer
+    in un colpo solo. Utile per quality assessment pre-intake.
+    """
+    from toolkit.profile.preview import preview_url as _preview_url
+
+    result = _preview_url(url, known_encoding=known_encoding, known_delim=known_delim)
+
+    if json_output:
+        typer.echo(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+        return
+
+    typer.echo(f"URL: {url}")
+    typer.echo(f"  Reachable:       {result.get('reachable')}")
+    typer.echo(f"  HTTP status:     {result.get('http_status')}")
+    typer.echo(f"  File size:       {result.get('file_size')}")
+    typer.echo(f"  Format:          {result.get('resource_format')}")
+    typer.echo(f"  Encoding:        {result.get('encoding_suggested')}")
+    typer.echo(f"  Delimiter:       {result.get('delim_suggested')}")
+    typer.echo(f"  Skip rows:       {result.get('skip_suggested')}")
+    typer.echo(f"  Granularity:     {result.get('granularity')}")
+    typer.echo(f"  Year range:      {result.get('year_min')} - {result.get('year_max')}")
+    typer.echo(f"  Row count:       {result.get('preview_row_count')}")
+    columns = result.get("columns")
+    if columns:
+        typer.echo(f"  Columns ({len(columns)}): {', '.join(str(c) for c in columns[:20])}")
+        if len(columns) > 20:
+            typer.echo(f"    ... and {len(columns) - 20} more")
+    typer.echo(f"  Enrich method:   {result.get('enrich_method')}")
+
+
 def register(app: typer.Typer) -> None:
     app.command("scout")(scout)
+    app.command("preview")(preview)

--- a/toolkit/mcp/scout_ops.py
+++ b/toolkit/mcp/scout_ops.py
@@ -51,6 +51,55 @@ def mcp_probe_url_headers(url: str, timeout: int = 15) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Preview URL (HEAD + Range GET + sniff + DuckDB profile + infer)
+# ---------------------------------------------------------------------------
+
+
+def mcp_preview_url(
+    url: str,
+    *,
+    known_encoding: str | None = None,
+    known_delim: str | None = None,
+    known_decimal: str | None = None,
+    known_skip: int | None = None,
+) -> dict[str, Any]:
+    """Preview remoto di un URL dati: reachability, colonne, tipi, anni, granularità.
+
+    Chiama ``toolkit.profile.preview.preview_url()`` che fa HEAD + Range GET
+    + sniff + DuckDB profile + infer in un colpo solo.
+
+    Args:
+        url: URL del file dati remoto.
+        known_encoding: Se già nota, salta sniff encoding.
+        known_delim: Se già noto, salta sniff delim.
+        known_decimal: Se già noto, salta sniff decimal.
+        known_skip: Se già noto, salta sniff skip.
+
+    Returns:
+        Dict con reachable, http_status, file_size, resource_format,
+        encoding_suggested, delim_suggested, decimal_suggested, skip_suggested,
+        columns, col_types, preview_row_count, mapping_suggestions,
+        robust_read_suggested, granularity, year_min, year_max.
+    """
+    from toolkit.profile.preview import preview_url as _preview_url
+
+    try:
+        return _preview_url(
+            url,
+            known_encoding=known_encoding,
+            known_delim=known_delim,
+            known_decimal=known_decimal,
+            known_skip=known_skip,
+        )
+    except Exception as exc:
+        return {
+            "url": url,
+            "reachable": False,
+            "error": f"preview failed: {type(exc).__name__}: {exc}",
+        }
+
+
+# ---------------------------------------------------------------------------
 # Topic inference
 # ---------------------------------------------------------------------------
 

--- a/toolkit/mcp/scout_ops.py
+++ b/toolkit/mcp/scout_ops.py
@@ -63,40 +63,29 @@ def mcp_preview_url(
     known_decimal: str | None = None,
     known_skip: int | None = None,
 ) -> dict[str, Any]:
-    """Preview remoto di un URL dati: reachability, colonne, tipi, anni, granularità.
+    """Preview remoto di un URL CSV/TSV: colonne, tipi, granularità, anni.
 
-    Chiama ``toolkit.profile.preview.preview_url()`` che fa HEAD + Range GET
-    + sniff + DuckDB profile + infer in un colpo solo.
-
-    Args:
-        url: URL del file dati remoto.
-        known_encoding: Se già nota, salta sniff encoding.
-        known_delim: Se già noto, salta sniff delim.
-        known_decimal: Se già noto, salta sniff decimal.
-        known_skip: Se già noto, salta sniff skip.
+    Chiama ``toolkit.profile.preview.preview_url()``: HEAD + Range GET
+    + sniff + DuckDB profile + infer in un colpo solo.  Solo CSV/TSV.
 
     Returns:
-        Dict con reachable, http_status, file_size, resource_format,
+        Dict con status, reachable, http_status, file_size, resource_format,
         encoding_suggested, delim_suggested, decimal_suggested, skip_suggested,
         columns, col_types, preview_row_count, mapping_suggestions,
         robust_read_suggested, granularity, year_min, year_max.
     """
+    from dataclasses import asdict
+
     from toolkit.profile.preview import preview_url as _preview_url
 
-    try:
-        return _preview_url(
-            url,
-            known_encoding=known_encoding,
-            known_delim=known_delim,
-            known_decimal=known_decimal,
-            known_skip=known_skip,
-        )
-    except Exception as exc:
-        return {
-            "url": url,
-            "reachable": False,
-            "error": f"preview failed: {type(exc).__name__}: {exc}",
-        }
+    result = _preview_url(
+        url,
+        known_encoding=known_encoding,
+        known_delim=known_delim,
+        known_decimal=known_decimal,
+        known_skip=known_skip,
+    )
+    return asdict(result)
 
 
 # ---------------------------------------------------------------------------

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -37,6 +37,7 @@ from .toolkit_client import (
     mcp_infer_topic as infer_topic_impl,
     mcp_list_ckan_datasets as list_ckan_datasets_impl,
     mcp_list_sdmx_dataflows as list_sdmx_dataflows_impl,
+    mcp_preview_url as preview_url_impl,
     mcp_probe_url as probe_url_impl,
     mcp_probe_url_routed as probe_url_routed_impl,
     mcp_sparql_query as sparql_query_impl,
@@ -282,6 +283,30 @@ def toolkit_validate_config(config_path: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Scout tools
 # ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description="Preview remoto di un URL dati: reachability, colonne, tipi, anni, granularità. "
+    "FAST: HEAD + Range GET + sniff + DuckDB profile + infer in un colpo solo. "
+    "Rispetto a probe_url, scarica un chunk preview e lo profila con DuckDB.",
+    structured_output=True,
+)
+def toolkit_preview_url(
+    url: str,
+    known_encoding: str | None = None,
+    known_delim: str | None = None,
+    known_decimal: str | None = None,
+    known_skip: int | None = None,
+) -> dict[str, Any]:
+    return guard_timed(
+        preview_url_impl,
+        "toolkit_preview_url",
+        url,
+        known_encoding=known_encoding,
+        known_delim=known_delim,
+        known_decimal=known_decimal,
+        known_skip=known_skip,
+    )
 
 
 @mcp.tool(

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -286,9 +286,9 @@ def toolkit_validate_config(config_path: str) -> dict[str, Any]:
 
 
 @mcp.tool(
-    description="Preview remoto di un URL dati: reachability, colonne, tipi, anni, granularità. "
-    "FAST: HEAD + Range GET + sniff + DuckDB profile + infer in un colpo solo. "
-    "Rispetto a probe_url, scarica un chunk preview e lo profila con DuckDB.",
+    description="Preview remoto di un URL CSV/TSV: colonne, tipi, granularità, anni. "
+    "HEAD + Range GET + sniff + DuckDB profile + infer in un colpo solo. "
+    "Solo CSV/TSV. Usa toolkit_probe_url per probe generico.",
     structured_output=True,
 )
 def toolkit_preview_url(

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -44,6 +44,7 @@ from toolkit.mcp.scout_ops import (
     mcp_infer_topic,
     mcp_list_ckan_datasets,
     mcp_list_sdmx_dataflows,
+    mcp_preview_url,
     mcp_probe_url,
     mcp_probe_url_routed,
     mcp_sparql_query,

--- a/toolkit/profile/__init__.py
+++ b/toolkit/profile/__init__.py
@@ -1,5 +1,6 @@
-"""Public profiling API for RAW diagnostics."""
+"""Public profiling API for RAW diagnostics and remote URL preview."""
 
+from toolkit.profile.preview import preview_url
 from toolkit.profile.raw import (
     RawProfile,
     build_suggested_read_cfg,
@@ -14,6 +15,7 @@ from toolkit.profile.raw import (
 __all__ = [
     "RawProfile",
     "build_suggested_read_cfg",
+    "preview_url",
     "profile_excel",
     "profile_raw",
     "profile_with_read_cfg",

--- a/toolkit/profile/__init__.py
+++ b/toolkit/profile/__init__.py
@@ -1,6 +1,6 @@
 """Public profiling API for RAW diagnostics and remote URL preview."""
 
-from toolkit.profile.preview import preview_url
+from toolkit.profile.preview import PreviewResult, preview_url
 from toolkit.profile.raw import (
     RawProfile,
     build_suggested_read_cfg,
@@ -13,6 +13,7 @@ from toolkit.profile.raw import (
 )
 
 __all__ = [
+    "PreviewResult",
     "RawProfile",
     "build_suggested_read_cfg",
     "preview_url",

--- a/toolkit/profile/preview.py
+++ b/toolkit/profile/preview.py
@@ -94,9 +94,7 @@ def _extract_years_from_columns(columns: list[str]) -> tuple[int | None, int | N
     return (min(vals), max(vals)) if vals else (None, None)
 
 
-def extract_year_values_from_sample(
-    sample: list[dict], columns: list[str]
-) -> list[int]:
+def extract_year_values_from_sample(sample: list[dict], columns: list[str]) -> list[int]:
     """Estrae anni da sample rows (valori 1900-2100 in colonne numeriche)."""
     if not sample:
         return []
@@ -191,14 +189,17 @@ def preview_url(
             fetched = fetch_content(url, client=client, max_bytes=1024 * 1024)
         except RuntimeError:
             return PreviewResult(
-                url=url, status="download_failed", reachable=reachable,
-                http_status=http_status, resource_format=fmt.upper(),
+                url=url,
+                status="download_failed",
+                reachable=reachable,
+                http_status=http_status,
+                resource_format=fmt.upper(),
             )
 
         content: bytes = fetched["content"]
-        content_file_size = len(content)
-
-        # Content-Length incerto su Range — usiamo la lunghezza reale
+        # Content-Length da fetch_content: su 206 con Content-Range e' la
+        # dimensione reale del file; altrimenti la lunghezza del chunk.
+        content_file_size = fetched.get("content_length") or len(content)
         if not file_size:
             file_size = content_file_size
 
@@ -248,11 +249,16 @@ def preview_url(
             except Exception as exc:
                 logger.warning("DuckDB profile failed for %s: %s", url, exc)
                 return PreviewResult(
-                    url=url, status="profile_failed", reachable=reachable,
-                    http_status=http_status, file_size=file_size,
+                    url=url,
+                    status="profile_failed",
+                    reachable=reachable,
+                    http_status=http_status,
+                    file_size=file_size,
                     resource_format=fmt.upper(),
-                    encoding_suggested=enc, delim_suggested=delim,
-                    decimal_suggested=dec, skip_suggested=skip,
+                    encoding_suggested=enc,
+                    delim_suggested=delim,
+                    decimal_suggested=dec,
+                    skip_suggested=skip,
                 )
 
             columns_raw = profile.get("columns_raw", [])
@@ -265,9 +271,9 @@ def preview_url(
             robust_read_suggested = profile.get("robust_read_suggested", False)
 
             # ── 6. Infer ─────────────────────────────────────────────────────
-            combined = " ".join(
-                c.lower().replace("_", " ") for c in columns_raw
-            ) if columns_raw else ""
+            combined = (
+                " ".join(c.lower().replace("_", " ") for c in columns_raw) if columns_raw else ""
+            )
             granularity = infer_granularity(combined)
 
             year_min, year_max = _extract_years_from_columns(columns_raw)

--- a/toolkit/profile/preview.py
+++ b/toolkit/profile/preview.py
@@ -1,0 +1,481 @@
+"""Preview remoto di URL dati: HEAD → Range GET → sniff → profile → infer.
+
+Centralizza la logica che oggi è divisa tra SO (``source_check_fetch.py``:
+``_fetch_data_preview``, ``_profile_downloaded_*``, ``_download_preview_content``,
+``_extract_year_values_from_sample``, ``_infer_granularity_from_columns``) e
+toolkit (``sniff_source_file``, ``profile_with_read_cfg``, ``profile_excel``).
+
+Una chiamata restituisce tutto quello che serve a SO per l'enrichment e a DI
+per la valutazione pre-intake.
+
+Usage::
+
+    from toolkit.profile.preview import preview_url
+
+    result = preview_url("https://example.com/dati.csv")
+    print(result["columns"], result["granularity"], result["year_min"])
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from lab_connectors.http import CircuitOpenError, HttpClient
+
+from toolkit.profile.raw import (
+    profile_excel,
+    profile_with_read_cfg,
+    sniff_source_file,
+)
+from toolkit.scout.http import probe_url_headers, resolve_preview_kind
+from toolkit.scout.infer import infer_granularity
+
+logger = logging.getLogger("toolkit.profile.preview")
+
+# ── Costanti ──────────────────────────────────────────────────────────────────
+
+_PREVIEW_FORMATS = frozenset({"csv", "tsv", "json", "xlsx", "xls"})
+_RANGE_LIMIT: dict[str, int] = {
+    "csv": 1024 * 1024,  # 1 MB
+    "tsv": 1024 * 1024,
+    "json": 1024 * 1024,
+    "xlsx": 5 * 1024 * 1024,  # 5 MB
+    "xls": 5 * 1024 * 1024,
+}
+_SAMPLE_SIZE: dict[str, int] = {
+    "csv": 100 * 1024,
+    "tsv": 100 * 1024,
+    # JSON non viene campionato — la struttura deve essere integra per il parse.
+    # La Range request limita già a _RANGE_LIMIT["json"] = 1MB.
+}
+_YEAR_COLUMN_HINTS = frozenset(
+    {"anno", "year", "data", "date", "periodo", "period", "mese", "month"}
+)
+_YEAR_RE = re.compile(r"(?<!\d)(19\d{2}|20[012]\d)(?!\d)")
+
+
+# ── Preview orchestrator ──────────────────────────────────────────────────────
+
+
+def preview_url(
+    url: str,
+    client: HttpClient | None = None,
+    *,
+    known_encoding: str | None = None,
+    known_delim: str | None = None,
+    known_decimal: str | None = None,
+    known_skip: int | None = None,
+) -> dict[str, Any]:
+    """Preview remoto di un URL dati.
+
+    Esegue in sequenza:
+    1. HEAD probe → reachability, content-type, content-length
+    2. Risoluzione formato (CSV, JSON, XLSX, TSV)
+    3. Range GET → download chunk preview
+    4. Sniff (encoding, delim, decimal, skip) se formato testo
+    5. DuckDB profile (colonne, tipi, sample, mapping)
+    6. Infer granularità e anni da colonne/sample
+
+    Args:
+        url: URL del file dati remoto.
+        client: HttpClient opzionale (con circuit breaker).
+        known_encoding: Se già nota da inventory, salta sniff encoding.
+        known_delim: Se già noto, salta sniff delim.
+        known_decimal: Se già noto, salta sniff decimal.
+        known_skip: Se già noto, salta sniff skip.
+
+    Returns:
+        dict con chiavi:
+            - reachable, http_status, file_size, resource_format
+            - encoding_suggested, delim_suggested, decimal_suggested, skip_suggested
+            - columns, col_types, preview_row_count
+            - mapping_suggestions, robust_read_suggested
+            - granularity, year_min, year_max
+            - enrich_method (sempre ``"csv_preview"`` in caso di successo)
+    """
+    result: dict[str, Any] = {
+        "reachable": False,
+        "http_status": None,
+        "file_size": None,
+        "resource_format": None,
+        "encoding_suggested": None,
+        "delim_suggested": None,
+        "decimal_suggested": None,
+        "skip_suggested": 0,
+        "columns": None,
+        "col_types": None,
+        "preview_row_count": None,
+        "mapping_suggestions": None,
+        "robust_read_suggested": False,
+        "granularity": "non_determinato",
+        "year_min": None,
+        "year_max": None,
+        "enrich_method": None,
+    }
+
+    # ── 1. HEAD probe ────────────────────────────────────────────────────────
+    try:
+        probe = probe_url_headers(url, client=client)
+    except (RuntimeError, CircuitOpenError) as exc:
+        result["enrich_method"] = "probe_failed"
+        result["reachable"] = False
+        result["check_notes"] = str(exc)
+        return result
+
+    result["reachable"] = probe.get("status_code", 0) < 400
+    result["http_status"] = probe.get("status_code")
+    result["file_size"] = _parse_file_size(probe)
+
+    # ── 2. Risoluzione formato ───────────────────────────────────────────────
+    fmt = resolve_preview_kind(
+        url,
+        content_type=probe.get("content_type"),
+        content_disposition=probe.get("content_disposition"),
+    )
+    if fmt is None:
+        # Formato non supportato per preview
+        # Tentiamo comunque un HEAD per registrare il content-type come formato
+        ct = probe.get("content_type", "")
+        if ct:
+            fmt = ct.split(";")[0].strip()
+        result["resource_format"] = fmt
+        result["enrich_method"] = "unsupported_format"
+        return result
+
+    result["resource_format"] = fmt
+    fmt_lower = fmt.lower()
+
+    if fmt_lower not in _PREVIEW_FORMATS:
+        result["enrich_method"] = "unsupported_format"
+        return result
+
+    # ── 3. Range GET download chunk ──────────────────────────────────────────
+    content, file_size = _download_preview_chunk(url, fmt_lower, client)
+    if content is None:
+        result["enrich_method"] = "download_failed"
+        return result
+
+    # Aggiorna file_size se HEAD non l'aveva dato
+    if file_size and not result.get("file_size"):
+        result["file_size"] = file_size
+
+    # ── 4. Sniff + profile per formato ───────────────────────────────────────
+    with tempfile.NamedTemporaryFile(suffix=f".{fmt_lower}", delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = Path(tmp.name)
+
+    try:
+        if fmt_lower in ("csv", "tsv"):
+            _profile_csv(
+                tmp_path, result, fmt_lower, known_encoding, known_delim, known_decimal, known_skip
+            )
+        elif fmt_lower in ("xlsx", "xls"):
+            _profile_excel(tmp_path, result)
+        elif fmt_lower == "json":
+            _profile_json(content, result)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    # ── 6. Infer granularità e anni ─────────────────────────────────────────
+    columns = result.get("columns")
+    if isinstance(columns, str):
+        try:
+            columns_list = json.loads(columns)
+        except (json.JSONDecodeError, TypeError):
+            columns_list = []
+    elif isinstance(columns, list):
+        columns_list = columns
+    else:
+        columns_list = []
+
+    if columns_list:
+        _infer_granularity_from_columns(columns_list, result)
+        _infer_years_from_columns(columns_list, result)
+
+    # Infer years from sample rows if still not determined
+    if result["year_min"] is None and result.get("preview_row_count"):
+        sample = result.get("_sample_rows", [])
+        if sample:
+            year_vals = _extract_year_values_from_sample(sample, columns_list)
+            if year_vals:
+                result["year_min"] = min(year_vals)
+                result["year_max"] = max(year_vals)
+
+    result["enrich_method"] = "csv_preview"
+    return result
+
+
+# ── Step interni ──────────────────────────────────────────────────────────────
+
+
+def _parse_file_size(probe: dict) -> int | None:
+    """Estrai file_size dal probe result."""
+    # Tentativo da Content-Length via headers raw
+    ct_len = probe.get("content_length")
+    if ct_len:
+        try:
+            return int(ct_len)
+        except (ValueError, TypeError):
+            pass
+    return None
+
+
+def _download_preview_chunk(
+    url: str, fmt: str, client: HttpClient | None = None
+) -> tuple[bytes | None, int | None]:
+    """Scarica un chunk preview del file remoto."""
+    range_limit = _RANGE_LIMIT.get(fmt, 1024 * 1024)
+    sample_size = _SAMPLE_SIZE.get(fmt)
+
+    if client is None:
+        client = HttpClient(timeout=(5, 10))
+
+    fetch_result = client.get(url, headers={"Range": f"bytes=0-{range_limit - 1}"})
+    if fetch_result is None or not fetch_result.is_ok or fetch_result.response is None:
+        return None, None
+    if fetch_result.response.status_code >= 400:
+        return None, None
+
+    content = fetch_result.response.content
+    if sample_size is not None:
+        content = content[:sample_size]
+    elif len(content) > range_limit:
+        return None, None  # troppo grande
+
+    try:
+        file_size = int(fetch_result.response.headers.get("Content-Length", "0"))
+    except (ValueError, TypeError):
+        file_size = 0
+    if file_size <= 0:
+        file_size = len(content)
+
+    return content, file_size
+
+
+def _profile_csv(
+    tmp_path: Path,
+    result: dict[str, Any],
+    fmt: str,
+    known_encoding: str | None,
+    known_delim: str | None,
+    known_decimal: str | None,
+    known_skip: int | None,
+) -> None:
+    """Sniff + profile per CSV/TSV."""
+    if known_encoding and known_delim:
+        # Salta sniff — usa parametri noti dall'inventory
+        sniff: dict[str, Any] = {
+            "encoding_suggested": known_encoding,
+            "delim_suggested": known_delim,
+            "decimal_suggested": known_decimal,
+            "skip_suggested": known_skip or 0,
+            "header_line": None,
+            "true_header_line": None,
+            "warnings": [],
+            "is_binary_file": None,
+            "file_used": tmp_path.name,
+        }
+    else:
+        sniff = sniff_source_file(tmp_path)
+
+    result["encoding_suggested"] = sniff.get("encoding_suggested")
+    result["delim_suggested"] = sniff.get("delim_suggested")
+    result["decimal_suggested"] = sniff.get("decimal_suggested")
+    result["skip_suggested"] = sniff.get("skip_suggested", 0)
+
+    enc = sniff["encoding_suggested"]
+    delim = sniff["delim_suggested"]
+    dec = sniff["decimal_suggested"]
+    skip = sniff["skip_suggested"]
+
+    effective_read_cfg: dict[str, Any] = {}
+    if delim:
+        effective_read_cfg["delim"] = delim
+    if enc:
+        effective_read_cfg["encoding"] = enc
+    if dec:
+        effective_read_cfg["decimal"] = dec
+    if skip:
+        effective_read_cfg["skip"] = skip
+    effective_read_cfg.setdefault("header", True)
+
+    try:
+        profile = profile_with_read_cfg(tmp_path, sniff, effective_read_cfg)
+    except Exception as exc:
+        logger.warning("DuckDB profile failed for %s: %s", tmp_path, exc)
+        profile = {
+            "columns_raw": [],
+            "duckdb_types": [],
+            "sample_rows": [],
+            "mapping_suggestions": {},
+            "robust_read_suggested": True,
+            "warnings": [f"profile_failed: {exc}"],
+        }
+
+    columns_raw = profile.get("columns_raw", [])
+    duckdb_types = profile.get("duckdb_types", [])
+    sample_rows = profile.get("sample_rows", [])
+
+    result["columns"] = columns_raw
+    result["col_types"] = dict(zip(columns_raw, duckdb_types)) if columns_raw else {}
+    result["preview_row_count"] = len(sample_rows) if sample_rows else None
+    result["mapping_suggestions"] = profile.get("mapping_suggestions", {})
+    result["robust_read_suggested"] = profile.get("robust_read_suggested", False)
+    result["_sample_rows"] = sample_rows  # per infer anni
+
+
+def _profile_excel(tmp_path: Path, result: dict[str, Any]) -> None:
+    """Profile per Excel, con fallback CSV/TSV per file .xls mascherati."""
+    try:
+        profile = profile_excel(tmp_path)
+    except Exception as exc:
+        logger.warning("Excel profile failed: %s", exc)
+        profile = {"columns_raw": [], "sample_rows": [], "robust_read_suggested": True}
+
+    columns_raw = profile.get("columns_raw", [])
+
+    # Fallback: .xls falso (es. TSV con estensione .xls) → prova come CSV
+    if not columns_raw:
+        try:
+            sniff = sniff_source_file(tmp_path)
+            enc = sniff.get("encoding_suggested") or "utf-8"
+            delim = sniff.get("delim_suggested") or "\t"
+            read_cfg = {
+                "encoding": enc,
+                "delim": delim,
+                "header": True,
+                "skip": sniff.get("skip_suggested", 0),
+            }
+            csv_profile = profile_with_read_cfg(tmp_path, sniff, read_cfg)
+            columns_raw = csv_profile.get("columns_raw", [])
+            sample_rows = csv_profile.get("sample_rows", [])
+            result["columns"] = columns_raw
+            result["col_types"] = (
+                dict(zip(columns_raw, csv_profile.get("duckdb_types", []))) if columns_raw else {}
+            )
+            result["preview_row_count"] = len(sample_rows) if sample_rows else None
+            result["robust_read_suggested"] = csv_profile.get("robust_read_suggested", False)
+            result["_sample_rows"] = sample_rows
+            return
+        except Exception as exc:
+            logger.warning("Excel CSV fallback failed: %s", exc)
+
+    sample_rows = profile.get("sample_rows", [])
+    result["columns"] = columns_raw
+    result["col_types"] = {}
+    result["preview_row_count"] = len(sample_rows) if sample_rows else None
+    result["robust_read_suggested"] = profile.get("robust_read_suggested", False)
+    result["_sample_rows"] = sample_rows
+
+
+def _profile_json(content: bytes, result: dict[str, Any]) -> None:
+    """Profile per JSON (inline, nessuna dipendenza DuckDB)."""
+    try:
+        data = json.loads(content.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        result["enrich_method"] = "json_decode_failed"
+        return
+
+    if isinstance(data, dict):
+        columns = list(data.keys())
+        sample_rows = [data]
+    elif isinstance(data, list):
+        if data and isinstance(data[0], dict):
+            columns = list(data[0].keys())
+            sample_rows = data
+        elif data:
+            columns = []
+            sample_rows = data[:50]
+        else:
+            columns = []
+            sample_rows = []
+    else:
+        columns = []
+        sample_rows = []
+
+    result["columns"] = columns
+    result["col_types"] = (
+        {
+            col: type(data[0][col]).__name__
+            if data and isinstance(data, list) and data
+            else type(data[col]).__name__
+            if isinstance(data, dict)
+            else "unknown"
+            for col in columns
+        }
+        if columns
+        else {}
+    )
+    result["preview_row_count"] = len(sample_rows) if isinstance(data, list) else None
+    result["robust_read_suggested"] = False
+    result["mapping_suggestions"] = {}
+    result["_sample_rows"] = sample_rows
+
+
+# ── Infer helpers ─────────────────────────────────────────────────────────────
+
+
+def _infer_granularity_from_columns(columns: list[str], result: dict[str, Any]) -> None:
+    """Inferisci granularità territoriale dai nomi colonna.
+
+    Sostituisce underscore con spazi per garantire il match delle word
+    boundary (es. ``denominazione_comune`` → matcha ``comune``).
+    """
+    combined = " ".join(c.lower().replace("_", " ") for c in columns)
+    result["granularity"] = infer_granularity(combined)
+
+
+def _infer_years_from_columns(columns: list[str], result: dict[str, Any]) -> None:
+    """Inferisci anni da nomi colonna (anno, year, ...)."""
+    year_vals: set[int] = set()
+    for col in columns:
+        m = _YEAR_RE.search(col)
+        if m:
+            year_vals.add(int(m.group(1)))
+    # Cerca anche colonne hint
+    for col in columns:
+        if col.lower() in _YEAR_COLUMN_HINTS:
+            # Non possiamo estrarre anni dal nome colonna alone,
+            # ma è un segnale — li inferiamo dai sample rows
+            pass
+    if year_vals:
+        result["year_min"] = min(year_vals)
+        result["year_max"] = max(year_vals)
+
+
+def _extract_year_values_from_sample(sample: list[dict], columns: list[str]) -> list[int]:
+    """Extract year values from sample rows.
+
+    Prima prova colonne numeriche con almeno 2 valori in 1900-2100,
+    poi colonne con nome hint (``anno``, ``year``, ...).
+    """
+
+    def _safe_ints(vals: list) -> list[int]:
+        return [int(v) for v in vals if not (isinstance(v, float) and math.isnan(v))]
+
+    year_values: list[int] = []
+    if not sample:
+        return year_values
+
+    # Strategy 1: colonne numeriche con 2+ valori nel range anni
+    for col in columns:
+        vals = [r.get(col) for r in sample if isinstance(r.get(col), (int, float))]
+        if vals:
+            y_vals = [v for v in _safe_ints(vals) if 1900 <= v <= 2100]
+            if len(y_vals) >= 2:
+                return y_vals
+
+    # Strategy 2: colonne con nome hint
+    for col in columns:
+        if col.lower() in _YEAR_COLUMN_HINTS:
+            vals = [r.get(col) for r in sample if isinstance(r.get(col), (int, float))]
+            if vals:
+                return _safe_ints(vals)
+
+    return year_values

--- a/toolkit/profile/preview.py
+++ b/toolkit/profile/preview.py
@@ -1,469 +1,110 @@
-"""Preview remoto di URL dati: HEAD → Range GET → sniff → profile → infer.
+"""Preview remoto di URL CSV/TSV: HEAD → Range GET → sniff → DuckDB profile → infer.
 
-Centralizza la logica che oggi è divisa tra SO (``source_check_fetch.py``:
-``_fetch_data_preview``, ``_profile_downloaded_*``, ``_download_preview_content``,
-``_extract_year_values_from_sample``, ``_infer_granularity_from_columns``) e
-toolkit (``sniff_source_file``, ``profile_with_read_cfg``, ``profile_excel``).
-
-Una chiamata restituisce tutto quello che serve a SO per l'enrichment e a DI
-per la valutazione pre-intake.
+Centralizza la logica che era divisa tra SO (``_fetch_data_preview``,
+``_profile_downloaded_csv``) e toolkit (``sniff_source_file``,
+``profile_with_read_cfg``).  Una chiamata restituisce tutto quello che serve
+a SO per l'enrichment pre-intake.
 
 Usage::
 
     from toolkit.profile.preview import preview_url
 
     result = preview_url("https://example.com/dati.csv")
-    print(result["columns"], result["granularity"], result["year_min"])
+    print(result.columns, result.granularity, result.year_min)
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import math
 import re
 import tempfile
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
-from lab_connectors.http import CircuitOpenError, HttpClient
+from lab_connectors.http import HttpClient
 
-from toolkit.profile.raw import (
-    profile_excel,
-    profile_with_read_cfg,
-    sniff_source_file,
-)
-from toolkit.scout.http import probe_url_headers, resolve_preview_kind
+from toolkit.profile.raw import profile_with_read_cfg, sniff_source_file
+from toolkit.scout.http import fetch_content, probe_url_headers, resolve_preview_kind
 from toolkit.scout.infer import infer_granularity
 
 logger = logging.getLogger("toolkit.profile.preview")
 
-# ── Costanti ──────────────────────────────────────────────────────────────────
+# ── Public result type ────────────────────────────────────────────────────────
 
-_PREVIEW_FORMATS = frozenset({"csv", "tsv", "json", "xlsx", "xls"})
-_RANGE_LIMIT: dict[str, int] = {
-    "csv": 1024 * 1024,  # 1 MB
-    "tsv": 1024 * 1024,
-    "json": 1024 * 1024,
-    "xlsx": 5 * 1024 * 1024,  # 5 MB
-    "xls": 5 * 1024 * 1024,
-}
-_SAMPLE_SIZE: dict[str, int] = {
-    "csv": 100 * 1024,
-    "tsv": 100 * 1024,
-    # JSON non viene campionato — la struttura deve essere integra per il parse.
-    # La Range request limita già a _RANGE_LIMIT["json"] = 1MB.
-}
+PreviewStatus = Literal[
+    "success",
+    "probe_failed",
+    "unsupported_format",
+    "download_failed",
+    "profile_failed",
+]
+
+
+@dataclass
+class PreviewResult:
+    """Risultato strutturato di ``preview_url``.
+
+    Solo CSV/TSV per ora — JSON ed Excel hanno casi limite che richiedono
+    orchestrazione diversa.
+    """
+
+    url: str
+    status: PreviewStatus = "success"
+    reachable: bool = False
+    http_status: int | None = None
+    file_size: int | None = None
+    resource_format: str | None = None
+
+    # Sniff
+    encoding_suggested: str | None = None
+    delim_suggested: str | None = None
+    decimal_suggested: str | None = None
+    skip_suggested: int = 0
+
+    # Profile
+    columns: list[str] | None = None
+    col_types: dict[str, str] | None = None
+    preview_row_count: int | None = None
+    robust_read_suggested: bool = False
+    mapping_suggestions: dict[str, Any] = field(default_factory=dict)
+
+    # Infer
+    granularity: str = "non_determinato"
+    year_min: int | None = None
+    year_max: int | None = None
+
+
+# ── Year extraction helpers ───────────────────────────────────────────────────
+
+_YEAR_RE = re.compile(r"(?<!\d)(19\d{2}|20[012]\d)(?!\d)")
 _YEAR_COLUMN_HINTS = frozenset(
     {"anno", "year", "data", "date", "periodo", "period", "mese", "month"}
 )
-_YEAR_RE = re.compile(r"(?<!\d)(19\d{2}|20[012]\d)(?!\d)")
 
 
-# ── Preview orchestrator ──────────────────────────────────────────────────────
-
-
-def preview_url(
-    url: str,
-    client: HttpClient | None = None,
-    *,
-    known_encoding: str | None = None,
-    known_delim: str | None = None,
-    known_decimal: str | None = None,
-    known_skip: int | None = None,
-) -> dict[str, Any]:
-    """Preview remoto di un URL dati.
-
-    Esegue in sequenza:
-    1. HEAD probe → reachability, content-type, content-length
-    2. Risoluzione formato (CSV, JSON, XLSX, TSV)
-    3. Range GET → download chunk preview
-    4. Sniff (encoding, delim, decimal, skip) se formato testo
-    5. DuckDB profile (colonne, tipi, sample, mapping)
-    6. Infer granularità e anni da colonne/sample
-
-    Args:
-        url: URL del file dati remoto.
-        client: HttpClient opzionale (con circuit breaker).
-        known_encoding: Se già nota da inventory, salta sniff encoding.
-        known_delim: Se già noto, salta sniff delim.
-        known_decimal: Se già noto, salta sniff decimal.
-        known_skip: Se già noto, salta sniff skip.
-
-    Returns:
-        dict con chiavi:
-            - reachable, http_status, file_size, resource_format
-            - encoding_suggested, delim_suggested, decimal_suggested, skip_suggested
-            - columns, col_types, preview_row_count
-            - mapping_suggestions, robust_read_suggested
-            - granularity, year_min, year_max
-            - enrich_method (sempre ``"csv_preview"`` in caso di successo)
-    """
-    result: dict[str, Any] = {
-        "reachable": False,
-        "http_status": None,
-        "file_size": None,
-        "resource_format": None,
-        "encoding_suggested": None,
-        "delim_suggested": None,
-        "decimal_suggested": None,
-        "skip_suggested": 0,
-        "columns": None,
-        "col_types": None,
-        "preview_row_count": None,
-        "mapping_suggestions": None,
-        "robust_read_suggested": False,
-        "granularity": "non_determinato",
-        "year_min": None,
-        "year_max": None,
-        "enrich_method": None,
-    }
-
-    # ── 1. HEAD probe ────────────────────────────────────────────────────────
-    try:
-        probe = probe_url_headers(url, client=client)
-    except (RuntimeError, CircuitOpenError) as exc:
-        result["enrich_method"] = "probe_failed"
-        result["reachable"] = False
-        result["check_notes"] = str(exc)
-        return result
-
-    result["reachable"] = probe.get("status_code", 0) < 400
-    result["http_status"] = probe.get("status_code")
-    result["file_size"] = _parse_file_size(probe)
-
-    # ── 2. Risoluzione formato ───────────────────────────────────────────────
-    fmt = resolve_preview_kind(
-        url,
-        content_type=probe.get("content_type"),
-        content_disposition=probe.get("content_disposition"),
-    )
-    if fmt is None:
-        # Formato non supportato per preview
-        # Tentiamo comunque un HEAD per registrare il content-type come formato
-        ct = probe.get("content_type", "")
-        if ct:
-            fmt = ct.split(";")[0].strip()
-        result["resource_format"] = fmt
-        result["enrich_method"] = "unsupported_format"
-        return result
-
-    result["resource_format"] = fmt
-    fmt_lower = fmt.lower()
-
-    if fmt_lower not in _PREVIEW_FORMATS:
-        result["enrich_method"] = "unsupported_format"
-        return result
-
-    # ── 3. Range GET download chunk ──────────────────────────────────────────
-    content, file_size = _download_preview_chunk(url, fmt_lower, client)
-    if content is None:
-        result["enrich_method"] = "download_failed"
-        return result
-
-    # Aggiorna file_size se HEAD non l'aveva dato
-    if file_size and not result.get("file_size"):
-        result["file_size"] = file_size
-
-    # ── 4. Sniff + profile per formato ───────────────────────────────────────
-    with tempfile.NamedTemporaryFile(suffix=f".{fmt_lower}", delete=False) as tmp:
-        tmp.write(content)
-        tmp_path = Path(tmp.name)
-
-    try:
-        if fmt_lower in ("csv", "tsv"):
-            _profile_csv(
-                tmp_path, result, fmt_lower, known_encoding, known_delim, known_decimal, known_skip
-            )
-        elif fmt_lower in ("xlsx", "xls"):
-            _profile_excel(tmp_path, result)
-        elif fmt_lower == "json":
-            _profile_json(content, result)
-    finally:
-        tmp_path.unlink(missing_ok=True)
-
-    # ── 6. Infer granularità e anni ─────────────────────────────────────────
-    columns = result.get("columns")
-    if isinstance(columns, str):
-        try:
-            columns_list = json.loads(columns)
-        except (json.JSONDecodeError, TypeError):
-            columns_list = []
-    elif isinstance(columns, list):
-        columns_list = columns
-    else:
-        columns_list = []
-
-    if columns_list:
-        _infer_granularity_from_columns(columns_list, result)
-        _infer_years_from_columns(columns_list, result)
-
-    # Infer years from sample rows if still not determined
-    if result["year_min"] is None and result.get("preview_row_count"):
-        sample = result.get("_sample_rows", [])
-        if sample:
-            year_vals = _extract_year_values_from_sample(sample, columns_list)
-            if year_vals:
-                result["year_min"] = min(year_vals)
-                result["year_max"] = max(year_vals)
-
-    result["enrich_method"] = "csv_preview"
-    return result
-
-
-# ── Step interni ──────────────────────────────────────────────────────────────
-
-
-def _parse_file_size(probe: dict) -> int | None:
-    """Estrai file_size dal probe result."""
-    # Tentativo da Content-Length via headers raw
-    ct_len = probe.get("content_length")
-    if ct_len:
-        try:
-            return int(ct_len)
-        except (ValueError, TypeError):
-            pass
-    return None
-
-
-def _download_preview_chunk(
-    url: str, fmt: str, client: HttpClient | None = None
-) -> tuple[bytes | None, int | None]:
-    """Scarica un chunk preview del file remoto."""
-    range_limit = _RANGE_LIMIT.get(fmt, 1024 * 1024)
-    sample_size = _SAMPLE_SIZE.get(fmt)
-
-    if client is None:
-        client = HttpClient(timeout=(5, 10))
-
-    fetch_result = client.get(url, headers={"Range": f"bytes=0-{range_limit - 1}"})
-    if fetch_result is None or not fetch_result.is_ok or fetch_result.response is None:
-        return None, None
-    if fetch_result.response.status_code >= 400:
-        return None, None
-
-    content = fetch_result.response.content
-    if sample_size is not None:
-        content = content[:sample_size]
-    elif len(content) > range_limit:
-        return None, None  # troppo grande
-
-    try:
-        file_size = int(fetch_result.response.headers.get("Content-Length", "0"))
-    except (ValueError, TypeError):
-        file_size = 0
-    if file_size <= 0:
-        file_size = len(content)
-
-    return content, file_size
-
-
-def _profile_csv(
-    tmp_path: Path,
-    result: dict[str, Any],
-    fmt: str,
-    known_encoding: str | None,
-    known_delim: str | None,
-    known_decimal: str | None,
-    known_skip: int | None,
-) -> None:
-    """Sniff + profile per CSV/TSV."""
-    if known_encoding and known_delim:
-        # Salta sniff — usa parametri noti dall'inventory
-        sniff: dict[str, Any] = {
-            "encoding_suggested": known_encoding,
-            "delim_suggested": known_delim,
-            "decimal_suggested": known_decimal,
-            "skip_suggested": known_skip or 0,
-            "header_line": None,
-            "true_header_line": None,
-            "warnings": [],
-            "is_binary_file": None,
-            "file_used": tmp_path.name,
-        }
-    else:
-        sniff = sniff_source_file(tmp_path)
-
-    result["encoding_suggested"] = sniff.get("encoding_suggested")
-    result["delim_suggested"] = sniff.get("delim_suggested")
-    result["decimal_suggested"] = sniff.get("decimal_suggested")
-    result["skip_suggested"] = sniff.get("skip_suggested", 0)
-
-    enc = sniff["encoding_suggested"]
-    delim = sniff["delim_suggested"]
-    dec = sniff["decimal_suggested"]
-    skip = sniff["skip_suggested"]
-
-    effective_read_cfg: dict[str, Any] = {}
-    if delim:
-        effective_read_cfg["delim"] = delim
-    if enc:
-        effective_read_cfg["encoding"] = enc
-    if dec:
-        effective_read_cfg["decimal"] = dec
-    if skip:
-        effective_read_cfg["skip"] = skip
-    effective_read_cfg.setdefault("header", True)
-
-    try:
-        profile = profile_with_read_cfg(tmp_path, sniff, effective_read_cfg)
-    except Exception as exc:
-        logger.warning("DuckDB profile failed for %s: %s", tmp_path, exc)
-        profile = {
-            "columns_raw": [],
-            "duckdb_types": [],
-            "sample_rows": [],
-            "mapping_suggestions": {},
-            "robust_read_suggested": True,
-            "warnings": [f"profile_failed: {exc}"],
-        }
-
-    columns_raw = profile.get("columns_raw", [])
-    duckdb_types = profile.get("duckdb_types", [])
-    sample_rows = profile.get("sample_rows", [])
-
-    result["columns"] = columns_raw
-    result["col_types"] = dict(zip(columns_raw, duckdb_types)) if columns_raw else {}
-    result["preview_row_count"] = len(sample_rows) if sample_rows else None
-    result["mapping_suggestions"] = profile.get("mapping_suggestions", {})
-    result["robust_read_suggested"] = profile.get("robust_read_suggested", False)
-    result["_sample_rows"] = sample_rows  # per infer anni
-
-
-def _profile_excel(tmp_path: Path, result: dict[str, Any]) -> None:
-    """Profile per Excel, con fallback CSV/TSV per file .xls mascherati."""
-    try:
-        profile = profile_excel(tmp_path)
-    except Exception as exc:
-        logger.warning("Excel profile failed: %s", exc)
-        profile = {"columns_raw": [], "sample_rows": [], "robust_read_suggested": True}
-
-    columns_raw = profile.get("columns_raw", [])
-
-    # Fallback: .xls falso (es. TSV con estensione .xls) → prova come CSV
-    if not columns_raw:
-        try:
-            sniff = sniff_source_file(tmp_path)
-            enc = sniff.get("encoding_suggested") or "utf-8"
-            delim = sniff.get("delim_suggested") or "\t"
-            read_cfg = {
-                "encoding": enc,
-                "delim": delim,
-                "header": True,
-                "skip": sniff.get("skip_suggested", 0),
-            }
-            csv_profile = profile_with_read_cfg(tmp_path, sniff, read_cfg)
-            columns_raw = csv_profile.get("columns_raw", [])
-            sample_rows = csv_profile.get("sample_rows", [])
-            result["columns"] = columns_raw
-            result["col_types"] = (
-                dict(zip(columns_raw, csv_profile.get("duckdb_types", []))) if columns_raw else {}
-            )
-            result["preview_row_count"] = len(sample_rows) if sample_rows else None
-            result["robust_read_suggested"] = csv_profile.get("robust_read_suggested", False)
-            result["_sample_rows"] = sample_rows
-            return
-        except Exception as exc:
-            logger.warning("Excel CSV fallback failed: %s", exc)
-
-    sample_rows = profile.get("sample_rows", [])
-    result["columns"] = columns_raw
-    result["col_types"] = {}
-    result["preview_row_count"] = len(sample_rows) if sample_rows else None
-    result["robust_read_suggested"] = profile.get("robust_read_suggested", False)
-    result["_sample_rows"] = sample_rows
-
-
-def _profile_json(content: bytes, result: dict[str, Any]) -> None:
-    """Profile per JSON (inline, nessuna dipendenza DuckDB)."""
-    try:
-        data = json.loads(content.decode("utf-8"))
-    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
-        result["enrich_method"] = "json_decode_failed"
-        return
-
-    if isinstance(data, dict):
-        columns = list(data.keys())
-        sample_rows = [data]
-    elif isinstance(data, list):
-        if data and isinstance(data[0], dict):
-            columns = list(data[0].keys())
-            sample_rows = data
-        elif data:
-            columns = []
-            sample_rows = data[:50]
-        else:
-            columns = []
-            sample_rows = []
-    else:
-        columns = []
-        sample_rows = []
-
-    result["columns"] = columns
-    result["col_types"] = (
-        {
-            col: type(data[0][col]).__name__
-            if data and isinstance(data, list) and data
-            else type(data[col]).__name__
-            if isinstance(data, dict)
-            else "unknown"
-            for col in columns
-        }
-        if columns
-        else {}
-    )
-    result["preview_row_count"] = len(sample_rows) if isinstance(data, list) else None
-    result["robust_read_suggested"] = False
-    result["mapping_suggestions"] = {}
-    result["_sample_rows"] = sample_rows
-
-
-# ── Infer helpers ─────────────────────────────────────────────────────────────
-
-
-def _infer_granularity_from_columns(columns: list[str], result: dict[str, Any]) -> None:
-    """Inferisci granularità territoriale dai nomi colonna.
-
-    Sostituisce underscore con spazi per garantire il match delle word
-    boundary (es. ``denominazione_comune`` → matcha ``comune``).
-    """
-    combined = " ".join(c.lower().replace("_", " ") for c in columns)
-    result["granularity"] = infer_granularity(combined)
-
-
-def _infer_years_from_columns(columns: list[str], result: dict[str, Any]) -> None:
-    """Inferisci anni da nomi colonna (anno, year, ...)."""
-    year_vals: set[int] = set()
+def _extract_years_from_columns(columns: list[str]) -> tuple[int | None, int | None]:
+    """Estrae anni da nomi colonna (es. ``Anno``, ``anno_riferimento``)."""
+    vals: set[int] = set()
     for col in columns:
         m = _YEAR_RE.search(col)
         if m:
-            year_vals.add(int(m.group(1)))
-    # Cerca anche colonne hint
-    for col in columns:
-        if col.lower() in _YEAR_COLUMN_HINTS:
-            # Non possiamo estrarre anni dal nome colonna alone,
-            # ma è un segnale — li inferiamo dai sample rows
-            pass
-    if year_vals:
-        result["year_min"] = min(year_vals)
-        result["year_max"] = max(year_vals)
+            vals.add(int(m.group(1)))
+    return (min(vals), max(vals)) if vals else (None, None)
 
 
-def _extract_year_values_from_sample(sample: list[dict], columns: list[str]) -> list[int]:
-    """Extract year values from sample rows.
-
-    Prima prova colonne numeriche con almeno 2 valori in 1900-2100,
-    poi colonne con nome hint (``anno``, ``year``, ...).
-    """
+def extract_year_values_from_sample(
+    sample: list[dict], columns: list[str]
+) -> list[int]:
+    """Estrae anni da sample rows (valori 1900-2100 in colonne numeriche)."""
+    if not sample:
+        return []
 
     def _safe_ints(vals: list) -> list[int]:
         return [int(v) for v in vals if not (isinstance(v, float) and math.isnan(v))]
 
-    year_values: list[int] = []
-    if not sample:
-        return year_values
-
-    # Strategy 1: colonne numeriche con 2+ valori nel range anni
+    # Strategy 1: colonne con 2+ valori nel range anni
     for col in columns:
         vals = [r.get(col) for r in sample if isinstance(r.get(col), (int, float))]
         if vals:
@@ -478,4 +119,201 @@ def _extract_year_values_from_sample(sample: list[dict], columns: list[str]) -> 
             if vals:
                 return _safe_ints(vals)
 
-    return year_values
+    return []
+
+
+# ── Orchestrator ──────────────────────────────────────────────────────────────
+
+
+def preview_url(
+    url: str,
+    client: HttpClient | None = None,
+    *,
+    known_encoding: str | None = None,
+    known_delim: str | None = None,
+    known_decimal: str | None = None,
+    known_skip: int | None = None,
+) -> PreviewResult:
+    """Preview remoto di un URL CSV/TSV.
+
+    Passaggi:
+    1. HEAD probe — reachability, content-type, content-length
+    2. Risoluzione formato (solo CSV/TSV supportati)
+    3. Range GET — download chunk (max 1MB)
+    4. Sniff — encoding, delim, decimal, skip (saltabile con ``known_*``)
+    5. DuckDB profile — colonne, tipi, mapping, sample rows
+    6. Infer — granularità, anno minimo/massimo
+
+    Args:
+        url: URL del file CSV/TSV remoto.
+        client: HttpClient opzionale (con circuit breaker).
+        known_encoding: Se già noto (da inventory), salta sniff encoding.
+        known_delim: Se già noto, salta sniff delim.
+        known_decimal: Se già noto, salta sniff decimal.
+        known_skip: Se già noto, salta sniff skip.
+
+    Returns:
+        ``PreviewResult`` con tutti i campi compilati o stato di errore.
+    """
+    # ── 1. HEAD probe ────────────────────────────────────────────────────────
+    _owns_client = client is None
+    client = client or HttpClient(timeout=(5, 10))
+    try:
+        try:
+            probe = probe_url_headers(url, client=client)
+        except (RuntimeError, Exception):
+            return PreviewResult(url=url, status="probe_failed", reachable=False)
+
+        reachable = probe.get("status_code", 0) < 400
+        http_status = probe.get("status_code")
+        file_size = _parse_content_length(probe)
+
+        # ── 2. Risoluzione formato ───────────────────────────────────────────
+        fmt = resolve_preview_kind(
+            url,
+            content_type=probe.get("content_type"),
+            content_disposition=probe.get("content_disposition"),
+        )
+        if fmt is None or fmt.lower() not in ("csv", "tsv"):
+            return PreviewResult(
+                url=url,
+                status="unsupported_format",
+                reachable=reachable,
+                http_status=http_status,
+                file_size=file_size,
+                resource_format=fmt.upper() if fmt else None,
+            )
+
+        fmt_lower = fmt.lower()
+
+        # ── 3. Range GET ─────────────────────────────────────────────────────
+        try:
+            fetched = fetch_content(url, client=client, max_bytes=1024 * 1024)
+        except RuntimeError:
+            return PreviewResult(
+                url=url, status="download_failed", reachable=reachable,
+                http_status=http_status, resource_format=fmt.upper(),
+            )
+
+        content: bytes = fetched["content"]
+        content_file_size = len(content)
+
+        # Content-Length incerto su Range — usiamo la lunghezza reale
+        if not file_size:
+            file_size = content_file_size
+
+        # ── 4. Sniff ─────────────────────────────────────────────────────────
+        with tempfile.NamedTemporaryFile(
+            suffix=".csv" if fmt_lower == "tsv" else ".csv", delete=False
+        ) as tmp:
+            tmp.write(content)
+            tmp_path = Path(tmp.name)
+
+        try:
+            if known_encoding and known_delim:
+                # Usa parametri noti dall'inventory — salta sniff
+                sniff: dict[str, Any] = {
+                    "encoding_suggested": known_encoding,
+                    "delim_suggested": known_delim,
+                    "decimal_suggested": known_decimal,
+                    "skip_suggested": known_skip or 0,
+                    "header_line": None,
+                    "true_header_line": None,
+                    "warnings": [],
+                    "is_binary_file": None,
+                    "file_used": tmp_path.name,
+                }
+            else:
+                sniff = sniff_source_file(tmp_path)
+
+            enc = sniff.get("encoding_suggested")
+            delim = sniff.get("delim_suggested")
+            dec = sniff.get("decimal_suggested")
+            skip = sniff.get("skip_suggested", 0)
+
+            # ── 5. DuckDB profile ───────────────────────────────────────────
+            effective_read_cfg: dict[str, Any] = {}
+            if delim:
+                effective_read_cfg["delim"] = delim
+            if enc:
+                effective_read_cfg["encoding"] = enc
+            if dec:
+                effective_read_cfg["decimal"] = dec
+            if skip:
+                effective_read_cfg["skip"] = skip
+            effective_read_cfg.setdefault("header", True)
+
+            try:
+                profile = profile_with_read_cfg(tmp_path, sniff, effective_read_cfg)
+            except Exception as exc:
+                logger.warning("DuckDB profile failed for %s: %s", url, exc)
+                return PreviewResult(
+                    url=url, status="profile_failed", reachable=reachable,
+                    http_status=http_status, file_size=file_size,
+                    resource_format=fmt.upper(),
+                    encoding_suggested=enc, delim_suggested=delim,
+                    decimal_suggested=dec, skip_suggested=skip,
+                )
+
+            columns_raw = profile.get("columns_raw", [])
+            duckdb_types = profile.get("duckdb_types", [])
+            sample_rows = profile.get("sample_rows", [])
+
+            col_types = dict(zip(columns_raw, duckdb_types)) if columns_raw else {}
+            preview_row_count = len(sample_rows) if sample_rows else None
+            mapping_suggestions = profile.get("mapping_suggestions", {})
+            robust_read_suggested = profile.get("robust_read_suggested", False)
+
+            # ── 6. Infer ─────────────────────────────────────────────────────
+            combined = " ".join(
+                c.lower().replace("_", " ") for c in columns_raw
+            ) if columns_raw else ""
+            granularity = infer_granularity(combined)
+
+            year_min, year_max = _extract_years_from_columns(columns_raw)
+
+            # Fallback: anni da sample rows
+            if year_min is None and sample_rows:
+                year_vals = extract_year_values_from_sample(sample_rows, columns_raw)
+                if year_vals:
+                    year_min = min(year_vals)
+                    year_max = max(year_vals)
+
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+        return PreviewResult(
+            url=url,
+            status="success",
+            reachable=reachable,
+            http_status=http_status,
+            file_size=file_size,
+            resource_format=fmt.upper(),
+            encoding_suggested=enc,
+            delim_suggested=delim,
+            decimal_suggested=dec,
+            skip_suggested=skip,
+            columns=columns_raw,
+            col_types=col_types,
+            preview_row_count=preview_row_count,
+            robust_read_suggested=robust_read_suggested,
+            mapping_suggestions=mapping_suggestions,
+            granularity=granularity,
+            year_min=year_min,
+            year_max=year_max,
+        )
+
+    finally:
+        if _owns_client:
+            client.close()
+
+
+def _parse_content_length(probe: dict) -> int | None:
+    """Estrai Content-Length dal probe result."""
+    raw = probe.get("content_length")
+    if raw:
+        try:
+            return int(raw)
+        except (ValueError, TypeError):
+            pass
+    return None

--- a/toolkit/scout/http.py
+++ b/toolkit/scout/http.py
@@ -362,59 +362,84 @@ def fetch_content(
     user_agent: str = DEFAULT_USER_AGENT,
     client: HttpClient | None = None,
 ) -> dict[str, Any]:
-    """GET con Range header, fallback a GET streaming bounded se Range non supportato.
+    """GET bounded: Range header + fallback streaming, mai oltre ``max_bytes``.
+
+    Tutti i GET usano ``stream=True``: se il server ignora ``Range`` e risponde
+    con ``200`` (full body), ``iter_content`` legge solo ``max_bytes`` e chiude.
+    Nessun rischio di caricare file interi in memoria.
 
     Args:
         url: URL da scaricare.
-        max_bytes: Dimensione massima in bytes — letto al massimo questo.
+        max_bytes: Dimensione massima in bytes.
         timeout: Timeout HTTP (ignorato se client è fornito).
         user_agent: User-Agent (ignorato se client è fornito).
         client: HttpClient opzionale.
 
-    Returns dict: content (bytes), content_type, status_code, final_url, method.
+    Returns dict: content (bytes), content_type, status_code, final_url, method,
+                  content_length (int | None su 206 da Content-Range).
 
     Raises:
         RuntimeError: se la GET fallisce o non ritorna contenuto.
     """
     client = client or _mk_client(timeout=timeout, user_agent=user_agent)
 
-    # Tentativo con Range
-    range_result = client.get(url, headers={"Range": f"bytes=0-{max_bytes - 1}"})
+    def _read_bounded(resp: Any, max_b: int) -> bytes:
+        """Legge al massimo max_b bytes da una risposta streaming."""
+        chunks: list[bytes] = []
+        total = 0
+        for chunk in resp.iter_content(chunk_size=65536):
+            if chunk:
+                remaining = max_b - total
+                if remaining <= 0:
+                    break
+                chunks.append(chunk[:remaining])
+                total += len(chunks[-1])
+        return b"".join(chunks)
+
+    def _parse_content_range(resp: Any) -> int | None:
+        """Estrae la dimensione totale del file da Content-Range (es. ``bytes 0-0/123456``)."""
+        cr = resp.headers.get("Content-Range", "")
+        if cr and "/" in cr:
+            total_str = cr.split("/")[-1].strip()
+            if total_str.isdigit():
+                return int(total_str)
+        return None
+
+    # Tentativo con Range — usa stream=True, cosi' anche se il server ignora
+    # il Range e risponde 200, leggiamo solo max_bytes.
+    range_result = client.get(url, headers={"Range": f"bytes=0-{max_bytes - 1}"}, stream=True)
     if range_result.is_ok and range_result.response is not None:
         resp = range_result.response
-        if resp.status_code in (206, 200) and resp.content:
-            content = resp.content[:max_bytes]
-            return {
-                "content": content,
-                "content_type": resp.headers.get("Content-Type"),
-                "status_code": resp.status_code,
-                "final_url": resp.url,
-                "method": "range" if resp.status_code == 206 else "full",
-            }
+        if resp.status_code in (206, 200):
+            content = _read_bounded(resp, max_bytes)
+            if content:
+                # Su 206 il Content-Length e' la dimensione del chunk.
+                # La dimensione reale del file arriva da Content-Range.
+                file_size = _parse_content_range(resp) if resp.status_code == 206 else None
+                return {
+                    "content": content,
+                    "content_type": resp.headers.get("Content-Type"),
+                    "status_code": resp.status_code,
+                    "final_url": resp.url,
+                    "method": "range" if resp.status_code == 206 else "full",
+                    "content_length": file_size,
+                }
 
-    # Range fallito → GET streaming bounded: non scarica mai oltre max_bytes.
-    # Usa stream=True + iter_content per evitare che requests carichi tutto in memoria.
+    # Range fallito → GET streaming bounded
     full_result = client.get(url, stream=True)
     if full_result.is_ok and full_result.response is not None:
         resp = full_result.response
         if resp.status_code < 400:
-            chunks: list[bytes] = []
-            total = 0
-            for chunk in resp.iter_content(chunk_size=65536):
-                if chunk:
-                    remaining = max_bytes - total
-                    if remaining <= 0:
-                        break
-                    chunks.append(chunk[:remaining])
-                    total += len(chunks[-1])
-            content = b"".join(chunks)
-            return {
-                "content": content,
-                "content_type": resp.headers.get("Content-Type"),
-                "status_code": resp.status_code,
-                "final_url": resp.url,
-                "method": "full",
-            }
+            content = _read_bounded(resp, max_bytes)
+            if content:
+                return {
+                    "content": content,
+                    "content_type": resp.headers.get("Content-Type"),
+                    "status_code": resp.status_code,
+                    "final_url": resp.url,
+                    "method": "full",
+                    "content_length": None,
+                }
 
     raise RuntimeError(f"GET failed for {url}")
 

--- a/toolkit/scout/http.py
+++ b/toolkit/scout/http.py
@@ -263,11 +263,13 @@ def probe_url_headers(
             and head_result.response.status_code < 500
         ):
             resp = head_result.response
+            ct_len = resp.headers.get("Content-Length")
             return _build_probe_result(
                 requested_url=url,
                 status_code=resp.status_code,
                 content_type=resp.headers.get("Content-Type"),
                 content_disposition=resp.headers.get("Content-Disposition"),
+                content_length=int(ct_len) if ct_len and ct_len.isdigit() else None,
                 final_url=resp.url,
                 method="head",
             )
@@ -289,12 +291,15 @@ def probe_url_headers(
         range_result = client.get(url, headers={"Range": "bytes=0-0"})
         if range_result.is_ok and range_result.response is not None:
             resp = range_result.response
+            ct_len = resp.headers.get("Content-Length")
+            parsed_ct_len = int(ct_len) if ct_len and ct_len.isdigit() else None
             if resp.status_code < 400:
                 return _build_probe_result(
                     requested_url=url,
                     status_code=resp.status_code,
                     content_type=resp.headers.get("Content-Type"),
                     content_disposition=resp.headers.get("Content-Disposition"),
+                    content_length=parsed_ct_len,
                     final_url=resp.url,
                     method="get_range",
                 )
@@ -307,6 +312,7 @@ def probe_url_headers(
                 status_code=resp.status_code,
                 content_type=resp.headers.get("Content-Type"),
                 content_disposition=resp.headers.get("Content-Disposition"),
+                content_length=parsed_ct_len,
                 final_url=resp.url,
                 method="get_range",
             )
@@ -328,6 +334,7 @@ def _build_probe_result(
     status_code: int,
     content_type: str | None,
     content_disposition: str | None,
+    content_length: int | None = None,
     final_url: str,
     method: str,
 ) -> dict[str, Any]:
@@ -337,6 +344,7 @@ def _build_probe_result(
         "status_code": status_code,
         "content_type": content_type,
         "content_disposition": content_disposition,
+        "content_length": content_length,
         "method": method,
     }
 
@@ -354,16 +362,19 @@ def fetch_content(
     user_agent: str = DEFAULT_USER_AGENT,
     client: HttpClient | None = None,
 ) -> dict[str, Any]:
-    """GET con Range header, fallback a GET intero se Range non supportato.
+    """GET con Range header, fallback a GET streaming bounded se Range non supportato.
 
     Args:
         url: URL da scaricare.
-        max_bytes: Dimensione massima in bytes.
+        max_bytes: Dimensione massima in bytes — letto al massimo questo.
         timeout: Timeout HTTP (ignorato se client è fornito).
         user_agent: User-Agent (ignorato se client è fornito).
         client: HttpClient opzionale.
 
     Returns dict: content (bytes), content_type, status_code, final_url, method.
+
+    Raises:
+        RuntimeError: se la GET fallisce o non ritorna contenuto.
     """
     client = client or _mk_client(timeout=timeout, user_agent=user_agent)
 
@@ -381,12 +392,22 @@ def fetch_content(
                 "method": "range" if resp.status_code == 206 else "full",
             }
 
-    # Range fallito → GET intero
-    full_result = client.get(url)
+    # Range fallito → GET streaming bounded: non scarica mai oltre max_bytes.
+    # Usa stream=True + iter_content per evitare che requests carichi tutto in memoria.
+    full_result = client.get(url, stream=True)
     if full_result.is_ok and full_result.response is not None:
         resp = full_result.response
         if resp.status_code < 400:
-            content = resp.content[:max_bytes]
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in resp.iter_content(chunk_size=65536):
+                if chunk:
+                    remaining = max_bytes - total
+                    if remaining <= 0:
+                        break
+                    chunks.append(chunk[:remaining])
+                    total += len(chunks[-1])
+            content = b"".join(chunks)
             return {
                 "content": content,
                 "content_type": resp.headers.get("Content-Type"),

--- a/toolkit/scout/http.py
+++ b/toolkit/scout/http.py
@@ -292,15 +292,26 @@ def probe_url_headers(
         range_result = client.get(url, headers={"Range": "bytes=0-0"}, stream=True)
         if range_result.is_ok and range_result.response is not None:
             resp = range_result.response
-            ct_len = resp.headers.get("Content-Length")
-            parsed_ct_len = int(ct_len) if ct_len and ct_len.isdigit() else None
+            # Su 206, Content-Length vale 1 (un byte) — la dimensione reale
+            # del file e' in Content-Range: "bytes 0-0/TOTALE".
+            if resp.status_code == 206:
+                cr = resp.headers.get("Content-Range", "")
+                if cr and "/" in cr:
+                    total_str = cr.split("/")[-1].strip()
+                    file_size = int(total_str) if total_str.isdigit() else None
+                else:
+                    file_size = None
+            else:
+                ct_len = resp.headers.get("Content-Length")
+                file_size = int(ct_len) if ct_len and ct_len.isdigit() else None
+            getattr(resp, "close", lambda: None)()
             if resp.status_code < 400:
                 return _build_probe_result(
                     requested_url=url,
                     status_code=resp.status_code,
                     content_type=resp.headers.get("Content-Type"),
                     content_disposition=resp.headers.get("Content-Disposition"),
-                    content_length=parsed_ct_len,
+                    content_length=file_size,
                     final_url=resp.url,
                     method="get_range",
                 )
@@ -313,7 +324,7 @@ def probe_url_headers(
                 status_code=resp.status_code,
                 content_type=resp.headers.get("Content-Type"),
                 content_disposition=resp.headers.get("Content-Disposition"),
-                content_length=parsed_ct_len,
+                content_length=file_size,
                 final_url=resp.url,
                 method="get_range",
             )
@@ -406,41 +417,45 @@ def fetch_content(
                 return int(total_str)
         return None
 
-    # Tentativo con Range — usa stream=True, cosi' anche se il server ignora
-    # il Range e risponde 200, leggiamo solo max_bytes.
+    # Tentativo con Range — stream=True: se il server ignora Range e risponde
+    # 200, leggiamo solo max_bytes e chiudiamo.
     range_result = client.get(url, headers={"Range": f"bytes=0-{max_bytes - 1}"}, stream=True)
     if range_result.is_ok and range_result.response is not None:
         resp = range_result.response
-        if resp.status_code in (206, 200):
-            content = _read_bounded(resp, max_bytes)
-            if content:
-                # Su 206 il Content-Length e' la dimensione del chunk.
-                # La dimensione reale del file arriva da Content-Range.
-                file_size = _parse_content_range(resp) if resp.status_code == 206 else None
-                return {
-                    "content": content,
-                    "content_type": resp.headers.get("Content-Type"),
-                    "status_code": resp.status_code,
-                    "final_url": resp.url,
-                    "method": "range" if resp.status_code == 206 else "full",
-                    "content_length": file_size,
-                }
+        try:
+            if resp.status_code in (206, 200):
+                content = _read_bounded(resp, max_bytes)
+                if content:
+                    file_size = _parse_content_range(resp) if resp.status_code == 206 else None
+                    return {
+                        "content": content,
+                        "content_type": resp.headers.get("Content-Type"),
+                        "status_code": resp.status_code,
+                        "final_url": resp.url,
+                        "method": "range" if resp.status_code == 206 else "full",
+                        "content_length": file_size,
+                    }
+        finally:
+            getattr(resp, "close", lambda: None)()
 
     # Range fallito → GET streaming bounded
     full_result = client.get(url, stream=True)
     if full_result.is_ok and full_result.response is not None:
         resp = full_result.response
-        if resp.status_code < 400:
-            content = _read_bounded(resp, max_bytes)
-            if content:
-                return {
-                    "content": content,
-                    "content_type": resp.headers.get("Content-Type"),
-                    "status_code": resp.status_code,
-                    "final_url": resp.url,
-                    "method": "full",
-                    "content_length": None,
-                }
+        try:
+            if resp.status_code < 400:
+                content = _read_bounded(resp, max_bytes)
+                if content:
+                    return {
+                        "content": content,
+                        "content_type": resp.headers.get("Content-Type"),
+                        "status_code": resp.status_code,
+                        "final_url": resp.url,
+                        "method": "full",
+                        "content_length": None,
+                    }
+        finally:
+            resp.close()
 
     raise RuntimeError(f"GET failed for {url}")
 

--- a/toolkit/scout/http.py
+++ b/toolkit/scout/http.py
@@ -286,9 +286,10 @@ def probe_url_headers(
             continue
         break
 
-    # HEAD fallito → GET con Range: bytes=0-0
+    # HEAD fallito → GET con Range: bytes=0-0 (stream=True: se server ignora
+    # Range, non scarica l'intero file solo per leggere gli header).
     for attempt in range(1 + MAX_RETRIES):
-        range_result = client.get(url, headers={"Range": "bytes=0-0"})
+        range_result = client.get(url, headers={"Range": "bytes=0-0"}, stream=True)
         if range_result.is_ok and range_result.response is not None:
             resp = range_result.response
             ct_len = resp.headers.get("Content-Length")


### PR DESCRIPTION
## Sintesi

`preview_url(url)` fa in un colpo solo HEAD probe → Range GET bounded → sniff → DuckDB profile → infer, restituendo un `PreviewResult` strutturato.

Centralizza la logica di profiling remoto che era duplicata in SO (`_profile_downloaded_csv`, `_extract_year_values_from_sample`, ecc.).

## Cosa cambia

- [x] Nuova funzionalità del motore
- [x] CLI (`toolkit preview <URL>`)
- [x] MCP (`toolkit_preview_url`)

## Contratto pubblico

- `toolkit.profile.preview.preview_url(url, ...)` → `PreviewResult` (dataclass)
- `toolkit.profile.PreviewResult` esportato in `__all__`
- `toolkit.profile.preview.extract_year_values_from_sample()` — funzione pubblica
- CLI: `toolkit preview <URL>` (con `--json`, `--encoding`, `--delim`)
- MCP: `toolkit_preview_url(url, known_encoding, known_delim, ...)`

## Limiti v1

- Solo CSV/TSV. JSON e Excel (XLSX/XLS) hanno casi limite non coperti.
- Il download usa sempre `stream=True` + `iter_content()`: mai oltre `max_bytes` (1 MB).
- `file_size` su risposte 206 viene da `Content-Range`; altrimenti è la lunghezza del chunk scaricato.

## Verifica

```bash
pytest tests/test_profile_preview.py tests/test_profile_sniff.py -v
ruff check .
```

- [x] 988 test passano (13 preview + 19 sniff + resto suite)
- [x] `ruff check .` passa
- [x] Test con marker appropriato (`contract`, `regression`)

## Note per chi revisiona

- `fetch_content()` in `scout/http.py` è stato modificato per usare `stream=True` su tutti i GET — impatto su altri consumer (fetch_html_body, scout probe) da verificare.
