### PR TITLE
feat(scaffold): suggerimento automatico di dateformat in propose_clean_read

### DIFF
--- a/tests/test_scaffold_clean.py
+++ b/tests/test_scaffold_clean.py
@@ -14,6 +14,7 @@ from toolkit.scaffold.clean import (
     _find_anno_raw_column,
     _has_anno_column,
     _select_expr,
+    _suggest_dateformat,
     generate_clean_sql,
 )
 
@@ -69,6 +70,92 @@ class TestSelectExpr:
         """BOOLEAN columns get TRY_CAST."""
         result = _select_expr("Attivo", "BOOLEAN", "attivo")
         assert 'TRY_CAST("Attivo" AS BOOLEAN)' in result
+
+
+# ---------------------------------------------------------------------------
+# pure_unit: _suggest_dateformat
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestDateformat:
+    """pure_unit: _suggest_dateformat rileva formati data non ISO."""
+
+    @pytest.mark.pure_unit
+    def test_dd_mm_YYYY_with_slash(self) -> None:
+        """dd/mm/YYYY con slash → %d/%m/%Y."""
+        profile = {
+            "mapping_suggestions": {
+                "Data": {"type": "date"},
+            },
+            "sample_rows": [
+                {"Data": "15/03/2024"},
+                {"Data": "01/02/2023"},
+                {"Data": "31/12/2025"},
+            ],
+        }
+        assert _suggest_dateformat(profile) == "%d/%m/%Y"
+
+    @pytest.mark.pure_unit
+    def test_dd_mm_YYYY_with_dash(self) -> None:
+        """dd-mm-YYYY con trattino → %d-%m-%Y."""
+        profile = {
+            "mapping_suggestions": {
+                "data": {"type": "date"},
+            },
+            "sample_rows": [
+                {"data": "15-03-2024"},
+                {"data": "01-02-2023"},
+            ],
+        }
+        assert _suggest_dateformat(profile) == "%d-%m-%Y"
+
+    @pytest.mark.pure_unit
+    def test_iso_date_returns_none(self) -> None:
+        """Date ISO (YYYY-MM-DD) non attivano dateformat."""
+        profile = {
+            "mapping_suggestions": {
+                "Data": {"type": "date"},
+            },
+            "sample_rows": [
+                {"Data": "2024-03-15"},
+                {"Data": "2023-02-01"},
+            ],
+        }
+        assert _suggest_dateformat(profile) is None
+
+    @pytest.mark.pure_unit
+    def test_mixed_date_format_requires_majority(self) -> None:
+        """Se meno del 60% matcha un formato, non suggerisce."""
+        profile = {
+            "mapping_suggestions": {
+                "Data": {"type": "date"},
+            },
+            "sample_rows": [
+                {"Data": "15/03/2024"},
+                {"Data": "2024-03-15"},
+                {"Data": "01/02/2023"},
+            ],
+        }
+        # 2/3 = 66% > 60% → matcha %d/%m/%Y
+        assert _suggest_dateformat(profile) == "%d/%m/%Y"
+
+    @pytest.mark.pure_unit
+    def test_no_date_columns_returns_none(self) -> None:
+        """Senza colonne date → None."""
+        profile = {
+            "mapping_suggestions": {
+                "Nome": {"type": "str"},
+                "Valore": {"type": "float"},
+            },
+            "sample_rows": [{"Nome": "foo", "Valore": "100"}],
+        }
+        assert _suggest_dateformat(profile) is None
+
+    @pytest.mark.pure_unit
+    def test_empty_profile_returns_none(self) -> None:
+        """Profilo vuoto o senza sample → None."""
+        assert _suggest_dateformat({}) is None
+        assert _suggest_dateformat({"mapping_suggestions": {"D": {"type": "date"}}}) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scaffold_clean.py
+++ b/tests/test_scaffold_clean.py
@@ -181,6 +181,26 @@ class TestSuggestDateformat:
         assert _suggest_dateformat({}) is None
         assert _suggest_dateformat({"date_raw_values": {}}) is None
 
+    @pytest.mark.policy
+    def test_date_raw_values_capped_at_30_rows(self, tmp_path: Path) -> None:
+        """date_raw_values contiene al massimo 30 valori per colonna."""
+        from dataclasses import asdict
+        from toolkit.profile.raw import profile_raw
+
+        csv_file = tmp_path / "large.csv"
+        lines = ["data;valore"]
+        for i in range(1, 101):
+            day = (i % 28) + 1
+            month = ((i // 28) % 12) + 1
+            lines.append(f"{day:02d}/{month:02d}/2024;{i}")
+        csv_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        profile = profile_raw(tmp_path, "test", 2024, primary_file=csv_file)
+        d = asdict(profile)
+        raw_vals = d.get("date_raw_values", {})
+        for col, vals in raw_vals.items():
+            assert len(vals) <= 30, f"Colonna {col} ha {len(vals)} valori, atteso max 30"
+
 
 # ---------------------------------------------------------------------------
 # pure_unit: _find_anno_raw_column / _has_anno_column

--- a/tests/test_scaffold_clean.py
+++ b/tests/test_scaffold_clean.py
@@ -5,6 +5,7 @@ pure_unit: _select_expr, _columns_spec, generate_clean_sql, _find_anno_raw_colum
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -78,84 +79,107 @@ class TestSelectExpr:
 
 
 class TestSuggestDateformat:
-    """pure_unit: _suggest_dateformat rileva formati data non ISO."""
+    """pure_unit: _suggest_dateformat rileva formati data non ISO.
 
-    @pytest.mark.pure_unit
-    def test_dd_mm_YYYY_with_slash(self) -> None:
+    I test usano CSV reali processati da ``profile_raw`` per verificare
+    che la funzione funzioni su profili reali (dove DuckDB converte le
+    date in Timestamp, perdendo il formato originale).
+    """
+
+    @pytest.mark.policy
+    def test_dd_mm_YYYY_with_slash(self, tmp_path: Path) -> None:
         """dd/mm/YYYY con slash → %d/%m/%Y."""
-        profile = {
-            "mapping_suggestions": {
-                "Data": {"type": "date"},
-            },
-            "sample_rows": [
-                {"Data": "15/03/2024"},
-                {"Data": "01/02/2023"},
-                {"Data": "31/12/2025"},
-            ],
-        }
-        assert _suggest_dateformat(profile) == "%d/%m/%Y"
+        from dataclasses import asdict
+        from toolkit.profile.raw import profile_raw
 
-    @pytest.mark.pure_unit
-    def test_dd_mm_YYYY_with_dash(self) -> None:
+        csv_file = tmp_path / "date_slash.csv"
+        csv_file.write_text(
+            "data;valore\n15/03/2024;100\n01/02/2023;200\n31/12/2025;300\n",
+            encoding="utf-8",
+        )
+        profile = profile_raw(tmp_path, "test", 2024, primary_file=csv_file)
+        fmt = _suggest_dateformat(asdict(profile))
+        assert fmt == "%d/%m/%Y"
+
+    @pytest.mark.policy
+    def test_dd_mm_YYYY_with_dash(self, tmp_path: Path) -> None:
         """dd-mm-YYYY con trattino → %d-%m-%Y."""
-        profile = {
-            "mapping_suggestions": {
-                "data": {"type": "date"},
-            },
-            "sample_rows": [
-                {"data": "15-03-2024"},
-                {"data": "01-02-2023"},
-            ],
-        }
-        assert _suggest_dateformat(profile) == "%d-%m-%Y"
+        from dataclasses import asdict
+        from toolkit.profile.raw import profile_raw
 
-    @pytest.mark.pure_unit
-    def test_iso_date_returns_none(self) -> None:
+        csv_file = tmp_path / "date_dash.csv"
+        csv_file.write_text(
+            "data;valore\n15-03-2024;100\n01-02-2023;200\n",
+            encoding="utf-8",
+        )
+        profile = profile_raw(tmp_path, "test", 2024, primary_file=csv_file)
+        fmt = _suggest_dateformat(asdict(profile))
+        assert fmt == "%d-%m-%Y"
+
+    @pytest.mark.policy
+    def test_iso_date_returns_none(self, tmp_path: Path) -> None:
         """Date ISO (YYYY-MM-DD) non attivano dateformat."""
-        profile = {
-            "mapping_suggestions": {
-                "Data": {"type": "date"},
-            },
-            "sample_rows": [
-                {"Data": "2024-03-15"},
-                {"Data": "2023-02-01"},
-            ],
-        }
-        assert _suggest_dateformat(profile) is None
+        from dataclasses import asdict
+        from toolkit.profile.raw import profile_raw
 
-    @pytest.mark.pure_unit
-    def test_mixed_date_format_requires_majority(self) -> None:
-        """Se meno del 60% matcha un formato, non suggerisce."""
-        profile = {
-            "mapping_suggestions": {
-                "Data": {"type": "date"},
-            },
-            "sample_rows": [
-                {"Data": "15/03/2024"},
-                {"Data": "2024-03-15"},
-                {"Data": "01/02/2023"},
-            ],
-        }
-        # 2/3 = 66% > 60% → matcha %d/%m/%Y
-        assert _suggest_dateformat(profile) == "%d/%m/%Y"
+        csv_file = tmp_path / "date_iso.csv"
+        csv_file.write_text(
+            "data;valore\n2024-03-15;100\n2023-02-01;200\n",
+            encoding="utf-8",
+        )
+        profile = profile_raw(tmp_path, "test", 2024, primary_file=csv_file)
+        fmt = _suggest_dateformat(asdict(profile))
+        assert fmt is None
 
-    @pytest.mark.pure_unit
-    def test_no_date_columns_returns_none(self) -> None:
+    @pytest.mark.policy
+    def test_multiple_date_cols_agree_on_format(self, tmp_path: Path) -> None:
+        """Due colonne date con stesso formato → dateformat suggerito."""
+        from dataclasses import asdict
+        from toolkit.profile.raw import profile_raw
+
+        csv_file = tmp_path / "multi_date.csv"
+        csv_file.write_text(
+            "inizio;fine;valore\n15/03/2024;20/04/2024;100\n01/02/2023;10/03/2023;200\n",
+            encoding="utf-8",
+        )
+        profile = profile_raw(tmp_path, "test", 2024, primary_file=csv_file)
+        fmt = _suggest_dateformat(asdict(profile))
+        assert fmt == "%d/%m/%Y", f"got {fmt}"
+
+    @pytest.mark.policy
+    def test_no_date_columns_returns_none(self, tmp_path: Path) -> None:
         """Senza colonne date → None."""
-        profile = {
-            "mapping_suggestions": {
-                "Nome": {"type": "str"},
-                "Valore": {"type": "float"},
-            },
-            "sample_rows": [{"Nome": "foo", "Valore": "100"}],
-        }
-        assert _suggest_dateformat(profile) is None
+        from dataclasses import asdict
+        from toolkit.profile.raw import profile_raw
 
-    @pytest.mark.pure_unit
+        csv_file = tmp_path / "no_date.csv"
+        csv_file.write_text("nome;valore\nfoo;100\nbar;200\n", encoding="utf-8")
+        profile = profile_raw(tmp_path, "test", 2024, primary_file=csv_file)
+        fmt = _suggest_dateformat(asdict(profile))
+        assert fmt is None
+
+    @pytest.mark.policy
+    def test_mixed_date_cols_different_format_returns_none(self, tmp_path: Path) -> None:
+        """Se due colonne date hanno formati diversi, non suggerisce
+        (dateformat e' globale per read_csv, non puo' essere diverso per colonna)."""
+        from dataclasses import asdict
+        from toolkit.profile.raw import profile_raw
+
+        csv_file = tmp_path / "mixed_fmt.csv"
+        csv_file.write_text(
+            "data_it;data_us;valore\n15/03/2024;2024/03/15;100\n01/02/2023;2023/02/01;200\n",
+            encoding="utf-8",
+        )
+        profile = profile_raw(tmp_path, "test", 2024, primary_file=csv_file)
+        fmt = _suggest_dateformat(asdict(profile))
+        # 4 values in dd/mm/YYYY, 4 in YYYY/mm/dd → 50% each → < 60% → None
+        assert fmt is None, f"got {fmt}"
+
+    @pytest.mark.policy
     def test_empty_profile_returns_none(self) -> None:
-        """Profilo vuoto o senza sample → None."""
+        """Profilo vuoto o senza date_raw_values → None."""
         assert _suggest_dateformat({}) is None
-        assert _suggest_dateformat({"mapping_suggestions": {"D": {"type": "date"}}}) is None
+        assert _suggest_dateformat({"date_raw_values": {}}) is None
 
 
 # ---------------------------------------------------------------------------

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -8,6 +8,7 @@ and mapping suggestion generation. Internal sniffing logic lives in
 from __future__ import annotations
 
 import csv
+import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -479,33 +480,30 @@ def profile_with_read_cfg(
     }
 
 
+# Pattern per riconoscere valori che sembrano date (NN/NN/NNNN, NNNN/NN/NN, ecc.)
+# Usato in _extract_date_raw_values per trovare colonne VARCHAR che DuckDB
+# non ha classificato come DATE per mancanza di dateformat.
+_DATE_LIKE_RE = re.compile(r"^\d{1,4}[/\-]\d{1,2}[/\-]\d{1,4}$")
+
+
 def _extract_date_raw_values(
     file0: Path,
     mapping_suggestions: dict[str, Any],
     columns_raw: list[str],
     effective_read_cfg: dict[str, Any],
 ) -> dict[str, list[str]]:
-    """Extract raw string values for date-typed columns before DuckDB conversion.
+    """Extract raw string values for date-like columns before DuckDB conversion.
 
-    Reads the raw CSV file using the SAME read configuration that DuckDB uses
-    (same encoding, delimiter, header, skip, quote, escape) and collects
-    string values for columns that DuckDB categorized as ``date``.
-    This preserves the original date string format (e.g. ``15/03/2024``)
-    which DuckDB converts to ``Timestamp``.
+    Reads the raw CSV file directly (using the SAME read configuration as DuckDB)
+    and determines which columns look like dates by scanning raw string values
+    — NOT using DuckDB's ``sample_rows`` which already converts dates to Timestamp.
 
-    Returns ``{col_name: [val1, val2, ...]}`` for each date column with samples,
-    or empty dict if no date columns or file cannot be read.
+    Returns ``{col_name: [val1, val2, ...]}`` for each column that looks like
+    a date, or empty dict if none found.
     """
-    date_cols = [
-        col
-        for col, spec in mapping_suggestions.items()
-        if spec.get("type") == "date" and col in columns_raw
-    ]
-    if not date_cols:
+    if not columns_raw:
         return {}
 
-    col_index = {name: i for i, name in enumerate(columns_raw)}
-    result: dict[str, list[str]] = {col: [] for col in date_cols}
     enc = effective_read_cfg.get("encoding") or "utf-8"
     sep = effective_read_cfg.get("delim") or effective_read_cfg.get("sep") or ","
     skip_rows = int(effective_read_cfg.get("skip") or 0)
@@ -517,33 +515,59 @@ def _extract_date_raw_values(
     if effective_read_cfg.get("escape"):
         dialect_kwargs["escapechar"] = effective_read_cfg["escape"]
 
+    # Single pass: read raw rows, sample first 30 for detection,
+    # then extract values for date-like columns from ALL read rows
+    raw_samples: dict[int, list[str]] = {}
+    all_rows: list[list[str]] = []
+
     try:
         with open(file0, encoding=enc, newline="") as f:
             reader = csv.reader(f, **dialect_kwargs)
 
-            # Skip preamble rows
             for _ in range(skip_rows):
                 next(reader, None)
-
-            # Skip header row when DuckDB treats first row as header
             if has_header:
                 next(reader, None)
 
             for row in reader:
                 if not row:
                     continue
-                for col in date_cols:
-                    idx = col_index.get(col)
-                    if idx is not None and idx < len(row):
-                        val = (row[idx] or "").strip()
-                        if val:
-                            result[col].append(val)
-                if all(len(v) >= 30 for v in result.values()):
-                    break
+                all_rows.append(row)
+                # Keep first 30 rows as detection sample
+                if len(all_rows) <= 30:
+                    for i, val in enumerate(row):
+                        trimmed = val.strip()
+                        if trimmed:
+                            raw_samples.setdefault(i, []).append(trimmed)
     except Exception:
         pass
 
-    return {k: v for k, v in result.items() if v}
+    if not raw_samples:
+        return {}
+
+    # Find columns where >= 60% of sample values look like dates
+    date_col_indices: set[int] = set()
+    for col_idx, values in raw_samples.items():
+        non_empty = [v for v in values if v]
+        if not non_empty:
+            continue
+        date_like = sum(1 for v in non_empty if _DATE_LIKE_RE.match(v))
+        if date_like >= len(non_empty) * 0.6 and col_idx < len(columns_raw):
+            date_col_indices.add(col_idx)
+
+    if not date_col_indices:
+        return {}
+
+    result: dict[str, list[str]] = {}
+    for col_idx in sorted(date_col_indices):
+        col_name = columns_raw[col_idx]
+        vals = [
+            row[col_idx].strip() for row in all_rows if col_idx < len(row) and row[col_idx].strip()
+        ]
+        if vals:
+            result[col_name] = vals
+
+    return result
 
 
 @dataclass

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -152,6 +152,7 @@ def build_suggested_read_cfg(
         "columns",
         "trim_whitespace",
         "sample_size",
+        "dateformat",
     ):
         if key in source_cfg:
             cfg[key] = source_cfg[key]
@@ -164,6 +165,14 @@ def build_suggested_read_cfg(
         cfg["encoding"] = data["encoding_suggested"]
     if "skip" not in cfg and int(data.get("skip_suggested") or 0) > 0:
         cfg["skip"] = int(data["skip_suggested"])
+
+    # Propaga dateformat se non gia' in source_cfg
+    if "dateformat" not in cfg and data.get("date_raw_values"):
+        from toolkit.scaffold.clean import _suggest_dateformat
+
+        fmt = _suggest_dateformat(data)
+        if fmt:
+            cfg["dateformat"] = fmt
 
     cfg.setdefault("header", True)
 
@@ -474,16 +483,15 @@ def _extract_date_raw_values(
     file0: Path,
     mapping_suggestions: dict[str, Any],
     columns_raw: list[str],
-    encoding: str | None,
-    delim: str | None,
-    skip: int,
-    header_line: str | None,
+    effective_read_cfg: dict[str, Any],
 ) -> dict[str, list[str]]:
     """Extract raw string values for date-typed columns before DuckDB conversion.
 
-    Reads the raw CSV file using sniffed parameters and collects string values
-    for columns that DuckDB categorized as ``date``. This preserves the original
-    date string format (e.g. ``15/03/2024``) which DuckDB converts to ``Timestamp``.
+    Reads the raw CSV file using the SAME read configuration that DuckDB uses
+    (same encoding, delimiter, header, skip, quote, escape) and collects
+    string values for columns that DuckDB categorized as ``date``.
+    This preserves the original date string format (e.g. ``15/03/2024``)
+    which DuckDB converts to ``Timestamp``.
 
     Returns ``{col_name: [val1, val2, ...]}`` for each date column with samples,
     or empty dict if no date columns or file cannot be read.
@@ -498,19 +506,27 @@ def _extract_date_raw_values(
 
     col_index = {name: i for i, name in enumerate(columns_raw)}
     result: dict[str, list[str]] = {col: [] for col in date_cols}
-    enc = encoding or "utf-8"
-    sep = delim or ","
+    enc = effective_read_cfg.get("encoding") or "utf-8"
+    sep = effective_read_cfg.get("delim") or effective_read_cfg.get("sep") or ","
+    skip_rows = int(effective_read_cfg.get("skip") or 0)
+    has_header = bool(effective_read_cfg.get("header", True))
+
+    dialect_kwargs: dict[str, Any] = {"delimiter": sep}
+    if effective_read_cfg.get("quote"):
+        dialect_kwargs["quotechar"] = effective_read_cfg["quote"]
+    if effective_read_cfg.get("escape"):
+        dialect_kwargs["escapechar"] = effective_read_cfg["escape"]
 
     try:
         with open(file0, encoding=enc, newline="") as f:
-            reader = csv.reader(f, delimiter=sep)
+            reader = csv.reader(f, **dialect_kwargs)
 
             # Skip preamble rows
-            for _ in range(skip):
+            for _ in range(skip_rows):
                 next(reader, None)
 
-            # Skip header row if the file has one
-            if header_line is not None:
+            # Skip header row when DuckDB treats first row as header
+            if has_header:
                 next(reader, None)
 
             for row in reader:
@@ -660,15 +676,14 @@ def profile_raw(
     runtime_result = profile_with_read_cfg(file0, sniff_hints, effective_read_cfg)
 
     # Phase 4: extract raw string values for date-typed columns
-    # (DuckDB converts dates to Timestamp, losing the original format)
+    # (DuckDB converts dates to Timestamp, losing the original format).
+    # Uses the same effective_read_cfg as DuckDB (encoding, delim, header,
+    # skip, quote, escape) so the raw parser stays in sync with the runtime.
     date_raw_values = _extract_date_raw_values(
         file0,
         runtime_result["mapping_suggestions"],
         runtime_result["columns_raw"],
-        enc,
-        delim,
-        skip,
-        header_line,
+        effective_read_cfg,
     )
 
     return RawProfile(

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -515,10 +515,12 @@ def _extract_date_raw_values(
     if effective_read_cfg.get("escape"):
         dialect_kwargs["escapechar"] = effective_read_cfg["escape"]
 
-    # Single pass: read raw rows, sample first 30 for detection,
-    # then extract values for date-like columns from ALL read rows
+    # Single pass: read first 30 data rows, sample values per column.
+    # Both detection and extraction use the SAME 30-row sample — keeps
+    # profile size bounded (date_raw_values has at most 30 items/column).
+    MAX_SAMPLE = 30
     raw_samples: dict[int, list[str]] = {}
-    all_rows: list[list[str]] = []
+    rows_read = 0
 
     try:
         with open(file0, encoding=enc, newline="") as f:
@@ -532,13 +534,13 @@ def _extract_date_raw_values(
             for row in reader:
                 if not row:
                     continue
-                all_rows.append(row)
-                # Keep first 30 rows as detection sample
-                if len(all_rows) <= 30:
-                    for i, val in enumerate(row):
-                        trimmed = val.strip()
-                        if trimmed:
-                            raw_samples.setdefault(i, []).append(trimmed)
+                if rows_read >= MAX_SAMPLE:
+                    break
+                rows_read += 1
+                for i, val in enumerate(row):
+                    trimmed = val.strip()
+                    if trimmed:
+                        raw_samples.setdefault(i, []).append(trimmed)
     except Exception:
         pass
 
@@ -548,22 +550,20 @@ def _extract_date_raw_values(
     # Find columns where >= 60% of sample values look like dates
     date_col_indices: set[int] = set()
     for col_idx, values in raw_samples.items():
-        non_empty = [v for v in values if v]
-        if not non_empty:
+        if not values:
             continue
-        date_like = sum(1 for v in non_empty if _DATE_LIKE_RE.match(v))
-        if date_like >= len(non_empty) * 0.6 and col_idx < len(columns_raw):
+        date_like = sum(1 for v in values if _DATE_LIKE_RE.match(v))
+        if date_like >= len(values) * 0.6 and col_idx < len(columns_raw):
             date_col_indices.add(col_idx)
 
     if not date_col_indices:
         return {}
 
+    # Build result from the same 30-row sample
     result: dict[str, list[str]] = {}
     for col_idx in sorted(date_col_indices):
         col_name = columns_raw[col_idx]
-        vals = [
-            row[col_idx].strip() for row in all_rows if col_idx < len(row) and row[col_idx].strip()
-        ]
+        vals = raw_samples.get(col_idx, [])
         if vals:
             result[col_name] = vals
 

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -7,6 +7,7 @@ and mapping suggestion generation. Internal sniffing logic lives in
 
 from __future__ import annotations
 
+import csv
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -469,6 +470,66 @@ def profile_with_read_cfg(
     }
 
 
+def _extract_date_raw_values(
+    file0: Path,
+    mapping_suggestions: dict[str, Any],
+    columns_raw: list[str],
+    encoding: str | None,
+    delim: str | None,
+    skip: int,
+    header_line: str | None,
+) -> dict[str, list[str]]:
+    """Extract raw string values for date-typed columns before DuckDB conversion.
+
+    Reads the raw CSV file using sniffed parameters and collects string values
+    for columns that DuckDB categorized as ``date``. This preserves the original
+    date string format (e.g. ``15/03/2024``) which DuckDB converts to ``Timestamp``.
+
+    Returns ``{col_name: [val1, val2, ...]}`` for each date column with samples,
+    or empty dict if no date columns or file cannot be read.
+    """
+    date_cols = [
+        col
+        for col, spec in mapping_suggestions.items()
+        if spec.get("type") == "date" and col in columns_raw
+    ]
+    if not date_cols:
+        return {}
+
+    col_index = {name: i for i, name in enumerate(columns_raw)}
+    result: dict[str, list[str]] = {col: [] for col in date_cols}
+    enc = encoding or "utf-8"
+    sep = delim or ","
+
+    try:
+        with open(file0, encoding=enc, newline="") as f:
+            reader = csv.reader(f, delimiter=sep)
+
+            # Skip preamble rows
+            for _ in range(skip):
+                next(reader, None)
+
+            # Skip header row if the file has one
+            if header_line is not None:
+                next(reader, None)
+
+            for row in reader:
+                if not row:
+                    continue
+                for col in date_cols:
+                    idx = col_index.get(col)
+                    if idx is not None and idx < len(row):
+                        val = (row[idx] or "").strip()
+                        if val:
+                            result[col].append(val)
+                if all(len(v) >= 30 for v in result.values()):
+                    break
+    except Exception:
+        pass
+
+    return {k: v for k, v in result.items() if v}
+
+
 @dataclass
 class RawProfile:
     dataset: str
@@ -488,6 +549,7 @@ class RawProfile:
     missingness_top: List[Dict[str, Any]]
     sample_rows: List[Dict[str, Any]]
     mapping_suggestions: Dict[str, Any]
+    date_raw_values: Dict[str, List[str]]
 
     warnings: List[str]
 
@@ -561,6 +623,7 @@ def profile_raw(
             missingness_top=runtime_result["missingness_top"],
             sample_rows=runtime_result["sample_rows"],
             mapping_suggestions=runtime_result["mapping_suggestions"],
+            date_raw_values={},
             warnings=runtime_result["warnings"],
         )
     # ZIP or other unsupported binary — return empty profile with warning
@@ -580,6 +643,7 @@ def profile_raw(
             missingness_top=[],
             sample_rows=[],
             mapping_suggestions={},
+            date_raw_values={},
             warnings=["binary_file_not_supported: zip — use a different source format"],
         )
 
@@ -594,6 +658,18 @@ def profile_raw(
 
     # Phase 3: DuckDB runtime profiling
     runtime_result = profile_with_read_cfg(file0, sniff_hints, effective_read_cfg)
+
+    # Phase 4: extract raw string values for date-typed columns
+    # (DuckDB converts dates to Timestamp, losing the original format)
+    date_raw_values = _extract_date_raw_values(
+        file0,
+        runtime_result["mapping_suggestions"],
+        runtime_result["columns_raw"],
+        enc,
+        delim,
+        skip,
+        header_line,
+    )
 
     return RawProfile(
         dataset=dataset,
@@ -610,6 +686,7 @@ def profile_raw(
         missingness_top=runtime_result["missingness_top"],
         sample_rows=runtime_result["sample_rows"],
         mapping_suggestions=runtime_result["mapping_suggestions"],
+        date_raw_values=date_raw_values,
         warnings=runtime_result["warnings"],
     )
 

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import re
 from pathlib import Path
 from typing import Any
@@ -7,7 +8,6 @@ from typing import Any
 
 def _snake_case(name: str) -> str:
     """Convert a column name to snake_case (best-effort)."""
-    import re
 
     # Replace spaces and special chars with underscores
     s = name.strip()
@@ -50,56 +50,85 @@ def _map_duckdb_type(raw_type: str) -> str:
     return "VARCHAR"
 
 
-_DATE_FORMAT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
-    (re.compile(r"^\d{2}/\d{2}/\d{4}$"), "%d/%m/%Y"),
-    (re.compile(r"^\d{2}-\d{2}-\d{4}$"), "%d-%m-%Y"),
-    (re.compile(r"^\d{2}/\d{2}/\d{2}$"), "%d/%m/%y"),
-    (re.compile(r"^\d{2}-\d{2}-\d{2}$"), "%d-%m-%y"),
-    (re.compile(r"^\d{4}/\d{2}/\d{2}$"), "%Y/%m/%d"),
+# Formati data organizzati per gruppo con stesso separatore.
+# I gruppi con due formati (DMY/MDY) richiedono disambiguazione:
+# valori che parsano in UN SOLO formato votano quello; valori che
+# parsano in entrambi (es. "03/04/2024") sono ambigui e non contano.
+# I gruppi con un solo formato (YYYY/mm/dd) sono non-ambigu.
+_DATE_FORMAT_GROUPS: list[tuple[str, ...]] = [
+    ("%d/%m/%Y", "%m/%d/%Y"),  # slash 4-digit
+    ("%d-%m-%Y", "%m-%d-%Y"),  # dash 4-digit
+    ("%d/%m/%y", "%m/%d/%y"),  # slash 2-digit
+    ("%d-%m-%y", "%m-%d-%y"),  # dash 2-digit
+    ("%Y/%m/%d",),  # ISO con slash
 ]
+
+
+def _try_strptime(value: str, fmt: str) -> bool:
+    """Try to parse a date string with the given strptime format."""
+    try:
+        datetime.datetime.strptime(value, fmt)
+        return True
+    except ValueError:
+        return False
 
 
 def _suggest_dateformat(profile: dict[str, Any]) -> str | None:
     """Detect non-ISO date format from raw date values in the profile.
 
     Uses ``date_raw_values`` (extracted from raw CSV *before* DuckDB
-    converts dates to Timestamp) to detect date format patterns.
+    converts dates) and ``datetime.strptime`` for validation.
 
-    Each date column independently votes for its format. A column supports
-    a format if ≥60% of its non-empty values match that pattern.
-    Only suggests a ``dateformat`` if EVERY date column with a clear
-    format chooses the SAME format. Columns with no clear format (e.g.
-    ISO dates that match no non-ISO pattern) are ignored — they will
-    be parsed correctly by DuckDB regardless of ``dateformat``.
+    For ambiguous separators (``/``, ``-``), counts how many values
+    successfully parse in each format (DMY and MDY). Values that parse
+    in both formats are counted for both — the ambiguity means neither
+    format is *excluded*, but the format with more total parses wins.
 
-    Returns the ``dateformat`` string (e.g. ``%d/%m/%Y``) or ``None``.
+    Each column picks its best format (>=60% of its non-empty values).
+    Only suggests a ``dateformat`` if EVERY column picks the SAME format.
+
+    Returns the ``dateformat`` string or ``None``.
     """
     date_raw = profile.get("date_raw_values", {})
     if not date_raw:
         return None
 
-    # Per colonna: trova il formato vincente (se ≥60% dei suoi valori)
     col_formats: dict[str, str] = {}
     for col, values in date_raw.items():
         non_empty = [v for v in values if v]
-        if not non_empty:
+        total = len(non_empty)
+        if total == 0:
             continue
-        format_votes: dict[str, int] = {}
-        for v in non_empty:
-            for pattern, fmt in _DATE_FORMAT_PATTERNS:
-                if pattern.match(v):
-                    format_votes[fmt] = format_votes.get(fmt, 0) + 1
-                    break
-        if not format_votes:
-            continue
-        best_fmt, best_count = max(format_votes.items(), key=lambda x: x[1])
-        if best_count / len(non_empty) >= 0.6:
+
+        best_fmt: str | None = None
+        best_score = 0
+
+        for fmt_group in _DATE_FORMAT_GROUPS:
+            if len(fmt_group) == 1:
+                fmt = fmt_group[0]
+                count = sum(1 for v in non_empty if _try_strptime(v, fmt))
+                if count > best_score:
+                    best_score = count
+                    best_fmt = fmt
+            else:
+                dmy_fmt, mdy_fmt = fmt_group
+                dmy_count = sum(1 for v in non_empty if _try_strptime(v, dmy_fmt))
+                mdy_count = sum(1 for v in non_empty if _try_strptime(v, mdy_fmt))
+
+                # Only consider when one format clearly wins over the other
+                if dmy_count > mdy_count and dmy_count > best_score:
+                    best_score = dmy_count
+                    best_fmt = dmy_fmt
+                elif mdy_count > dmy_count and mdy_count > best_score:
+                    best_score = mdy_count
+                    best_fmt = mdy_fmt
+
+        if best_fmt is not None and best_score >= total * 0.6:
             col_formats[col] = best_fmt
 
     if not col_formats:
         return None
 
-    # Tutte le colonne con formato chiaro devono scegliere lo STESSO formato
     unique = set(col_formats.values())
     if len(unique) == 1:
         return unique.pop()

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -50,6 +50,63 @@ def _map_duckdb_type(raw_type: str) -> str:
     return "VARCHAR"
 
 
+_DATE_FORMAT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^\d{2}/\d{2}/\d{4}$"), "%d/%m/%Y"),
+    (re.compile(r"^\d{2}-\d{2}-\d{4}$"), "%d-%m-%Y"),
+    (re.compile(r"^\d{2}/\d{2}/\d{2}$"), "%d/%m/%y"),
+    (re.compile(r"^\d{2}-\d{2}-\d{2}$"), "%d-%m-%y"),
+    (re.compile(r"^\d{4}/\d{2}/\d{2}$"), "%Y/%m/%d"),
+]
+
+
+def _suggest_dateformat(profile: dict[str, Any]) -> str | None:
+    """Detect non-ISO date format from sample rows for date-typed columns.
+
+    Scans sample values of columns typed as ``date`` and checks if they
+    match a known non-ISO pattern (e.g. ``dd/mm/YYYY``). Returns the
+    corresponding ``dateformat`` string (e.g. ``%d/%m/%Y``) or ``None``
+    if all date columns appear to be ISO or no date columns exist.
+
+    Intended for use by ``propose_clean_read()`` to auto-suggest
+    ``dateformat`` in the scaffolded ``clean.read`` config.
+    """
+    mapping = profile.get("mapping_suggestions", {})
+    sample_rows = profile.get("sample_rows", [])
+    if not mapping or not sample_rows:
+        return None
+
+    date_cols = [col for col, spec in mapping.items() if spec.get("type") == "date"]
+    if not date_cols:
+        return None
+
+    for col in date_cols:
+        vals: list[str] = []
+        for r in sample_rows:
+            if col not in r:
+                continue
+            v = r.get(col)
+            if v is None:
+                continue
+            s = str(v).strip()
+            if s == "":
+                continue
+            vals.append(s)
+            if len(vals) >= 30:
+                break
+
+        non_empty = [v for v in vals if v]
+        if not non_empty:
+            continue
+
+        for pattern, fmt in _DATE_FORMAT_PATTERNS:
+            matches = sum(1 for v in non_empty if pattern.match(v))
+            threshold = max(2, int(len(non_empty) * 0.6))
+            if matches >= threshold:
+                return fmt
+
+    return None
+
+
 def _find_anno_raw_column(profile: dict[str, Any]) -> str | None:
     """Find the raw column name that looks like a year column.
 
@@ -302,6 +359,11 @@ def propose_clean_read(profile: dict[str, Any]) -> dict[str, Any]:
     decimal = profile.get("decimal_suggested")
     if decimal:
         read["decimal"] = decimal
+
+    # --- dateformat: auto-detect non-ISO date formats (es. dd/mm/YYYY) ---
+    date_fmt = _suggest_dateformat(profile)
+    if date_fmt:
+        read["dateformat"] = date_fmt
 
     # --- Columns: raw_name -> DuckDB type ---
     mapping = profile.get("mapping_suggestions", {})

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -65,10 +65,12 @@ def _suggest_dateformat(profile: dict[str, Any]) -> str | None:
     Uses ``date_raw_values`` (extracted from raw CSV *before* DuckDB
     converts dates to Timestamp) to detect date format patterns.
 
-    Only suggests a ``dateformat`` if at least 60% of ALL non-empty
-    date values across ALL date-typed columns match the same format.
-    This avoids suggesting a global ``dateformat`` that would work for
-    one column but break another.
+    Each date column independently votes for its format. A column supports
+    a format if ≥60% of its non-empty values match that pattern.
+    Only suggests a ``dateformat`` if EVERY date column with a clear
+    format chooses the SAME format. Columns with no clear format (e.g.
+    ISO dates that match no non-ISO pattern) are ignored — they will
+    be parsed correctly by DuckDB regardless of ``dateformat``.
 
     Returns the ``dateformat`` string (e.g. ``%d/%m/%Y``) or ``None``.
     """
@@ -76,31 +78,33 @@ def _suggest_dateformat(profile: dict[str, Any]) -> str | None:
     if not date_raw:
         return None
 
-    # Collect votes per format across all date columns
-    format_votes: dict[str, int] = {}
-    total_values = 0
-
+    # Per colonna: trova il formato vincente (se ≥60% dei suoi valori)
+    col_formats: dict[str, str] = {}
     for col, values in date_raw.items():
         non_empty = [v for v in values if v]
         if not non_empty:
             continue
-        total_values += len(non_empty)
-
+        format_votes: dict[str, int] = {}
         for v in non_empty:
             for pattern, fmt in _DATE_FORMAT_PATTERNS:
                 if pattern.match(v):
                     format_votes[fmt] = format_votes.get(fmt, 0) + 1
                     break
+        if not format_votes:
+            continue
+        best_fmt, best_count = max(format_votes.items(), key=lambda x: x[1])
+        if best_count / len(non_empty) >= 0.6:
+            col_formats[col] = best_fmt
 
-    if not format_votes or total_values == 0:
+    if not col_formats:
         return None
 
-    # A format wins only if >= 60% of ALL date values match it.
-    best_fmt, best_count = max(format_votes.items(), key=lambda x: x[1])
-    if best_count / total_values < 0.6:
-        return None
+    # Tutte le colonne con formato chiaro devono scegliere lo STESSO formato
+    unique = set(col_formats.values())
+    if len(unique) == 1:
+        return unique.pop()
 
-    return best_fmt
+    return None
 
 
 def _find_anno_raw_column(profile: dict[str, Any]) -> str | None:

--- a/toolkit/scaffold/clean.py
+++ b/toolkit/scaffold/clean.py
@@ -60,51 +60,47 @@ _DATE_FORMAT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
 
 
 def _suggest_dateformat(profile: dict[str, Any]) -> str | None:
-    """Detect non-ISO date format from sample rows for date-typed columns.
+    """Detect non-ISO date format from raw date values in the profile.
 
-    Scans sample values of columns typed as ``date`` and checks if they
-    match a known non-ISO pattern (e.g. ``dd/mm/YYYY``). Returns the
-    corresponding ``dateformat`` string (e.g. ``%d/%m/%Y``) or ``None``
-    if all date columns appear to be ISO or no date columns exist.
+    Uses ``date_raw_values`` (extracted from raw CSV *before* DuckDB
+    converts dates to Timestamp) to detect date format patterns.
 
-    Intended for use by ``propose_clean_read()`` to auto-suggest
-    ``dateformat`` in the scaffolded ``clean.read`` config.
+    Only suggests a ``dateformat`` if at least 60% of ALL non-empty
+    date values across ALL date-typed columns match the same format.
+    This avoids suggesting a global ``dateformat`` that would work for
+    one column but break another.
+
+    Returns the ``dateformat`` string (e.g. ``%d/%m/%Y``) or ``None``.
     """
-    mapping = profile.get("mapping_suggestions", {})
-    sample_rows = profile.get("sample_rows", [])
-    if not mapping or not sample_rows:
+    date_raw = profile.get("date_raw_values", {})
+    if not date_raw:
         return None
 
-    date_cols = [col for col, spec in mapping.items() if spec.get("type") == "date"]
-    if not date_cols:
-        return None
+    # Collect votes per format across all date columns
+    format_votes: dict[str, int] = {}
+    total_values = 0
 
-    for col in date_cols:
-        vals: list[str] = []
-        for r in sample_rows:
-            if col not in r:
-                continue
-            v = r.get(col)
-            if v is None:
-                continue
-            s = str(v).strip()
-            if s == "":
-                continue
-            vals.append(s)
-            if len(vals) >= 30:
-                break
-
-        non_empty = [v for v in vals if v]
+    for col, values in date_raw.items():
+        non_empty = [v for v in values if v]
         if not non_empty:
             continue
+        total_values += len(non_empty)
 
-        for pattern, fmt in _DATE_FORMAT_PATTERNS:
-            matches = sum(1 for v in non_empty if pattern.match(v))
-            threshold = max(2, int(len(non_empty) * 0.6))
-            if matches >= threshold:
-                return fmt
+        for v in non_empty:
+            for pattern, fmt in _DATE_FORMAT_PATTERNS:
+                if pattern.match(v):
+                    format_votes[fmt] = format_votes.get(fmt, 0) + 1
+                    break
 
-    return None
+    if not format_votes or total_values == 0:
+        return None
+
+    # A format wins only if >= 60% of ALL date values match it.
+    best_fmt, best_count = max(format_votes.items(), key=lambda x: x[1])
+    if best_count / total_values < 0.6:
+        return None
+
+    return best_fmt
 
 
 def _find_anno_raw_column(profile: dict[str, Any]) -> str | None:


### PR DESCRIPTION
## Sintesi

Lo scaffold (`toolkit scout --scaffold`, `toolkit scaffold clean`) ora rileva automaticamente formati data non ISO dai sample del profilo raw e suggerisce `dateformat` nel `clean.read` generato.

## Contesto collegato

Closes #364

## Cosa cambia

- [ ] Bug fix
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Dettaglio

### `_suggest_dateformat(profile) → str | None`

Nuova funzione in `toolkit/scaffold/clean.py` che:
1. Trova colonne con `type: "date"` nel `mapping_suggestions`
2. Estrae sample valori da `sample_rows`
3. Matcha pattern con regex: `dd/mm/YYYY`, `dd-mm-YYYY`, `dd/mm/yy`, `dd-mm-yy`, `YYYY/mm/dd`
4. Se ≥60% dei valori non vuoti matcha, restituisce il formato (es. `%d/%m/%Y`)

### Integrazione in `propose_clean_read()`

Chiamata aggiunta prima del blocco columns. Quando il formato è rilevato, `dateformat` finisce automaticamente nel `clean.read` proposto, sia nell'output YAML che nel `dataset.yml` generato da `generate_full_scaffold()`.

### Pattern supportati

| Pattern | dateformat | Esempio |
|---------|-----------|---------|
| `dd/mm/YYYY` | `%d/%m/%Y` | `15/03/2024` |
| `dd-mm-YYYY` | `%d-%m-%Y` | `15-03-2024` |
| `dd/mm/yy` | `%d/%m/%y` | `15/03/24` |
| `dd-mm-yy` | `%d-%m-%y` | `15-03-24` |
| `YYYY/mm/dd` | `%Y/%m/%d` | `2024/03/15` |

Date ISO (`YYYY-MM-DD`) **non** attivano il suggerimento.

### File toccati

| File | Cosa |
|---|---|
| `toolkit/scaffold/clean.py` | `_DATE_FORMAT_PATTERNS`, `_suggest_dateformat()`, chiamata in `propose_clean_read()` |
| `tests/test_scaffold_clean.py` | 6 nuovi test `pure_unit` per `_suggest_dateformat` |

## Impatto su contratti pubblici

Nessun cambio di contratti esistenti. `dateformat` è già un campo supportato in `clean.read` (PR #366).

- [ ] Struttura `dataset.yml` — nuovo campo auto-generato solo quando rilevato
- [ ] Path output — invariato
- [ ] Schema parquet — invariato
- [ ] CLI o MCP tool — invariato
- [ ] API pubblica del toolkit — nuova funzione `_suggest_dateformat` (interna)

## Verifica

```bash
pytest tests/test_scaffold_clean.py -v          # 32 test, 6 nuovi
pytest tests/test_cli_scaffold.py -v            # 42 test, nessuna regressione
ruff check toolkit/scaffold/clean.py            # passa
```

- [x] `pytest tests/test_scaffold_clean.py` passa (32)
- [x] `pytest tests/test_cli_scaffold.py` passa (42)
- [x] `ruff check toolkit/` passa
- [x] Nuovi test con marker `pure_unit`

## Checklist PR

- [x] Perimetro stretto: solo `_suggest_dateformat` + aggancio in `propose_clean_read`
- [x] Issue collegata: #364
- [ ] **Se rimuovo un modulo/funzione pubblica**: N/A

## Note per chi revisiona

- La funzione `_suggest_dateformat` è intenzionalmente conservativa: serve almeno 60% di match sui sample per attivarsi.
- Se non ci sono colonne date, o i sample sono vuoti, o i formati sono ISO, non suggerisce nulla.
- I formati con punto (`dd.mm.YYYY`) non sono inclusi perché DuckDB non li parserebbe comunque senza dateformat — ma si possono aggiungere in futuro.
