### PR TITLE
fix: rendere trim sicuro con CAST AS VARCHAR nello scaffold clean

### DIFF
--- a/tests/test_scaffold_clean.py
+++ b/tests/test_scaffold_clean.py
@@ -30,7 +30,7 @@ class TestSelectExpr:
     def test_varchar_gets_trim(self) -> None:
         """VARCHAR columns use TRIM instead of unnecessary TRY_CAST."""
         result = _select_expr("Nome", "VARCHAR", "nome")
-        assert result == 'trim("Nome") AS nome'
+        assert result == 'trim(CAST("Nome" AS VARCHAR)) AS nome'
 
     @pytest.mark.pure_unit
     def test_integer_gets_try_cast(self) -> None:
@@ -148,7 +148,7 @@ class TestColumnsSpec:
             },
         }
         exprs, spec = _columns_spec(profile, 2024)
-        assert 'trim("Nome") AS nome' in exprs
+        assert 'trim(CAST("Nome" AS VARCHAR)) AS nome' in exprs
         assert 'TRY_CAST("Anno" AS BIGINT) AS anno' in exprs
         assert 'TRY_CAST("Valore" AS DOUBLE) AS valore' in exprs
         assert spec["Nome"] == "VARCHAR"
@@ -168,7 +168,7 @@ class TestColumnsSpec:
         }
         exprs, _ = _columns_spec(profile, 2024)
         joined = "\n".join(exprs)
-        assert 'trim("Nome") AS nome' in joined
+        assert 'trim(CAST("Nome" AS VARCHAR)) AS nome' in joined
         assert 'TRY_CAST("Importo" AS DOUBLE)' in joined
         assert "REPLACE" not in joined
 
@@ -213,7 +213,7 @@ class TestGenerateCleanSql:
         assert "{year}::INTEGER AS anno" in sql
         assert "FROM raw_input" in sql
         assert "WHERE" not in sql
-        assert 'trim("Nome")' in sql
+        assert 'trim(CAST("Nome" AS VARCHAR))' in sql
         assert 'TRY_CAST("Valore"' in sql
 
     @pytest.mark.pure_unit
@@ -231,7 +231,7 @@ class TestGenerateCleanSql:
         assert "{year}::INTEGER" not in sql  # non injectato
         assert 'TRY_CAST("Anno" AS BIGINT) AS anno' in sql
         assert 'WHERE try_cast("Anno" AS INTEGER) IS NOT NULL' in sql
-        assert 'trim("Regione")' in sql
+        assert 'trim(CAST("Regione" AS VARCHAR))' in sql
 
     @pytest.mark.pure_unit
     def test_with_anno_di_imposta_adds_where(self) -> None:
@@ -341,6 +341,6 @@ class TestSuggestCleanSqlIntegration:
             },
         }
         sql = suggest_clean_sql(cols, profile)
-        assert 'trim("nome")' in sql
-        assert 'trim("categoria")' in sql
+        assert 'trim(CAST("nome" AS VARCHAR))' in sql
+        assert 'trim(CAST("categoria" AS VARCHAR))' in sql
         assert 'TRY_CAST("valore" AS DOUBLE)' in sql

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -81,13 +81,13 @@ def _select_expr(
 ) -> str:
     """Build a SELECT expression for one column with smart transformations.
 
-    - VARCHAR columns: TRIM instead of TRY_CAST (avoids unnecessary type coercion)
+    - VARCHAR columns: TRIM with CAST AS VARCHAR (safe for columns sniffed as BIGINT)
       Comma-decimal numbers are handled by clean.read.decimal in dataset.yml
       (see propose_clean_read()), not by REPLACE in SQL — DuckDB's read_csv
       native decimal support is more reliable and avoids DOUBLE→STRING round-trips.
     """
     if sql_type == "VARCHAR":
-        return f'trim("{raw_col}") AS {out_name}'
+        return f'trim(CAST("{raw_col}" AS VARCHAR)) AS {out_name}'
 
     return f'TRY_CAST("{raw_col}" AS {sql_type}) AS {out_name}'
 


### PR DESCRIPTION
## Problema

Lo scaffold di `toolkit scout --scaffold` genera `trim("colonna")` per colonne VARCHAR. Se DuckDB sniffa la colonna come BIGINT (valori tutti numerici nel sample), `trim()` crasha perché accetta solo VARCHAR. Succede con CSV che hanno colonne alfanumeriche ma con sample iniziale tutto numerico.

## Causa

`toolkit/scaffold/clean.py:_select_expr()` riga 90:
```python
return f'trim("{raw_col}") AS {out_name}'
```

Il fallback senza mapping (riga 105) usa già la forma sicura `trim(CAST(x AS VARCHAR))`, ma il percorso principale (con mapping) no.

## Fix

`trim("col")` → `trim(CAST("col" AS VARCHAR))`

- 1 riga nel codice, 7 righe nei test aggiornate
- Comportamento identico per colonne già VARCHAR (CAST è no-op)
- Previene crash su colonne sniffate come BIGINT

## Test

```
26 passed in 0.16s
```
