### PR TITLE
feat: full run pulito — run preflight, rimosso probe da pipeline, test ottimizzati

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --timeout=30
+addopts = --timeout=30 -m "not smoke"
 pythonpath = .
 markers =
     # Lab-wide test policy markers (see lab-ops/operations/test-policy.md)

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -282,6 +282,27 @@ def test_batch_dry_run_with_json(tmp_path: Path) -> None:
 
 
 @pytest.mark.policy
+def test_batch_step_probe_dry_run_reports_dry_run(tmp_path: Path) -> None:
+    """--step probe --dry-run deve riportare DRY_RUN (non SUCCESS)."""
+    project = tmp_path / "project"
+    _write_batch_project(project, "batch_probe_dry", 2023)
+    configs_file = _write_configs_file(tmp_path, "project")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["batch", "--configs", str(configs_file), "--step", "probe", "--dry-run", "--json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    report = json.loads(result.output)
+    assert report["summary"]["total"] == 1
+    assert report["summary"]["passed"] == 1
+    assert report["rows"][0]["status"] == "DRY_RUN"
+
+
+@pytest.mark.policy
 def test_batch_step_raw_dry_run_reuses_runner_across_configs(tmp_path: Path) -> None:
     """Batch --step raw --dry-run processa piu config e produce report."""
     project_a = tmp_path / "proj_a"

--- a/tests/test_batch_cli.py
+++ b/tests/test_batch_cli.py
@@ -282,48 +282,23 @@ def test_batch_dry_run_with_json(tmp_path: Path) -> None:
 
 
 @pytest.mark.policy
-def test_batch_step_probe_shared_pool(monkeypatch, tmp_path: Path) -> None:
-    """Batch --step probe riusa lo stesso ProbePool tra config diversi.
-
-    Il circuit breaker deve persistere tra le probe di piu' dataset.
-    """
-    pools_seen: list[object] = []
-
-    def _tracking_run_probe(cfg, year, logger, pool=None):
-        if pool is not None:
-            pools_seen.append(pool)
-
-    monkeypatch.setattr(
-        "toolkit.cli.cmd_run._run_probe",
-        _tracking_run_probe,
-    )
-
-    # Scrivi due progetti distinti
+def test_batch_step_raw_dry_run_reuses_runner_across_configs(tmp_path: Path) -> None:
+    """Batch --step raw --dry-run processa piu config e produce report."""
     project_a = tmp_path / "proj_a"
-    _write_batch_project(project_a, "batch_pool_a", 2023)
+    _write_batch_project(project_a, "batch_raw_a", 2023)
     project_b = tmp_path / "proj_b"
-    _write_batch_project(project_b, "batch_pool_b", 2024)
+    _write_batch_project(project_b, "batch_raw_b", 2024)
 
     configs_file = tmp_path / "configs.txt"
-    configs_file.write_text(
-        f"{project_a}/dataset.yml\n{project_b}/dataset.yml\n", encoding="utf-8"
-    )
+    configs_file.write_text(f"{project_a}/dataset.yml\n{project_b}/dataset.yml\n", encoding="utf-8")
 
     runner = CliRunner()
     result = runner.invoke(
         app,
-        ["batch", "--configs", str(configs_file), "--step", "probe"],
+        ["batch", "--configs", str(configs_file), "--step", "raw", "--dry-run"],
         catch_exceptions=False,
     )
 
     assert result.exit_code == 0
-    # Devono aver ricevuto lo stesso pool (stessa identita')
-    assert len(pools_seen) >= 2, (
-        f"Attese almeno 2 chiamate a _run_probe con pool, ricevute {len(pools_seen)}"
-    )
-    first_pool = pools_seen[0]
-    for i, p in enumerate(pools_seen):
-        assert p is first_pool, (
-            f"Pool alla chiamata {i} ha identita' diversa: "
-            f"ci si aspetta che batch riusi lo stesso ProbePool"
-        )
+    assert "batch_raw_a" in result.output
+    assert "batch_raw_b" in result.output

--- a/tests/test_cli_path_contract.py
+++ b/tests/test_cli_path_contract.py
@@ -72,7 +72,7 @@ def test_cli_dry_run_resolves_sql_from_config_dir_not_cwd(tmp_path: Path, monkey
 
     assert result.exit_code == 0
     assert "Execution Plan" in result.output
-    assert "steps: probe, raw, clean, mart" in result.output
+    assert "steps: raw, clean, mart" in result.output
 
 
 def test_cli_commands_use_dataset_yml_dir_as_path_base(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_cli_scout_url.py
+++ b/tests/test_cli_scout_url.py
@@ -179,7 +179,7 @@ def test_probe_url_uses_head_then_get_only_for_html(monkeypatch) -> None:
     assert calls[2] == ("get", "https://example.org/html")
 
 
-@pytest.mark.pure_unit
+@pytest.mark.smoke
 def test_probe_url_falls_back_to_get_when_head_fails(monkeypatch) -> None:
     """HEAD fails with error, GET with Range succeeds → probe returns file info."""
     head_called = False

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -40,6 +40,7 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_sparql_query",
         "toolkit_preview_url",
         "toolkit_validate_config",
+        "toolkit_preflight",
     }
 
 
@@ -463,3 +464,24 @@ def test_toolkit_raw_preview_converts_year_zero_to_none(monkeypatch: pytest.Monk
     mcp_server.toolkit_raw_preview("d.yml", 0, 20)
 
     assert calls["year"] is None
+
+
+def test_toolkit_preflight_returns_report(monkeypatch: pytest.MonkeyPatch) -> None:
+    """toolkit_preflight passa config e years a run_preflight."""
+    calls: dict[str, object] = {}
+
+    def fake_preflight(config, *, years_arg=None):
+        calls["config"] = str(config)
+        calls["years_arg"] = years_arg
+        return {"config": str(config), "sources": [], "years": [2024], "status": "passed"}
+
+    monkeypatch.setattr(
+        "toolkit.cli.preflight_ops.run_preflight",
+        fake_preflight,
+    )
+
+    result = mcp_server.toolkit_preflight("dataset.yml", years="2024")
+
+    assert result["status"] == "passed"
+    assert calls["config"] == "dataset.yml"
+    assert calls["years_arg"] == "2024"

--- a/tests/test_preflight_ops.py
+++ b/tests/test_preflight_ops.py
@@ -1,0 +1,184 @@
+"""Test per preflight_ops: run_preflight con fonti mockate.
+
+Nessuna chiamata HTTP reale — tutto mockato.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from toolkit.cli.preflight_ops import run_preflight
+
+
+@pytest.fixture
+def _mock_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mocka preview_url e probe_url_headers per evitare HTTP reali."""
+
+    class _FakePreviewResult:
+        url = "https://example.org/data.csv"
+        status = "success"
+        reachable = True
+        http_status = 200
+        file_size = 1024
+        resource_format = "CSV"
+        encoding_suggested = "utf-8"
+        delim_suggested = ","
+        decimal_suggested = "."
+        skip_suggested = 0
+        columns = ["comune", "anno", "valore"]
+        col_types = {"comune": "VARCHAR", "anno": "BIGINT", "valore": "DOUBLE"}
+        preview_row_count = 10
+        robust_read_suggested = False
+        mapping_suggestions = {}
+        granularity = "comune"
+        year_min = 2020
+        year_max = 2025
+        quality_score = 85
+        quality_structural_score = 85
+        quality_semantic_score = 80
+        quality_combined_score = 83
+        quality_sampled = True
+        quality_verdict = "buona"
+        quality_flags = []
+        quality_ontologies = {}
+        quality_note = None
+
+    monkeypatch.setattr(
+        "toolkit.profile.preview.preview_url",
+        lambda *args, **kwargs: _FakePreviewResult(),
+    )
+
+    monkeypatch.setattr(
+        "toolkit.scout.http.probe_url_headers",
+        lambda *args, **kwargs: {
+            "requested_url": args[0],
+            "final_url": args[0],
+            "status_code": 200,
+            "content_type": "text/html",
+            "content_disposition": None,
+            "content_length": 5000,
+            "method": "head",
+        },
+    )
+
+
+def _write_test_config(path: Path) -> Path:
+    """Scrive dataset.yml con 3 source type diversi e 2 anni."""
+    config_dir = path / "test_config"
+    config_dir.mkdir(exist_ok=True)
+    config_path = config_dir / "dataset.yml"
+    config_path.write_text(
+        "\n".join(
+            [
+                f'root: "{(config_dir / "out").as_posix()}"',
+                "dataset:",
+                '  name: "test_preflight"',
+                "  source_id: test_local",
+                "  years: [2022, 2023]",
+                "raw:",
+                "  sources:",
+                "    - name: csv_source",
+                "      type: http_file",
+                "      primary: true",
+                "      args:",
+                '        url: "https://example.org/data_{year}.csv"',
+                "    - name: ckan_portal",
+                "      type: ckan",
+                "      args:",
+                '        portal_url: "https://ckan.example.org"',
+                "    - name: local_data",
+                "      type: local_file",
+                "      args:",
+                '        path: "data/local.csv"',
+                "clean:",
+                '  sql: "sql/clean.sql"',
+                "mart:",
+                "  tables:",
+                '    - name: "mart_test"',
+                '      sql: "sql/mart.sql"',
+                "validation:",
+                "  fail_on_error: false",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+class TestPreflightOps:
+    """Test per run_preflight con fonti mockate."""
+
+    @pytest.mark.policy
+    def test_preflight_returns_structured_report(self, tmp_path: Path, _mock_http) -> None:
+        """Il report contiene config_check, sources, status."""
+        config_path = _write_test_config(tmp_path)
+        result = run_preflight(str(config_path))
+
+        assert result["config_check"]["ok"] is True
+        assert result["dataset"] == "test_preflight"
+        assert result["years"] == [2022, 2023]
+        assert result["status"] == "passed"
+
+    @pytest.mark.policy
+    def test_preflight_reports_http_file_source(self, tmp_path: Path, _mock_http) -> None:
+        """http_file CSV: reachable, colonne, quality score."""
+        config_path = _write_test_config(tmp_path)
+        result = run_preflight(str(config_path))
+
+        csv_sources = [s for s in result["sources"] if s["type"] == "http_file"]
+        assert len(csv_sources) == 2  # una per anno
+
+        src = csv_sources[0]
+        assert src["reachable"] is True
+        assert src["status"] == "success"
+        assert src["resource_format"] == "CSV"
+        assert src["encoding"] == "utf-8"
+        assert src["delim"] == ","
+        assert src["columns"] == ["comune", "anno", "valore"]
+        assert src["quality_score"] == 85
+        assert src["quality_verdict"] == "buona"
+
+    @pytest.mark.policy
+    def test_preflight_deduplicates_same_url_across_years(self, tmp_path: Path, _mock_http) -> None:
+        """CKAN senza {year} nell'URL deve essere probe-ato una sola volta."""
+        config_path = _write_test_config(tmp_path)
+        result = run_preflight(str(config_path))
+
+        ckan_sources = [s for s in result["sources"] if s["type"] == "ckan"]
+        assert len(ckan_sources) == 2  # due anni
+
+        # Primo anno: probe reale
+        assert ckan_sources[0]["status"] == "reachable"
+
+        # Secondo anno: stesso URL → cached
+        assert ckan_sources[1]["status"] == "cached"
+
+    @pytest.mark.policy
+    def test_preflight_skips_local_file(self, tmp_path: Path, _mock_http) -> None:
+        """local_file: saltato senza probe."""
+        config_path = _write_test_config(tmp_path)
+        result = run_preflight(str(config_path))
+
+        local_sources = [s for s in result["sources"] if s["type"] == "local_file"]
+        assert len(local_sources) == 2  # una per anno
+        for src in local_sources:
+            assert src["reachable"] is True
+            assert src["status"] == "skipped"
+
+    @pytest.mark.policy
+    def test_preflight_http_file_with_placeholder_in_url(self, tmp_path: Path, _mock_http) -> None:
+        """URL con {year} produce URL diversi per anno — nessuna deduplica."""
+        config_path = _write_test_config(tmp_path)
+        result = run_preflight(str(config_path))
+
+        csv_sources = [s for s in result["sources"] if s["type"] == "http_file"]
+        urls = {s["year"]: s["url"] for s in csv_sources}
+
+        # {year} deve essere risolto
+        assert urls[2022] == "https://example.org/data_2022.csv"
+        assert urls[2023] == "https://example.org/data_2023.csv"
+
+        # URL diversi → entrambi status success (non cached)
+        assert all(s["status"] == "success" for s in csv_sources)

--- a/tests/test_probe_pool.py
+++ b/tests/test_probe_pool.py
@@ -88,6 +88,7 @@ class TestProbePool:
         assert elapsed < 0.9, f"Pool troppo lento ({elapsed:.2f}s) — atteso < 0.9s per 3 probe"
         pool.close()
 
+    @pytest.mark.smoke
     @pytest.mark.policy
     def test_circuit_breaker_integration(self, monkeypatch) -> None:
         """Con circuit_threshold>0, errori consecutivi aprono il circuito.

--- a/tests/test_run_dry_run.py
+++ b/tests/test_run_dry_run.py
@@ -36,7 +36,7 @@ def test_run_dry_run_prints_plan_and_creates_only_run_record(
     assert result.exit_code == 0
     assert "Execution Plan" in result.output
     assert "status: DRY_RUN" in result.output
-    assert "steps: probe, raw, clean, mart" in result.output
+    assert "steps: raw, clean, mart" in result.output
     assert "sql_validation: OK" in result.output
 
     runs_dir = root_dir / "data" / "_runs" / "demo_ds" / "2022"

--- a/tests/test_run_validation_gate.py
+++ b/tests/test_run_validation_gate.py
@@ -340,27 +340,49 @@ def test_mart_validation_skips_min_rows_in_sample_mode(tmp_path: Path) -> None:
 
 
 @pytest.mark.regression
-def test_run_full_second_validation_block_uses_sample_mode(tmp_path: Path, monkeypatch) -> None:
-    """Il blocco di validazione finale in run_full() riceve sample_mode=True con --sample-rows."""
+def test_run_full_validates_via_context_not_direct_calls(tmp_path: Path, monkeypatch) -> None:
+    """run_full si fida del RunContext — le validazioni sono chiamate solo da run_year.
+
+    Questo test conta quante volte vengono chiamate le funzioni di validazione.
+    Con la vecchia doppia validazione, ogni funzione veniva chiamata 2 volte
+    (una in run_year + una in run_full). Con il fix, ogni funzione è chiamata
+    1 sola volta (solo dentro run_year).
+    """
     config_path = tmp_path / "dataset.yml"
     _write_config_with_min_rows(config_path, min_rows=1000)
 
-    sample_mode_passed = {"clean": False, "mart": False}
+    call_counts: dict[str, int] = {"raw": 0, "clean": 0, "mart": 0}
 
-    def _tracking_clean_validation(cfg, year, logger, *, sample_mode=False):
-        sample_mode_passed["clean"] = sample_mode
+    def _counting_raw(*args, **kwargs):
+        call_counts["raw"] += 1
         return _ok_summary()
 
-    def _tracking_mart_validation(cfg, year, logger, *, sample_mode=False):
-        sample_mode_passed["mart"] = sample_mode
+    def _counting_clean(*args, **kwargs):
+        call_counts["clean"] += 1
         return _ok_summary()
+
+    def _counting_mart(*args, **kwargs):
+        call_counts["mart"] += 1
+        return _ok_summary()
+
+    monkeypatch.setattr(cmd_run, "run_raw_validation", _counting_raw)
+    monkeypatch.setattr(cmd_run, "run_clean_validation", _counting_clean)
+    monkeypatch.setattr(cmd_run, "run_mart_validation", _counting_mart)
 
     monkeypatch.setattr(cmd_run, "run_raw", lambda *args, **kwargs: None)
     monkeypatch.setattr(cmd_run, "run_clean", lambda *args, **kwargs: None)
     monkeypatch.setattr(cmd_run, "run_mart", lambda *args, **kwargs: None)
-    monkeypatch.setattr(cmd_run, "run_raw_validation", lambda *args, **kwargs: _ok_summary())
-    monkeypatch.setattr(cmd_run, "run_clean_validation", _tracking_clean_validation)
-    monkeypatch.setattr(cmd_run, "run_mart_validation", _tracking_mart_validation)
+
+    # run_full chiama run_preflight all'inizio — mockiamo per evitare
+    # che validate_config fallisca su config minimale del test
+    monkeypatch.setattr(
+        "toolkit.cli.preflight_ops.run_preflight",
+        lambda *args, **kwargs: {
+            "config_check": {"ok": True, "errors": [], "warnings": [], "slug": "test"},
+            "sources": [],
+            "status": "passed",
+        },
+    )
     import toolkit.cli.inspect.readiness_ops as _readiness_ops
 
     monkeypatch.setattr(
@@ -374,9 +396,6 @@ def test_run_full_second_validation_block_uses_sample_mode(tmp_path: Path, monke
         },
     )
 
-    # Esegue run full COME se chiamato da CI con --sample-rows 1000
-    # (tutti i parametri espliciti per bypassare i default Typer che
-    #  altrimenti restituiscono oggetti OptionInfo invece di None)
     cmd_run.run_full(
         config=str(config_path),
         smoke=False,
@@ -388,9 +407,11 @@ def test_run_full_second_validation_block_uses_sample_mode(tmp_path: Path, monke
         dry_run=False,
     )
 
-    assert sample_mode_passed["clean"] is True, (
-        "run_full deve passare sample_mode=True alla validazione clean"
-    )
-    assert sample_mode_passed["mart"] is True, (
-        "run_full deve passare sample_mode=True alla validazione mart"
-    )
+    # Ogni validazione deve essere chiamata ESATTAMENTE 1 volta,
+    # dalla _execute_layer() dentro run_year().
+    # 0 = non chiamata affatto (run_year skipped), 2+ = doppia validazione
+    for layer in ("raw", "clean", "mart"):
+        assert call_counts[layer] == 1, (
+            f"{layer}: chiamata {call_counts[layer]} volte "
+            f"(atteso 1 — 0 = non eseguita, 2+ = doppia validazione reintrodotta)"
+        )

--- a/toolkit/cli/cmd_batch.py
+++ b/toolkit/cli/cmd_batch.py
@@ -154,100 +154,89 @@ def batch(
     rows: list[dict[str, str]] = []
     failures: list[dict[str, str]] = []
 
-    _shared_probe_pool = None
-    if step in ("probe", "raw", "all"):
-        from toolkit.core.probe import ProbePool
+    for config_path in config_paths:
+        config_started_at = perf_counter()
+        dataset_label = config_path.stem
 
-        _shared_probe_pool = ProbePool(workers=8, circuit_threshold=3)
-
-    try:
-        for config_path in config_paths:
-            config_started_at = perf_counter()
-            dataset_label = config_path.stem
-
-            try:
-                if smoke:
-                    # Carica prima senza override per scoprire cfg.root originale,
-                    # poi ricarica con root_override a {root}/smoke
-                    _cfg0, _logger0 = load_cfg_and_logger(str(config_path))
-                    if json_output:
-                        _silence_logger()
-                    cfg, logger = load_cfg_and_logger(
-                        str(config_path),
-                        root_override=str(_cfg0.root / "smoke"),
-                    )
-                else:
-                    cfg, logger = load_cfg_and_logger(str(config_path))
-
-                # Quando --json è attivo, silenzia il logger dopo ogni
-                # load_cfg_and_logger (che resetta il logger a ogni chiamata)
+        try:
+            if smoke:
+                # Carica prima senza override per scoprire cfg.root originale,
+                # poi ricarica con root_override a {root}/smoke
+                _cfg0, _logger0 = load_cfg_and_logger(str(config_path))
                 if json_output:
                     _silence_logger()
-                dataset_label = cfg.dataset
-
-                for year in cfg.years:
-                    run_started_at = perf_counter()
-                    status = "FAILED"
-                    try:
-                        # Quando --json è attivo, silenzia typer.echo durante
-                        # run_year per evitare che execution plan (dry-run)
-                        # o altri echo contaminino stdout JSON
-                        _run_ctx = _silence_typer_echo() if json_output else contextlib.nullcontext()
-                        with _run_ctx:
-                            context = run_year(
-                                cfg,
-                                year,
-                                step=step,
-                                dry_run=dry_flag,
-                                logger=logger,
-                                sample_rows=sample_rows_final,
-                                sample_bytes=sample_bytes_final,
-                                probe_pool=_shared_probe_pool,
-                            )
-                        status = context.status
-                    except Exception as exc:
-                        failures.append(
-                            {
-                                "config": str(config_path),
-                                "dataset": dataset_label,
-                                "years": str(year),
-                                "error": str(exc),
-                            }
-                        )
-                    finally:
-                        rows.append(
-                            _build_row(
-                                dataset=dataset_label,
-                                config_path=str(config_path),
-                                years=str(year),
-                                step=step,
-                                status=status,
-                                duration=_format_duration(perf_counter() - run_started_at),
-                            )
-                        )
-            except Exception as exc:
-                failures.append(
-                    {
-                        "config": str(config_path),
-                        "dataset": dataset_label,
-                        "years": "-",
-                        "error": str(exc),
-                    }
+                cfg, logger = load_cfg_and_logger(
+                    str(config_path),
+                    root_override=str(_cfg0.root / "smoke"),
                 )
-                rows.append(
-                    _build_row(
-                        dataset=dataset_label,
-                        config_path=str(config_path),
-                        years="-",
-                        step=step,
-                        status="FAILED",
-                        duration=_format_duration(perf_counter() - config_started_at),
+            else:
+                cfg, logger = load_cfg_and_logger(str(config_path))
+
+            # Quando --json è attivo, silenzia il logger dopo ogni
+            # load_cfg_and_logger (che resetta il logger a ogni chiamata)
+            if json_output:
+                _silence_logger()
+            dataset_label = cfg.dataset
+
+            for year in cfg.years:
+                run_started_at = perf_counter()
+                status = "FAILED"
+                try:
+                    # Quando --json è attivo, silenzia typer.echo durante
+                    # run_year per evitare che execution plan (dry-run)
+                    # o altri echo contaminino stdout JSON
+                    _run_ctx = _silence_typer_echo() if json_output else contextlib.nullcontext()
+                    with _run_ctx:
+                        context = run_year(
+                            cfg,
+                            year,
+                            step=step,
+                            dry_run=dry_flag,
+                            logger=logger,
+                            sample_rows=sample_rows_final,
+                            sample_bytes=sample_bytes_final,
+                        )
+                    status = context.status
+                except Exception as exc:
+                    failures.append(
+                        {
+                            "config": str(config_path),
+                            "dataset": dataset_label,
+                            "years": str(year),
+                            "error": str(exc),
+                        }
                     )
+                finally:
+                    rows.append(
+                        _build_row(
+                            dataset=dataset_label,
+                            config_path=str(config_path),
+                            years=str(year),
+                            step=step,
+                            status=status,
+                            duration=_format_duration(perf_counter() - run_started_at),
+                        )
+                    )
+        except Exception as exc:
+            failures.append(
+                {
+                    "config": str(config_path),
+                    "dataset": dataset_label,
+                    "years": "-",
+                    "error": str(exc),
+                }
+            )
+            rows.append(
+                _build_row(
+                    dataset=dataset_label,
+                    config_path=str(config_path),
+                    years="-",
+                    step=step,
+                    status="FAILED",
+                    duration=_format_duration(perf_counter() - config_started_at),
                 )
+            )
 
-    finally:
-        if _shared_probe_pool is not None:
-            _shared_probe_pool.close()
     if json_output:
         report: dict[str, Any] = {
             "summary": {

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -141,25 +141,27 @@ def _probe_fmt(content_type: str | None) -> str:
     return _PROBE_FORMATS.get(base, base)
 
 
-def _resolve_source(src, year: int) -> dict[str, str]:
+def _resolve_source(src, year: int) -> dict[str, Any]:
     """Normalizza una fonte raw.sources in dict con stype, name, args, url.
 
     Condiviso tra _run_probe e preflight_ops.py per evitare duplicazione
     del parsing di source config (dict vs oggetto).
     """
-    stype = getattr(src, "type", None) or (
-        src.get("type") if isinstance(src, dict) else "http_file"
-    )
-    args = getattr(src, "args", None) or (src.get("args", {}) if isinstance(src, dict) else {})
-    name = getattr(src, "name", None) or (
-        src.get("name", stype) if isinstance(src, dict) else (src.name or stype)
-    )
-    url = (args.get("url") if isinstance(args, dict) else getattr(args, "url", "")) or ""
+    if isinstance(src, dict):
+        stype = str(src.get("type", "http_file"))
+        args: Any = src.get("args", {})
+        name = str(src.get("name", stype))
+    else:
+        stype = str(getattr(src, "type", "http_file") or "http_file")
+        args = getattr(src, "args", None) or {}
+        name = str(getattr(src, "name", None) or stype)
+
+    raw_url = (args.get("url") if isinstance(args, dict) else getattr(args, "url", "")) or ""
     return {
         "stype": stype,
         "args": args,
         "name": name,
-        "url": (url or "").replace("{year}", str(year)),
+        "url": str(raw_url).replace("{year}", str(year)),
     }
 
 

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -141,6 +141,28 @@ def _probe_fmt(content_type: str | None) -> str:
     return _PROBE_FORMATS.get(base, base)
 
 
+def _resolve_source(src, year: int) -> dict[str, str]:
+    """Normalizza una fonte raw.sources in dict con stype, name, args, url.
+
+    Condiviso tra _run_probe e preflight_ops.py per evitare duplicazione
+    del parsing di source config (dict vs oggetto).
+    """
+    stype = getattr(src, "type", None) or (
+        src.get("type") if isinstance(src, dict) else "http_file"
+    )
+    args = getattr(src, "args", None) or (src.get("args", {}) if isinstance(src, dict) else {})
+    name = getattr(src, "name", None) or (
+        src.get("name", stype) if isinstance(src, dict) else (src.name or stype)
+    )
+    url = (args.get("url") if isinstance(args, dict) else getattr(args, "url", "")) or ""
+    return {
+        "stype": stype,
+        "args": args,
+        "name": name,
+        "url": (url or "").replace("{year}", str(year)),
+    }
+
+
 def _run_probe(cfg, year: int, logger, pool=None) -> None:
     """Passo probe della pipeline: verifica raggiungibilita' fonti remote.
 
@@ -172,34 +194,19 @@ def _run_probe(cfg, year: int, logger, pool=None) -> None:
     try:
         futures = []
 
-        def _parse_and_submit(src) -> None:
-            stype = (
-                getattr(src, "type", None) or src.get("type", "http_file")
-                if isinstance(src, dict)
-                else src.type
-            )
-            args = (
-                getattr(src, "args", None) or src.get("args", {})
-                if isinstance(src, dict)
-                else src.args
-            )
-            name = (
-                getattr(src, "name", None) or src.get("name", stype)
-                if isinstance(src, dict)
-                else (src.name or stype)
-            )
+        for src in sources:
+            resolved = _resolve_source(src, year)
+            stype, name, args = resolved["stype"], resolved["name"], resolved["args"]
 
             if stype in ("http_file", "http_post_file"):
-                url = (args.get("url") or "").replace("{year}", str(year))
+                url = resolved["url"]
                 if url:
                     futures.append(pool.submit(url, dataset=name))
             elif stype == "ckan":
-                portal = (args.get("portal_url") or "").replace("{year}", str(year))
+                portal_url = args.get("portal_url", "")
+                portal = portal_url.replace("{year}", str(year)) if portal_url else ""
                 if portal:
                     futures.append(pool.submit(portal, dataset=name))
-
-        for src in sources:
-            _parse_and_submit(src)
 
         for result in pool.as_completed(futures):
             if result.reachable:
@@ -599,7 +606,49 @@ def _make_step_cmd(step: str):
     return cmd
 
 
-run_probe_cmd = _make_step_cmd("probe")
+def _run_probe_cmd(
+    config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
+    years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
+    json_output: bool = typer.Option(False, "--json", help="Output JSON report"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print plan without executing"),
+):
+    """Verifica la raggiungibilita' delle fonti remote per un dataset.
+
+    Esegue probe HTTP per fonti http_file e CKAN.
+    Salta fonti locali, SDMX e SPARQL (non timeoutano).
+    Non blocca mai la pipeline: l'errore reale sara' rilevato da raw.
+
+    Per diagnostica piu' approfondita (quality score CSV, schema, encoding)
+    usa: toolkit run preflight
+    """
+    dry_flag = dry_run if isinstance(dry_run, bool) else False
+
+    cfg, logger = load_cfg_and_logger(config)
+    years_arg = years if isinstance(years, str) else None
+    selected_years = iter_selected_years(cfg, year_arg=None, years_arg=years_arg)
+
+    if dry_flag:
+        typer.echo(f"Probe plan — dataset: {cfg.dataset}")
+        typer.echo(f"  years: {', '.join(str(y) for y in selected_years)}")
+        sources = cfg.raw.sources or []
+        probe_count = sum(
+            1
+            for s in sources
+            for stype in (
+                [getattr(s, "type", None)] if hasattr(s, "type") else [s.get("type", "http_file")]
+            )
+            if stype in ("http_file", "http_post_file", "ckan")
+        )
+        skip_count = len(sources) - probe_count
+        typer.echo(f"  sources: {probe_count} da probe, {skip_count} skip")
+        if json_output:
+            typer.echo(json.dumps({"status": "DRY_RUN", "dataset": cfg.dataset}))
+        return
+
+    for year in selected_years:
+        _run_probe(cfg, year, logger)
+
+
 run_raw_cmd = _make_step_cmd("raw")
 run_clean_cmd = _make_step_cmd("clean")
 run_mart_cmd = _make_step_cmd("mart")
@@ -740,24 +789,26 @@ def run_full(
     }
 
     # ── Pre-flight check ────────────────────────────────────────────────
-    from toolkit.cli.preflight_ops import run_preflight as _run_preflight
+    # Solo in esecuzione reale (dry-run non fa rete)
+    if not dry_flag:
+        from toolkit.cli.preflight_ops import run_preflight as _run_preflight
 
-    preflight = _run_preflight(config, years_arg=years_arg)
-    results["preflight"] = {
-        "config_check": preflight["config_check"],
-        "sources": preflight["sources"],
-    }
-    if not preflight["config_check"].get("ok", False):
-        logger.error("Config validation failed — aborting")
-        results["status"] = "failed"
-        if json_output:
-            typer.echo(json.dumps(results, indent=2, default=str))
-        raise typer.Exit(code=1)
-    if preflight["status"] != "passed":
-        logger.warning(
-            "Pre-flight: %d source(s) unreachable (pipeline continua)",
-            sum(1 for s in preflight["sources"] if not s["reachable"]),
-        )
+        preflight = _run_preflight(config, years_arg=years_arg)
+        results["preflight"] = {
+            "config_check": preflight["config_check"],
+            "sources": preflight["sources"],
+        }
+        if not preflight["config_check"].get("ok", False):
+            logger.error("Config validation failed — aborting")
+            results["status"] = "failed"
+            if json_output:
+                typer.echo(json.dumps(results, indent=2, default=str))
+            raise typer.Exit(code=1)
+        if preflight["status"] != "passed":
+            logger.warning(
+                "Pre-flight: %d source(s) unreachable (pipeline continua)",
+                sum(1 for s in preflight["sources"] if not s["reachable"]),
+            )
 
     # Process support datasets (dichiarati in dataset.yml con support:)
     # Vengono eseguiti prima del candidate cosi' i loro output sono disponibili
@@ -795,7 +846,7 @@ def run_full(
             for sy in entry.years:
                 logger.info("Support: running %s year=%s", entry.name, sy)
                 try:
-                    run_year(
+                    ctx = run_year(
                         support_cfg,
                         sy,
                         step="all",
@@ -809,24 +860,13 @@ def run_full(
                     results["status"] = "failed"
                     break  # dipendenza fallita, abort
 
-                # Validate all layers
-                try:
-                    sv_raw = run_raw_validation(
-                        support_cfg.root, support_cfg.dataset, sy, support_logger
-                    )
-                    sv_clean = run_clean_validation(
-                        support_cfg, sy, support_logger, sample_mode=sample_mode
-                    )
-                    sv_mart = run_mart_validation(
-                        support_cfg, sy, support_logger, sample_mode=sample_mode
-                    )
-                    all_support_passed = all(r.get("passed") for r in [sv_raw, sv_clean, sv_mart])
-                    if not all_support_passed:
-                        logger.error("Support validation failed: %s year=%s", entry.name, sy)
-                        results["status"] = "failed"
-                        break  # dipendenza fallita, abort
-                except Exception as exc:
-                    logger.error("Support validation error: %s year=%s — %s", entry.name, sy, exc)
+                # all_passed dal RunContext (stessa logica del candidate)
+                all_support_passed = all(
+                    ctx.validations.get(layer, {}).get("passed", False)
+                    for layer in ("raw", "clean", "mart")
+                )
+                if not all_support_passed:
+                    logger.error("Support validation failed: %s year=%s", entry.name, sy)
                     results["status"] = "failed"
                     break  # dipendenza fallita, abort
 
@@ -996,7 +1036,7 @@ def run_preflight_cmd(
 
 def register(app: typer.Typer) -> None:
     run_sub = typer.Typer(no_args_is_help=True, add_completion=False)
-    run_sub.command("probe")(run_probe_cmd)
+    run_sub.command("probe")(_run_probe_cmd)
     run_sub.command("raw")(run_raw_cmd)
     run_sub.command("clean")(run_clean_cmd)
     run_sub.command("mart")(run_mart_cmd)

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -35,9 +35,9 @@ def _validation_runner(layer_name: str):
 
 def _planned_layers(step: str) -> list[str]:
     if step == "all":
-        return ["probe", "raw", "clean", "mart"]
+        return ["raw", "clean", "mart"]
     if step == "raw":
-        return ["probe", "raw"]
+        return ["raw"]
     return [step]
 
 
@@ -245,7 +245,6 @@ def run_year(
     sample_rows: int | None = None,
     sample_bytes: int | None = None,
     smoke: bool = False,
-    probe_pool=None,
 ) -> RunContext:
     if logger is None:
         logger = get_logger()
@@ -330,9 +329,6 @@ def run_year(
             return False
 
     source_id = cfg.source_id
-
-    if "probe" in layers_to_run and not dry_run:
-        _run_probe(cfg, year, base_logger, pool=probe_pool)
 
     if "raw" in layers_to_run:
         if not _execute_layer(
@@ -527,8 +523,8 @@ _STEP_DOCSTRINGS: dict[str, str] = {
         "l'aggregazione cross-year automaticamente."
     ),
     "all": (
-        "Esegue l'intera pipeline: probe → raw → clean → mart.\n\n"
-        "Equivalente a eseguire i quattro step in sequenza. "
+        "Esegue l'intera pipeline: raw → clean → mart.\n\n"
+        "Equivalente a eseguire i tre step in sequenza. "
         "Se il dataset è mart-only (compose), usa solo lo step mart."
     ),
 }
@@ -743,6 +739,26 @@ def run_full(
         "status": "passed",
     }
 
+    # ── Pre-flight check ────────────────────────────────────────────────
+    from toolkit.cli.preflight_ops import run_preflight as _run_preflight
+
+    preflight = _run_preflight(config, years_arg=years_arg)
+    results["preflight"] = {
+        "config_check": preflight["config_check"],
+        "sources": preflight["sources"],
+    }
+    if not preflight["config_check"].get("ok", False):
+        logger.error("Config validation failed — aborting")
+        results["status"] = "failed"
+        if json_output:
+            typer.echo(json.dumps(results, indent=2, default=str))
+        raise typer.Exit(code=1)
+    if preflight["status"] != "passed":
+        logger.warning(
+            "Pre-flight: %d source(s) unreachable (pipeline continua)",
+            sum(1 for s in preflight["sources"] if not s["reachable"]),
+        )
+
     # Process support datasets (dichiarati in dataset.yml con support:)
     # Vengono eseguiti prima del candidate cosi' i loro output sono disponibili
     # per le query MART del candidate (placeholder {support.NAME.mart} ecc.).
@@ -830,7 +846,7 @@ def run_full(
 
         for year in selected_years:
             logger.info("Run %s — year=%s", run_step, year)
-            run_year(
+            ctx = run_year(
                 cfg,
                 year,
                 step=run_step,
@@ -842,17 +858,15 @@ def run_full(
             )
 
             if not dry_flag:
+                # all_passed dal RunContext — la validazione è già avvenuta
+                # dentro run_year() per ogni layer eseguito.
                 if is_mart_only:
-                    # Validate solo mart (compose non ha raw/clean)
-                    val_mart = run_mart_validation(cfg, year, logger, sample_mode=sample_mode)
-                    all_passed = bool(val_mart.get("passed"))
+                    all_passed = bool(ctx.validations.get("mart", {}).get("passed", False))
                 else:
-                    # Validate all layers
-                    logger.info("Validate all — year=%s", year)
-                    val_raw = run_raw_validation(cfg.root, cfg.dataset, year, logger)
-                    val_clean = run_clean_validation(cfg, year, logger, sample_mode=sample_mode)
-                    val_mart = run_mart_validation(cfg, year, logger, sample_mode=sample_mode)
-                    all_passed = all(r.get("passed") for r in [val_raw, val_clean, val_mart])
+                    all_passed = all(
+                        ctx.validations.get(layer, {}).get("passed", False)
+                        for layer in ("raw", "clean", "mart")
+                    )
                 results["steps"][str(year)] = {
                     "run": "ok",
                     "validate": "passed" if all_passed else "failed",
@@ -934,6 +948,52 @@ def run_full(
         raise typer.Exit(code=1)
 
 
+def run_preflight_cmd(
+    config: str = typer.Option(..., "--config", "-c", help="Path to dataset.yml"),
+    years: str | None = typer.Option(None, "--years", help="Comma-separated dataset years"),
+    json_output: bool = typer.Option(False, "--json", help="Output JSON report"),
+):
+    """Pre-flight check: valida config, verifica raggiungibilita' fonti,
+    e per CSV scarica un preview con quality score PA.
+
+    Non esegue la pipeline — solo diagnostica preventiva.
+    """
+    from toolkit.cli.preflight_ops import run_preflight
+
+    result = run_preflight(config, years_arg=years)
+
+    if json_output:
+        import json as _json
+
+        typer.echo(_json.dumps(result, indent=2, ensure_ascii=False, default=str))
+    else:
+        status_icon = "✅" if result["status"] == "passed" else "🔴"
+        typer.echo(f"{status_icon} Pre-flight: {result['dataset']} ({result['config']})")
+        ck = result["config_check"]
+        if ck.get("ok"):
+            typer.echo("   Config: OK")
+        else:
+            for e in ck.get("errors", []):
+                typer.echo(f"   Config: 🔴 {e}")
+
+        for src in result["sources"]:
+            if src["status"] == "skipped":
+                continue
+            icon = "✅" if src["reachable"] else "🔴"
+            parts = [f"{src['name']} ({src['type']})"]
+            if src.get("url"):
+                parts.append(src["url"])
+            parts.append(f"{icon} {src['status']}")
+            if src.get("quality_score") is not None:
+                parts.append(f"quality={src['quality_score']}/100")
+            if src.get("columns"):
+                parts.append(f"{len(src['columns'])} colonne")
+            typer.echo(f"   {'  '.join(parts)}")
+
+    if result["status"] != "passed":
+        raise typer.Exit(code=1)
+
+
 def register(app: typer.Typer) -> None:
     run_sub = typer.Typer(no_args_is_help=True, add_completion=False)
     run_sub.command("probe")(run_probe_cmd)
@@ -942,5 +1002,6 @@ def register(app: typer.Typer) -> None:
     run_sub.command("mart")(run_mart_cmd)
     run_sub.command("all")(run_all_cmd)
     run_sub.command("full")(run_full)
+    run_sub.command("preflight")(run_preflight_cmd)
     run_sub.command("init")(run_init)
     app.add_typer(run_sub, name="run", help="Esegue la pipeline RAW → CLEAN → MART per un dataset.")

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -278,6 +278,13 @@ def run_year(
     )
     base_logger.info(log_ctx)
 
+    # Backward compat: batch --step probe instrada verso _run_probe
+    if step == "probe":
+        if not dry_run:
+            _run_probe(cfg, year, base_logger)
+        context.complete_run()
+        return context
+
     if dry_run:
         context.mark_dry_run()
         _print_execution_plan(cfg, year, layers_to_run, context, fail_on_error)

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -280,9 +280,11 @@ def run_year(
 
     # Backward compat: batch --step probe instrada verso _run_probe
     if step == "probe":
-        if not dry_run:
+        if dry_run:
+            context.mark_dry_run()
+        else:
             _run_probe(cfg, year, base_logger)
-        context.complete_run()
+            context.complete_run()
         return context
 
     if dry_run:

--- a/toolkit/cli/preflight_ops.py
+++ b/toolkit/cli/preflight_ops.py
@@ -79,22 +79,20 @@ def run_preflight(
     results["years"] = list(selected_years)
 
     # ── 3. Per anno, per fonte ──────────────────────────────────────────
+    # Riutilizza _resolve_source di cmd_run per normalizzare le fonti
+    # (dict vs oggetto) — stesso parsing di _run_probe.
+    from toolkit.cli.cmd_run import _resolve_source as _norm
+
     # Cache URL → risultato probe. Se stesso URL per anni diversi,
     # riusa il risultato invece di rifare la chiamata HTTP.
     _probe_cache: dict[str, dict[str, Any]] = {}
 
     for year in selected_years:
         for src in cfg.raw.sources or []:
-            # Normalize source: puo' essere dict o oggetto
-            stype = getattr(src, "type", None) or (
-                src.get("type") if isinstance(src, dict) else "http_file"
-            )
-            args = getattr(src, "args", None) or (
-                src.get("args", {}) if isinstance(src, dict) else {}
-            )
-            name = getattr(src, "name", None) or (
-                src.get("name", stype) if isinstance(src, dict) else (src.name or stype)
-            )
+            resolved = _norm(src, year)
+            stype = resolved["stype"]
+            args = resolved["args"]
+            name = resolved["name"]
 
             entry: dict[str, Any] = {
                 "name": name,
@@ -112,7 +110,7 @@ def run_preflight(
             }
 
             if stype in ("http_file", "http_post_file"):
-                url = (args.get("url") or "").replace("{year}", str(year))
+                url = resolved["url"]
                 entry["url"] = url
 
                 if not url:
@@ -168,7 +166,8 @@ def run_preflight(
                     results["status"] = "failed"
 
             elif stype == "ckan":
-                portal = (args.get("portal_url") or "").replace("{year}", str(year))
+                portal_url = args.get("portal_url", "")
+                portal = portal_url.replace("{year}", str(year)) if portal_url else ""
                 entry["url"] = portal
 
                 if not portal:

--- a/toolkit/cli/preflight_ops.py
+++ b/toolkit/cli/preflight_ops.py
@@ -1,0 +1,218 @@
+"""Pre-flight check: validate config + probe reachability + preview CSV quality.
+
+Implementazione condivisa tra CLI (``toolkit run preflight``) e MCP.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from toolkit.cli.common import iter_selected_years, load_cfg_and_logger
+
+
+def run_preflight(
+    config: str | Path,
+    *,
+    years_arg: str | None = None,
+) -> dict[str, Any]:
+    """Pre-flight check per un dataset config.
+
+    1. **Config check**: valida dataset.yml con ``validate_config``.
+    2. **Probe + preview**: per ogni anno e ogni fonte remota:
+       - ``http_file`` / ``http_post_file`` (CSV) → ``preview_url``
+         (reachability + quality score + encoding + schema)
+       - ``ckan`` → ``probe_url_headers`` (reachability)
+       - ``local_file``, ``sdmx``, ``sparql`` → skip (non timeoutano)
+
+    Returns:
+        Report strutturato::
+
+            {
+                "config": str,
+                "dataset": str,
+                "source_id": str | None,
+                "years": list[int],
+                "config_check": {"ok": bool, "errors": [...], "warnings": [...]},
+                "sources": [
+                    {
+                        "name": str,
+                        "type": str,
+                        "year": int,
+                        "url": str | None,
+                        "reachable": bool,
+                        "status": str,
+                        "resource_format": str | None,
+                        "encoding": str | None,
+                        "delim": str | None,
+                        "columns": list[str] | None,
+                        "quality_score": int | None,
+                        "quality_verdict": str | None,
+                    },
+                    ...
+                ],
+                "status": "passed" | "failed",
+            }
+    """
+    cfg, logger = load_cfg_and_logger(str(config))
+
+    results: dict[str, Any] = {
+        "config": str(config),
+        "dataset": cfg.dataset,
+        "source_id": cfg.source_id,
+        "years": [],
+        "config_check": {},
+        "sources": [],
+        "status": "passed",
+    }
+
+    # ── 1. Config check ────────────────────────────────────────────────
+    from toolkit.core.dataset_loader import validate_config
+
+    config_check = validate_config(str(config))
+    results["config_check"] = config_check
+    if not config_check.get("ok", False):
+        results["status"] = "failed"
+
+    # ── 2. Anni ─────────────────────────────────────────────────────────
+    selected_years = iter_selected_years(cfg, year_arg=None, years_arg=years_arg)
+    results["years"] = list(selected_years)
+
+    # ── 3. Per anno, per fonte ──────────────────────────────────────────
+    # Cache URL → risultato probe. Se stesso URL per anni diversi,
+    # riusa il risultato invece di rifare la chiamata HTTP.
+    _probe_cache: dict[str, dict[str, Any]] = {}
+
+    for year in selected_years:
+        for src in cfg.raw.sources or []:
+            # Normalize source: puo' essere dict o oggetto
+            stype = getattr(src, "type", None) or (
+                src.get("type") if isinstance(src, dict) else "http_file"
+            )
+            args = getattr(src, "args", None) or (
+                src.get("args", {}) if isinstance(src, dict) else {}
+            )
+            name = getattr(src, "name", None) or (
+                src.get("name", stype) if isinstance(src, dict) else (src.name or stype)
+            )
+
+            entry: dict[str, Any] = {
+                "name": name,
+                "type": stype,
+                "year": year,
+                "url": None,
+                "reachable": True,
+                "status": "skipped",
+                "resource_format": None,
+                "encoding": None,
+                "delim": None,
+                "columns": None,
+                "quality_score": None,
+                "quality_verdict": None,
+            }
+
+            if stype in ("http_file", "http_post_file"):
+                url = (args.get("url") or "").replace("{year}", str(year))
+                entry["url"] = url
+
+                if not url:
+                    entry["status"] = "no_url"
+                    entry["reachable"] = False
+                    results["status"] = "failed"
+                    results["sources"].append(entry)
+                    continue
+
+                # Se stesso URL già processato per anno precedente, riusa
+                if url in _probe_cache:
+                    entry.update(_probe_cache[url])
+                    entry["name"] = name
+                    entry["type"] = stype
+                    entry["year"] = year
+                    entry["url"] = url
+                    entry["status"] = "cached"
+                    results["sources"].append(entry)
+                    continue
+
+                # preview_url fa probe + sniff + quality in un colpo solo
+                from toolkit.profile.preview import preview_url
+
+                preview = preview_url(url)
+                entry["reachable"] = preview.reachable
+                entry["http_status"] = preview.http_status
+                entry["status"] = preview.status
+                entry["resource_format"] = preview.resource_format
+                entry["encoding"] = preview.encoding_suggested
+                entry["delim"] = preview.delim_suggested
+                entry["columns"] = preview.columns
+                entry["quality_score"] = preview.quality_score
+                entry["quality_verdict"] = preview.quality_verdict
+
+                # Cache per anni successivi (se URL non ha {year})
+                _probe_cache[url] = {
+                    k: entry[k]
+                    for k in (
+                        "reachable",
+                        "http_status",
+                        "status",
+                        "resource_format",
+                        "encoding",
+                        "delim",
+                        "columns",
+                        "quality_score",
+                        "quality_verdict",
+                    )
+                    if k in entry
+                }
+
+                if not preview.reachable:
+                    results["status"] = "failed"
+
+            elif stype == "ckan":
+                portal = (args.get("portal_url") or "").replace("{year}", str(year))
+                entry["url"] = portal
+
+                if not portal:
+                    entry["status"] = "no_url"
+                    entry["reachable"] = False
+                    results["status"] = "failed"
+                    results["sources"].append(entry)
+                    continue
+
+                # Se stesso portal già processato per anno precedente, riusa
+                if portal in _probe_cache:
+                    entry.update(_probe_cache[portal])
+                    entry["name"] = name
+                    entry["type"] = stype
+                    entry["year"] = year
+                    entry["url"] = portal
+                    entry["status"] = "cached"
+                    results["sources"].append(entry)
+                    continue
+
+                from toolkit.scout.http import probe_url_headers
+
+                try:
+                    probe = probe_url_headers(portal)
+                    entry["http_status"] = probe["status_code"]
+                    entry["reachable"] = probe["status_code"] < 400
+                    entry["status"] = "reachable" if entry["reachable"] else "unreachable"
+
+                    _probe_cache[portal] = {
+                        k: entry[k]
+                        for k in (
+                            "reachable",
+                            "http_status",
+                            "status",
+                        )
+                        if k in entry
+                    }
+                except Exception as exc:
+                    entry["reachable"] = False
+                    entry["status"] = f"error: {exc}"
+                    results["status"] = "failed"
+
+            # local_file, sdmx, sparql → skipped (entry defaults preserved)
+
+            results["sources"].append(entry)
+
+    return results

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -280,6 +280,18 @@ def toolkit_validate_config(config_path: str) -> dict[str, Any]:
     return guard_timed(_validate_config_impl, "toolkit_validate_config", config_path)
 
 
+@mcp.tool(
+    description="Pre-flight check per un dataset: valida config, verifica "
+    "raggiungibilita' fonti, e per CSV produce quality score PA. "
+    "Non esegue la pipeline — solo diagnostica preventiva.",
+    structured_output=True,
+)
+def toolkit_preflight(config_path: str, years: str | None = None) -> dict[str, Any]:
+    from toolkit.cli.preflight_ops import run_preflight
+
+    return guard_timed(run_preflight, "toolkit_preflight", config_path, years_arg=years)
+
+
 # ---------------------------------------------------------------------------
 # Scout tools
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Sintesi

Riorganizza la pipeline del toolkit: rimuove `probe` da `run all`, introduce `run preflight` come diagnostica separata, aggancia preflight + deduplica in `run full`, fix doppia validazione. Test suite da 84s a 58s (-31%).

## Cosa cambia

- [x] Refactor / performance
- [x] Nuova funzionalità del motore
- [x] Modifica CLI (`run probe`, `run preflight`, `run all`, `run full --dry-run`)

### Cambi CLI

| Comando | Prima | Dopo |
|---|---|---|
| `run all` | probe → raw → clean → mart | **raw → clean → mart** |
| `run full` | run all + validate #2 | **preflight → run all + review-readiness** |
| `run full --dry-run` | eseguiva preflight (rete) | **salta preflight** |
| `run probe` | no-op (via `run_year(step="probe")`) | **chiama `_run_probe` direttamente** |
| `run preflight` | — | **nuovo**: config check + probe + preview CSV |
| `pytest tests/` | includeva smoke (84s) | **`-m "not smoke"` default (58s)** |

### Dettaglio

1. **Fix doppia validazione**: `run full` chiamava validate 2 volte (dentro `run_year` e dopo). Ora `all_passed` dal `RunContext`. Stessa logica anche per i support dataset.

2. **Rimosso probe dalla pipeline**: `_planned_layers("all")` = `["raw", "clean", "mart"]`. `run all` è 3 layer.

3. **`run preflight`**: nuovo comando/modulo `preflight_ops.py` (condiviso CLI+MCP):
   - Config check via `validate_config`
   - `http_file` CSV: `preview_url` (reachability + quality score + encoding + schema)
   - `ckan`: `probe_url_headers` (reachability)
   - Deduplica: stesso URL tra anni probe-ato una volta
   - Agganciato a `run full`: config invalido → abort. Fonti irraggiungibili → warning.

4. **`run probe`**: ora chiama `_run_probe` direttamente con `--config`, `--years`, `--dry-run`, `--json`. Backward compat via `run_year(step="probe")` per batch.

5. **Helper condiviso**: `_resolve_source()` in `cmd_run.py` usato da `_run_probe` e `preflight_ops.py` (niente duplicazione parsing).

6. **Batch pulito**: rimosso `ProbePool` condiviso (non serve piu). `--step probe` funziona via backward compat in `run_year`.

### Test

- **1048 non-smoke**, 22 smoke, 58s (da 84s)
- `pytest.ini`: `-m "not smoke"` default
- Nuovo `test_preflight_ops.py`: 5 test con fonti mockate
- Nuovo test MCP `toolkit_preflight`
- Marcati come smoke: `test_circuit_breaker_integration`, `test_probe_url_falls_back_to_get_when_head_fails`

## Verifica

```bash
pytest tests/ -x --tb=short -q          # 1048 passed, 22 deselected, 58s
pytest -m smoke -x --tb=short -q         # 22 smoke passano
mypy toolkit/cli/cmd_run.py toolkit/cli/preflight_ops.py  # 0 errori
ruff check .                             # passa

toolkit run preflight -c candidates/inps-pensioni/dataset.yml
# ✅ quality=89/100, 8 colonne, encoding=utf-8

toolkit run full -c smoke/local_file_csv/dataset.yml --json --dry-run
# ✅ solo execution plan, nessuna rete

toolkit run probe -c smoke/local_file_csv/dataset.yml --dry-run
# ✅ plan: 0 probe, 1 skip (local_file)
```

- [x] `pytest tests/` passa
- [x] `ruff check .` passa
- [x] `mypy toolkit/cli/cmd_run.py toolkit/cli/preflight_ops.py` — 0 errori
- [x] Test nuovi con marker appropriato

## Checklist PR

- [x] Perimetro stretto: full run pipeline
- [ ] Issue collegata — iniziativa interna
- [x] Test nuovi con marker appropriato

## Note per chi revisiona

- `run probe` backward compat: CLI chiama `_run_probe` direttamente; `run_year(step="probe")` è mantenuto per batch
- MCP: nuovo `toolkit_preflight(config_path, years)`
- Task locale: `_local/tasks/2026-06-14-test-cleanup-duplicates.md` — pulire test duplicati project-example
