### PR TITLE
feat(config): clean.read.overrides per anno

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -171,6 +171,9 @@ Note pratiche per `http_post_file`:
 | `trim_whitespace` | `bool` | `true` |
 | `sample_size` | `int \| null` | `null` |
 | `sheet_name` | `string \| int \| null` | `null` |
+| `dateformat` | `string \| null` | `null` |
+| `timestampformat` | `string \| null` | `null` |
+| `overrides` | `dict` | `null` |
 | `mode` | `explicit \| latest \| largest \| all \| null` | `latest`¹ |
 | `glob` | `string` | `*` |
 | `prefer_from_raw_run` | `bool` | `true` |
@@ -191,6 +194,16 @@ Note pratiche:
 - `normalize_rows_to_columns: true` ha senso solo insieme a `columns`
 - con `normalize_rows_to_columns: true`, il toolkit normalizza le righe corte del CSV allo schema atteso prima di esporre `raw_input`
 - `align_by_header: true` (insieme a `normalize_rows_to_columns: true`) allinea le righe per nome colonna invece che per posizione: colonne attese ma non presenti nell'header vengono riempite con stringa vuota; colonne extra nel CSV vengono ignorate; colonne in ordine diverso vengono riallineate. Richiede `header: true`.
+- `dateformat` / `timestampformat`: specificano il formato di date/timestamp nel CSV (es. `%d/%m/%Y`). DuckDB usa questi formati in `read_csv` invece di auto-detect, risolvendo date in formato italiano o altri formati non ISO.
+- `overrides`: mapping `{year: {param: value}}` per parametri di parsing diversi per anno. Utile quando la struttura raw varia tra anni (es. skip diverso, colonna `_id` presente solo in un anno). Le chiavi consentite sono le stesse di `CleanRead` esclusi i parametri di selezione (`mode`, `glob`, `include`, `prefer_from_raw_run`, `allow_ambiguous`). Esempio:
+  ```yaml
+  read:
+    columns: {nome: VARCHAR, anno: BIGINT}
+    overrides:
+      2023:
+        columns: {_id: BIGINT, nome: VARCHAR, anno: BIGINT}
+        skip: 2
+  ```
 
 `CleanValidate`:
 

--- a/tests/test_clean_csv_columns.py
+++ b/tests/test_clean_csv_columns.py
@@ -509,8 +509,7 @@ def test_run_clean_align_by_header_requires_normalize_runtime(tmp_path: Path):
             },
             NoopLogger(),
         )
-    # L'errore originale è incatenato come causa diretta
-    assert exc_info.value.__cause__ is not None
-    assert "align_by_header=true requires normalize_rows_to_columns=true" in str(
-        exc_info.value.__cause__
-    )
+    # La validazione ora avviene in resolve_clean_read_cfg tramite
+    # CleanReadConfig.model_validate, non piu' in duckdb_read.
+    # Il messaggio di errore e' preservato.
+    assert "align_by_header=true requires normalize_rows_to_columns=true" in str(exc_info.value)

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -574,6 +574,36 @@ class TestCleanReadOverrides:
             )
 
 
+@pytest.mark.policy
+def test_apply_year_overrides_merge(tmp_path: Path):
+    """apply_year_overrides fonde override per anno e rimuove overrides."""
+    from toolkit.clean.read_config import apply_year_overrides
+
+    base = {
+        "delim": ";",
+        "encoding": "utf-8",
+        "overrides": {2024: {"encoding": "latin-1", "skip": 2}},
+    }
+    result = apply_year_overrides(base, 2024)
+    assert result["delim"] == ";"  # dalla base
+    assert result["encoding"] == "latin-1"  # override vince
+    assert result["skip"] == 2  # solo nell'override
+    assert "overrides" not in result  # rimosso
+
+
+@pytest.mark.policy
+def test_apply_year_overrides_no_match(tmp_path: Path):
+    """apply_year_overrides con anno senza override non modifica."""
+    from toolkit.clean.read_config import apply_year_overrides
+
+    base = {"delim": ";", "overrides": {2025: {"skip": 1}}}
+    result = apply_year_overrides(base, 2024)
+    assert result["delim"] == ";"
+    assert result.get("skip") is None
+    assert "overrides" not in result
+
+
+@pytest.mark.policy
 def test_read_raw_to_relation_with_thousands_separator(tmp_path: Path):
     """DuckDB read_csv respects decimal=',' + thousands='.'.
 

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -631,6 +631,26 @@ def test_resolve_clean_read_cfg_overrides_columns(tmp_path: Path):
 
 
 @pytest.mark.policy
+def test_apply_year_overrides_normalizes_raw_yaml(tmp_path: Path):
+    """apply_year_overrides normalizza YAML raw (columns lista, \"false\" stringa)."""
+    from toolkit.clean.read_config import apply_year_overrides
+
+    # Simula YAML raw: columns in formato lista, booleano come stringa
+    raw_cfg = {
+        "header": "false",  # stringa YAML, non bool
+        "columns": [{"name": "a", "type": "VARCHAR"}, {"name": "b", "type": "VARCHAR"}],  # lista
+        "overrides": {2024: {"skip": 2, "columns": [{"name": "_id", "type": "BIGINT"}]}},
+    }
+    result = apply_year_overrides(raw_cfg, 2024)
+
+    # header normalizzato a bool (non stringa)
+    assert result["header"] is False
+    # columns normalizzato a dict (non lista) con override fuso
+    assert isinstance(result["columns"], dict)
+    assert list(result["columns"].keys()) == ["_id"]
+
+
+@pytest.mark.policy
 def test_read_raw_to_relation_with_thousands_separator(tmp_path: Path):
     """DuckDB read_csv respects decimal=',' + thousands='.'.
 

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -562,18 +562,16 @@ class TestCleanReadOverrides:
         assert not any("year_override" in s for s in src)
 
     @pytest.mark.policy
-    def test_invalid_override_key_silently_ignored(self, tmp_path: Path):
-        """Chiave inesistente nell'override ('delmi') viene ignorata, non blocca."""
+    def test_invalid_override_key_raises(self, tmp_path: Path):
+        """Chiave inesistente nell'override ('delmi') solleva ValueError."""
         raw_dir = tmp_path / "raw" / "demo" / "2024"
         raw_dir.mkdir(parents=True)
-        _, cfg, _ = resolve_clean_read_cfg(
-            raw_dir,
-            {"read": {"overrides": {2024: {"delmi": ";", "skip": 2}}}},
-            logging.getLogger("tests.clean.duckdb_read.override"),
-        )
-        # skip viene applicato, delmi ignorato
-        assert cfg.get("skip") == 2
-        assert "delmi" not in cfg
+        with pytest.raises(ValueError, match="clean.read.overrides.2024"):
+            resolve_clean_read_cfg(
+                raw_dir,
+                {"read": {"overrides": {2024: {"delmi": ";", "skip": 2}}}},
+                logging.getLogger("tests.clean.duckdb_read.override"),
+            )
 
     @pytest.mark.policy
     def test_override_with_interdependent_fields(self, tmp_path: Path):

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -562,16 +562,37 @@ class TestCleanReadOverrides:
         assert not any("year_override" in s for s in src)
 
     @pytest.mark.policy
-    def test_invalid_key_raises(self, tmp_path: Path):
-        """Chiave inesistente ('delmi') solleva ValueError."""
+    def test_invalid_override_key_silently_ignored(self, tmp_path: Path):
+        """Chiave inesistente nell'override ('delmi') viene ignorata, non blocca."""
         raw_dir = tmp_path / "raw" / "demo" / "2024"
         raw_dir.mkdir(parents=True)
-        with pytest.raises(ValueError, match="clean.read.overrides.2024"):
-            resolve_clean_read_cfg(
-                raw_dir,
-                {"read": {"overrides": {2024: {"delmi": ";"}}}},
-                logging.getLogger("tests.clean.duckdb_read.override"),
-            )
+        _, cfg, _ = resolve_clean_read_cfg(
+            raw_dir,
+            {"read": {"overrides": {2024: {"delmi": ";", "skip": 2}}}},
+            logging.getLogger("tests.clean.duckdb_read.override"),
+        )
+        # skip viene applicato, delmi ignorato
+        assert cfg.get("skip") == 2
+        assert "delmi" not in cfg
+
+    @pytest.mark.policy
+    def test_override_with_interdependent_fields(self, tmp_path: Path):
+        """Override con campo che dipende dalla base non viene rifiutato in isolamento."""
+        raw_dir = tmp_path / "raw" / "demo" / "2024"
+        raw_dir.mkdir(parents=True)
+        _, cfg, _ = resolve_clean_read_cfg(
+            raw_dir,
+            {
+                "read": {
+                    "normalize_rows_to_columns": True,
+                    "overrides": {2024: {"align_by_header": True}},
+                }
+            },
+            logging.getLogger("tests.clean.duckdb_read.override"),
+        )
+        # La combinazione base+override e' valida -> nessun errore, align_by_header applicato
+        assert cfg.get("normalize_rows_to_columns") is True
+        assert cfg.get("align_by_header") is True
 
 
 @pytest.mark.policy

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -483,106 +483,95 @@ def test_filter_suggested_read_excludes_robustness_keys(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.policy
-def test_clean_read_overrides_int_year(tmp_path: Path):
-    """Override per anno int: raw_year_dir.name='2023', overrides:{2023:{skip:2}} → skip=2."""
-    raw_dir = tmp_path / "raw" / "demo" / "2023"
-    raw_dir.mkdir(parents=True)
+class TestCleanReadOverrides:
+    """clean.read.overrides: merge per anno, validazione, no leakage."""
 
-    _, relation_cfg, params_source = resolve_clean_read_cfg(
-        raw_dir,
-        {"read": {"overrides": {2023: {"skip": 2}}}},
-        logging.getLogger("tests.clean.duckdb_read.override_int"),
-    )
+    @pytest.fixture
+    def override_dir(self, tmp_path: Path, request: pytest.FixtureRequest) -> Path:
+        """Crea raw_dir con anno parametrizzato via marker o default 2024."""
+        year = getattr(request, "param", 2024)
+        raw_dir = tmp_path / "raw" / "demo" / str(year)
+        raw_dir.mkdir(parents=True)
+        return raw_dir
 
-    assert relation_cfg.get("skip") == 2
-    assert "year_override_2023" in params_source
-
-
-@pytest.mark.policy
-def test_clean_read_overrides_str_year(tmp_path: Path):
-    """Override per anno str: overrides:{'2024':{...}} → applicato quando year=2024."""
-    raw_dir = tmp_path / "raw" / "demo" / "2024"
-    raw_dir.mkdir(parents=True)
-
-    _, relation_cfg, params_source = resolve_clean_read_cfg(
-        raw_dir,
-        {"read": {"overrides": {"2024": {"encoding": "latin-1", "skip": 1}}}},
-        logging.getLogger("tests.clean.duckdb_read.override_str"),
-    )
-
-    assert relation_cfg.get("encoding") == "latin-1"
-    assert relation_cfg.get("skip") == 1
-    assert "year_override_2024" in params_source
-
-
-@pytest.mark.policy
-def test_clean_read_overrides_wins_over_base(tmp_path: Path):
-    """Override per anno vince sulla config base."""
-    raw_dir = tmp_path / "raw" / "demo" / "2025"
-    raw_dir.mkdir(parents=True)
-
-    _, relation_cfg, params_source = resolve_clean_read_cfg(
-        raw_dir,
-        {
-            "read": {
-                "delim": ";",
-                "encoding": "utf-8",
-                "overrides": {2025: {"encoding": "latin-1", "skip": 2}},
-            }
-        },
-        logging.getLogger("tests.clean.duckdb_read.override_win"),
-    )
-
-    assert relation_cfg["delim"] == ";"  # dalla base
-    assert relation_cfg["encoding"] == "latin-1"  # override vince
-    assert relation_cfg["skip"] == 2  # solo nell'override
-    assert "year_override_2025" in params_source
-
-
-@pytest.mark.policy
-def test_clean_read_overrides_no_leakage(tmp_path: Path):
-    """overrides NON deve comparire in relation_cfg (non e' parametro DuckDB)."""
-    raw_dir = tmp_path / "raw" / "demo" / "2024"
-    raw_dir.mkdir(parents=True)
-
-    _, relation_cfg, _ = resolve_clean_read_cfg(
-        raw_dir,
-        {"read": {"overrides": {2024: {"skip": 1}}}},
-        logging.getLogger("tests.clean.duckdb_read.override_leak"),
-    )
-
-    assert "overrides" not in relation_cfg
-
-
-@pytest.mark.policy
-def test_clean_read_overrides_no_match_year(tmp_path: Path):
-    """Override per anno diverso da quello corrente non viene applicato."""
-    raw_dir = tmp_path / "raw" / "demo" / "2023"
-    raw_dir.mkdir(parents=True)
-
-    _, relation_cfg, params_source = resolve_clean_read_cfg(
-        raw_dir,
-        {"read": {"overrides": {2024: {"skip": 1}}}},
-        logging.getLogger("tests.clean.duckdb_read.override_nomatch"),
-    )
-
-    assert relation_cfg.get("skip") is None
-    assert not any("year_override" in s for s in params_source)
-
-
-@pytest.mark.policy
-def test_clean_read_overrides_invalid_key_raises(tmp_path: Path):
-    """Override con chiave inesistente ('delmi' invece di 'delim') solleva ValueError."""
-    raw_dir = tmp_path / "raw" / "demo" / "2024"
-    raw_dir.mkdir(parents=True)
-
-    with pytest.raises(ValueError, match="clean.read.overrides.2024"):
-        resolve_clean_read_cfg(
-            raw_dir,
-            {"read": {"overrides": {2024: {"delmi": ";"}}}},
-            logging.getLogger("tests.clean.duckdb_read.override_invalid"),
+    @pytest.mark.policy
+    @pytest.mark.parametrize("override_dir", [2023], indirect=True)
+    def test_int_year(self, override_dir: Path):
+        """Override per anno int: {2023: {skip: 2}} → skip=2."""
+        _, cfg, src = resolve_clean_read_cfg(
+            override_dir,
+            {"read": {"overrides": {2023: {"skip": 2}}}},
+            logging.getLogger("tests.clean.duckdb_read.override"),
         )
+        assert cfg.get("skip") == 2
+        assert "year_override_2023" in src
+
+    @pytest.mark.policy
+    @pytest.mark.parametrize("override_dir", [2024], indirect=True)
+    def test_str_year(self, override_dir: Path):
+        """Override per anno str: {'2024': {...}}."""
+        _, cfg, src = resolve_clean_read_cfg(
+            override_dir,
+            {"read": {"overrides": {"2024": {"encoding": "latin-1"}}}},
+            logging.getLogger("tests.clean.duckdb_read.override"),
+        )
+        assert cfg.get("encoding") == "latin-1"
+        assert "year_override_2024" in src
+
+    @pytest.mark.policy
+    @pytest.mark.parametrize("override_dir", [2025], indirect=True)
+    def test_wins_over_base(self, override_dir: Path):
+        """Override vince sulla config base."""
+        _, cfg, src = resolve_clean_read_cfg(
+            override_dir,
+            {
+                "read": {
+                    "delim": ";",
+                    "encoding": "utf-8",
+                    "overrides": {2025: {"encoding": "latin-1", "skip": 2}},
+                }
+            },
+            logging.getLogger("tests.clean.duckdb_read.override"),
+        )
+        assert cfg["delim"] == ";"  # dalla base
+        assert cfg["encoding"] == "latin-1"  # override vince
+        assert cfg["skip"] == 2  # solo nell'override
+        assert "year_override_2025" in src
+
+    @pytest.mark.policy
+    @pytest.mark.parametrize("override_dir", [2024], indirect=True)
+    def test_no_leakage(self, override_dir: Path):
+        """overrides NON compare in relation_cfg."""
+        _, cfg, _ = resolve_clean_read_cfg(
+            override_dir,
+            {"read": {"overrides": {2024: {"skip": 1}}}},
+            logging.getLogger("tests.clean.duckdb_read.override"),
+        )
+        assert "overrides" not in cfg
+
+    @pytest.mark.policy
+    @pytest.mark.parametrize("override_dir", [2023], indirect=True)
+    def test_no_match_year(self, override_dir: Path):
+        """Override per anno diverso non viene applicato."""
+        _, cfg, src = resolve_clean_read_cfg(
+            override_dir,
+            {"read": {"overrides": {2024: {"skip": 1}}}},
+            logging.getLogger("tests.clean.duckdb_read.override"),
+        )
+        assert cfg.get("skip") is None
+        assert not any("year_override" in s for s in src)
+
+    @pytest.mark.policy
+    def test_invalid_key_raises(self, tmp_path: Path):
+        """Chiave inesistente ('delmi') solleva ValueError."""
+        raw_dir = tmp_path / "raw" / "demo" / "2024"
+        raw_dir.mkdir(parents=True)
+        with pytest.raises(ValueError, match="clean.read.overrides.2024"):
+            resolve_clean_read_cfg(
+                raw_dir,
+                {"read": {"overrides": {2024: {"delmi": ";"}}}},
+                logging.getLogger("tests.clean.duckdb_read.override"),
+            )
 
 
 def test_read_raw_to_relation_with_thousands_separator(tmp_path: Path):

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -574,6 +574,18 @@ class TestCleanReadOverrides:
             )
 
     @pytest.mark.policy
+    def test_invalid_override_key_in_unused_year_raises(self, tmp_path: Path):
+        """Override per anno non eseguito con chiave invalida solleva ValueError."""
+        raw_dir = tmp_path / "raw" / "demo" / "2024"
+        raw_dir.mkdir(parents=True)
+        with pytest.raises(ValueError, match="clean.read.overrides.2025"):
+            resolve_clean_read_cfg(
+                raw_dir,
+                {"read": {"overrides": {2025: {"delmi": ";"}}}},
+                logging.getLogger("tests.clean.duckdb_read.override"),
+            )
+
+    @pytest.mark.policy
     def test_override_with_interdependent_fields(self, tmp_path: Path):
         """Override con campo che dipende dalla base non viene rifiutato in isolamento."""
         raw_dir = tmp_path / "raw" / "demo" / "2024"
@@ -597,7 +609,7 @@ class TestCleanReadOverrides:
         """Selection keys (mode, glob) negli override sollevano ValueError."""
         raw_dir = tmp_path / "raw" / "demo" / "2024"
         raw_dir.mkdir(parents=True)
-        with pytest.raises(ValueError, match="selection keys not allowed in overrides"):
+        with pytest.raises(ValueError, match="clean.read.overrides.2024"):
             resolve_clean_read_cfg(
                 raw_dir,
                 {"read": {"overrides": {2024: {"mode": "all"}}}},

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -592,6 +592,18 @@ class TestCleanReadOverrides:
         assert cfg.get("normalize_rows_to_columns") is True
         assert cfg.get("align_by_header") is True
 
+    @pytest.mark.policy
+    def test_override_selection_keys_rejected(self, tmp_path: Path):
+        """Selection keys (mode, glob) negli override sollevano ValueError."""
+        raw_dir = tmp_path / "raw" / "demo" / "2024"
+        raw_dir.mkdir(parents=True)
+        with pytest.raises(ValueError, match="selection keys not allowed in overrides"):
+            resolve_clean_read_cfg(
+                raw_dir,
+                {"read": {"overrides": {2024: {"mode": "all"}}}},
+                logging.getLogger("tests.clean.duckdb_read.override"),
+            )
+
 
 @pytest.mark.policy
 def test_apply_year_overrides_merge(tmp_path: Path):

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -604,6 +604,32 @@ def test_apply_year_overrides_no_match(tmp_path: Path):
 
 
 @pytest.mark.policy
+def test_apply_year_overrides_columns_extra(tmp_path: Path):
+    """columns_extra fonde colonne extra in quelle base."""
+    from toolkit.clean.read_config import apply_year_overrides
+
+    base = {
+        "columns": {"a": "VARCHAR", "b": "VARCHAR"},
+        "overrides": {2024: {"columns_extra": {"_id": "BIGINT"}}},
+    }
+    result = apply_year_overrides(base, 2024)
+    assert list(result["columns"].keys()) == ["a", "b", "_id"]
+
+
+@pytest.mark.policy
+def test_apply_year_overrides_columns_prepend(tmp_path: Path):
+    """columns_prepend aggiunge colonne all'inizio."""
+    from toolkit.clean.read_config import apply_year_overrides
+
+    base = {
+        "columns": {"a": "VARCHAR", "b": "VARCHAR"},
+        "overrides": {2024: {"columns_prepend": {"_id": "BIGINT"}}},
+    }
+    result = apply_year_overrides(base, 2024)
+    assert list(result["columns"].keys()) == ["_id", "a", "b"]
+
+
+@pytest.mark.policy
 def test_read_raw_to_relation_with_thousands_separator(tmp_path: Path):
     """DuckDB read_csv respects decimal=',' + thousands='.'.
 

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -586,6 +586,30 @@ class TestCleanReadOverrides:
             )
 
     @pytest.mark.policy
+    def test_override_unused_year_bad_type_raises(self, tmp_path: Path):
+        """Override anno non eseguito con tipo errato (skip='abc') solleva ValueError."""
+        raw_dir = tmp_path / "raw" / "demo" / "2024"
+        raw_dir.mkdir(parents=True)
+        with pytest.raises(ValueError, match="clean.read.overrides.2025"):
+            resolve_clean_read_cfg(
+                raw_dir,
+                {"read": {"overrides": {2025: {"skip": "abc"}}}},
+                logging.getLogger("tests.clean.duckdb_read.override"),
+            )
+
+    @pytest.mark.policy
+    def test_override_non_year_key_raises(self, tmp_path: Path):
+        """Chiave non numerica ('not-a-year') negli override solleva ValueError."""
+        raw_dir = tmp_path / "raw" / "demo" / "2024"
+        raw_dir.mkdir(parents=True)
+        with pytest.raises(ValueError, match="clean.read.overrides"):
+            resolve_clean_read_cfg(
+                raw_dir,
+                {"read": {"overrides": {"not-a-year": {"skip": 1}}}},
+                logging.getLogger("tests.clean.duckdb_read.override"),
+            )
+
+    @pytest.mark.policy
     def test_override_with_interdependent_fields(self, tmp_path: Path):
         """Override con campo che dipende dalla base non viene rifiutato in isolamento."""
         raw_dir = tmp_path / "raw" / "demo" / "2024"

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -604,29 +604,30 @@ def test_apply_year_overrides_no_match(tmp_path: Path):
 
 
 @pytest.mark.policy
-def test_apply_year_overrides_columns_extra(tmp_path: Path):
-    """columns_extra fonde colonne extra in quelle base."""
-    from toolkit.clean.read_config import apply_year_overrides
+def test_resolve_clean_read_cfg_overrides_columns(tmp_path: Path):
+    """resolve_clean_read_cfg applica override columns per anno via percorso reale."""
+    from toolkit.clean.read_config import resolve_clean_read_cfg
 
-    base = {
-        "columns": {"a": "VARCHAR", "b": "VARCHAR"},
-        "overrides": {2024: {"columns_extra": {"_id": "BIGINT"}}},
-    }
-    result = apply_year_overrides(base, 2024)
-    assert list(result["columns"].keys()) == ["a", "b", "_id"]
+    raw_dir = tmp_path / "raw" / "demo" / "2023"
+    raw_dir.mkdir(parents=True)
+    profile_dir = raw_dir / "_profile"
+    profile_dir.mkdir(parents=True)
 
+    _, relation_cfg, params_source = resolve_clean_read_cfg(
+        raw_dir,
+        {
+            "read": {
+                "source": "config_only",
+                "columns": {"a": "VARCHAR", "b": "VARCHAR"},
+                "overrides": {2023: {"columns": {"_id": "BIGINT", "a": "VARCHAR", "b": "VARCHAR"}}},
+            }
+        },
+        logging.getLogger("tests.clean.duckdb_read.override_cols"),
+    )
 
-@pytest.mark.policy
-def test_apply_year_overrides_columns_prepend(tmp_path: Path):
-    """columns_prepend aggiunge colonne all'inizio."""
-    from toolkit.clean.read_config import apply_year_overrides
-
-    base = {
-        "columns": {"a": "VARCHAR", "b": "VARCHAR"},
-        "overrides": {2024: {"columns_prepend": {"_id": "BIGINT"}}},
-    }
-    result = apply_year_overrides(base, 2024)
-    assert list(result["columns"].keys()) == ["_id", "a", "b"]
+    assert list(relation_cfg["columns"].keys()) == ["_id", "a", "b"]
+    assert "overrides" not in relation_cfg
+    assert "year_override_2023" in params_source
 
 
 @pytest.mark.policy

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -478,7 +478,113 @@ def test_filter_suggested_read_excludes_robustness_keys(tmp_path: Path):
     assert "sample_size" not in relation_cfg
 
 
+# ---------------------------------------------------------------------------
+# tests: clean.read.overrides per anno
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.policy
+def test_clean_read_overrides_int_year(tmp_path: Path):
+    """Override per anno int: raw_year_dir.name='2023', overrides:{2023:{skip:2}} → skip=2."""
+    raw_dir = tmp_path / "raw" / "demo" / "2023"
+    raw_dir.mkdir(parents=True)
+
+    _, relation_cfg, params_source = resolve_clean_read_cfg(
+        raw_dir,
+        {"read": {"overrides": {2023: {"skip": 2}}}},
+        logging.getLogger("tests.clean.duckdb_read.override_int"),
+    )
+
+    assert relation_cfg.get("skip") == 2
+    assert "year_override_2023" in params_source
+
+
+@pytest.mark.policy
+def test_clean_read_overrides_str_year(tmp_path: Path):
+    """Override per anno str: overrides:{'2024':{...}} → applicato quando year=2024."""
+    raw_dir = tmp_path / "raw" / "demo" / "2024"
+    raw_dir.mkdir(parents=True)
+
+    _, relation_cfg, params_source = resolve_clean_read_cfg(
+        raw_dir,
+        {"read": {"overrides": {"2024": {"encoding": "latin-1", "skip": 1}}}},
+        logging.getLogger("tests.clean.duckdb_read.override_str"),
+    )
+
+    assert relation_cfg.get("encoding") == "latin-1"
+    assert relation_cfg.get("skip") == 1
+    assert "year_override_2024" in params_source
+
+
+@pytest.mark.policy
+def test_clean_read_overrides_wins_over_base(tmp_path: Path):
+    """Override per anno vince sulla config base."""
+    raw_dir = tmp_path / "raw" / "demo" / "2025"
+    raw_dir.mkdir(parents=True)
+
+    _, relation_cfg, params_source = resolve_clean_read_cfg(
+        raw_dir,
+        {
+            "read": {
+                "delim": ";",
+                "encoding": "utf-8",
+                "overrides": {2025: {"encoding": "latin-1", "skip": 2}},
+            }
+        },
+        logging.getLogger("tests.clean.duckdb_read.override_win"),
+    )
+
+    assert relation_cfg["delim"] == ";"  # dalla base
+    assert relation_cfg["encoding"] == "latin-1"  # override vince
+    assert relation_cfg["skip"] == 2  # solo nell'override
+    assert "year_override_2025" in params_source
+
+
+@pytest.mark.policy
+def test_clean_read_overrides_no_leakage(tmp_path: Path):
+    """overrides NON deve comparire in relation_cfg (non e' parametro DuckDB)."""
+    raw_dir = tmp_path / "raw" / "demo" / "2024"
+    raw_dir.mkdir(parents=True)
+
+    _, relation_cfg, _ = resolve_clean_read_cfg(
+        raw_dir,
+        {"read": {"overrides": {2024: {"skip": 1}}}},
+        logging.getLogger("tests.clean.duckdb_read.override_leak"),
+    )
+
+    assert "overrides" not in relation_cfg
+
+
+@pytest.mark.policy
+def test_clean_read_overrides_no_match_year(tmp_path: Path):
+    """Override per anno diverso da quello corrente non viene applicato."""
+    raw_dir = tmp_path / "raw" / "demo" / "2023"
+    raw_dir.mkdir(parents=True)
+
+    _, relation_cfg, params_source = resolve_clean_read_cfg(
+        raw_dir,
+        {"read": {"overrides": {2024: {"skip": 1}}}},
+        logging.getLogger("tests.clean.duckdb_read.override_nomatch"),
+    )
+
+    assert relation_cfg.get("skip") is None
+    assert not any("year_override" in s for s in params_source)
+
+
+@pytest.mark.policy
+def test_clean_read_overrides_invalid_key_raises(tmp_path: Path):
+    """Override con chiave inesistente ('delmi' invece di 'delim') solleva ValueError."""
+    raw_dir = tmp_path / "raw" / "demo" / "2024"
+    raw_dir.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="clean.read.overrides.2024"):
+        resolve_clean_read_cfg(
+            raw_dir,
+            {"read": {"overrides": {2024: {"delmi": ";"}}}},
+            logging.getLogger("tests.clean.duckdb_read.override_invalid"),
+        )
+
+
 def test_read_raw_to_relation_with_thousands_separator(tmp_path: Path):
     """DuckDB read_csv respects decimal=',' + thousands='.'.
 

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -82,31 +82,37 @@ def filter_suggested_read(cfg: dict[str, Any] | None) -> dict[str, Any]:
 def apply_year_overrides(read_cfg: dict[str, Any], year: int) -> dict[str, Any]:
     """Return ``read_cfg`` with per-year overrides merged in for the given ``year``.
 
-    Extracts ``overrides`` from the config (if present), looks up the year,
-    and merges matching keys into the result.  The ``overrides`` key itself
-    is removed — it is not a DuckDB ``read_csv`` parameter.
+    **Self-validating**: raw YAML values (``columns`` as list, booleans as
+    ``"false"`` strings) are normalized through ``CleanReadConfig.model_validate``
+    before merging.  Works identically whether called from the clean runtime
+    (``resolve_clean_read_cfg``) or the RAW profiler (``run_raw``) —
+    guarantees no divergence between profile and runtime.
 
-    Override values are expected to be **already validated and normalized**
-    by ``_validate_and_normalize_overrides`` (called upstream in
-    ``resolve_clean_read_cfg``) — raw YAML values like ``columns`` in list
-    form are already converted to dict form, booleans are already parsed, etc.
-
-    This is the single shared resolution used by both the **clean runtime**
-    (via ``resolve_clean_read_cfg``) and the **RAW profiling** (via
-    ``profile_raw``) to guarantee profile and runtime never diverge.
+    The ``overrides`` key is removed from the result — it is not a DuckDB
+    ``read_csv`` parameter.
     """
     if not read_cfg:
         return {}
-    result = dict(read_cfg)
-    raw_overrides = result.pop("overrides", None) or {}
+
+    from toolkit.core.config_models.clean import CleanReadConfig
+
+    # Validate and normalize base config through CleanReadConfig.
+    # This converts raw YAML: columns=list→dict, "false"→False, etc.
+    validated = CleanReadConfig.model_validate(read_cfg).model_dump(exclude_unset=True)
+
+    # Extract overrides (already validated as part of CleanReadConfig)
+    raw_overrides = validated.pop("overrides", None) or {}
     year_override = raw_overrides.get(year) or raw_overrides.get(str(year))
     if not year_override:
-        return result
+        return validated
 
-    # Filter to valid DuckDB read_csv keys and merge
+    # Merge override values (still raw — columns could be list, booleans strings)
     filtered = {k: v for k, v in year_override.items() if k in ALLOWED_READ_CSV_KEYS}
-    result.update(filtered)
-    return result
+    validated.update(filtered)
+
+    # Re-validate merged result to normalize override values too
+    validated = CleanReadConfig.model_validate(validated).model_dump(exclude_unset=True)
+    return validated
 
 
 def resolve_clean_read_cfg(

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -86,6 +86,12 @@ def apply_year_overrides(read_cfg: dict[str, Any], year: int) -> dict[str, Any]:
     and merges matching keys into the result.  The ``overrides`` key itself
     is removed — it is not a DuckDB ``read_csv`` parameter.
 
+    Supported override keys:
+    - Any ``ALLOWED_READ_CSV_KEYS`` param (``skip``, ``encoding``, etc.)
+      → merged directly
+    - ``columns_extra``   → merged into base ``columns`` (replaces/adds keys)
+    - ``columns_prepend`` → merged into base ``columns``, placed FIRST
+
     This is the single shared resolution used by both the **clean runtime**
     (via ``resolve_clean_read_cfg``) and the **RAW profiling** (via
     ``profile_raw``) to guarantee profile and runtime never diverge.
@@ -95,9 +101,27 @@ def apply_year_overrides(read_cfg: dict[str, Any], year: int) -> dict[str, Any]:
     result = dict(read_cfg)
     raw_overrides = result.pop("overrides", None) or {}
     year_override = raw_overrides.get(year) or raw_overrides.get(str(year))
-    if year_override:
-        filtered = {k: v for k, v in year_override.items() if k in ALLOWED_READ_CSV_KEYS}
-        result.update(filtered)
+    if not year_override:
+        return result
+
+    year_cfg = dict(year_override)
+
+    # Handle columns_extra / columns_prepend: merge into base columns
+    extra = year_cfg.pop("columns_extra", None)
+    prepend = year_cfg.pop("columns_prepend", None)
+    if extra is not None or prepend is not None:
+        base_columns = result.get("columns")
+        if isinstance(base_columns, dict):
+            merged = dict(base_columns)
+            if isinstance(prepend, dict):
+                merged = {**prepend, **merged}
+            if isinstance(extra, dict):
+                merged.update(extra)
+            result["columns"] = merged
+
+    # Remaining keys: filter to valid DuckDB params and merge
+    filtered = {k: v for k, v in year_cfg.items() if k in ALLOWED_READ_CSV_KEYS}
+    result.update(filtered)
     return result
 
 

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -106,14 +106,22 @@ def apply_year_overrides(read_cfg: dict[str, Any], year: int) -> dict[str, Any]:
     if not year_override:
         return validated
 
-    # Merge override values — reject unknown keys
-    unknown = [k for k in year_override if k not in ALLOWED_READ_CSV_KEYS]
+    # Merge override values — reject selection keys and unknown params
+    invalid_selection = [k for k in year_override if k in READ_SELECTION_KEYS]
+    if invalid_selection:
+        raise ValueError(
+            f"clean.read.overrides.{year}: selection keys not allowed in overrides: "
+            f"{invalid_selection}. Use source-level configuration for per-year "
+            f"file selection."
+        )
+    known = ALLOWED_READ_CSV_KEYS - READ_SELECTION_KEYS
+    unknown = [k for k in year_override if k not in known]
     if unknown:
         raise ValueError(
             f"clean.read.overrides.{year}: unknown parameter(s): {unknown}. "
-            f"Allowed: {sorted(ALLOWED_READ_CSV_KEYS)}"
+            f"Allowed: {sorted(known)}"
         )
-    filtered = {k: v for k, v in year_override.items() if k in ALLOWED_READ_CSV_KEYS}
+    filtered = {k: v for k, v in year_override.items() if k in known}
     validated.update(filtered)
 
     # Re-validate merged result to normalize override values too

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -142,23 +142,43 @@ def resolve_clean_read_cfg(
     if "overrides" in explicit_cfg:
         raw_overrides = dict(explicit_cfg.pop("overrides", {}) or {})
 
-    # Validate STRUCTURE of ALL override entries (not just the executed year).
-    # Checks that every year's keys are known DuckDB params (parsing only,
-    # no selection keys).  Dependency validation (e.g. align_by_header needs
-    # normalize_rows_to_columns) happens later at merge time per-year.
+    # Validate STRUCTURE and TYPES of ALL override entries (not just the
+    # executed year).  Only field-DEPENDENCY checks (e.g. align_by_header
+    # needs normalize_rows_to_columns) are deferred to merge-time because
+    # they need the base config context.
     known_override_keys = ALLOWED_READ_CSV_KEYS - READ_SELECTION_KEYS
     for override_key, year_cfg in raw_overrides.items():
+        # Year key must be a valid integer
+        try:
+            int(str(override_key))
+        except (ValueError, TypeError):
+            raise ValueError(
+                f"clean.read.overrides: key must be a year (integer), got {override_key!r}"
+            )
         if not isinstance(year_cfg, dict):
             raise ValueError(
                 f"clean.read.overrides.{override_key}: must be a mapping (dict), "
                 f"got {type(year_cfg).__name__}"
             )
+        # Unknown keys → error
         unknown = [k for k in year_cfg if k not in known_override_keys]
         if unknown:
             raise ValueError(
                 f"clean.read.overrides.{override_key}: unknown parameter(s): "
                 f"{unknown}. Allowed: {sorted(known_override_keys)}"
             )
+        # Type validation via CleanReadConfig (catches e.g. skip="abc",
+        # columns=["bad"]).  Dependency errors (type="value_error") are
+        # deferred to merge-time because they need the base config.
+        from pydantic import ValidationError
+        from toolkit.core.config_models.clean import CleanReadConfig
+
+        try:
+            CleanReadConfig.model_validate(year_cfg)
+        except ValidationError as e:
+            type_errors = [err for err in e.errors() if err["type"] != "value_error"]
+            if type_errors:
+                raise ValueError(f"clean.read.overrides.{override_key}: {e}")
 
     selection_cfg, relation_overrides = _split_read_cfg(explicit_cfg)
     # Belt and suspenders: ensure overrides doesn't leak

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -106,7 +106,13 @@ def apply_year_overrides(read_cfg: dict[str, Any], year: int) -> dict[str, Any]:
     if not year_override:
         return validated
 
-    # Merge override values (still raw — columns could be list, booleans strings)
+    # Merge override values — reject unknown keys
+    unknown = [k for k in year_override if k not in ALLOWED_READ_CSV_KEYS]
+    if unknown:
+        raise ValueError(
+            f"clean.read.overrides.{year}: unknown parameter(s): {unknown}. "
+            f"Allowed: {sorted(ALLOWED_READ_CSV_KEYS)}"
+        )
     filtered = {k: v for k, v in year_override.items() if k in ALLOWED_READ_CSV_KEYS}
     validated.update(filtered)
 

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -86,11 +86,10 @@ def apply_year_overrides(read_cfg: dict[str, Any], year: int) -> dict[str, Any]:
     and merges matching keys into the result.  The ``overrides`` key itself
     is removed — it is not a DuckDB ``read_csv`` parameter.
 
-    Supported override keys:
-    - Any ``ALLOWED_READ_CSV_KEYS`` param (``skip``, ``encoding``, etc.)
-      → merged directly
-    - ``columns_extra``   → merged into base ``columns`` (replaces/adds keys)
-    - ``columns_prepend`` → merged into base ``columns``, placed FIRST
+    Override values are expected to be **already validated and normalized**
+    by ``_validate_and_normalize_overrides`` (called upstream in
+    ``resolve_clean_read_cfg``) — raw YAML values like ``columns`` in list
+    form are already converted to dict form, booleans are already parsed, etc.
 
     This is the single shared resolution used by both the **clean runtime**
     (via ``resolve_clean_read_cfg``) and the **RAW profiling** (via
@@ -104,23 +103,8 @@ def apply_year_overrides(read_cfg: dict[str, Any], year: int) -> dict[str, Any]:
     if not year_override:
         return result
 
-    year_cfg = dict(year_override)
-
-    # Handle columns_extra / columns_prepend: merge into base columns
-    extra = year_cfg.pop("columns_extra", None)
-    prepend = year_cfg.pop("columns_prepend", None)
-    if extra is not None or prepend is not None:
-        base_columns = result.get("columns")
-        if isinstance(base_columns, dict):
-            merged = dict(base_columns)
-            if isinstance(prepend, dict):
-                merged = {**prepend, **merged}
-            if isinstance(extra, dict):
-                merged.update(extra)
-            result["columns"] = merged
-
-    # Remaining keys: filter to valid DuckDB params and merge
-    filtered = {k: v for k, v in year_cfg.items() if k in ALLOWED_READ_CSV_KEYS}
+    # Filter to valid DuckDB read_csv keys and merge
+    filtered = {k: v for k, v in year_override.items() if k in ALLOWED_READ_CSV_KEYS}
     result.update(filtered)
     return result
 
@@ -142,8 +126,10 @@ def resolve_clean_read_cfg(
     # Belt and suspenders: ensure overrides doesn't leak
     relation_overrides.pop("overrides", None)
 
-    # Validate each year's override dict against CleanReadConfig
-    _validate_overrides(raw_overrides, logger)
+    # Validate and normalize each year's override against CleanReadConfig.
+    # model_dump() returns the validated/normalized values (e.g. columns list
+    # converted to dict, booleans parsed from YAML strings).
+    validated_overrides = _validate_and_normalize_overrides(raw_overrides, logger)
 
     suggested_cfg = load_suggested_read(raw_year_dir)
     filtered_suggested = filter_suggested_read(suggested_cfg)
@@ -162,7 +148,7 @@ def resolve_clean_read_cfg(
     # Apply per-year override via the shared resolver (same as profile_raw uses)
     year = int(raw_year_dir.name)
     year_override_cfg = apply_year_overrides(
-        {"overrides": dict(raw_overrides)} if raw_overrides else {},
+        {"overrides": dict(validated_overrides)} if validated_overrides else {},
         year,
     )
     if year_override_cfg:
@@ -172,21 +158,33 @@ def resolve_clean_read_cfg(
     return selection_cfg, merged_relation_cfg, params_source
 
 
-def _validate_overrides(
+def _validate_and_normalize_overrides(
     raw_overrides: dict[str | int, dict[str, Any]],
     logger=None,
-) -> None:
-    """Validate per-year override configs against ``CleanReadConfig``.
+) -> dict[str | int, dict[str, Any]]:
+    """Validate and normalize per-year override configs against ``CleanReadConfig``.
+
+    Each year's override is validated with ``CleanReadConfig.model_validate``
+    and then ``model_dump`` returns the normalized form (e.g. ``columns`` in
+    list format is converted to dict, YAML string booleans are parsed).
 
     Raises ``ValueError`` with the offending year key if any override
     contains invalid or unknown fields (catches typos like ``delmi``).
+
+    Returns a dict of ``{year: validated_dict}`` with the same structure
+    as the input but with normalized values.
     """
+    result: dict[str | int, dict[str, Any]] = {}
     if not raw_overrides:
-        return
+        return result
+
     from toolkit.core.config_models.clean import CleanReadConfig
 
     for year, cfg in raw_overrides.items():
         try:
-            CleanReadConfig(**cfg)
+            validated = CleanReadConfig.model_validate(cfg)
+            result[year] = validated.model_dump(exclude_unset=True)
         except Exception as exc:
             raise ValueError(f"clean.read.overrides.{year}: invalid config: {exc}") from exc
+
+    return result

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -84,14 +84,20 @@ def resolve_clean_read_cfg(
     logger=None,
 ) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
     normalized_source, explicit_cfg = _read_source_mode(clean_cfg, logger)
-    selection_cfg, relation_overrides = _split_read_cfg(explicit_cfg)
 
-    # Extract per-year overrides from clean.read BEFORE they pollute merge
+    # Extract per-year overrides BEFORE _split_read_cfg, so they NEVER
+    # enter relation_overrides (overrides is NOT a DuckDB read_csv parameter)
     raw_overrides: dict[str | int, dict[str, Any]] = {}
     if "overrides" in explicit_cfg:
         raw_overrides = dict(explicit_cfg.pop("overrides", {}) or {})
-    elif "overrides" in relation_overrides:
-        raw_overrides = dict(relation_overrides.pop("overrides", {}) or {})
+
+    selection_cfg, relation_overrides = _split_read_cfg(explicit_cfg)
+
+    # Belt and suspenders: ensure overrides doesn't leak into relation config
+    relation_overrides.pop("overrides", None)
+
+    # Validate each year's override dict against CleanReadConfig
+    _validate_overrides(raw_overrides, logger)
 
     suggested_cfg = load_suggested_read(raw_year_dir)
     filtered_suggested = filter_suggested_read(suggested_cfg)
@@ -107,17 +113,36 @@ def resolve_clean_read_cfg(
         overrides=relation_overrides,
     )
 
-    # Apply per-year override if one exists
+    # Apply per-year override if one exists for this year
     year = int(raw_year_dir.name)
-    if year in raw_overrides or str(year) in raw_overrides:
-        key = year if year in raw_overrides else str(year)
-        year_cfg = dict(raw_overrides[key])
-        # Filter to valid read CSV keys (exclude non-DuckDB keys like overrides)
+    year_override = raw_overrides.get(year) or raw_overrides.get(str(year))
+    if year_override:
+        # Filter to valid DuckDB read_csv keys only
         from toolkit.core.csv_read import ALLOWED_READ_CSV_KEYS
 
-        year_cfg = {k: v for k, v in year_cfg.items() if k in ALLOWED_READ_CSV_KEYS}
-        if year_cfg:
-            merged_relation_cfg.update(year_cfg)
+        filtered = {k: v for k, v in year_override.items() if k in ALLOWED_READ_CSV_KEYS}
+        if filtered:
+            merged_relation_cfg.update(filtered)
             params_source.append(f"year_override_{year}")
 
     return selection_cfg, merged_relation_cfg, params_source
+
+
+def _validate_overrides(
+    raw_overrides: dict[str | int, dict[str, Any]],
+    logger=None,
+) -> None:
+    """Validate per-year override configs against ``CleanReadConfig``.
+
+    Raises ``ValueError`` with the offending year key if any override
+    contains invalid or unknown fields (catches typos like ``delmi``).
+    """
+    if not raw_overrides:
+        return
+    from toolkit.core.config_models.clean import CleanReadConfig
+
+    for year, cfg in raw_overrides.items():
+        try:
+            CleanReadConfig(**cfg)
+        except Exception as exc:
+            raise ValueError(f"clean.read.overrides.{year}: invalid config: {exc}") from exc

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from toolkit.core.io import read_yaml
 from toolkit.core.csv_read import (
+    ALLOWED_READ_CSV_KEYS,
     READ_SELECTION_KEYS,
     READ_SOURCE_MODES,
     filter_suggested_format_keys,
@@ -78,6 +79,28 @@ def filter_suggested_read(cfg: dict[str, Any] | None) -> dict[str, Any]:
     return filter_suggested_format_keys(cfg)
 
 
+def apply_year_overrides(read_cfg: dict[str, Any], year: int) -> dict[str, Any]:
+    """Return ``read_cfg`` with per-year overrides merged in for the given ``year``.
+
+    Extracts ``overrides`` from the config (if present), looks up the year,
+    and merges matching keys into the result.  The ``overrides`` key itself
+    is removed — it is not a DuckDB ``read_csv`` parameter.
+
+    This is the single shared resolution used by both the **clean runtime**
+    (via ``resolve_clean_read_cfg``) and the **RAW profiling** (via
+    ``profile_raw``) to guarantee profile and runtime never diverge.
+    """
+    if not read_cfg:
+        return {}
+    result = dict(read_cfg)
+    raw_overrides = result.pop("overrides", None) or {}
+    year_override = raw_overrides.get(year) or raw_overrides.get(str(year))
+    if year_override:
+        filtered = {k: v for k, v in year_override.items() if k in ALLOWED_READ_CSV_KEYS}
+        result.update(filtered)
+    return result
+
+
 def resolve_clean_read_cfg(
     raw_year_dir: Path,
     clean_cfg: dict[str, Any],
@@ -92,8 +115,7 @@ def resolve_clean_read_cfg(
         raw_overrides = dict(explicit_cfg.pop("overrides", {}) or {})
 
     selection_cfg, relation_overrides = _split_read_cfg(explicit_cfg)
-
-    # Belt and suspenders: ensure overrides doesn't leak into relation config
+    # Belt and suspenders: ensure overrides doesn't leak
     relation_overrides.pop("overrides", None)
 
     # Validate each year's override dict against CleanReadConfig
@@ -113,17 +135,15 @@ def resolve_clean_read_cfg(
         overrides=relation_overrides,
     )
 
-    # Apply per-year override if one exists for this year
+    # Apply per-year override via the shared resolver (same as profile_raw uses)
     year = int(raw_year_dir.name)
-    year_override = raw_overrides.get(year) or raw_overrides.get(str(year))
-    if year_override:
-        # Filter to valid DuckDB read_csv keys only
-        from toolkit.core.csv_read import ALLOWED_READ_CSV_KEYS
-
-        filtered = {k: v for k, v in year_override.items() if k in ALLOWED_READ_CSV_KEYS}
-        if filtered:
-            merged_relation_cfg.update(filtered)
-            params_source.append(f"year_override_{year}")
+    year_override_cfg = apply_year_overrides(
+        {"overrides": dict(raw_overrides)} if raw_overrides else {},
+        year,
+    )
+    if year_override_cfg:
+        merged_relation_cfg.update(year_override_cfg)
+        params_source.append(f"year_override_{year}")
 
     return selection_cfg, merged_relation_cfg, params_source
 

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -142,6 +142,24 @@ def resolve_clean_read_cfg(
     if "overrides" in explicit_cfg:
         raw_overrides = dict(explicit_cfg.pop("overrides", {}) or {})
 
+    # Validate STRUCTURE of ALL override entries (not just the executed year).
+    # Checks that every year's keys are known DuckDB params (parsing only,
+    # no selection keys).  Dependency validation (e.g. align_by_header needs
+    # normalize_rows_to_columns) happens later at merge time per-year.
+    known_override_keys = ALLOWED_READ_CSV_KEYS - READ_SELECTION_KEYS
+    for override_key, year_cfg in raw_overrides.items():
+        if not isinstance(year_cfg, dict):
+            raise ValueError(
+                f"clean.read.overrides.{override_key}: must be a mapping (dict), "
+                f"got {type(year_cfg).__name__}"
+            )
+        unknown = [k for k in year_cfg if k not in known_override_keys]
+        if unknown:
+            raise ValueError(
+                f"clean.read.overrides.{override_key}: unknown parameter(s): "
+                f"{unknown}. Allowed: {sorted(known_override_keys)}"
+            )
+
     selection_cfg, relation_overrides = _split_read_cfg(explicit_cfg)
     # Belt and suspenders: ensure overrides doesn't leak
     relation_overrides.pop("overrides", None)
@@ -180,35 +198,3 @@ def resolve_clean_read_cfg(
     )
 
     return selection_cfg, merged_relation_cfg, params_source
-
-
-def _validate_and_normalize_overrides(
-    raw_overrides: dict[str | int, dict[str, Any]],
-    logger=None,
-) -> dict[str | int, dict[str, Any]]:
-    """Validate and normalize per-year override configs against ``CleanReadConfig``.
-
-    Each year's override is validated with ``CleanReadConfig.model_validate``
-    and then ``model_dump`` returns the normalized form (e.g. ``columns`` in
-    list format is converted to dict, YAML string booleans are parsed).
-
-    Raises ``ValueError`` with the offending year key if any override
-    contains invalid or unknown fields (catches typos like ``delmi``).
-
-    Returns a dict of ``{year: validated_dict}`` with the same structure
-    as the input but with normalized values.
-    """
-    result: dict[str | int, dict[str, Any]] = {}
-    if not raw_overrides:
-        return result
-
-    from toolkit.core.config_models.clean import CleanReadConfig
-
-    for year, cfg in raw_overrides.items():
-        try:
-            validated = CleanReadConfig.model_validate(cfg)
-            result[year] = validated.model_dump(exclude_unset=True)
-        except Exception as exc:
-            raise ValueError(f"clean.read.overrides.{year}: invalid config: {exc}") from exc
-
-    return result

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -132,11 +132,6 @@ def resolve_clean_read_cfg(
     # Belt and suspenders: ensure overrides doesn't leak
     relation_overrides.pop("overrides", None)
 
-    # Validate and normalize each year's override against CleanReadConfig.
-    # model_dump() returns the validated/normalized values (e.g. columns list
-    # converted to dict, booleans parsed from YAML strings).
-    validated_overrides = _validate_and_normalize_overrides(raw_overrides, logger)
-
     suggested_cfg = load_suggested_read(raw_year_dir)
     filtered_suggested = filter_suggested_read(suggested_cfg)
     if normalized_source == "auto" and filtered_suggested and logger is not None:
@@ -151,15 +146,24 @@ def resolve_clean_read_cfg(
         overrides=relation_overrides,
     )
 
-    # Apply per-year override via the shared resolver (same as profile_raw uses)
+    # Apply per-year override with full base context (apply_year_overrides
+    # needs the entire config to validate inter-dependent fields like
+    # align_by_header + normalize_rows_to_columns)
     year = int(raw_year_dir.name)
-    year_override_cfg = apply_year_overrides(
-        {"overrides": dict(validated_overrides)} if validated_overrides else {},
-        year,
-    )
-    if year_override_cfg:
-        merged_relation_cfg.update(year_override_cfg)
+    if raw_overrides and (year in raw_overrides or str(year) in raw_overrides):
+        merged_relation_cfg = apply_year_overrides(
+            {**merged_relation_cfg, "overrides": dict(raw_overrides)},
+            year,
+        )
         params_source.append(f"year_override_{year}")
+
+    # Single normalisation pass after all merges — catches raw YAML values
+    # (columns list, string booleans) from BOTH base and override in one shot.
+    from toolkit.core.config_models.clean import CleanReadConfig
+
+    merged_relation_cfg = CleanReadConfig.model_validate(merged_relation_cfg).model_dump(
+        exclude_unset=True
+    )
 
     return selection_cfg, merged_relation_cfg, params_source
 

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -86,6 +86,13 @@ def resolve_clean_read_cfg(
     normalized_source, explicit_cfg = _read_source_mode(clean_cfg, logger)
     selection_cfg, relation_overrides = _split_read_cfg(explicit_cfg)
 
+    # Extract per-year overrides from clean.read BEFORE they pollute merge
+    raw_overrides: dict[str | int, dict[str, Any]] = {}
+    if "overrides" in explicit_cfg:
+        raw_overrides = dict(explicit_cfg.pop("overrides", {}) or {})
+    elif "overrides" in relation_overrides:
+        raw_overrides = dict(relation_overrides.pop("overrides", {}) or {})
+
     suggested_cfg = load_suggested_read(raw_year_dir)
     filtered_suggested = filter_suggested_read(suggested_cfg)
     if normalized_source == "auto" and filtered_suggested and logger is not None:
@@ -99,5 +106,18 @@ def resolve_clean_read_cfg(
         suggested=suggested_cfg,
         overrides=relation_overrides,
     )
+
+    # Apply per-year override if one exists
+    year = int(raw_year_dir.name)
+    if year in raw_overrides or str(year) in raw_overrides:
+        key = year if year in raw_overrides else str(year)
+        year_cfg = dict(raw_overrides[key])
+        # Filter to valid read CSV keys (exclude non-DuckDB keys like overrides)
+        from toolkit.core.csv_read import ALLOWED_READ_CSV_KEYS
+
+        year_cfg = {k: v for k, v in year_cfg.items() if k in ALLOWED_READ_CSV_KEYS}
+        if year_cfg:
+            merged_relation_cfg.update(year_cfg)
+            params_source.append(f"year_override_{year}")
 
     return selection_cfg, merged_relation_cfg, params_source

--- a/toolkit/core/config_models/clean.py
+++ b/toolkit/core/config_models/clean.py
@@ -48,6 +48,7 @@ class CleanReadConfig(BaseModel):
     prefer_from_raw_run: bool = True
     allow_ambiguous: bool = False
     include: list[str] | None = None
+    overrides: dict[str | int, dict[str, Any]] | None = None
 
     @field_validator("columns", mode="before")
     @classmethod

--- a/toolkit/core/csv_read.py
+++ b/toolkit/core/csv_read.py
@@ -35,6 +35,7 @@ ALLOWED_READ_CSV_KEYS = {
     "sheet_name",
     "dateformat",
     "timestampformat",
+    "overrides",
 }
 FORMAT_HINT_KEYS = {
     "delim",

--- a/toolkit/core/csv_read.py
+++ b/toolkit/core/csv_read.py
@@ -35,7 +35,6 @@ ALLOWED_READ_CSV_KEYS = {
     "sheet_name",
     "dateformat",
     "timestampformat",
-    "overrides",
 }
 FORMAT_HINT_KEYS = {
     "delim",

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -20,6 +20,7 @@ from toolkit.profile.raw import (
     write_raw_profile,
     write_suggested_read_yml,
 )
+from toolkit.clean.read_config import apply_year_overrides
 from toolkit.scaffold.clean import scaffold_clean_if_missing
 from toolkit.raw._fetch_utils import (
     _choose_primary_output,
@@ -179,7 +180,7 @@ def run_raw(
                     out_dir,
                     dataset,
                     year,
-                    read_cfg=(clean_cfg or {}).get("read", {}),
+                    read_cfg=apply_year_overrides((clean_cfg or {}).get("read", {}), year),
                     primary_file=primary_output_path,
                 )
                 profile_dir = out_dir / "_profile"


### PR DESCRIPTION
## Sintesi

Aggiunge `clean.read.overrides` per dichiarare parametri di parsing diversi per anno.

## Uso

```yaml
clean:
  read:
    columns: {nome: VARCHAR, anno: BIGINT}
    overrides:
      2023:
        columns: {_id: BIGINT, nome: VARCHAR, anno: BIGINT}  # colonna extra
        skip: 2
      2024:
        decimal: ","
```

## Cosa fa

- Parametri semplici per anno: `skip`, `encoding`, `decimal`, `dateformat`, ecc.
- Colonne diverse per anno: `columns` completo nell'override
- Auto-validante: normalizza YAML raw (lista→dict, "false"→bool)
- Condiviso tra clean runtime e RAW profiling (nessuna divergenza)
- Tutti gli override validati strutturalmente (tipi, chiavi sconosciute, chiavi anno)
- Dipendenze tra campi (es. `align_by_header` + `normalize_rows_to_columns`) verificate al merge con la base

## Cosa NON fa

- Non permette chiavi di selezione (`mode`, `glob`, `include`, ...) — sono di pertinenza source, non anno
- Non permette chiavi anno non numeriche
- Non valida dipendenze tra campi in isolamento (serve la base per quelle)

## File

- `core/config_models/clean.py`: `overrides: dict[str | int, dict[str, Any]] | None`
- `clean/read_config.py`: estrazione, validazione, applicazione override
- `raw/run.py`: override applicato anche in fase di profiling
- `docs/config-schema.md`: documentato

## Test

58 test, boiler ok.
