### PR TITLE
feat: lettura Excel nativa con DuckDB (sostituisce pandas/openpyxl)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ dependencies = [
   "pyyaml>=6.0.3",
   "pydantic>=2.8.0",
   "pandas>=2.0",
-  "openpyxl>=3.1.0",
-  "xlrd>=2.0.0",
+
   "duckdb>=1.5.3",
   "mcp>=1.0",
   "requests>=2.33.1",
@@ -44,6 +43,7 @@ parquet = [
 dev = [
   "build>=1.4.3",
   "mypy>=1.20",
+  "openpyxl>=3.1.0",
   "pytest>=8.0",
   "pytest-cov>=5.0.0",
   "pytest-timeout>=2.3.0",

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -316,46 +316,34 @@ def test_read_raw_to_relation_reads_xlsx_with_explicit_sheet_and_columns(tmp_pat
     assert info.source == "excel"
     assert info.params_used["sheet_name"] == "Export"
     assert info.params_used["columns"] == {"col0": "VARCHAR", "col1": "VARCHAR"}
-    assert rows == [("A", 1), ("B", 2)]
+    # DuckDB header=false legge tutto VARCHAR (numeric come "1.0")
+    assert rows == [("A", "1.0"), ("B", "2.0")]
     con.close()
 
 
 @pytest.mark.policy
-def test_read_raw_to_relation_reads_xls_with_xlrd_engine(tmp_path: Path):
-    """Test that .xls files use the xlrd engine."""
+def test_read_raw_to_relation_rejects_xls(tmp_path: Path):
+    """DuckDB excel extension non supporta .xls, deve sollevare ValueError."""
     import xlwt
 
     input_file = tmp_path / "ok.xls"
     wb = xlwt.Workbook()
     ws = wb.add_sheet("Sheet1")
     ws.write(0, 0, "Anno")
-    ws.write(0, 1, "Regione")
-    ws.write(0, 2, "Domanda")
     ws.write(1, 0, 2022)
-    ws.write(1, 1, "Lazio")
-    ws.write(1, 2, 123.4)
-    ws.write(2, 0, 2022)
-    ws.write(2, 1, "Umbria")
-    ws.write(2, 2, 56.7)
     wb.save(input_file)
 
     con = duckdb.connect(":memory:")
     logger = logging.getLogger("tests.clean.duckdb_read.xls")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {"header": True},
-        "fallback",
-        logger,
-    )
-
-    rows = con.execute(
-        'SELECT "Anno", "Regione", "Domanda" FROM raw_input ORDER BY "Regione"'
-    ).fetchall()
-    assert info.source == "excel"
-    assert info.params_used["sheet_name"] == 0
-    assert rows == [(2022, "Lazio", 123.4), (2022, "Umbria", 56.7)]
+    with pytest.raises(ValueError, match="does not support .xls"):
+        duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {"header": True},
+            "fallback",
+            logger,
+        )
     con.close()
 
 

--- a/tests/test_mart_hierarchy.py
+++ b/tests/test_mart_hierarchy.py
@@ -51,8 +51,6 @@ def test_hierarchy_generates_aggregation(tmp_path: Path) -> None:
                 ],
             }
         },
-        "test",
-        2024,
         mart_dir,
         logger=_null_logger,
     )
@@ -85,8 +83,6 @@ def test_hierarchy_generates_aggregation(tmp_path: Path) -> None:
                 ],
             }
         },
-        "test",
-        2024,
         mart_dir,
         logger=_null_logger,
     )
@@ -115,8 +111,6 @@ def test_hierarchy_count_fallback(tmp_path: Path) -> None:
                 "levels": [{"level": "c", "table": "h_c", "grain": ["comune"]}],
             }
         },
-        "test",
-        2024,
         mart_dir,
         logger=_null_logger,
     )
@@ -156,8 +150,6 @@ def test_hierarchy_exclude_metrics(tmp_path: Path) -> None:
                 ],
             }
         },
-        "test",
-        2024,
         mart_dir,
         logger=_null_logger,
     )
@@ -191,7 +183,7 @@ def test_hierarchy_edge_cases(tmp_path: Path) -> None:
     d.mkdir()
 
     # Empty hierarchy → empty result
-    w, e, r = _run_hierarchy_levels(con, {}, "t", 2024, d, logger=_null_logger)
+    w, e, r = _run_hierarchy_levels(con, {}, d, logger=_null_logger)
     assert (w, e, r) == ([], [], 0)
 
     # Numeric grain column (valore=INTEGER) must NOT appear as SUM metric
@@ -204,8 +196,6 @@ def test_hierarchy_edge_cases(tmp_path: Path) -> None:
                 "levels": [{"level": "x", "table": "h_test", "grain": ["valore"]}],
             }
         },
-        "t",
-        2024,
         d,
         logger=_null_logger,
     )
@@ -232,8 +222,6 @@ def test_hierarchy_edge_cases(tmp_path: Path) -> None:
                     "levels": [{"level": "x", "table": "x", "grain": ["comune"]}],
                 }
             },
-            "t",
-            2024,
             d2,
             logger=_null_logger,
         )

--- a/tests/test_profile_sniff.py
+++ b/tests/test_profile_sniff.py
@@ -409,7 +409,8 @@ def test_profile_excel_parity_header_false_columns(tmp_path: Path):
     # No warnings — valid sheet + config
     assert result["warnings"] == []
     # Sample rows contain the data from "Export" sheet (as dicts, not raw lists)
-    assert result["sample_rows"] == [{"col0": "A", "col1": 1}, {"col0": "B", "col1": 2}]
+    # DuckDB header=false legge tutto VARCHAR → "1.0" invece di 1
+    assert result["sample_rows"] == [{"col0": "A", "col1": "1.0"}, {"col0": "B", "col1": "2.0"}]
 
 
 @pytest.mark.policy

--- a/tests/test_scaffold_clean.py
+++ b/tests/test_scaffold_clean.py
@@ -147,7 +147,7 @@ class TestColumnsSpec:
                 "Valore": {"type": "float"},
             },
         }
-        exprs, spec = _columns_spec(profile, 2024)
+        exprs, spec = _columns_spec(profile)
         assert 'trim("Nome") AS nome' in exprs
         assert 'TRY_CAST("Anno" AS BIGINT) AS anno' in exprs
         assert 'TRY_CAST("Valore" AS DOUBLE) AS valore' in exprs
@@ -166,7 +166,7 @@ class TestColumnsSpec:
                 "Importo": {"type": "float"},
             },
         }
-        exprs, _ = _columns_spec(profile, 2024)
+        exprs, _ = _columns_spec(profile)
         joined = "\n".join(exprs)
         assert 'trim("Nome") AS nome' in joined
         assert 'TRY_CAST("Importo" AS DOUBLE)' in joined
@@ -179,7 +179,7 @@ class TestColumnsSpec:
             "mapping_suggestions": {},
             "columns_raw": ["Col1", "Col2"],
         }
-        exprs, spec = _columns_spec(profile, 2024)
+        exprs, spec = _columns_spec(profile)
         assert 'trim(CAST("Col1" AS VARCHAR)) AS col1' in exprs
         assert 'trim(CAST("Col2" AS VARCHAR)) AS col2' in exprs
         assert spec == {"Col1": "VARCHAR", "Col2": "VARCHAR"}
@@ -188,7 +188,7 @@ class TestColumnsSpec:
     def test_no_mapping_no_columns(self) -> None:
         """Senza mapping né columns_raw: wildcard."""
         profile: dict[str, Any] = {}
-        exprs, _ = _columns_spec(profile, 2024)
+        exprs, _ = _columns_spec(profile)
         assert exprs == ["*"]
 
 

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -24,7 +24,7 @@ from toolkit.core.csv_read import (
 from toolkit.core.paths import RAW_PROFILE_DIR, RAW_SUGGESTED_READ
 
 
-def _read_source_mode(clean_cfg: dict[str, Any], logger=None) -> tuple[str, dict[str, Any]]:
+def _read_source_mode(clean_cfg: dict[str, Any], logger=None) -> tuple[str, dict[str, Any]]:  # noqa: ARG001
     raw_read_cfg = clean_cfg.get("read")
     read_source = clean_cfg.get("read_source")
     explicit_cfg: dict[str, Any] = {}

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -24,7 +24,7 @@ from toolkit.core.csv_read import (
 from toolkit.core.paths import RAW_PROFILE_DIR, RAW_SUGGESTED_READ
 
 
-def _read_source_mode(clean_cfg: dict[str, Any], logger=None) -> tuple[str, dict[str, Any]]:  # noqa: ARG001
+def _read_source_mode(clean_cfg: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     raw_read_cfg = clean_cfg.get("read")
     read_source = clean_cfg.get("read_source")
     explicit_cfg: dict[str, Any] = {}
@@ -83,7 +83,7 @@ def resolve_clean_read_cfg(
     clean_cfg: dict[str, Any],
     logger=None,
 ) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
-    normalized_source, explicit_cfg = _read_source_mode(clean_cfg, logger)
+    normalized_source, explicit_cfg = _read_source_mode(clean_cfg)
     selection_cfg, relation_overrides = _split_read_cfg(explicit_cfg)
 
     suggested_cfg = load_suggested_read(raw_year_dir)

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -86,7 +86,7 @@ def _write_rendered_sql(
     return rendered_sql_path
 
 
-def _selection_params(read_cfg: dict[str, Any], logger) -> tuple[str, str, bool, bool]:  # noqa: ARG001
+def _selection_params(read_cfg: dict[str, Any]) -> tuple[str, str, bool, bool]:
     selection_mode = read_cfg.get("mode")
     glob_pattern = read_cfg.get("glob", "*")
     prefer_from_raw_run = bool(read_cfg.get("prefer_from_raw_run", True))
@@ -225,7 +225,6 @@ def run_clean(
     )
     selection_mode, glob_pattern, prefer_from_raw_run, allow_ambiguous = _selection_params(
         read_cfg,
-        logger,
     )
     sql_path_obj, sql, template_ctx = load_clean_sql(
         clean_cfg,

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -86,7 +86,7 @@ def _write_rendered_sql(
     return rendered_sql_path
 
 
-def _selection_params(read_cfg: dict[str, Any], logger) -> tuple[str, str, bool, bool]:
+def _selection_params(read_cfg: dict[str, Any], logger) -> tuple[str, str, bool, bool]:  # noqa: ARG001
     selection_mode = read_cfg.get("mode")
     glob_pattern = read_cfg.get("glob", "*")
     prefer_from_raw_run = bool(read_cfg.get("prefer_from_raw_run", True))

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -24,7 +24,7 @@ def _silence_typer_echo() -> Any:
     typer.echo e lo sostituiamo con un no-op.
     """
     original_echo = typer.echo
-    typer.echo = lambda *args, **kwargs: None
+    typer.echo = lambda *_, **__: None
     try:
         yield
     finally:
@@ -192,7 +192,9 @@ def batch(
                         # Quando --json è attivo, silenzia typer.echo durante
                         # run_year per evitare che execution plan (dry-run)
                         # o altri echo contaminino stdout JSON
-                        _run_ctx = _silence_typer_echo() if json_output else contextlib.nullcontext()
+                        _run_ctx = (
+                            _silence_typer_echo() if json_output else contextlib.nullcontext()
+                        )
                         with _run_ctx:
                             context = run_year(
                                 cfg,

--- a/toolkit/cli/cmd_scout.py
+++ b/toolkit/cli/cmd_scout.py
@@ -229,7 +229,7 @@ def _scaffold_file(
     typer.echo(f"  Delimiter: {sniff_hints.get('delim_suggested')}")
     typer.echo(f"  Columns: {sniff_hints.get('columns_preview')}")
 
-    # XLSX → profiling via openpyxl (stesso reader del runtime clean)
+    # XLSX → profiling via DuckDB read_xlsx (stesso reader del runtime clean)
     binary_fmt = sniff_hints.get("is_binary_file")
     if binary_fmt in ("xlsx", "xls"):
         from toolkit.profile.raw import profile_excel

--- a/toolkit/cli/cmd_scout.py
+++ b/toolkit/cli/cmd_scout.py
@@ -377,10 +377,10 @@ def _scaffold_ckan(
 
 def _scaffold_minimal_ckan(
     url: str,
-    probe_result: dict[str, Any],
+    probe_result: dict[str, Any],  # noqa: ARG001
     resources: list[dict[str, Any]],
     *,
-    run_raw: bool = False,
+    run_raw: bool = False,  # noqa: ARG001
     slug: str | None = None,
 ) -> None:
     """Genera scaffold minimale CKAN quando il profiling fallisce."""
@@ -442,10 +442,10 @@ def _scaffold_minimal_ckan(
 
 
 def _scaffold_html(
-    url: str,
-    probe_result: dict[str, Any],
+    url: str,  # noqa: ARG001
+    probe_result: dict[str, Any],  # noqa: ARG001
     *,
-    run_raw: bool = False,
+    run_raw: bool = False,  # noqa: ARG001
     slug: str | None = None,
 ) -> None:
     """Scaffold per pagina HTML con link."""
@@ -465,7 +465,7 @@ def _scaffold_sparql(
     url: str,
     probe_result: dict[str, Any],
     *,
-    run_raw: bool = False,
+    run_raw: bool = False,  # noqa: ARG001
     slug: str | None = None,
 ) -> None:
     """Scaffold per endpoint SPARQL."""

--- a/toolkit/cli/cmd_scout.py
+++ b/toolkit/cli/cmd_scout.py
@@ -128,7 +128,7 @@ def scout_url(
         if len(candidates) > 5:
             _echo(f"    ... and {len(candidates) - 5} more")
         if scaffold and not json_output:
-            _scaffold_html(url, probe, run_raw=run_raw, slug=slug)
+            _scaffold_html(probe, run_raw=run_raw, slug=slug)
 
     elif source_type == "sparql":
         sparql_info = probe.get("sparql_info") or {}
@@ -141,7 +141,7 @@ def scout_url(
             if ds_count > 5:
                 _echo(f"    ... e altri {ds_count - 5}")
         if scaffold and not json_output:
-            _scaffold_sparql(url, probe, run_raw=run_raw, slug=slug)
+            _scaffold_sparql(url, probe, slug=slug)
 
     elif source_type == "sdmx":
         _echo(f"  SDMX flow: {probe.get('sdmx_info', {}).get('flow_id', '?')}")
@@ -372,15 +372,13 @@ def _scaffold_ckan(
         return
     except (typer.Exit, Exception):
         typer.echo("  Warning: profiling failed for resource, generating minimal scaffold")
-        _scaffold_minimal_ckan(url, probe_result, resources, run_raw=run_raw, slug=slug)
+        _scaffold_minimal_ckan(url, resources, slug=slug)
 
 
 def _scaffold_minimal_ckan(
     url: str,
-    probe_result: dict[str, Any],  # noqa: ARG001
     resources: list[dict[str, Any]],
     *,
-    run_raw: bool = False,  # noqa: ARG001
     slug: str | None = None,
 ) -> None:
     """Genera scaffold minimale CKAN quando il profiling fallisce."""
@@ -442,10 +440,9 @@ def _scaffold_minimal_ckan(
 
 
 def _scaffold_html(
-    url: str,  # noqa: ARG001
-    probe_result: dict[str, Any],  # noqa: ARG001
+    probe_result: dict[str, Any],
     *,
-    run_raw: bool = False,  # noqa: ARG001
+    run_raw: bool = False,
     slug: str | None = None,
 ) -> None:
     """Scaffold per pagina HTML con link."""
@@ -465,7 +462,6 @@ def _scaffold_sparql(
     url: str,
     probe_result: dict[str, Any],
     *,
-    run_raw: bool = False,  # noqa: ARG001
     slug: str | None = None,
 ) -> None:
     """Scaffold per endpoint SPARQL."""

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -132,7 +132,7 @@ def _clean_paths(root: Path, dataset: str, year: int) -> dict[str, str]:
     }
 
 
-def _mart_output_paths(root: Path, year_dir: Path, tables: list[Any]) -> list[Path]:
+def _mart_output_paths(root: Path, year_dir: Path, tables: list[Any]) -> list[Path]:  # noqa: ARG001
     result: list[Path] = []
     for table in tables:
         if isinstance(table, dict):

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -132,7 +132,7 @@ def _clean_paths(root: Path, dataset: str, year: int) -> dict[str, str]:
     }
 
 
-def _mart_output_paths(root: Path, year_dir: Path, tables: list[Any]) -> list[Path]:  # noqa: ARG001
+def _mart_output_paths(year_dir: Path, tables: list[Any]) -> list[Path]:
     result: list[Path] = []
     for table in tables:
         if isinstance(table, dict):
@@ -152,7 +152,7 @@ def _mart_paths(
     mart_dir = layer_year_dir(root, "mart", dataset, year)
     return {
         "dir": str(mart_dir),
-        "outputs": [str(path) for path in _mart_output_paths(root, mart_dir, tables)],
+        "outputs": [str(path) for path in _mart_output_paths(mart_dir, tables)],
         "metadata": str(mart_dir / METADATA),
         "validation": str(mart_dir / MART_VALIDATION),
     }

--- a/toolkit/core/config_models/_loader.py
+++ b/toolkit/core/config_models/_loader.py
@@ -107,7 +107,7 @@ def load_config_model(
         raise _err("dataset.years deve essere una lista non vuota, es: [2022, 2023].", path=p)
 
     strict_mode = strict_config or _read_strict_config(data, path=p)
-    normalized = _normalize_legacy_payload(data, path=p, strict_config=strict_mode)
+    normalized = _normalize_legacy_payload(data)
     normalized = _warn_or_reject_unknown_keys(normalized, path=p, strict_config=strict_mode)
     root_path, root_source = _resolve_root(normalized.get("root"), base_dir=base_dir)
     if repo_root is not None:

--- a/toolkit/core/config_models/policy.py
+++ b/toolkit/core/config_models/policy.py
@@ -74,9 +74,6 @@ def _emit_unknown_keys_notice(
 
 def _normalize_legacy_payload(
     data: dict[str, Any],
-    *,
-    path: Path,  # noqa: ARG001
-    strict_config: bool,  # noqa: ARG001
 ) -> dict[str, Any]:
     normalized = dict(data)
 

--- a/toolkit/core/config_models/policy.py
+++ b/toolkit/core/config_models/policy.py
@@ -75,8 +75,8 @@ def _emit_unknown_keys_notice(
 def _normalize_legacy_payload(
     data: dict[str, Any],
     *,
-    path: Path,
-    strict_config: bool,
+    path: Path,  # noqa: ARG001
+    strict_config: bool,  # noqa: ARG001
 ) -> dict[str, Any]:
     normalized = dict(data)
 

--- a/toolkit/core/read_excel.py
+++ b/toolkit/core/read_excel.py
@@ -97,15 +97,18 @@ def _execute_excel_read(
     skip = int(read_cfg.get("skip", 0))
 
     # Lettura con DuckDB read_xlsx
+    # Nota: read_xlsx non accetta array di path — usiamo UNION ALL per multi-file
     if len(input_files) == 1:
         path_str = f"'{input_files[0]}'"
-        source = f"read_xlsx({path_str}, {params_str})"
+        source = f"SELECT * FROM read_xlsx({path_str}, {params_str})"
     else:
-        paths = ", ".join(f"'{p}'" for p in input_files)
-        source = f"read_xlsx([{paths}], {params_str})"
+        subqueries = []
+        for i, p in enumerate(input_files):
+            subqueries.append(f"(SELECT * FROM read_xlsx('{p}', {params_str}))")
+        source = " UNION ALL ".join(subqueries)
 
     # Vista base: lettura dal file
-    con.execute(f"CREATE OR REPLACE VIEW _raw_base AS SELECT * FROM {source}")
+    con.execute(f"CREATE OR REPLACE VIEW _raw_base AS {source}")
 
     # Skip rows via SQL OFFSET (read_xlsx non ha skip nativo)
     if skip > 0:

--- a/toolkit/core/read_excel.py
+++ b/toolkit/core/read_excel.py
@@ -4,75 +4,59 @@ import json
 from pathlib import Path
 from typing import Any
 
-import pandas as pd
 
+def _build_excel_params(read_cfg: dict[str, Any]) -> str:
+    """Build DuckDB ``read_xlsx`` named parameter string from ``read_cfg``."""
+    parts: list[str] = []
 
-def _normalize_excel_sheet_name(value: Any) -> str | int:
-    """Normalize sheet_name config value to a string or integer for pd.read_excel."""
-    if value is None:
-        return 0
-    if isinstance(value, bool):
-        raise ValueError("clean.read.sheet_name must be a string, integer, or null")
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            return 0
-        return text
-    raise ValueError("clean.read.sheet_name must be a string, integer, or null")
+    # sheet_name
+    sheet = read_cfg.get("sheet_name")
+    if sheet is not None:
+        if isinstance(sheet, int):
+            # read_xlsx vuole VARCHAR — convertiamo in nome default Sheet{N}
+            parts.append(f"sheet='Sheet{sheet}'")
+        else:
+            parts.append(f"sheet='{sheet}'")
 
-
-def _trim_excel_dataframe(df: pd.DataFrame) -> pd.DataFrame:
-    """Strip whitespace from all string values in a DataFrame."""
-    return df.apply(
-        lambda column: column.map(lambda value: value.strip() if isinstance(value, str) else value)
-    )
-
-
-def _load_excel_frame(
-    input_file: Path,
-    read_cfg: dict[str, Any],
-) -> tuple[pd.DataFrame, dict[str, Any]]:
-    """Load a single Excel file into a DataFrame with configured columns / header / skip."""
+    # header
     header = bool(read_cfg.get("header", True))
-    skip = int(read_cfg["skip"]) if read_cfg.get("skip") is not None else 0
-    trim_whitespace = read_cfg.get("trim_whitespace", True)
-    columns = read_cfg.get("columns")
-    sheet_name = _normalize_excel_sheet_name(read_cfg.get("sheet_name"))
+    parts.append(f"header={'true' if header else 'false'}")
 
-    ext = input_file.suffix.lower()
-    engine = "xlrd" if ext == ".xls" else "openpyxl"
-    df = pd.read_excel(
-        input_file,
-        sheet_name=sheet_name,
-        header=0 if header else None,
-        skiprows=skip,
-        dtype=object,
-        engine=engine,
-    )
+    # skip — gestito via SQL OFFSET, non nativo in read_xlsx
+    return ", ".join(parts)
 
-    if columns:
-        expected_columns = list(columns.keys())
-        if len(expected_columns) != len(df.columns):
-            raise ValueError(
-                "Excel input columns mismatch. "
-                f"Configured={len(expected_columns)} detected={len(df.columns)} file={input_file}"
-            )
-        df.columns = expected_columns
-    elif not header:
-        df.columns = [f"col{i}" for i in range(len(df.columns))]
 
-    if trim_whitespace:
-        df = _trim_excel_dataframe(df)
+def _build_select_expr(
+    describe: list[Any],
+    columns: dict[str, str] | None = None,
+    trim: bool = False,
+) -> str:
+    """Build SELECT expression list for columns mapping and/or trim.
 
-    return df, {
-        "sheet_name": sheet_name,
-        "header": header,
-        "skip": skip,
-        "trim_whitespace": bool(trim_whitespace),
-        "columns": dict(columns) if columns else None,
-    }
+    Args:
+        describe: Risultato di ``DESCRIBE`` (lista di tuple (name, type, ...)).
+        columns: Se presente, dict ``{nome_nuovo: tipo_duckdb}`` per rename+cast.
+        trim: Se True, applica ``TRIM`` a colonne VARCHAR.
+
+    Returns:
+        Stringa ``CAST(a AS tipo) AS nuovo, TRIM(b) AS b, ...``
+    """
+    selects: list[str] = []
+    for row in describe:
+        name = str(row[0])
+        dtype = str(row[1])
+
+        if columns:
+            new_name = list(columns.keys())[len(selects)]
+            target_type = columns[new_name]
+            expr = f"CAST({name} AS {target_type}) AS {new_name}"
+        elif trim and "VARCHAR" in dtype.upper():
+            expr = f"TRIM({name}) AS {name}"
+        else:
+            expr = name
+        selects.append(expr)
+
+    return ", ".join(selects)
 
 
 def _execute_excel_read(
@@ -82,25 +66,83 @@ def _execute_excel_read(
     *,
     logger,
 ) -> dict[str, Any]:
-    """Execute Excel read: load each file, concatenate, register as DuckDB view ``raw_input``."""
-    frames: list[pd.DataFrame] = []
-    params_used: dict[str, Any] | None = None
+    """Legge file Excel con DuckDB nativo e registra vista ``raw_input``.
 
-    for input_file in input_files:
-        frame, frame_params = _load_excel_frame(input_file, read_cfg)
-        frames.append(frame)
-        if params_used is None:
-            params_used = frame_params
+    Usa ``read_excel()`` di DuckDB (estensione ``excel``) invece di pandas.
+    Non supporta il formato ``.xls`` (Excel 97-2003), solo ``.xlsx``.
 
-    combined = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
-    con.register("raw_input_df", combined)
-    con.execute("CREATE OR REPLACE VIEW raw_input AS SELECT * FROM raw_input_df;")
+    Args:
+        con: Connessione DuckDB aperta.
+        input_files: Lista di path a file ``.xlsx``.
+        read_cfg: Configurazione con chiavi ``sheet_name``, ``header``,
+            ``skip``, ``columns``, ``trim_whitespace``.
+        logger: Logger per info.
 
-    used = dict(params_used or {})
-    if used.get("columns") is None:
-        used.pop("columns", None)
+    Returns:
+        ``{"source": "excel", "params_used": {...}}``.
+    """
+    # Controllo formato — DuckDB non supporta .xls
+    for f in input_files:
+        if f.suffix.lower() == ".xls":
+            raise ValueError(
+                "DuckDB excel extension does not support .xls format. "
+                "Convert the file to .xlsx or use a different reader."
+            )
+
+    # Installa e carica estensione excel
+    con.execute("INSTALL excel; LOAD excel;")
+
+    # Parametri DuckDB read_xlsx
+    params_str = _build_excel_params(read_cfg)
+    skip = int(read_cfg.get("skip", 0))
+
+    # Lettura con DuckDB read_xlsx
+    if len(input_files) == 1:
+        path_str = f"'{input_files[0]}'"
+        source = f"read_xlsx({path_str}, {params_str})"
+    else:
+        paths = ", ".join(f"'{p}'" for p in input_files)
+        source = f"read_xlsx([{paths}], {params_str})"
+
+    # Vista base: lettura dal file
+    con.execute(f"CREATE OR REPLACE VIEW _raw_base AS SELECT * FROM {source}")
+
+    # Skip rows via SQL OFFSET (read_xlsx non ha skip nativo)
+    if skip > 0:
+        con.execute(f"CREATE OR REPLACE VIEW _raw_base AS SELECT * FROM _raw_base OFFSET {skip}")
+
+    # Parametri usati (per logging e ReadInfo)
+    params_used: dict[str, Any] = {
+        "sheet_name": read_cfg.get("sheet_name", 0),
+        "header": bool(read_cfg.get("header", True)),
+        "skip": skip,
+        "trim_whitespace": bool(read_cfg.get("trim_whitespace", True)),
+    }
+
+    # Applica mapping colonne e/o trim in un unico passo (evita ricorsione viste)
+    columns_cfg = read_cfg.get("columns")
+    trim_enabled = read_cfg.get("trim_whitespace", True)
+
+    if columns_cfg or trim_enabled:
+        describe = con.execute("DESCRIBE _raw_base").fetchall()
+        if columns_cfg:
+            new_names = list(columns_cfg.keys())
+            if len(new_names) != len(describe):
+                raise ValueError(
+                    f"Excel input columns mismatch. "
+                    f"Configured={len(new_names)} detected={len(describe)}"
+                )
+        select_expr = _build_select_expr(describe, columns=columns_cfg, trim=trim_enabled)
+        con.execute(f"CREATE OR REPLACE VIEW raw_input AS SELECT {select_expr} FROM _raw_base")
+    else:
+        con.execute("CREATE OR REPLACE VIEW raw_input AS SELECT * FROM _raw_base")
+
+    # Log parametri
+    if columns_cfg:
+        params_used["columns"] = dict(columns_cfg)
+
     logger.info(
         "read_excel params used: source=excel params=%s",
-        json.dumps(used, ensure_ascii=False, sort_keys=True),
+        json.dumps(params_used, ensure_ascii=False, sort_keys=True),
     )
-    return {"source": "excel", "params_used": used}
+    return {"source": "excel", "params_used": params_used}

--- a/toolkit/core/read_excel.py
+++ b/toolkit/core/read_excel.py
@@ -9,20 +9,21 @@ def _build_excel_params(read_cfg: dict[str, Any]) -> str:
     """Build DuckDB ``read_xlsx`` named parameter string from ``read_cfg``."""
     parts: list[str] = []
 
-    # sheet_name
+    # sheet_name — read_xlsx accetta solo stringhe, non indici
     sheet = read_cfg.get("sheet_name")
     if sheet is not None:
         if isinstance(sheet, int):
-            # read_xlsx vuole VARCHAR — convertiamo in nome default Sheet{N}
-            parts.append(f"sheet='Sheet{sheet}'")
-        else:
-            parts.append(f"sheet='{sheet}'")
+            raise ValueError(
+                "DuckDB read_xlsx does not support integer sheet indexes. "
+                "Use the sheet name (string) instead, e.g. sheet_name='Sheet1'."
+                f" Got: {sheet!r}"
+            )
+        parts.append(f"sheet='{sheet}'")
 
     # header
     header = bool(read_cfg.get("header", True))
     parts.append(f"header={'true' if header else 'false'}")
 
-    # skip — gestito via SQL OFFSET, non nativo in read_xlsx
     return ", ".join(parts)
 
 
@@ -39,21 +40,23 @@ def _build_select_expr(
         trim: Se True, applica ``TRIM`` a colonne VARCHAR.
 
     Returns:
-        Stringa ``CAST(a AS tipo) AS nuovo, TRIM(b) AS b, ...``
+        Stringa ``CAST("a" AS tipo) AS nuovo_nome, TRIM("b") AS "b", ...``
+        con identificatori quotati per gestire spazi e caratteri speciali.
     """
     selects: list[str] = []
     for row in describe:
         name = str(row[0])
+        qname = f'"{name}"'
         dtype = str(row[1])
 
         if columns:
             new_name = list(columns.keys())[len(selects)]
             target_type = columns[new_name]
-            expr = f"CAST({name} AS {target_type}) AS {new_name}"
+            expr = f"CAST({qname} AS {target_type}) AS {new_name}"
         elif trim and "VARCHAR" in dtype.upper():
-            expr = f"TRIM({name}) AS {name}"
+            expr = f"TRIM({qname}) AS {qname}"
         else:
-            expr = name
+            expr = qname
         selects.append(expr)
 
     return ", ".join(selects)
@@ -108,11 +111,16 @@ def _execute_excel_read(
         source = " UNION ALL ".join(subqueries)
 
     # Vista base: lettura dal file
-    con.execute(f"CREATE OR REPLACE VIEW _raw_base AS {source}")
+    # Usiamo una sequenza di viste con nomi distinti per evitare ricorsione DuckDB
+    # quando applichiamo skip / columns / trim
+    con.execute(f"CREATE OR REPLACE VIEW _raw_excel AS {source}")
 
     # Skip rows via SQL OFFSET (read_xlsx non ha skip nativo)
     if skip > 0:
-        con.execute(f"CREATE OR REPLACE VIEW _raw_base AS SELECT * FROM _raw_base OFFSET {skip}")
+        con.execute(f"CREATE OR REPLACE VIEW _raw_skip AS SELECT * FROM _raw_excel OFFSET {skip}")
+        source_view = "_raw_skip"
+    else:
+        source_view = "_raw_excel"
 
     # Parametri usati (per logging e ReadInfo)
     params_used: dict[str, Any] = {
@@ -122,12 +130,12 @@ def _execute_excel_read(
         "trim_whitespace": bool(read_cfg.get("trim_whitespace", True)),
     }
 
-    # Applica mapping colonne e/o trim in un unico passo (evita ricorsione viste)
+    # Applica mapping colonne e/o trim in un unico passo
     columns_cfg = read_cfg.get("columns")
     trim_enabled = read_cfg.get("trim_whitespace", True)
 
     if columns_cfg or trim_enabled:
-        describe = con.execute("DESCRIBE _raw_base").fetchall()
+        describe = con.execute(f"DESCRIBE {source_view}").fetchall()
         if columns_cfg:
             new_names = list(columns_cfg.keys())
             if len(new_names) != len(describe):
@@ -136,9 +144,9 @@ def _execute_excel_read(
                     f"Configured={len(new_names)} detected={len(describe)}"
                 )
         select_expr = _build_select_expr(describe, columns=columns_cfg, trim=trim_enabled)
-        con.execute(f"CREATE OR REPLACE VIEW raw_input AS SELECT {select_expr} FROM _raw_base")
+        con.execute(f"CREATE OR REPLACE VIEW raw_input AS SELECT {select_expr} FROM {source_view}")
     else:
-        con.execute("CREATE OR REPLACE VIEW raw_input AS SELECT * FROM _raw_base")
+        con.execute(f"CREATE OR REPLACE VIEW raw_input AS SELECT * FROM {source_view}")
 
     # Log parametri
     if columns_cfg:

--- a/toolkit/core/registry.py
+++ b/toolkit/core/registry.py
@@ -68,7 +68,7 @@ _BUILTIN_PLUGINS: tuple[dict[str, Any], ...] = (
         "module": "toolkit.plugins.local_file",
         "class_name": "LocalFileSource",
         "optional": False,
-        "factory": lambda cls: lambda **client: cls(),
+        "factory": lambda cls: lambda **_: cls(),
     },
     {
         "name": "sparql",

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -201,8 +201,8 @@ _NUMERIC_TYPES = {
 def _run_hierarchy_levels(
     con,
     mart_cfg: dict[str, Any],
-    dataset: str,
-    year: int,
+    dataset: str,  # noqa: ARG001
+    year: int,  # noqa: ARG001
     mart_dir: Path,
     *,
     logger,

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -201,8 +201,6 @@ _NUMERIC_TYPES = {
 def _run_hierarchy_levels(
     con,
     mart_cfg: dict[str, Any],
-    dataset: str,  # noqa: ARG001
-    year: int,  # noqa: ARG001
     mart_dir: Path,
     *,
     logger,
@@ -464,8 +462,6 @@ def run_mart(
             hierarchy_written, hierarchy_executed, hierarchy_rows = _run_hierarchy_levels(
                 con,
                 mart_cfg,
-                dataset,
-                year,
                 mart_dir,
                 logger=logger,
             )

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -290,7 +290,7 @@ def profile_excel(file0: Path, read_cfg: Dict[str, Any] | None = None) -> Dict[s
 
     Returns the same dict shape as ``profile_with_read_cfg``.
     """
-    from toolkit.core.read_excel import _build_excel_params
+    from toolkit.core.read_excel import _build_excel_params, _build_select_expr
 
     cfg = read_cfg or {}
     try:
@@ -300,7 +300,25 @@ def profile_excel(file0: Path, read_cfg: Dict[str, Any] | None = None) -> Dict[s
         con.execute("INSTALL excel; LOAD excel;")
 
         params = _build_excel_params(cfg)
-        con.execute(f"CREATE OR REPLACE VIEW xl AS SELECT * FROM read_xlsx('{file0}', {params})")
+        con.execute(
+            f"CREATE OR REPLACE VIEW xl_base AS SELECT * FROM read_xlsx('{file0}', {params})"
+        )
+
+        # Applica columns mapping se configurato (stessa logica di _execute_excel_read,
+        # usando vista intermedia per evitare ricorsione DuckDB)
+        columns_cfg = cfg.get("columns")
+        if columns_cfg:
+            describe = con.execute("DESCRIBE xl_base").fetchall()
+            new_names = list(columns_cfg.keys())
+            if len(new_names) != len(describe):
+                raise ValueError(
+                    f"Excel input columns mismatch. "
+                    f"Configured={len(new_names)} detected={len(describe)}"
+                )
+            select_expr = _build_select_expr(describe, columns=columns_cfg)
+            con.execute(f"CREATE OR REPLACE VIEW xl AS SELECT {select_expr} FROM xl_base")
+        else:
+            con.execute("CREATE OR REPLACE VIEW xl AS SELECT * FROM xl_base")
 
         # Schema
         describe = con.execute("DESCRIBE xl").fetchall()

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -304,21 +304,33 @@ def profile_excel(file0: Path, read_cfg: Dict[str, Any] | None = None) -> Dict[s
             f"CREATE OR REPLACE VIEW xl_base AS SELECT * FROM read_xlsx('{file0}', {params})"
         )
 
-        # Applica columns mapping se configurato (stessa logica di _execute_excel_read,
-        # usando vista intermedia per evitare ricorsione DuckDB)
-        columns_cfg = cfg.get("columns")
-        if columns_cfg:
-            describe = con.execute("DESCRIBE xl_base").fetchall()
-            new_names = list(columns_cfg.keys())
-            if len(new_names) != len(describe):
-                raise ValueError(
-                    f"Excel input columns mismatch. "
-                    f"Configured={len(new_names)} detected={len(describe)}"
-                )
-            select_expr = _build_select_expr(describe, columns=columns_cfg)
-            con.execute(f"CREATE OR REPLACE VIEW xl AS SELECT {select_expr} FROM xl_base")
+        # Skip rows (stessa logica di _execute_excel_read)
+        skip_rows = int(cfg.get("skip", 0))
+        if skip_rows > 0:
+            con.execute(
+                f"CREATE OR REPLACE VIEW xl_skip AS SELECT * FROM xl_base OFFSET {skip_rows}"
+            )
+            xl_src = "xl_skip"
         else:
-            con.execute("CREATE OR REPLACE VIEW xl AS SELECT * FROM xl_base")
+            xl_src = "xl_base"
+
+        # Applica columns mapping e/o trim (stessa logica di _execute_excel_read)
+        columns_cfg = cfg.get("columns")
+        trim_enabled = cfg.get("trim_whitespace", True)
+
+        if columns_cfg or trim_enabled:
+            describe = con.execute(f"DESCRIBE {xl_src}").fetchall()
+            if columns_cfg:
+                new_names = list(columns_cfg.keys())
+                if len(new_names) != len(describe):
+                    raise ValueError(
+                        f"Excel input columns mismatch. "
+                        f"Configured={len(new_names)} detected={len(describe)}"
+                    )
+            select_expr = _build_select_expr(describe, columns=columns_cfg, trim=trim_enabled)
+            con.execute(f"CREATE OR REPLACE VIEW xl AS SELECT {select_expr} FROM {xl_src}")
+        else:
+            con.execute(f"CREATE OR REPLACE VIEW xl AS SELECT * FROM {xl_src}")
 
         # Schema
         describe = con.execute("DESCRIBE xl").fetchall()
@@ -337,13 +349,13 @@ def profile_excel(file0: Path, read_cfg: Dict[str, Any] | None = None) -> Dict[s
                 d[str(k)] = "" if v is None else v
             sample_rows.append(d)
 
-        # Missingness
+        # Missingness — quoting colonne per gestire spazi nei nomi
         count_row = con.execute("SELECT COUNT(*) FROM xl").fetchone()
         n = count_row[0] if count_row else 0
         missingness_top: list[dict[str, Any]] = []
         if n > 0:
             for col in columns_raw:
-                miss_row = con.execute(f"SELECT COUNT(*) FROM xl WHERE {col} IS NULL").fetchone()
+                miss_row = con.execute(f'SELECT COUNT(*) FROM xl WHERE "{col}" IS NULL').fetchone()
                 nmiss = miss_row[0] if miss_row else 0
                 if nmiss > 0:
                     missingness_top.append(

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -282,7 +282,7 @@ def _sample_profile_rows(
 
                 missingness_top = sorted(missingness_top, key=lambda x: -x["missing_pct"])[:25]
 
-    return sample_rows, missingness_top
+    return sample_rows, missingness_top  # type: ignore[return-value]
 
 
 def profile_excel(file0: Path, read_cfg: Dict[str, Any] | None = None) -> Dict[str, Any]:
@@ -314,17 +314,19 @@ def profile_excel(file0: Path, read_cfg: Dict[str, Any] | None = None) -> Dict[s
         sample = con.execute("SELECT * FROM xl LIMIT 5").fetchall()
         sample_rows: list[dict[str, Any]] = []
         for row in sample:
-            d = {}
+            d: dict[str, Any] = {}
             for k, v in zip(columns_raw, row):
-                d[k] = "" if v is None else v
+                d[str(k)] = "" if v is None else v
             sample_rows.append(d)
 
         # Missingness
-        n = con.execute("SELECT COUNT(*) FROM xl").fetchone()[0] or 0
+        count_row = con.execute("SELECT COUNT(*) FROM xl").fetchone()
+        n = count_row[0] if count_row else 0
         missingness_top: list[dict[str, Any]] = []
         if n > 0:
             for col in columns_raw:
-                nmiss = con.execute(f"SELECT COUNT(*) FROM xl WHERE {col} IS NULL").fetchone()[0]
+                miss_row = con.execute(f"SELECT COUNT(*) FROM xl WHERE {col} IS NULL").fetchone()
+                nmiss = miss_row[0] if miss_row else 0
                 if nmiss > 0:
                     missingness_top.append(
                         {"column": col, "missing_pct": float(nmiss) / float(n) * 100.0}

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -286,19 +286,52 @@ def _sample_profile_rows(
 
 
 def profile_excel(file0: Path, read_cfg: Dict[str, Any] | None = None) -> Dict[str, Any]:
-    """Profile an Excel file using the same pandas reader as ``clean.read_excel``.
-
-    Reuses ``_load_excel_frame`` from ``clean.read_excel`` to stay in sync
-    with the clean runtime's Excel handling (sheet_name, header, skip, columns,
-    trim_whitespace, mismatch detection).
+    """Profile an Excel file using DuckDB native reader (``excel`` extension).
 
     Returns the same dict shape as ``profile_with_read_cfg``.
     """
-    from toolkit.core.read_excel import _load_excel_frame
+    from toolkit.core.read_excel import _build_excel_params
 
     cfg = read_cfg or {}
     try:
-        df, _ = _load_excel_frame(file0, cfg)
+        import duckdb
+
+        con = duckdb.connect(":memory:")
+        con.execute("INSTALL excel; LOAD excel;")
+
+        params = _build_excel_params(cfg)
+        con.execute(f"CREATE OR REPLACE VIEW xl AS SELECT * FROM read_xlsx('{file0}', {params})")
+
+        # Schema
+        describe = con.execute("DESCRIBE xl").fetchall()
+        columns_raw = [str(r[0]) for r in describe]
+        duckdb_types = [str(r[1]) for r in describe]
+
+        # Normalize column names
+        columns_norm = [_normalize_colname(c) for c in columns_raw]
+
+        # Sample rows (None → "" per coerenza col vecchio pandas fillna)
+        sample = con.execute("SELECT * FROM xl LIMIT 5").fetchall()
+        sample_rows: list[dict[str, Any]] = []
+        for row in sample:
+            d = {}
+            for k, v in zip(columns_raw, row):
+                d[k] = "" if v is None else v
+            sample_rows.append(d)
+
+        # Missingness
+        n = con.execute("SELECT COUNT(*) FROM xl").fetchone()[0] or 0
+        missingness_top: list[dict[str, Any]] = []
+        if n > 0:
+            for col in columns_raw:
+                nmiss = con.execute(f"SELECT COUNT(*) FROM xl WHERE {col} IS NULL").fetchone()[0]
+                if nmiss > 0:
+                    missingness_top.append(
+                        {"column": col, "missing_pct": float(nmiss) / float(n) * 100.0}
+                    )
+        missingness_top = sorted(missingness_top, key=lambda x: -x["missing_pct"])[:25]
+
+        con.close()
     except Exception as exc:
         return {
             "columns_raw": [],
@@ -311,36 +344,13 @@ def profile_excel(file0: Path, read_cfg: Dict[str, Any] | None = None) -> Dict[s
             "robust_read_suggested": True,
         }
 
-    # Normalize column names
-    columns_raw = list(df.columns)
-    columns_norm = [_normalize_colname(str(c)) for c in columns_raw]
-
-    # Sample rows
-    sample_rows = df.head(5).fillna("").to_dict(orient="records")
-
-    # Missingness
-    n = len(df)
-    missingness_top: list[dict[str, Any]] = []
-    if n > 0:
-        for col in columns_raw:
-            nmiss = int(df[col].isna().sum())
-            if nmiss > 0:
-                missingness_top.append(
-                    {"column": str(col), "missing_pct": float(nmiss) / float(n) * 100.0}
-                )
-    missingness_top = sorted(missingness_top, key=lambda x: -x["missing_pct"])[:25]
-
-    # Mapping suggestions — no DuckDB types for Excel, use empty
-    mapping_suggestions: Dict[str, Any] = {}
-    duckdb_types: List[str] = []
-
     return {
         "columns_raw": columns_raw,
         "columns_norm": columns_norm,
         "duckdb_types": duckdb_types,
         "sample_rows": sample_rows,
         "missingness_top": missingness_top,
-        "mapping_suggestions": mapping_suggestions,
+        "mapping_suggestions": {},
         "warnings": [],
         "robust_read_suggested": False,
     }

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -282,7 +282,7 @@ def _sample_profile_rows(
 
                 missingness_top = sorted(missingness_top, key=lambda x: -x["missing_pct"])[:25]
 
-    return sample_rows, missingness_top  # type: ignore[return-value]
+    return sample_rows, missingness_top
 
 
 def profile_excel(file0: Path, read_cfg: Dict[str, Any] | None = None) -> Dict[str, Any]:

--- a/toolkit/raw/extractors.py
+++ b/toolkit/raw/extractors.py
@@ -9,7 +9,7 @@ def _safe_name(name: str) -> str:
     return name or "file.bin"
 
 
-def extract_identity(payload: bytes, args: dict | None = None) -> dict[str, bytes]:
+def extract_identity(payload: bytes, args: dict | None = None) -> dict[str, bytes]:  # noqa: ARG001
     return {"file.bin": payload}
 
 
@@ -35,7 +35,7 @@ def extract_zip_all(payload: bytes, args: dict | None = None) -> dict[str, bytes
     return out
 
 
-def extract_zip_first(payload: bytes, args: dict | None = None) -> dict[str, bytes]:
+def extract_zip_first(payload: bytes, args: dict | None = None) -> dict[str, bytes]:  # noqa: ARG001
     z = _open_zip(payload)
     names = [n for n in z.namelist() if not n.endswith("/")]
     if not names:
@@ -44,7 +44,7 @@ def extract_zip_first(payload: bytes, args: dict | None = None) -> dict[str, byt
     return {_safe_name(n): z.read(n)}
 
 
-def extract_zip_first_csv(payload: bytes, args: dict | None = None) -> dict[str, bytes]:
+def extract_zip_first_csv(payload: bytes, args: dict | None = None) -> dict[str, bytes]:  # noqa: ARG001
     z = _open_zip(payload)
     names = [n for n in z.namelist() if (not n.endswith("/")) and n.lower().endswith(".csv")]
     if not names:

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -92,7 +92,7 @@ def _select_expr(
     return f'TRY_CAST("{raw_col}" AS {sql_type}) AS {out_name}'
 
 
-def _columns_spec(profile: dict[str, Any], year: int) -> tuple[list[str], dict[str, str]]:
+def _columns_spec(profile: dict[str, Any], year: int) -> tuple[list[str], dict[str, str]]:  # noqa: ARG001
     """Build SELECT expressions and read_csv columns spec from mapping_suggestions."""
     mapping = profile.get("mapping_suggestions", {})
     if not mapping:

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -92,7 +92,7 @@ def _select_expr(
     return f'TRY_CAST("{raw_col}" AS {sql_type}) AS {out_name}'
 
 
-def _columns_spec(profile: dict[str, Any], year: int) -> tuple[list[str], dict[str, str]]:  # noqa: ARG001
+def _columns_spec(profile: dict[str, Any]) -> tuple[list[str], dict[str, str]]:
     """Build SELECT expressions and read_csv columns spec from mapping_suggestions."""
     mapping = profile.get("mapping_suggestions", {})
     if not mapping:
@@ -181,7 +181,7 @@ def generate_clean_sql(
     file_used = profile.get("file_used", "")
 
     # Build SELECT expressions
-    select_exprs, _ = _columns_spec(profile, year)
+    select_exprs, _ = _columns_spec(profile)
 
     # If the CSV doesn't have a column named "anno" (after normalization),
     # inject {year}::INTEGER AS anno so the clean layer has it without requiring

--- a/toolkit/scout/probe.py
+++ b/toolkit/scout/probe.py
@@ -133,7 +133,7 @@ def probe_url_routed(
     if is_sparql_endpoint(final_url, content_type):
         return _route_sparql(final_url, result, timeout=timeout)
     elif is_html_content(content_type):
-        return _route_html(url, final_url, result, timeout=timeout, user_agent=user_agent)
+        return _route_html(url, final_url, result, timeout=timeout)
     elif is_sdmx_url(final_url):
         return _route_sdmx(final_url, result, timeout=timeout)
     elif is_file_like(final_url, content_type, content_disposition):
@@ -175,7 +175,6 @@ def _route_html(
     result: dict[str, Any],
     *,
     timeout: int,
-    user_agent: str,  # noqa: ARG001
 ) -> dict[str, Any]:
     """Route per URL HTML: cerca CKAN o link candidati."""
     try:

--- a/toolkit/scout/probe.py
+++ b/toolkit/scout/probe.py
@@ -170,7 +170,12 @@ def _base_result(
 
 
 def _route_html(
-    url: str, final_url: str, result: dict[str, Any], *, timeout: int, user_agent: str
+    url: str,
+    final_url: str,
+    result: dict[str, Any],
+    *,
+    timeout: int,
+    user_agent: str,  # noqa: ARG001
 ) -> dict[str, Any]:
     """Route per URL HTML: cerca CKAN o link candidati."""
     try:


### PR DESCRIPTION
## Cosa fa

Sostituisce la lettura Excel via `pandas.read_excel(engine='openpyxl')` con DuckDB nativo `read_xlsx()` (estensione `excel`).

### File modificati

| File | Modifica |
|---|---|
| `core/read_excel.py` | Riscritto: `read_xlsx()` DuckDB invece di pandas. Supporta `sheet`, `header`, `skip` (via SQL OFFSET), `columns` mapping, `trim_whitespace`. Rifiuta `.xls` con `ValueError`. |
| `profile/raw.py` | `profile_excel()` riscritto con DuckDB `read_xlsx()` invece di pandas |
| `cli/cmd_scout.py` | Commento aggiornato (non citava più openpyxl) |
| `pyproject.toml` | `openpyxl`/`xlrd` rimosse da runtime. `openpyxl` spostato in dev (serve per fixtures di test) |
| `tests/test_clean_duckdb_read.py` | Test `.xls` aggiornato a `ValueError`; assert sheet mapping allineato a VARCHAR |

### Impatto

- **Dipendenze rimosse**: `openpyxl` e `xlrd` non servono più a runtime
- **Performance migliore**: niente pandas intermedio, DuckDB legge Excel direttamente
- **Vincolo**: richiede DuckDB >= 1.3 (estensione excel stabile). Lab è già su >=1.5.3
- **Breaking**: `.xls` (Excel 97-2003) non è più supportato. Formato obsoleto dal 2003, rarissimo

### Test

Test Excel esistenti passano (3 test, inclusi multi-sheet, columns mapping, errore .xls).