### PR TITLE
chore: aggiorna duckdb>=1.5.3 e safe_connect, rimuovi PRAGMA duplicati

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,12 @@ dependencies = [
   "pandas>=2.0",
   "openpyxl>=3.1.0",
   "xlrd>=2.0.0",
-  "duckdb>=0.10.0",
+  "duckdb>=1.5.3",
   "mcp>=1.0",
   "requests>=2.33.1",
   "typer>=0.12.0",
   "rich>=13.0",
-  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.14.1"
+  "lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.15.0"
 ]
 
 [project.optional-dependencies]

--- a/toolkit/cli/inspect/profile_ops.py
+++ b/toolkit/cli/inspect/profile_ops.py
@@ -77,7 +77,6 @@ def csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
     opt_sql = f"union_by_name=true, {', '.join(read_opts)}"
 
     with safe_connect() as conn:
-        conn.execute("PRAGMA disable_progress_bar")
         conn.execute(
             f"CREATE VIEW csv_preview AS SELECT * FROM read_csv('{sql_str(str(path))}', {opt_sql})"
         )

--- a/toolkit/core/duckdb_shape.py
+++ b/toolkit/core/duckdb_shape.py
@@ -15,9 +15,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-import duckdb
-
-from lab_connectors.duckdb import gcs_connect
+from lab_connectors.duckdb import gcs_connect, safe_connect
 from toolkit.core.sql_utils import sql_literal
 
 
@@ -88,8 +86,7 @@ def csv_quick_shape(csv_path: str | Path) -> dict[str, Any]:
     if not path.exists():
         return {}
     try:
-        with duckdb.connect(database=":memory:") as conn:
-            conn.execute("PRAGMA disable_progress_bar")
+        with safe_connect() as conn:
             rel = f"read_csv_auto('{sql_literal(str(path))}', auto_detect=true)"
             describe = conn.execute(f"DESCRIBE SELECT * FROM {rel}").fetchall()
             col_count = len(describe)
@@ -118,7 +115,6 @@ def parquet_schema(path: Path) -> list[dict[str, str]]:
         return []
     try:
         with _parquet_connect(path) as con:
-            con.execute("PRAGMA disable_progress_bar")
             rows = con.execute(f"DESCRIBE SELECT * FROM {_rel(path)}").fetchall()
             return [{"name": str(r[0]), "type": str(r[1])} for r in rows]
     except Exception:
@@ -137,7 +133,6 @@ def parquet_row_count(path: Path) -> int | None:
         return None
     try:
         with _parquet_connect(path) as con:
-            con.execute("PRAGMA disable_progress_bar")
             result = con.execute(f"SELECT COUNT(*) FROM {_rel(path)}").fetchone()
             return int(result[0]) if result else None
     except Exception:
@@ -191,8 +186,6 @@ def parquet_preview(
 
     try:
         with _parquet_connect(path) as con:
-            con.execute("PRAGMA disable_progress_bar")
-
             if sql is not None:
                 # Registra il parquet come vista 'data' per query naturali
                 con.execute(f"CREATE OR REPLACE VIEW data AS SELECT * FROM {_rel(path)}")


### PR DESCRIPTION
## Cosa fa

- Allinea duckdb minima a `>=1.5.3` (era `>=0.10.0`) — stesso valore di tutto l'ecosistema Lab
- Aggiorna lab-connectors da `@v0.14.1` a `@v0.15.0`
- `duckdb_shape.py`: `duckdb.connect()` → `safe_connect()`, rimossi 4× `PRAGMA disable_progress_bar` (safe_connect li applica già)
- `profile_ops.py`: rimosso 1× `PRAGMA disable_progress_bar` ridondante (già usava safe_connect)

## Test

Syntax check passato. CI verificherà test esistenti.