### PR TITLE
feat(run-report): report aggregato JSON per anno + README multi-anno

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ CORE_TESTS = {
     "test_paths.py",
     "test_project_example_metadata.py",
     "test_run_context.py",
+    "test_report_ops.py",
     "test_smoke_templates_golden_path.py",
     "test_smoke_templates_contract_years.py",
     "test_run_dry_run.py",

--- a/tests/test_report_ops.py
+++ b/tests/test_report_ops.py
@@ -1,0 +1,197 @@
+"""Test per report_ops: build_dataset_readme e integrazione run full."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from toolkit.cli.inspect.report_ops import (
+    build_dataset_readme,
+    write_run_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# build_dataset_readme — test su output markdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+class TestBuildDatasetReadme:
+    """Verifica che il README markdown aggregato abbia la struttura attesa."""
+
+    def _make_report(self, year: int, **overrides: object) -> dict:
+        """Report sintetico minimale per test."""
+        report: dict = {
+            "dataset": "test_dataset",
+            "config_path": "/path/to/dataset.yml",
+            "year": year,
+            "status": "SUCCESS",
+            "duration_seconds": 2.5,
+            "readiness": "ready",
+            "readiness_checks": {"total": 5, "ok": 5, "fail": 0},
+            "preflight": {
+                "config_ok": True,
+                "sources_reachable": 1,
+                "sources_total": 1,
+                "quality_score_avg": 88,
+            },
+            "layers": {
+                "raw": {
+                    "status": "SUCCESS",
+                    "validation": {"ok": True, "errors": 0, "warnings": 0},
+                    "warnings": [],
+                    "errors": [],
+                    "encoding": "utf-8",
+                    "delim": ",",
+                    "file_size_bytes": 1024,
+                },
+                "clean": {
+                    "status": "SUCCESS",
+                    "validation": {"ok": True, "errors": 0, "warnings": 2},
+                    "warnings": ["colonna X rimossa", "colonna Y rinominata"],
+                    "errors": [],
+                    "rows": 150,
+                    "columns": 12,
+                    "file_size_bytes": 4096,
+                },
+                "mart": {
+                    "status": "SUCCESS",
+                    "validation": {"ok": True, "errors": 0, "warnings": 1},
+                    "warnings": ["colonna Z rimossa"],
+                    "errors": [],
+                    "tables": [{"name": "t1", "rows": 50}, {"name": "t2", "rows": 100}],
+                    "total_rows": 150,
+                    "file_size_bytes": 2048,
+                },
+            },
+            "support_datasets": [],
+        }
+        report.update(overrides)
+        return report
+
+    def test_ha_titolo_e_dataset(self) -> None:
+        """Il README contiene titolo e nome dataset."""
+        md = build_dataset_readme("test", "/c.yml", [self._make_report(2023)])
+        assert "# Run Report: `test`" in md
+        assert "/c.yml" in md
+
+    def test_tabella_ha_tutti_gli_anni(self) -> None:
+        """La tabella elenca tutti gli anni presenti."""
+        reports = [self._make_report(2023), self._make_report(2024)]
+        md = build_dataset_readme("test", "/c.yml", reports)
+        assert "| 2023 |" in md
+        assert "| 2024 |" in md
+
+    def test_tabella_mostra_righe_e_warning(self) -> None:
+        """La tabella include righe, warning, dimensione file."""
+        md = build_dataset_readme("test", "/c.yml", [self._make_report(2023)])
+        assert "150 righe" in md
+        assert "2w" in md
+        assert "1.0KB" in md or "4.0KB" in md or "4KB" in md
+
+    def test_sezione_warning_per_anno(self) -> None:
+        """Warning compaiono nella sezione dedicata per anno."""
+        md = build_dataset_readme("test", "/c.yml", [self._make_report(2023)])
+        assert "### Anno 2023" in md
+        assert "colonna X rimossa" in md
+        assert "colonna Z rimossa" in md
+
+    def test_sezione_readiness(self) -> None:
+        """La sezione Review Readiness e' presente."""
+        md = build_dataset_readme("test", "/c.yml", [self._make_report(2023)])
+        assert "Review Readiness" in md
+        assert "ready" in md
+        assert "5/5" in md
+
+    def test_qualita_nella_tabella(self) -> None:
+        """Il quality score compare nella tabella."""
+        md = build_dataset_readme("test", "/c.yml", [self._make_report(2023)])
+        assert "**88**" in md
+
+    def test_nessun_warning_silenziato(self) -> None:
+        """Report senza warning non genera sezione warning."""
+        r = self._make_report(2023)
+        r["layers"]["clean"]["warnings"] = []
+        r["layers"]["clean"]["validation"]["warnings"] = 0
+        r["layers"]["mart"]["warnings"] = []
+        r["layers"]["mart"]["validation"]["warnings"] = 0
+        md = build_dataset_readme("test", "/c.yml", [r])
+        assert "Warning ed errori" not in md
+
+    def test_readiness_needs_review(self) -> None:
+        """Verdetto needs-review ha icona appropriata."""
+        r = self._make_report(
+            2023, readiness="needs-review", readiness_checks={"total": 5, "ok": 4, "fail": 1}
+        )
+        md = build_dataset_readme("test", "/c.yml", [r])
+        assert "needs-review" in md
+        assert "4/5" in md
+
+    def test_readiness_incomplete(self) -> None:
+        r = self._make_report(
+            2023, readiness="incomplete", readiness_checks={"total": 5, "ok": 2, "fail": 3}
+        )
+        md = build_dataset_readme("test", "/c.yml", [r])
+        assert "incomplete" in md
+        assert "2/5" in md
+
+    def test_status_failed(self) -> None:
+        r = self._make_report(2023, status="FAILED")
+        md = build_dataset_readme("test", "/c.yml", [r], overall_status="failed")
+        assert "FAILED" in md
+        assert "failed" in md
+
+    def test_quality_null_non_mostra_valore(self) -> None:
+        r = self._make_report(2023)
+        r["preflight"]["quality_score_avg"] = None
+        md = build_dataset_readme("test", "/c.yml", [r])
+        # La cella qualita' dovrebbe essere "-"
+        lines = [line for line in md.split("\n") if "2023" in line and "|" in line]
+        assert any("| - |" in line or "| - " in line for line in lines)
+
+    def test_support_datasets(self) -> None:
+        r = self._make_report(
+            2023,
+            support_datasets=[{"name": "istat-elenco-comuni", "year": 2026, "status": "SUCCESS"}],
+        )
+        md = build_dataset_readme("test", "/c.yml", [r])
+        assert "Support Datasets" in md
+        assert "istat-elenco-comuni" in md
+
+
+# ---------------------------------------------------------------------------
+# write_run_report — verifica che il JSON sia valido e abbia campi minimi
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+class TestWriteRunReport:
+    def test_write_e_lettura(self, tmp_path: Path) -> None:
+        """Scrive un report e verifica che sia JSON valido con i campi base."""
+        report = {
+            "dataset": "prova",
+            "config_path": "/c.yml",
+            "year": 2024,
+            "run_id": "test_123",
+            "status": "SUCCESS",
+            "readiness": "ready",
+            "preflight": {"config_ok": True},
+            "layers": {},
+            "support_datasets": [],
+        }
+        path = write_run_report(report, tmp_path, "prova", 2024)
+        assert path.exists()
+        assert path.name == "2024_run_report.json"
+        raw = path.read_text(encoding="utf-8")
+        loaded = json.loads(raw)
+        assert loaded["dataset"] == "prova"
+        assert loaded["year"] == 2024
+        assert loaded["status"] == "SUCCESS"
+
+
+# (Lo smoke test di integrazione viene eseguito dalla suite smoke del toolkit
+# tramite `run_full` con smoke template local_file_csv. I test unitari sopra
+# coprono il contratto del markdown e del JSON.)

--- a/tests/test_report_ops.py
+++ b/tests/test_report_ops.py
@@ -19,6 +19,7 @@ from toolkit.cli.inspect.report_ops import (
 
 
 @pytest.mark.contract
+@pytest.mark.pure_unit
 class TestBuildDatasetReadme:
     """Verifica che il README markdown aggregato abbia la struttura attesa."""
 

--- a/tests/test_report_ops.py
+++ b/tests/test_report_ops.py
@@ -214,6 +214,179 @@ class TestWriteRunReport:
         assert loaded["status"] == "SUCCESS"
 
 
-# (Lo smoke test di integrazione viene eseguito dalla suite smoke del toolkit
-# tramite `run_full` con smoke template local_file_csv. I test unitari sopra
-# coprono il contratto del markdown e del JSON.)
+# ---------------------------------------------------------------------------
+# FAILED report — simulazione run fallito
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+class TestRunFullFailedReport:
+    """run_full con run_year che fallisce produce report FAILED e rilancia."""
+
+    def _make_config(self, tmp_path: Path) -> Path:
+        """Crea un dataset.yml minimale per test."""
+        sql_dir = tmp_path / "sql" / "mart"
+        sql_dir.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "sql" / "clean.sql").write_text("select 1 as value", encoding="utf-8")
+        (sql_dir / "mart_example.sql").write_text("select * from clean_input", encoding="utf-8")
+        cfg = tmp_path / "dataset.yml"
+        cfg.write_text(
+            "\n".join(
+                [
+                    f'root: "{(tmp_path / "out").as_posix()}"',
+                    "dataset:",
+                    '  name: "test_fail"',
+                    "  years: [2023, 2024]",
+                    "raw: {}",
+                    "clean:",
+                    '  sql: "sql/clean.sql"',
+                    "mart:",
+                    "  tables:",
+                    '    - name: "mart_example"',
+                    '      sql: "sql/mart/mart_example.sql"',
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return cfg
+
+    def test_run_full_fail_produce_report_failed_e_rilancia(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """run_full con run_year che fallisce:
+        - scrive report FAILED per l'anno fallito
+        - NON scrive report per l'anno successivo (non eseguito)
+        - rilancia l'eccezione originale
+        """
+        from toolkit.cli import cmd_run
+
+        config_path = self._make_config(tmp_path)
+
+        # Mock preflight per saltare check rete
+        monkeypatch.setattr(
+            "toolkit.cli.preflight_ops.run_preflight",
+            lambda *args, **kwargs: {
+                "config_check": {"ok": True, "errors": [], "warnings": [], "slug": "test"},
+                "sources": [],
+                "status": "passed",
+            },
+        )
+
+        # Mock review_readiness
+        import toolkit.cli.inspect.readiness_ops as _readiness_ops
+
+        monkeypatch.setattr(
+            _readiness_ops,
+            "review_readiness",
+            lambda *args, **kwargs: {
+                "readiness": "ready",
+                "check_count": 5,
+                "ok_count": 5,
+                "fail_count": 0,
+                "layers": {},
+            },
+        )
+
+        # Mock run_year per fallire al primo anno
+        call_count = {"n": 0}
+
+        def _failing_run_year(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("simulated run failure")
+            return None  # non dovrebbe arrivare qui
+
+        monkeypatch.setattr(cmd_run, "run_year", _failing_run_year)
+
+        # Chiamata: deve rilanciare l'eccezione
+        with pytest.raises(RuntimeError, match="simulated run failure"):
+            cmd_run.run_full(
+                config=str(config_path),
+                years=None,
+                smoke=False,
+                sample_rows=None,
+                sample_bytes=None,
+                root=None,
+                json_output=False,
+                dry_run=False,
+            )
+
+        # Verifica: report per anno 2023 esiste (fallito)
+        report_dir = tmp_path / "out" / "data" / "_reports" / "test_fail"
+        report_2023 = report_dir / "2023_run_report.json"
+        assert report_2023.exists(), "Report per anno fallito non trovato"
+
+        # Verifica: report per 2024 NON esiste (mai eseguito)
+        report_2024 = report_dir / "2024_run_report.json"
+        assert not report_2024.exists(), "Report per anno non eseguito non dovrebbe esistere"
+
+        # run_year chiamato solo 1 volta (secondo anno skippato)
+        assert call_count["n"] == 1, "run_year non dovrebbe essere chiamato per il secondo anno"
+
+        # Verifica: README aggregato esiste e contiene lo stato
+        readme = report_dir / "README.md"
+        assert readme.exists()
+        assert "test_fail" in readme.read_text(encoding="utf-8")
+
+
+class TestFailedReport:
+    """build_run_report chiamato con step_results minimale (come dopo eccezione)."""
+
+    @pytest.mark.contract
+    def test_failed_report_da_step_results_minimi(self, tmp_path: Path) -> None:
+        """Con step_results={'run':'failed'}, build_run_report produce status FAILED
+        e non solleva eccezioni (tollerante a layers assenti)."""
+        from toolkit.cli.inspect.report_ops import build_run_report
+
+        report = build_run_report(
+            config_path="/c.yml",
+            year=2024,
+            root=tmp_path,
+            dataset="fallito",
+            step_results={"run": "failed", "validate": "failed"},
+            run_mode="full",
+        )
+        assert report["dataset"] == "fallito"
+        assert report["year"] == 2024
+        assert report["readiness"] is None  # nessun readiness disponibile
+        # I layer ci sono sempre (raw/clean/mart) ma con validation=None
+        for lname in ("raw", "clean", "mart"):
+            assert lname in report["layers"]
+            assert report["layers"][lname]["validation"]["ok"] is None
+        assert report["preflight"]["sources_total"] == 0
+        assert report["status"] is None  # nessun run record su tmp_path
+
+    @pytest.mark.contract
+    def test_failed_report_scritto_su_disco(self, tmp_path: Path) -> None:
+        """write_run_report con status FAILED produce JSON valido."""
+        report = {
+            "dataset": "fallito",
+            "config_path": "/c.yml",
+            "year": 2024,
+            "run_id": None,
+            "status": "FAILED",
+            "readiness": None,
+            "layers": {},
+            "support_datasets": [],
+        }
+        path = write_run_report(report, tmp_path, "fallito", 2024)
+        assert path.exists()
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        assert loaded["status"] == "FAILED"
+        assert loaded["layers"] == {}
+
+    @pytest.mark.contract
+    def test_readme_con_anno_fallito(self) -> None:
+        """Un report FAILED nel README mostra stato FAILED e readiness assente."""
+        r = {
+            "dataset": "test",
+            "config_path": "/c.yml",
+            "year": 2024,
+            "status": "FAILED",
+            "readiness": None,
+            "layers": {},
+            "support_datasets": [],
+        }
+        md = build_dataset_readme("test", "/c.yml", [r])
+        assert "FAILED" in md
+        assert "🔴" in md

--- a/tests/test_report_ops.py
+++ b/tests/test_report_ops.py
@@ -219,7 +219,6 @@ class TestWriteRunReport:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.contract
 class TestRunFullFailedReport:
     """run_full con run_year che fallisce produce report FAILED e rilancia."""
 
@@ -312,10 +311,14 @@ class TestRunFullFailedReport:
                 dry_run=False,
             )
 
-        # Verifica: report per anno 2023 esiste (fallito)
+        # Verifica: report per anno 2023 esiste con status FAILED
         report_dir = tmp_path / "out" / "data" / "_reports" / "test_fail"
         report_2023 = report_dir / "2023_run_report.json"
         assert report_2023.exists(), "Report per anno fallito non trovato"
+        import json
+
+        loaded = json.loads(report_2023.read_text(encoding="utf-8"))
+        assert loaded["status"] == "FAILED", f"Status atteso FAILED, got {loaded['status']}"
 
         # Verifica: report per 2024 NON esiste (mai eseguito)
         report_2024 = report_dir / "2024_run_report.json"
@@ -355,7 +358,8 @@ class TestFailedReport:
             assert lname in report["layers"]
             assert report["layers"][lname]["validation"]["ok"] is None
         assert report["preflight"]["sources_total"] == 0
-        assert report["status"] is None  # nessun run record su tmp_path
+        # step_results={"run":"failed"} → status="FAILED" (fallback senza run record)
+        assert report["status"] == "FAILED"
 
     @pytest.mark.contract
     def test_failed_report_scritto_su_disco(self, tmp_path: Path) -> None:

--- a/tests/test_report_ops.py
+++ b/tests/test_report_ops.py
@@ -18,8 +18,6 @@ from toolkit.cli.inspect.report_ops import (
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.contract
-@pytest.mark.pure_unit
 class TestBuildDatasetReadme:
     """Verifica che il README markdown aggregato abbia la struttura attesa."""
 
@@ -73,12 +71,16 @@ class TestBuildDatasetReadme:
         report.update(overrides)
         return report
 
+    @pytest.mark.contract
+    @pytest.mark.pure_unit
     def test_ha_titolo_e_dataset(self) -> None:
         """Il README contiene titolo e nome dataset."""
         md = build_dataset_readme("test", "/c.yml", [self._make_report(2023)])
         assert "# Run Report: `test`" in md
         assert "/c.yml" in md
 
+    @pytest.mark.contract
+    @pytest.mark.pure_unit
     def test_tabella_ha_tutti_gli_anni(self) -> None:
         """La tabella elenca tutti gli anni presenti."""
         reports = [self._make_report(2023), self._make_report(2024)]
@@ -86,6 +88,8 @@ class TestBuildDatasetReadme:
         assert "| 2023 |" in md
         assert "| 2024 |" in md
 
+    @pytest.mark.contract
+    @pytest.mark.pure_unit
     def test_tabella_mostra_righe_e_warning(self) -> None:
         """La tabella include righe, warning, dimensione file."""
         md = build_dataset_readme("test", "/c.yml", [self._make_report(2023)])
@@ -93,6 +97,8 @@ class TestBuildDatasetReadme:
         assert "2w" in md
         assert "1.0KB" in md or "4.0KB" in md or "4KB" in md
 
+    @pytest.mark.contract
+    @pytest.mark.pure_unit
     def test_sezione_warning_per_anno(self) -> None:
         """Warning compaiono nella sezione dedicata per anno."""
         md = build_dataset_readme("test", "/c.yml", [self._make_report(2023)])
@@ -100,6 +106,8 @@ class TestBuildDatasetReadme:
         assert "colonna X rimossa" in md
         assert "colonna Z rimossa" in md
 
+    @pytest.mark.contract
+    @pytest.mark.pure_unit
     def test_sezione_readiness(self) -> None:
         """La sezione Review Readiness e' presente."""
         md = build_dataset_readme("test", "/c.yml", [self._make_report(2023)])
@@ -107,11 +115,15 @@ class TestBuildDatasetReadme:
         assert "ready" in md
         assert "5/5" in md
 
+    @pytest.mark.contract
+    @pytest.mark.pure_unit
     def test_qualita_nella_tabella(self) -> None:
         """Il quality score compare nella tabella."""
         md = build_dataset_readme("test", "/c.yml", [self._make_report(2023)])
         assert "**88**" in md
 
+    @pytest.mark.contract
+    @pytest.mark.pure_unit
     def test_nessun_warning_silenziato(self) -> None:
         """Report senza warning non genera sezione warning."""
         r = self._make_report(2023)
@@ -122,6 +134,8 @@ class TestBuildDatasetReadme:
         md = build_dataset_readme("test", "/c.yml", [r])
         assert "Warning ed errori" not in md
 
+    @pytest.mark.contract
+    @pytest.mark.pure_unit
     def test_readiness_needs_review(self) -> None:
         """Verdetto needs-review ha icona appropriata."""
         r = self._make_report(
@@ -131,6 +145,8 @@ class TestBuildDatasetReadme:
         assert "needs-review" in md
         assert "4/5" in md
 
+    @pytest.mark.contract
+    @pytest.mark.pure_unit
     def test_readiness_incomplete(self) -> None:
         r = self._make_report(
             2023, readiness="incomplete", readiness_checks={"total": 5, "ok": 2, "fail": 3}
@@ -139,20 +155,25 @@ class TestBuildDatasetReadme:
         assert "incomplete" in md
         assert "2/5" in md
 
+    @pytest.mark.contract
+    @pytest.mark.pure_unit
     def test_status_failed(self) -> None:
         r = self._make_report(2023, status="FAILED")
         md = build_dataset_readme("test", "/c.yml", [r], overall_status="failed")
         assert "FAILED" in md
         assert "failed" in md
 
+    @pytest.mark.contract
+    @pytest.mark.pure_unit
     def test_quality_null_non_mostra_valore(self) -> None:
         r = self._make_report(2023)
         r["preflight"]["quality_score_avg"] = None
         md = build_dataset_readme("test", "/c.yml", [r])
-        # La cella qualita' dovrebbe essere "-"
         lines = [line for line in md.split("\n") if "2023" in line and "|" in line]
         assert any("| - |" in line or "| - " in line for line in lines)
 
+    @pytest.mark.contract
+    @pytest.mark.pure_unit
     def test_support_datasets(self) -> None:
         r = self._make_report(
             2023,
@@ -168,8 +189,8 @@ class TestBuildDatasetReadme:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.contract
 class TestWriteRunReport:
+    @pytest.mark.contract
     def test_write_e_lettura(self, tmp_path: Path) -> None:
         """Scrive un report e verifica che sia JSON valido con i campi base."""
         report = {

--- a/tests/test_report_ops.py
+++ b/tests/test_report_ops.py
@@ -250,6 +250,7 @@ class TestRunFullFailedReport:
         )
         return cfg
 
+    @pytest.mark.contract
     def test_run_full_fail_produce_report_failed_e_rilancia(
         self, tmp_path: Path, monkeypatch
     ) -> None:

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +14,7 @@ from toolkit.clean.validate import run_clean_validation
 from toolkit.core.logging import bind_logger, get_logger
 from toolkit.core.paths import RAW_PROFILE, layer_dataset_dir, layer_year_dir
 from toolkit.core.run_context import RunContext
+from toolkit.core.run_records import get_run_dir, latest_run
 from toolkit.mart.run import run_mart, run_mart_multi_year
 from toolkit.mart.validate import run_mart_validation
 from toolkit.raw.run import run_raw
@@ -946,6 +948,67 @@ def run_full(
                 results["multi_year_mart"] = f"failed: {exc}"
                 if fail_on_error_flag:
                     results["status"] = "failed"
+
+        # ── Run report ────────────────────────────────────────────────────
+        if not dry_flag:
+            from toolkit.cli.inspect.report_ops import (
+                build_run_report,
+                write_run_report,
+                write_dataset_readme,
+            )
+
+            # Determina run_mode
+            run_mode = "smoke" if sample_mode else "full"
+
+            # Raccogli info dai support (eseguiti sopra)
+            support_info: list[dict[str, Any]] = []
+            if support_entries:
+                for entry in support_entries:
+                    for sy in entry.years:
+                        sup_run_dir = get_run_dir(Path(cfg.root), entry.name, sy)
+                        try:
+                            sup_rec = latest_run(sup_run_dir)
+                        except (FileNotFoundError, OSError):
+                            sup_rec = None
+                        support_info.append(
+                            {
+                                "name": entry.name,
+                                "year": sy,
+                                "status": (sup_rec or {}).get("status"),
+                            }
+                        )
+
+            _reports_for_readme: list[dict[str, Any]] = []
+            for year in selected_years:
+                step_data = results["steps"].get(str(year))
+                if not step_data:
+                    continue
+                report = build_run_report(
+                    config_path=config,
+                    year=year,
+                    root=cfg.root,
+                    dataset=cfg.dataset,
+                    preflight=results.get("preflight"),
+                    step_results=step_data,
+                    run_mode=run_mode,
+                    support_datasets=support_info,
+                )
+                write_run_report(report, cfg.root, cfg.dataset, year)
+                _reports_for_readme.append(report)
+            if _reports_for_readme:
+                readme_path = write_dataset_readme(
+                    cfg.root,
+                    cfg.dataset,
+                    _reports_for_readme,
+                    overall_status=results.get("status"),
+                    config_path=config,
+                )
+                # Copia il report come RUN_REPORT.md nel candidate (non sovrascrive README.md manuale)
+                cfg_dir = Path(config).parent
+                if cfg_dir.parent.name == "candidates":
+                    run_report_path = cfg_dir / "RUN_REPORT.md"
+                    shutil.copy2(str(readme_path), str(run_report_path))
+                    logger.info("RUN_REPORT.md candidato aggiornato: %s", run_report_path)
 
     if json_output:
         typer.echo(json.dumps(results, indent=2, default=str))

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -55,6 +55,37 @@ def _is_mart_only_cfg(cfg) -> bool:
     return not bool(cfg.clean.sql)
 
 
+def _write_blocked_report(
+    config_path: str,
+    year: int,
+    root: str | Path,
+    dataset: str,
+    run_mode: str,
+    support_datasets: list[dict[str, Any]],
+) -> None:
+    """Scrive un report minimale per un anno non eseguito (candidate bloccato)."""
+    from toolkit.cli.inspect.report_ops import write_run_report
+
+    report = {
+        "dataset": dataset,
+        "config_path": str(config_path),
+        "year": year,
+        "run_id": None,
+        "run_mode": run_mode,
+        "toolkit_version": None,
+        "status": "BLOCKED",
+        "duration_seconds": None,
+        "config_hash": None,
+        "source_urls": [],
+        "readiness": None,
+        "readiness_checks": {"total": 0, "ok": 0, "fail": 0},
+        "preflight": {},
+        "layers": {},
+        "support_datasets": support_datasets,
+    }
+    write_run_report(report, root, dataset, year)
+
+
 def _validate_execution_plan(cfg, step: str) -> list[str]:
     layers = _planned_layers(step)
 
@@ -888,15 +919,15 @@ def run_full(
     # Se un support e' fallito, non eseguire il candidate (dipendenza assente)
     candidate_blocked = results["status"] == "failed" and not dry_flag
 
-    # Esecuzione candidate: wrappata in try/except per garantire
-    # che il report venga generato anche in caso di eccezione.
-    try:
-        if not candidate_blocked:
-            is_mart_only = _is_mart_only_cfg(cfg)
-            run_step = "mart" if is_mart_only else "all"
-            fail_on_error_flag = bool(cfg.validation.fail_on_error)
+    # Esecuzione candidate: salva eccezione per rilanciarla DOPO il report.
+    _candidate_exc: BaseException | None = None
+    if not candidate_blocked:
+        is_mart_only = _is_mart_only_cfg(cfg)
+        run_step = "mart" if is_mart_only else "all"
+        fail_on_error_flag = bool(cfg.validation.fail_on_error)
 
-            for year in selected_years:
+        for year in selected_years:
+            try:
                 logger.info("Run %s — year=%s", run_step, year)
                 ctx = run_year(
                     cfg,
@@ -908,52 +939,53 @@ def run_full(
                     sample_bytes=sample_bytes_final,
                     smoke=smoke,
                 )
+            except BaseException as exc:
+                logger.error("Run %s year=%s fallito: %s", run_step, year, exc)
+                results["status"] = "failed"
+                _candidate_exc = exc
+                break  # interrompe il loop anni
 
-                if not dry_flag:
-                    if is_mart_only:
-                        all_passed = bool(ctx.validations.get("mart", {}).get("passed", False))
-                    else:
-                        all_passed = all(
-                            ctx.validations.get(layer, {}).get("passed", False)
-                            for layer in ("raw", "clean", "mart")
-                        )
-                    results["steps"][str(year)] = {
-                        "run": "ok",
-                        "validate": "passed" if all_passed else "failed",
-                    }
-                    if not all_passed and fail_on_error_flag:
-                        results["status"] = "failed"
-
-                    from toolkit.cli.inspect.readiness_ops import (
-                        review_readiness as _review_readiness,
+            if not dry_flag:
+                if is_mart_only:
+                    all_passed = bool(ctx.validations.get("mart", {}).get("passed", False))
+                else:
+                    all_passed = all(
+                        ctx.validations.get(layer, {}).get("passed", False)
+                        for layer in ("raw", "clean", "mart")
                     )
+                results["steps"][str(year)] = {
+                    "run": "ok",
+                    "validate": "passed" if all_passed else "failed",
+                }
+                if not all_passed and fail_on_error_flag:
+                    results["status"] = "failed"
 
-                    readiness = _review_readiness(config, year or None)
-                    results["steps"][str(year)]["readiness"] = readiness.get("readiness")
-                    results["steps"][str(year)]["checks"] = readiness.get("check_count", 0)
-                    results["steps"][str(year)]["checks_ok"] = readiness.get("ok_count", 0)
-                    results["steps"][str(year)]["checks_fail"] = readiness.get("fail_count", 0)
-                    results["steps"][str(year)]["layers"] = readiness.get("layers", {})
+                from toolkit.cli.inspect.readiness_ops import (
+                    review_readiness as _review_readiness,
+                )
 
-            # Multi-year mart
-            if not dry_flag and _has_multi_year_mart(cfg):
-                try:
-                    _maybe_run_multi_year_mart(
-                        cfg,
-                        selected_years,
-                        dry_run=False,
-                        logger=logger,
-                        sampling_active=sample_mode,
-                    )
-                    results["multi_year_mart"] = "ok"
-                except Exception as exc:
-                    results["multi_year_mart"] = f"failed: {exc}"
-                    if fail_on_error_flag:
-                        results["status"] = "failed"
+                readiness = _review_readiness(config, year or None)
+                results["steps"][str(year)]["readiness"] = readiness.get("readiness")
+                results["steps"][str(year)]["checks"] = readiness.get("check_count", 0)
+                results["steps"][str(year)]["checks_ok"] = readiness.get("ok_count", 0)
+                results["steps"][str(year)]["checks_fail"] = readiness.get("fail_count", 0)
+                results["steps"][str(year)]["layers"] = readiness.get("layers", {})
 
-    except Exception as _run_err:
-        logger.error("Run candidate fallito con eccezione: %s", _run_err)
-        results["status"] = "failed"
+        # Multi-year mart (solo se il loop anni e' completo)
+        if _candidate_exc is None and not dry_flag and _has_multi_year_mart(cfg):
+            try:
+                _maybe_run_multi_year_mart(
+                    cfg,
+                    selected_years,
+                    dry_run=False,
+                    logger=logger,
+                    sampling_active=sample_mode,
+                )
+                results["multi_year_mart"] = "ok"
+            except Exception as exc:
+                results["multi_year_mart"] = f"failed: {exc}"
+                if fail_on_error_flag:
+                    results["status"] = "failed"
 
     # ── Run report (best-effort: non fa fallire il run) ────────────────────
     # Eseguito sempre: anche con candidate bloccato, run fallito, o eccezione.
@@ -987,13 +1019,24 @@ def run_full(
                             }
                         )
 
-            # Genera report per ogni anno del run corrente
+            # Anni effettivamente eseguiti (hanno una voce in results["steps"])
+            attempted_years = set(results["steps"].keys())
+
+            # Genera report solo per gli anni tentati (non per quelli saltati
+            # da un'eccezione o da candidate_blocked), per evitare di
+            # riusare artifact di run precedenti.
             for year in selected_years:
-                step_data = results["steps"].get(str(year))
-                # Se candidate bloccato, step_data e' None: non scrivere report
-                # fittizio che riusa run record precedenti.
-                if candidate_blocked:
+                sy = str(year)
+                if sy not in attempted_years:
+                    # Anno non eseguito: scrive report BLOCKED esplicito
+                    # solo se il candidate era bloccato da support.
+                    if candidate_blocked:
+                        _write_blocked_report(
+                            config, year, cfg.root, cfg.dataset, run_mode, support_info
+                        )
                     continue
+
+                step_data = results["steps"][sy]
                 report = build_run_report(
                     config_path=config,
                     year=year,
@@ -1006,7 +1049,7 @@ def run_full(
                 )
                 write_run_report(report, cfg.root, cfg.dataset, year)
 
-            # Leggi TUTTI i report JSON esistenti su disco (anche anni precedenti)
+            # Leggi TUTTI i report JSON esistenti su disco
             # e rigenera il README completo con stato aggregato
             all_reports = _all_reports_for_dataset(cfg.root, cfg.dataset)
             if all_reports:
@@ -1020,6 +1063,10 @@ def run_full(
                 )
     except Exception as _report_err:
         logger.warning("Generazione report saltata: %s", _report_err)
+
+    # Rilancia l'eccezione originale del candidate (preserva traceback)
+    if _candidate_exc is not None:
+        raise _candidate_exc
 
     if json_output:
         typer.echo(json.dumps(results, indent=2, default=str))

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -948,66 +948,68 @@ def run_full(
                 if fail_on_error_flag:
                     results["status"] = "failed"
 
-        # ── Run report (best-effort: non fa fallire il run) ────────────────
-        try:
-            if not dry_flag:
-                from toolkit.cli.inspect.report_ops import (
-                    build_run_report,
-                    write_run_report,
-                    write_dataset_readme,
-                    _all_reports_for_dataset,
+    # ── Run report (best-effort: non fa fallire il run) ────────────────────
+    # Generato anche se candidate bloccato o run fallito — eseguito
+    # fuori dal blocco `if not candidate_blocked:` sopra.
+    try:
+        if not dry_flag:
+            from toolkit.cli.inspect.report_ops import (
+                build_run_report,
+                write_run_report,
+                write_dataset_readme,
+                _all_reports_for_dataset,
+                _derive_overall_status,
+            )
+
+            run_mode = "smoke" if sample_mode else "full"
+
+            # Raccogli info dai support
+            support_info: list[dict[str, Any]] = []
+            if support_entries:
+                for entry in support_entries:
+                    for sy in entry.years:
+                        sup_run_dir = get_run_dir(Path(cfg.root), entry.name, sy)
+                        try:
+                            sup_rec = latest_run(sup_run_dir)
+                        except (FileNotFoundError, OSError):
+                            sup_rec = None
+                        support_info.append(
+                            {
+                                "name": entry.name,
+                                "year": sy,
+                                "status": (sup_rec or {}).get("status"),
+                            }
+                        )
+
+            # Genera report per ogni anno del run corrente
+            for year in selected_years:
+                step_data = results["steps"].get(str(year))
+                report = build_run_report(
+                    config_path=config,
+                    year=year,
+                    root=cfg.root,
+                    dataset=cfg.dataset,
+                    preflight=results.get("preflight"),
+                    step_results=step_data,
+                    run_mode=run_mode,
+                    support_datasets=support_info,
                 )
+                write_run_report(report, cfg.root, cfg.dataset, year)
 
-                run_mode = "smoke" if sample_mode else "full"
-
-                # Raccogli info dai support
-                support_info: list[dict[str, Any]] = []
-                if support_entries:
-                    for entry in support_entries:
-                        for sy in entry.years:
-                            sup_run_dir = get_run_dir(Path(cfg.root), entry.name, sy)
-                            try:
-                                sup_rec = latest_run(sup_run_dir)
-                            except (FileNotFoundError, OSError):
-                                sup_rec = None
-                            support_info.append(
-                                {
-                                    "name": entry.name,
-                                    "year": sy,
-                                    "status": (sup_rec or {}).get("status"),
-                                }
-                            )
-
-                # Genera report per ogni anno del run corrente
-                for year in selected_years:
-                    step_data = results["steps"].get(str(year))
-                    if not step_data:
-                        continue
-                    report = build_run_report(
-                        config_path=config,
-                        year=year,
-                        root=cfg.root,
-                        dataset=cfg.dataset,
-                        preflight=results.get("preflight"),
-                        step_results=step_data,
-                        run_mode=run_mode,
-                        support_datasets=support_info,
-                    )
-                    write_run_report(report, cfg.root, cfg.dataset, year)
-
-                # Leggi TUTTI i report JSON esistenti su disco (anche anni precedenti)
-                # e rigenera il README completo
-                all_reports = _all_reports_for_dataset(cfg.root, cfg.dataset)
-                if all_reports:
-                    write_dataset_readme(
-                        cfg.root,
-                        cfg.dataset,
-                        all_reports,
-                        overall_status=results.get("status"),
-                        config_path=config,
-                    )
-        except Exception as _report_err:
-            logger.warning("Generazione report saltata: %s", _report_err)
+            # Leggi TUTTI i report JSON esistenti su disco (anche anni precedenti)
+            # e rigenera il README completo con stato aggregato
+            all_reports = _all_reports_for_dataset(cfg.root, cfg.dataset)
+            if all_reports:
+                agg_status = _derive_overall_status(all_reports)
+                write_dataset_readme(
+                    cfg.root,
+                    cfg.dataset,
+                    all_reports,
+                    overall_status=agg_status,
+                    config_path=config,
+                )
+    except Exception as _report_err:
+        logger.warning("Generazione report saltata: %s", _report_err)
 
     if json_output:
         typer.echo(json.dumps(results, indent=2, default=str))

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -1070,7 +1070,7 @@ def run_full(
 
     # Rilancia l'eccezione originale del candidate (preserva traceback)
     if _candidate_exc is not None:
-        raise _candidate_exc from _candidate_exc
+        raise _candidate_exc
 
     if json_output:
         typer.echo(json.dumps(results, indent=2, default=str))

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -888,69 +888,75 @@ def run_full(
     # Se un support e' fallito, non eseguire il candidate (dipendenza assente)
     candidate_blocked = results["status"] == "failed" and not dry_flag
 
-    if not candidate_blocked:
-        # Mart-only config (compose): non ha raw/clean, solo mart.
-        # run full usa step="mart" e valida solo mart.
-        is_mart_only = _is_mart_only_cfg(cfg)
-        run_step = "mart" if is_mart_only else "all"
+    # Esecuzione candidate: wrappata in try/except per garantire
+    # che il report venga generato anche in caso di eccezione.
+    try:
+        if not candidate_blocked:
+            is_mart_only = _is_mart_only_cfg(cfg)
+            run_step = "mart" if is_mart_only else "all"
+            fail_on_error_flag = bool(cfg.validation.fail_on_error)
 
-        fail_on_error_flag = bool(cfg.validation.fail_on_error)
-
-        for year in selected_years:
-            logger.info("Run %s — year=%s", run_step, year)
-            ctx = run_year(
-                cfg,
-                year,
-                step=run_step,
-                dry_run=dry_flag,
-                logger=logger,
-                sample_rows=sample_rows_final,
-                sample_bytes=sample_bytes_final,
-                smoke=smoke,
-            )
-
-            if not dry_flag:
-                # all_passed dal RunContext — la validazione è già avvenuta
-                # dentro run_year() per ogni layer eseguito.
-                if is_mart_only:
-                    all_passed = bool(ctx.validations.get("mart", {}).get("passed", False))
-                else:
-                    all_passed = all(
-                        ctx.validations.get(layer, {}).get("passed", False)
-                        for layer in ("raw", "clean", "mart")
-                    )
-                results["steps"][str(year)] = {
-                    "run": "ok",
-                    "validate": "passed" if all_passed else "failed",
-                }
-                if not all_passed and fail_on_error_flag:
-                    results["status"] = "failed"
-
-                # Review readiness (capture full result including layers)
-                from toolkit.cli.inspect.readiness_ops import review_readiness as _review_readiness
-
-                readiness = _review_readiness(config, year or None)
-                results["steps"][str(year)]["readiness"] = readiness.get("readiness")
-                results["steps"][str(year)]["checks"] = readiness.get("check_count", 0)
-                results["steps"][str(year)]["checks_ok"] = readiness.get("ok_count", 0)
-                results["steps"][str(year)]["checks_fail"] = readiness.get("fail_count", 0)
-                results["steps"][str(year)]["layers"] = readiness.get("layers", {})
-
-        # Multi-year mart: run once per dataset after per-year processing
-        if not dry_flag and _has_multi_year_mart(cfg):
-            try:
-                _maybe_run_multi_year_mart(
-                    cfg, selected_years, dry_run=False, logger=logger, sampling_active=sample_mode
+            for year in selected_years:
+                logger.info("Run %s — year=%s", run_step, year)
+                ctx = run_year(
+                    cfg,
+                    year,
+                    step=run_step,
+                    dry_run=dry_flag,
+                    logger=logger,
+                    sample_rows=sample_rows_final,
+                    sample_bytes=sample_bytes_final,
+                    smoke=smoke,
                 )
-                results["multi_year_mart"] = "ok"
-            except Exception as exc:
-                results["multi_year_mart"] = f"failed: {exc}"
-                if fail_on_error_flag:
-                    results["status"] = "failed"
+
+                if not dry_flag:
+                    if is_mart_only:
+                        all_passed = bool(ctx.validations.get("mart", {}).get("passed", False))
+                    else:
+                        all_passed = all(
+                            ctx.validations.get(layer, {}).get("passed", False)
+                            for layer in ("raw", "clean", "mart")
+                        )
+                    results["steps"][str(year)] = {
+                        "run": "ok",
+                        "validate": "passed" if all_passed else "failed",
+                    }
+                    if not all_passed and fail_on_error_flag:
+                        results["status"] = "failed"
+
+                    from toolkit.cli.inspect.readiness_ops import (
+                        review_readiness as _review_readiness,
+                    )
+
+                    readiness = _review_readiness(config, year or None)
+                    results["steps"][str(year)]["readiness"] = readiness.get("readiness")
+                    results["steps"][str(year)]["checks"] = readiness.get("check_count", 0)
+                    results["steps"][str(year)]["checks_ok"] = readiness.get("ok_count", 0)
+                    results["steps"][str(year)]["checks_fail"] = readiness.get("fail_count", 0)
+                    results["steps"][str(year)]["layers"] = readiness.get("layers", {})
+
+            # Multi-year mart
+            if not dry_flag and _has_multi_year_mart(cfg):
+                try:
+                    _maybe_run_multi_year_mart(
+                        cfg,
+                        selected_years,
+                        dry_run=False,
+                        logger=logger,
+                        sampling_active=sample_mode,
+                    )
+                    results["multi_year_mart"] = "ok"
+                except Exception as exc:
+                    results["multi_year_mart"] = f"failed: {exc}"
+                    if fail_on_error_flag:
+                        results["status"] = "failed"
+
+    except Exception as _run_err:
+        logger.error("Run candidate fallito con eccezione: %s", _run_err)
+        results["status"] = "failed"
 
     # ── Run report (best-effort: non fa fallire il run) ────────────────────
-    # Generato anche se candidate bloccato o run fallito — eseguito
-    # fuori dal blocco `if not candidate_blocked:` sopra.
+    # Eseguito sempre: anche con candidate bloccato, run fallito, o eccezione.
     try:
         if not dry_flag:
             from toolkit.cli.inspect.report_ops import (
@@ -984,6 +990,10 @@ def run_full(
             # Genera report per ogni anno del run corrente
             for year in selected_years:
                 step_data = results["steps"].get(str(year))
+                # Se candidate bloccato, step_data e' None: non scrivere report
+                # fittizio che riusa run record precedenti.
+                if candidate_blocked:
+                    continue
                 report = build_run_report(
                     config_path=config,
                     year=year,

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import shutil
 from pathlib import Path
 from typing import Any
 
@@ -949,66 +948,66 @@ def run_full(
                 if fail_on_error_flag:
                     results["status"] = "failed"
 
-        # ── Run report ────────────────────────────────────────────────────
-        if not dry_flag:
-            from toolkit.cli.inspect.report_ops import (
-                build_run_report,
-                write_run_report,
-                write_dataset_readme,
-            )
-
-            # Determina run_mode
-            run_mode = "smoke" if sample_mode else "full"
-
-            # Raccogli info dai support (eseguiti sopra)
-            support_info: list[dict[str, Any]] = []
-            if support_entries:
-                for entry in support_entries:
-                    for sy in entry.years:
-                        sup_run_dir = get_run_dir(Path(cfg.root), entry.name, sy)
-                        try:
-                            sup_rec = latest_run(sup_run_dir)
-                        except (FileNotFoundError, OSError):
-                            sup_rec = None
-                        support_info.append(
-                            {
-                                "name": entry.name,
-                                "year": sy,
-                                "status": (sup_rec or {}).get("status"),
-                            }
-                        )
-
-            _reports_for_readme: list[dict[str, Any]] = []
-            for year in selected_years:
-                step_data = results["steps"].get(str(year))
-                if not step_data:
-                    continue
-                report = build_run_report(
-                    config_path=config,
-                    year=year,
-                    root=cfg.root,
-                    dataset=cfg.dataset,
-                    preflight=results.get("preflight"),
-                    step_results=step_data,
-                    run_mode=run_mode,
-                    support_datasets=support_info,
+        # ── Run report (best-effort: non fa fallire il run) ────────────────
+        try:
+            if not dry_flag:
+                from toolkit.cli.inspect.report_ops import (
+                    build_run_report,
+                    write_run_report,
+                    write_dataset_readme,
+                    _all_reports_for_dataset,
                 )
-                write_run_report(report, cfg.root, cfg.dataset, year)
-                _reports_for_readme.append(report)
-            if _reports_for_readme:
-                readme_path = write_dataset_readme(
-                    cfg.root,
-                    cfg.dataset,
-                    _reports_for_readme,
-                    overall_status=results.get("status"),
-                    config_path=config,
-                )
-                # Copia il report come RUN_REPORT.md nel candidate (non sovrascrive README.md manuale)
-                cfg_dir = Path(config).parent
-                if cfg_dir.parent.name == "candidates":
-                    run_report_path = cfg_dir / "RUN_REPORT.md"
-                    shutil.copy2(str(readme_path), str(run_report_path))
-                    logger.info("RUN_REPORT.md candidato aggiornato: %s", run_report_path)
+
+                run_mode = "smoke" if sample_mode else "full"
+
+                # Raccogli info dai support
+                support_info: list[dict[str, Any]] = []
+                if support_entries:
+                    for entry in support_entries:
+                        for sy in entry.years:
+                            sup_run_dir = get_run_dir(Path(cfg.root), entry.name, sy)
+                            try:
+                                sup_rec = latest_run(sup_run_dir)
+                            except (FileNotFoundError, OSError):
+                                sup_rec = None
+                            support_info.append(
+                                {
+                                    "name": entry.name,
+                                    "year": sy,
+                                    "status": (sup_rec or {}).get("status"),
+                                }
+                            )
+
+                # Genera report per ogni anno del run corrente
+                for year in selected_years:
+                    step_data = results["steps"].get(str(year))
+                    if not step_data:
+                        continue
+                    report = build_run_report(
+                        config_path=config,
+                        year=year,
+                        root=cfg.root,
+                        dataset=cfg.dataset,
+                        preflight=results.get("preflight"),
+                        step_results=step_data,
+                        run_mode=run_mode,
+                        support_datasets=support_info,
+                    )
+                    write_run_report(report, cfg.root, cfg.dataset, year)
+
+                # Leggi TUTTI i report JSON esistenti su disco (anche anni precedenti)
+                # e rigenera il README completo
+                all_reports = _all_reports_for_dataset(cfg.root, cfg.dataset)
+                if all_reports:
+                    write_dataset_readme(
+                        cfg.root,
+                        cfg.dataset,
+                        all_reports,
+                        overall_status=results.get("status"),
+                        config_path=config,
+                    )
+        except Exception as _report_err:
+            logger.warning("Generazione report saltata: %s", _report_err)
 
     if json_output:
         typer.echo(json.dumps(results, indent=2, default=str))

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -920,13 +920,16 @@ def run_full(
     candidate_blocked = results["status"] == "failed" and not dry_flag
 
     # Esecuzione candidate: salva eccezione per rilanciarla DOPO il report.
-    _candidate_exc: BaseException | None = None
+    _candidate_exc: Exception | None = None
     if not candidate_blocked:
         is_mart_only = _is_mart_only_cfg(cfg)
         run_step = "mart" if is_mart_only else "all"
         fail_on_error_flag = bool(cfg.validation.fail_on_error)
 
         for year in selected_years:
+            # Registra anno come tentato PRIMA di run_year(), cosi'
+            # anche un'eccezione produce un report FAILED.
+            results["steps"][str(year)] = {"run": "running", "validate": "running"}
             try:
                 logger.info("Run %s — year=%s", run_step, year)
                 ctx = run_year(
@@ -939,8 +942,9 @@ def run_full(
                     sample_bytes=sample_bytes_final,
                     smoke=smoke,
                 )
-            except BaseException as exc:
+            except Exception as exc:
                 logger.error("Run %s year=%s fallito: %s", run_step, year, exc)
+                results["steps"][str(year)] = {"run": "failed", "validate": "failed"}
                 results["status"] = "failed"
                 _candidate_exc = exc
                 break  # interrompe il loop anni
@@ -1066,7 +1070,7 @@ def run_full(
 
     # Rilancia l'eccezione originale del candidate (preserva traceback)
     if _candidate_exc is not None:
-        raise _candidate_exc
+        raise _candidate_exc from _candidate_exc
 
     if json_output:
         typer.echo(json.dumps(results, indent=2, default=str))

--- a/toolkit/cli/inspect/report_ops.py
+++ b/toolkit/cli/inspect/report_ops.py
@@ -1,0 +1,597 @@
+"""Report di run aggregato: JSON per anno + markdown multi-anno.
+
+Costruisce un report unico a partire dagli artifact del run
+(run record, validazione, readiness, preflight) e lo persiste su disco.
+
+Implementazione condivisa — non dipende da CLI o MCP.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from toolkit.core.io import read_json_or_none
+from toolkit.core.metadata import read_layer_metadata
+from toolkit.core.paths import (
+    CLEAN_VALIDATION,
+    MART_VALIDATION,
+    METADATA,
+    RAW_PROFILE,
+    RAW_PROFILE_DIR,
+    RAW_VALIDATION,
+    layer_year_dir,
+)
+from toolkit.core.run_records import get_run_dir, latest_run
+
+_REPORT_DIR = "_reports"
+_RUN_REPORT_FILENAME = "run_report.json"
+_DATASET_README = "README.md"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_validation(root: Path, layer: str, dataset: str, year: int) -> dict[str, Any]:
+    """Legge il validation JSON di un layer, restituendo dict vuoto se non presente."""
+    val_map = {
+        "raw": RAW_VALIDATION,
+        "clean": CLEAN_VALIDATION,
+        "mart": MART_VALIDATION,
+    }
+    val_name = val_map.get(layer)
+    if not val_name:
+        return {}
+    val_path = layer_year_dir(root, layer, dataset, year) / val_name
+    if val_path.exists():
+        return read_json_or_none(val_path) or {}
+    val_path2 = layer_year_dir(root, layer, dataset, year) / "_validate" / val_name
+    if val_path2.exists():
+        return read_json_or_none(val_path2) or {}
+    return {}
+
+
+def _get_warnings(validation: dict[str, Any]) -> list[str]:
+    return validation.get("warnings", [])
+
+
+def _get_errors(validation: dict[str, Any]) -> list[str]:
+    return validation.get("errors", [])
+
+
+def _get_run_record(root: Path, dataset: str, year: int) -> dict[str, Any] | None:
+    """Legge il run record più recente per un dataset/anno."""
+    run_dir = get_run_dir(root, dataset, year)
+    try:
+        return latest_run(run_dir)
+    except (FileNotFoundError, OSError):
+        return None
+
+
+def _collect_mart_tables(root: Path, dataset: str, year: int) -> list[dict[str, Any]]:
+    """Legge dalla metadata del mart l'elenco tabelle con row count."""
+    mart_dir = layer_year_dir(root, "mart", dataset, year)
+    meta = read_layer_metadata(mart_dir)
+    table_profiles = meta.get("table_profiles") or {}
+    if not table_profiles:
+        tables = []
+        for f in sorted(mart_dir.glob("*.parquet")):
+            tables.append({"name": f.stem, "rows": None})
+        return tables
+    return [
+        {"name": name, "rows": profile.get("row_count")} for name, profile in table_profiles.items()
+    ]
+
+
+def _collect_clean_profile(root: Path, dataset: str, year: int) -> dict[str, Any]:
+    """Legge profilo clean da metadata.json."""
+    clean_dir = layer_year_dir(root, "clean", dataset, year)
+    meta = read_layer_metadata(clean_dir)
+    output_profile = meta.get("output_profile") or {}
+    return {
+        "row_count": output_profile.get("row_count"),
+        "col_count": len(output_profile.get("columns") or [])
+        if output_profile.get("columns")
+        else None,
+    }
+
+
+def _collect_raw_profile(root: Path, dataset: str, year: int) -> dict[str, Any]:
+    """Legge profilo raw da metadata.json (encoding, delim, primary_output)."""
+    raw_dir = layer_year_dir(root, "raw", dataset, year)
+    meta = read_layer_metadata(raw_dir)
+    hints = meta.get("profile_hints") or {}
+    return {
+        "encoding": hints.get("encoding_suggested"),
+        "delim": hints.get("delim_suggested"),
+        "primary_output": meta.get("primary_output_file"),
+    }
+
+
+def _collect_raw_row_count(root: Path, dataset: str, year: int) -> int | None:
+    """Legge row count dal raw_profile.json."""
+    raw_dir = layer_year_dir(root, "raw", dataset, year)
+    profile_path = raw_dir / RAW_PROFILE_DIR / RAW_PROFILE
+    if profile_path.exists():
+        pf = read_json_or_none(profile_path) or {}
+        return pf.get("row_count")
+    return None
+
+
+def _collect_config_hash(root: Path, dataset: str, year: int) -> str | None:
+    """Legge config_hash da raw metadata.json (o clean, mart)."""
+    for layer in ("raw", "clean", "mart"):
+        ld = layer_year_dir(root, layer, dataset, year)
+        meta_path = ld / METADATA
+        if meta_path.exists():
+            meta = read_json_or_none(meta_path) or {}
+            ch = meta.get("config_hash")
+            if ch:
+                return ch
+    return None
+
+
+def _collect_output_bytes(root: Path, layer: str, dataset: str, year: int) -> int | None:
+    """Legge il totale bytes dal metadata.json di un layer."""
+    ld = layer_year_dir(root, layer, dataset, year)
+    meta = read_layer_metadata(ld)
+    outputs = meta.get("outputs") or []
+    if outputs:
+        total = sum(o.get("bytes", 0) for o in outputs if o.get("bytes") is not None)
+        return total if total else None
+    return None
+
+
+def _collect_mart_transitions(root: Path, dataset: str, year: int) -> list[dict[str, Any]]:
+    """Legge transition_profiles dal mart metadata.json (clean→mart)."""
+    mart_dir = layer_year_dir(root, "mart", dataset, year)
+    meta = read_layer_metadata(mart_dir)
+    return meta.get("transition_profiles") or []
+
+
+def _duration_seconds(start: str | None, end: str | None) -> float | None:
+    """Calcola secondi tra due timestamp ISO."""
+    if not start or not end:
+        return None
+    try:
+        fmt = "%Y-%m-%dT%H:%M:%S"
+        s = datetime.strptime(start[:19], fmt)
+        e = datetime.strptime(end[:19], fmt)
+        return (e - s).total_seconds()
+    except (ValueError, TypeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Build report
+# ---------------------------------------------------------------------------
+
+
+def build_run_report(
+    config_path: str,
+    year: int,
+    *,
+    root: str | Path,
+    dataset: str,
+    run_ctx: dict[str, Any] | None = None,
+    preflight: dict[str, Any] | None = None,
+    step_results: dict[str, Any] | None = None,
+    run_mode: str = "full",
+    support_datasets: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Costruisce un report di run aggregato per un singolo anno.
+
+    Args:
+        config_path: path al dataset.yml
+        year: anno del run
+        root: root directory degli output
+        dataset: slug del dataset
+        run_ctx: RunContext.to_dict() — dal run corrente
+        preflight: dict dal preflight (opzionale)
+        step_results: dict dal passo run_full per l'anno (opzionale)
+        run_mode: full / smoke / dry-run
+        support_datasets: lista support eseguiti (nome, stato)
+
+    Returns:
+        Dict con report strutturato.
+    """
+    root_path = Path(root)
+
+    # --- Run record ---
+    record = run_ctx if run_ctx else _get_run_record(root_path, dataset, year)
+    run_status = (record or {}).get("status")
+    run_id = (record or {}).get("run_id")
+    duration = (record or {}).get("duration_seconds")
+    source_urls = (record or {}).get("source_urls") or []
+
+    # Tempi per layer dal run record
+    layer_timings: dict[str, float | None] = {}
+    if record:
+        layers = record.get("layers") or {}
+        for name in ("raw", "clean", "mart"):
+            info = layers.get(name) or {}
+            layer_timings[name] = _duration_seconds(info.get("started_at"), info.get("finished_at"))
+
+    # --- Readiness (da step_results o calcola) ---
+    readiness = (step_results or {}).get("readiness")
+    if step_results:
+        readiness_checks = {
+            "total": step_results.get("checks", 0),
+            "ok": step_results.get("checks_ok", 0),
+            "fail": step_results.get("checks_fail", 0),
+        }
+    else:
+        readiness_checks = {"total": 0, "ok": 0, "fail": 0}
+
+    # --- Preflight ---
+    preflight_summary: dict[str, Any] = {
+        "config_ok": False,
+        "sources_reachable": 0,
+        "sources_total": 0,
+    }
+    if preflight:
+        cs = preflight.get("config_check") or {}
+        sources = preflight.get("sources") or []
+        reachable = sum(1 for s in sources if s.get("reachable"))
+        quality_scores = [
+            s.get("quality_score") for s in sources if s.get("quality_score") is not None
+        ]
+        avg_quality = round(sum(quality_scores) / len(quality_scores)) if quality_scores else None
+        preflight_summary = {
+            "config_ok": cs.get("ok", False),
+            "sources_reachable": reachable,
+            "sources_total": len(sources),
+            "quality_score_avg": avg_quality,
+        }
+
+    # --- Config hash (da metadata di qualsiasi layer) ---
+    config_hash = _collect_config_hash(root_path, dataset, year)
+
+    # --- Validation per layer ---
+    layers_report: dict[str, Any] = {}
+    for lname in ("raw", "clean", "mart"):
+        val = _read_validation(root_path, lname, dataset, year)
+        warnings = _get_warnings(val)
+        errors = _get_errors(val)
+        file_bytes = _collect_output_bytes(root_path, lname, dataset, year)
+        layer_entry: dict[str, Any] = {
+            "status": ((record or {}).get("layers") or {}).get(lname, {}).get("status"),
+            "duration_seconds": layer_timings.get(lname),
+            "file_size_bytes": file_bytes,
+            "validation": {
+                "ok": val.get("ok", False),
+                "errors": len(errors),
+                "warnings": len(warnings),
+            },
+            "warnings": warnings[:5] if warnings else [],
+            "errors": errors[:5] if errors else [],
+        }
+
+        if lname == "raw":
+            raw_p = _collect_raw_profile(root_path, dataset, year)
+            layer_entry["encoding"] = raw_p.get("encoding")
+            layer_entry["delim"] = raw_p.get("delim")
+            layer_entry["primary_output"] = raw_p.get("primary_output")
+            raw_rows = _collect_raw_row_count(root_path, dataset, year)
+            layer_entry["raw_rows"] = raw_rows
+
+        elif lname == "clean":
+            clean_p = _collect_clean_profile(root_path, dataset, year)
+            layer_entry["rows"] = clean_p.get("row_count")
+            layer_entry["columns"] = clean_p.get("col_count")
+            # Transition raw→clean dal readiness step
+            rl = (step_results or {}).get("layers") or {}
+            cl = rl.get("clean") or {}
+            layer_entry["transition"] = cl.get("transition")
+
+        elif lname == "mart":
+            tables = _collect_mart_tables(root_path, dataset, year)
+            layer_entry["tables"] = tables
+            total_rows = sum(t.get("rows") or 0 for t in tables if t.get("rows") is not None)
+            layer_entry["total_rows"] = total_rows if total_rows else None
+            # Transizioni clean→mart
+            transitions = _collect_mart_transitions(root_path, dataset, year)
+            if transitions:
+                layer_entry["transitions"] = [
+                    {
+                        "target": t.get("target_name"),
+                        "source_rows": t.get("source_row_count"),
+                        "target_rows": t.get("target_row_count"),
+                        "delta": t.get("row_count_delta"),
+                        "added_columns": t.get("added_columns"),
+                        "removed_columns": t.get("removed_columns"),
+                    }
+                    for t in transitions
+                ]
+
+        layers_report[lname] = layer_entry
+
+    return {
+        "dataset": dataset,
+        "config_path": str(config_path),
+        "year": year,
+        "run_id": run_id,
+        "run_mode": run_mode,
+        "toolkit_version": (record or {}).get("toolkit_version"),
+        "status": run_status,
+        "duration_seconds": duration,
+        "config_hash": config_hash,
+        "source_urls": source_urls,
+        "readiness": readiness,
+        "readiness_checks": readiness_checks,
+        "preflight": preflight_summary,
+        "layers": layers_report,
+        "support_datasets": support_datasets or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Write report to disk
+# ---------------------------------------------------------------------------
+
+
+def write_run_report(report: dict[str, Any], root: str | Path, dataset: str, year: int) -> Path:
+    """Scrive il report JSON su disco.
+
+    Path: {root}/data/_reports/{dataset}/{year}_run_report.json
+    """
+    root_path = Path(root)
+    report_dir = root_path / "data" / _REPORT_DIR / dataset
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / f"{year}_{_RUN_REPORT_FILENAME}"
+    import json
+
+    report_path.write_text(json.dumps(report, indent=2, default=str), encoding="utf-8")
+    return report_path
+
+
+# ---------------------------------------------------------------------------
+# Build e write Markdown aggregato
+# ---------------------------------------------------------------------------
+
+
+def _status_icon(status: str | None) -> str:
+    if status == "SUCCESS":
+        return "✅"
+    if status in ("FAILED",):
+        return "🔴"
+    if status in ("SUCCESS_WITH_WARNINGS",):
+        return "⚠️"
+    return "·"
+
+
+def _readiness_icon(readiness: str | None) -> str:
+    if readiness == "ready":
+        return "✅"
+    if readiness == "needs-review":
+        return "🔶"
+    if readiness == "incomplete":
+        return "🔴"
+    return "·"
+
+
+def _validation_icon(ok: bool | None) -> str:
+    if ok is True:
+        return "✅"
+    if ok is False:
+        return "🔴"
+    return "·"
+
+
+def _fmt_duration(sec: float | None) -> str:
+    if sec is None:
+        return "-"
+    if sec < 1:
+        return f"{sec * 1000:.0f}ms"
+    return f"{sec:.1f}s"
+
+
+def _fmt_bytes(b: int | None) -> str:
+    """Formatta byte in KB/MB leggibile."""
+    if b is None:
+        return "-"
+    if b < 1024:
+        return f"{b}B"
+    if b < 1024 * 1024:
+        return f"{b / 1024:.1f}KB"
+    return f"{b / (1024 * 1024):.1f}MB"
+
+
+def build_dataset_readme(
+    dataset: str,
+    config_path: str,
+    reports: list[dict[str, Any]],
+    overall_status: str | None = None,
+) -> str:
+    """Genera un README.md aggregato per tutti gli anni di un dataset.
+
+    Args:
+        dataset: slug del dataset
+        config_path: path al dataset.yml
+        reports: lista di report JSON (uno per anno)
+        overall_status: stato complessivo (passed/failed)
+
+    Returns:
+        Testo markdown del README.
+    """
+    status = overall_status or "passed"
+    status_icon = "✅" if status == "passed" else "🔴"
+
+    lines = [
+        f"# Run Report: `{dataset}`\n",
+    ]
+
+    # Metadata
+    lines.append("## Dataset\n")
+    lines.append(f"- Config: `{config_path}`")
+    lines.append(f"- Stato complessivo: {status_icon} **{status}**")
+    years_list = sorted({int(r["year"]) for r in reports if r.get("year") is not None})
+    lines.append(f"- Anni processati: {', '.join(str(y) for y in years_list)}")
+    lines.append(f"- Anni con report: {len(reports)}")
+    lines.append("")
+
+    # Tabella riepilogativa per anno
+    lines.append("## Riepilogo per anno\n")
+    lines.append("| Anno | Status | Readiness | Qualità | Raw | Clean | Mart | Durata |")
+    lines.append("|------|--------|-----------|---------|-----|-------|------|--------|")
+
+    for r in sorted(reports, key=lambda x: x.get("year", 0)):
+        year = r.get("year", "?")
+        status_icon_col = _status_icon(r.get("status"))
+        status_name = r.get("status", "?")
+        readiness_icon_col = _readiness_icon(r.get("readiness"))
+        readiness_name = r.get("readiness", "?")
+
+        # Qualità
+        pf = r.get("preflight") or {}
+        qs = pf.get("quality_score_avg")
+        q_str = f"**{qs}**" if qs else "-"
+
+        layers = r.get("layers") or {}
+
+        # Raw
+        r_raw = layers.get("raw") or {}
+        raw_info = f"{_validation_icon(r_raw.get('validation', {}).get('ok'))}"
+        enc = r_raw.get("encoding") or ""
+        w_count = r_raw.get("validation", {}).get("warnings", 0)
+        raw_info += f" {enc}" if enc else ""
+        raw_info += f" ({w_count}w)" if w_count else ""
+        raw_bytes = r_raw.get("file_size_bytes")
+        raw_info += f" · {_fmt_bytes(raw_bytes)}" if raw_bytes else ""
+
+        # Clean
+        r_clean = layers.get("clean") or {}
+        clean_info = f"{_validation_icon(r_clean.get('validation', {}).get('ok'))}"
+        rows = r_clean.get("rows")
+        rows_str = f"{rows} righe" if rows is not None else ""
+        w_count = r_clean.get("validation", {}).get("warnings", 0)
+        clean_info += f" {rows_str}" if rows_str else ""
+        clean_info += f" ({w_count}w)" if w_count else ""
+        clean_bytes = r_clean.get("file_size_bytes")
+        clean_info += f" · {_fmt_bytes(clean_bytes)}" if clean_bytes else ""
+
+        # Mart
+        r_mart = layers.get("mart") or {}
+        mart_info = f"{_validation_icon(r_mart.get('validation', {}).get('ok'))}"
+        tables = r_mart.get("tables") or []
+        n_tables = len(tables)
+        mart_rows = r_mart.get("total_rows")
+        mart_str = f"{n_tables} tabelle"
+        if mart_rows is not None:
+            mart_str += f" ({mart_rows} righe)"
+        w_count = r_mart.get("validation", {}).get("warnings", 0)
+        mart_info += f" {mart_str}"
+        mart_info += f" ({w_count}w)" if w_count else ""
+
+        duration_str = _fmt_duration(r.get("duration_seconds"))
+
+        lines.append(
+            f"| {year} | {status_icon_col} {status_name} | {readiness_icon_col} {readiness_name} "
+            f"| {q_str} | {raw_info} | {clean_info} | {mart_info} | {duration_str} |"
+        )
+
+    lines.append("")
+
+    # Preflight
+    preflight_info = None
+    for r in reports:
+        pf = r.get("preflight") or {}
+        if pf:
+            preflight_info = pf
+            break
+
+    if preflight_info:
+        lines.append("## Preflight\n")
+        lines.append(f"- Config valida: {'✅' if preflight_info.get('config_ok') else '🔴'}")
+        lines.append(
+            f"- Fonti: {preflight_info.get('sources_reachable', '?')}/"
+            f"{preflight_info.get('sources_total', '?')} raggiungibili"
+        )
+        qs = preflight_info.get("quality_score_avg")
+        if qs is not None:
+            lines.append(f"- Quality score medio: **{qs}/100**")
+        lines.append("")
+
+    # Warning ed errori per anno
+    lines.append("## Warning ed errori\n")
+    for r in sorted(reports, key=lambda x: x.get("year", 0)):
+        year = r.get("year", "?")
+        layers = r.get("layers") or {}
+        has_issues = False
+        for lname in ("raw", "clean", "mart"):
+            lr = layers.get(lname) or {}
+            ws = lr.get("warnings") or []
+            es = lr.get("errors") or []
+            if ws or es:
+                if not has_issues:
+                    lines.append(f"### Anno {year}\n")
+                    has_issues = True
+                lines.append(f"**{lname}**: {len(es)} errori, {len(ws)} warning")
+                for w in ws[:3]:
+                    lines.append(f"  - ⚠ {w}")
+                for e in es[:3]:
+                    lines.append(f"  - ❌ {e}")
+        if has_issues:
+            lines.append("")
+
+    # Readiness per anno
+    has_readiness = any(r.get("readiness") for r in reports)
+    if has_readiness:
+        lines.append("## Review Readiness\n")
+        for r in sorted(reports, key=lambda x: x.get("year", 0)):
+            year = r.get("year", "?")
+            rd = r.get("readiness", "?")
+            rc = r.get("readiness_checks") or {}
+            icon = _readiness_icon(rd)
+            lines.append(
+                f"- Anno {year}: {icon} **{rd}** ({rc.get('ok', 0)}/{rc.get('total', 0)} check ok)"
+            )
+        lines.append("")
+
+    # Support datasets
+    has_support = any(r.get("support_datasets") for r in reports if r.get("support_datasets"))
+    if has_support:
+        lines.append("## Support Datasets\n")
+        seen = set()
+        for r in reports:
+            for s in r.get("support_datasets") or []:
+                name = s.get("name")
+                if name and name not in seen:
+                    seen.add(name)
+                    lines.append(f"- {name}")
+        lines.append("")
+
+    lines.append("---")
+    lines.append(
+        f"*Report generato il {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')} "
+        f"dal toolkit*"
+    )
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def write_dataset_readme(
+    root: str | Path,
+    dataset: str,
+    reports: list[dict[str, Any]],
+    overall_status: str | None = None,
+    config_path: str | None = None,
+) -> Path:
+    """Scrive il README.md aggregato per un dataset.
+
+    Path: {root}/data/_reports/{dataset}/README.md
+    """
+    root_path = Path(root)
+    report_dir = root_path / "data" / _REPORT_DIR / dataset
+    report_dir.mkdir(parents=True, exist_ok=True)
+    readme_path = report_dir / _DATASET_README
+
+    # Prendi config_path dal primo report se non fornito
+    cfg_path: str = config_path or (str(reports[0].get("config_path", "?")) if reports else "?")
+    md = build_dataset_readme(dataset, cfg_path, reports, overall_status)
+    readme_path.write_text(md, encoding="utf-8")
+    return readme_path

--- a/toolkit/cli/inspect/report_ops.py
+++ b/toolkit/cli/inspect/report_ops.py
@@ -252,6 +252,13 @@ def build_run_report(
     # --- Run record ---
     record = run_ctx if run_ctx else _get_run_record(root_path, dataset, year)
     run_status = (record or {}).get("status")
+    # Se il run record non esiste (es. run_year solleva eccezione prima
+    # di scriverlo), usa lo step_results come fallback.
+    if run_status is None and step_results:
+        if step_results.get("run") == "failed":
+            run_status = "FAILED"
+        elif step_results.get("run") == "ok":
+            run_status = "SUCCESS"
     run_id = (record or {}).get("run_id")
     duration = (record or {}).get("duration_seconds")
     source_urls = (record or {}).get("source_urls") or []

--- a/toolkit/cli/inspect/report_ops.py
+++ b/toolkit/cli/inspect/report_ops.py
@@ -152,6 +152,24 @@ def _collect_mart_transitions(root: Path, dataset: str, year: int) -> list[dict[
     return meta.get("transition_profiles") or []
 
 
+def _all_reports_for_dataset(root: str | Path, dataset: str) -> list[dict[str, Any]]:
+    """Legge tutti i report JSON esistenti per un dataset, ordinati per anno.
+
+    Cerca in {root}/data/_reports/{dataset}/*_run_report.json.
+    """
+    root_path = Path(root)
+    reports_dir = root_path / "data" / _REPORT_DIR / dataset
+    if not reports_dir.exists():
+        return []
+
+    reports: list[dict[str, Any]] = []
+    for f in sorted(reports_dir.glob("*_run_report.json")):
+        raw = read_json_or_none(f)
+        if raw:
+            reports.append(raw)
+    return reports
+
+
 def _duration_seconds(start: str | None, end: str | None) -> float | None:
     """Calcola secondi tra due timestamp ISO."""
     if not start or not end:
@@ -257,12 +275,19 @@ def build_run_report(
         warnings = _get_warnings(val)
         errors = _get_errors(val)
         file_bytes = _collect_output_bytes(root_path, lname, dataset, year)
+        layer_status = ((record or {}).get("layers") or {}).get(lname, {}).get("status")
+
+        # Distingue layer non presente (es. mart-only: raw/clean assenti) da layer fallito
+        val_ok: bool | None = val.get("ok")
+        if val_ok is None and not val and layer_status is None:
+            val_ok = None  # layer non eseguito (non è un fallimento)
+
         layer_entry: dict[str, Any] = {
-            "status": ((record or {}).get("layers") or {}).get(lname, {}).get("status"),
+            "status": layer_status,
             "duration_seconds": layer_timings.get(lname),
             "file_size_bytes": file_bytes,
             "validation": {
-                "ok": val.get("ok", False),
+                "ok": val_ok,
                 "errors": len(errors),
                 "warnings": len(warnings),
             },
@@ -378,6 +403,7 @@ def _validation_icon(ok: bool | None) -> str:
         return "✅"
     if ok is False:
         return "🔴"
+    # None = layer non eseguito (es. mart-only)
     return "·"
 
 
@@ -515,27 +541,38 @@ def build_dataset_readme(
             lines.append(f"- Quality score medio: **{qs}/100**")
         lines.append("")
 
-    # Warning ed errori per anno
-    lines.append("## Warning ed errori\n")
-    for r in sorted(reports, key=lambda x: x.get("year", 0)):
-        year = r.get("year", "?")
-        layers = r.get("layers") or {}
-        has_issues = False
+    # Warning ed errori per anno (solo se presenti)
+    _any_issues = False
+    for r in reports:
         for lname in ("raw", "clean", "mart"):
-            lr = layers.get(lname) or {}
-            ws = lr.get("warnings") or []
-            es = lr.get("errors") or []
-            if ws or es:
-                if not has_issues:
-                    lines.append(f"### Anno {year}\n")
-                    has_issues = True
-                lines.append(f"**{lname}**: {len(es)} errori, {len(ws)} warning")
-                for w in ws[:3]:
-                    lines.append(f"  - ⚠ {w}")
-                for e in es[:3]:
-                    lines.append(f"  - ❌ {e}")
-        if has_issues:
-            lines.append("")
+            lr = (r.get("layers") or {}).get(lname) or {}
+            if lr.get("warnings") or lr.get("errors"):
+                _any_issues = True
+                break
+        if _any_issues:
+            break
+
+    if _any_issues:
+        lines.append("## Warning ed errori\n")
+        for r in sorted(reports, key=lambda x: x.get("year", 0)):
+            year = r.get("year", "?")
+            layers = r.get("layers") or {}
+            has_issues = False
+            for lname in ("raw", "clean", "mart"):
+                lr = layers.get(lname) or {}
+                ws = lr.get("warnings") or []
+                es = lr.get("errors") or []
+                if ws or es:
+                    if not has_issues:
+                        lines.append(f"### Anno {year}\n")
+                        has_issues = True
+                    lines.append(f"**{lname}**: {len(es)} errori, {len(ws)} warning")
+                    for w in ws[:3]:
+                        lines.append(f"  - ⚠ {w}")
+                    for e in es[:3]:
+                        lines.append(f"  - ❌ {e}")
+            if has_issues:
+                lines.append("")
 
     # Readiness per anno
     has_readiness = any(r.get("readiness") for r in reports)

--- a/toolkit/cli/inspect/report_ops.py
+++ b/toolkit/cli/inspect/report_ops.py
@@ -152,6 +152,20 @@ def _collect_mart_transitions(root: Path, dataset: str, year: int) -> list[dict[
     return meta.get("transition_profiles") or []
 
 
+def _derive_overall_status(reports: list[dict[str, Any]]) -> str:
+    """Deriva lo stato complessivo da una lista di report.
+
+    - Se almeno un report e' FAILED → 'failed'
+    - Se nessun FAILED ma almeno un SUCCESS_WITH_WARNINGS → 'passed_with_warnings'
+    - Altrimenti → 'passed'
+    """
+    if any(r.get("status") == "FAILED" for r in reports):
+        return "failed"
+    if any(r.get("status") == "SUCCESS_WITH_WARNINGS" for r in reports):
+        return "passed_with_warnings"
+    return "passed"
+
+
 def _all_reports_for_dataset(root: str | Path, dataset: str) -> list[dict[str, Any]]:
     """Legge tutti i report JSON esistenti per un dataset, ordinati per anno.
 
@@ -444,7 +458,12 @@ def build_dataset_readme(
         Testo markdown del README.
     """
     status = overall_status or "passed"
-    status_icon = "✅" if status == "passed" else "🔴"
+    if status == "failed":
+        status_icon = "🔴"
+    elif status == "passed_with_warnings":
+        status_icon = "⚠️"
+    else:
+        status_icon = "✅"
 
     lines = [
         f"# Run Report: `{dataset}`\n",

--- a/toolkit/cli/inspect/report_ops.py
+++ b/toolkit/cli/inspect/report_ops.py
@@ -152,15 +152,15 @@ def _collect_mart_transitions(root: Path, dataset: str, year: int) -> list[dict[
     return meta.get("transition_profiles") or []
 
 
-_VALID_PASSED = frozenset({"SUCCESS", "SUCCESS_WITH_WARNINGS"})
 _VALID_FAILED = frozenset({"FAILED", "BLOCKED", "ERROR"})
+_VALID_INCOMPLETE = frozenset({"RUNNING", "DRY_RUN"})
 
 
 def _derive_overall_status(reports: list[dict[str, Any]]) -> str:
     """Deriva lo stato complessivo da una lista di report.
 
     - Se almeno un report e' FAILED/BLOCKED/ERROR → 'failed'
-    - Se almeno un report e' None/RUNNING → 'incomplete'
+    - Se almeno un report e' None/RUNNING/DRY_RUN → 'incomplete'
     - Se almeno un report e' SUCCESS_WITH_WARNINGS → 'passed_with_warnings'
     - Se tutti sono SUCCESS → 'passed'
     - Se lista vuota → 'unknown'
@@ -173,7 +173,7 @@ def _derive_overall_status(reports: list[dict[str, Any]]) -> str:
         s = r.get("status")
         if s in _VALID_FAILED:
             return "failed"
-        if s is None or s == "RUNNING":
+        if s is None or s in _VALID_INCOMPLETE or s not in ("SUCCESS", "SUCCESS_WITH_WARNINGS"):
             has_incomplete = True
 
     if has_incomplete:

--- a/toolkit/cli/inspect/report_ops.py
+++ b/toolkit/cli/inspect/report_ops.py
@@ -152,15 +152,32 @@ def _collect_mart_transitions(root: Path, dataset: str, year: int) -> list[dict[
     return meta.get("transition_profiles") or []
 
 
+_VALID_PASSED = frozenset({"SUCCESS", "SUCCESS_WITH_WARNINGS"})
+_VALID_FAILED = frozenset({"FAILED", "BLOCKED", "ERROR"})
+
+
 def _derive_overall_status(reports: list[dict[str, Any]]) -> str:
     """Deriva lo stato complessivo da una lista di report.
 
-    - Se almeno un report e' FAILED → 'failed'
-    - Se nessun FAILED ma almeno un SUCCESS_WITH_WARNINGS → 'passed_with_warnings'
-    - Altrimenti → 'passed'
+    - Se almeno un report e' FAILED/BLOCKED/ERROR → 'failed'
+    - Se almeno un report e' None/RUNNING → 'incomplete'
+    - Se almeno un report e' SUCCESS_WITH_WARNINGS → 'passed_with_warnings'
+    - Se tutti sono SUCCESS → 'passed'
+    - Se lista vuota → 'unknown'
     """
-    if any(r.get("status") == "FAILED" for r in reports):
-        return "failed"
+    if not reports:
+        return "unknown"
+
+    has_incomplete = False
+    for r in reports:
+        s = r.get("status")
+        if s in _VALID_FAILED:
+            return "failed"
+        if s is None or s == "RUNNING":
+            has_incomplete = True
+
+    if has_incomplete:
+        return "incomplete"
     if any(r.get("status") == "SUCCESS_WITH_WARNINGS" for r in reports):
         return "passed_with_warnings"
     return "passed"
@@ -462,6 +479,8 @@ def build_dataset_readme(
         status_icon = "🔴"
     elif status == "passed_with_warnings":
         status_icon = "⚠️"
+    elif status == "incomplete":
+        status_icon = "🔶"
     else:
         status_icon = "✅"
 


### PR DESCRIPTION
## Sintesi

Nuovo report di run generato automaticamente da `toolkit run full`. Dopo ogni run:

1. **JSON per anno** — `{root}/data/_reports/{dataset}/{year}_run_report.json`
2. **README aggregato multi-anno** — `{root}/data/_reports/{dataset}/README.md` (legge e unisce TUTTI i JSON esistenti, non solo l'ultimo run)

## Contesto collegato

Nessuna issue — iniziativa interna emersa da stress test (sessione 2026-06-14).

## Cosa cambia

- [x] Nuova funzionalità del motore

## Dettaglio

### Nuovo file: `toolkit/cli/inspect/report_ops.py`

Modulo core che costruisce il report aggregato a partire da:
- Run record (`_runs/*.json`)
- Validation JSON per layer (`*_validation.json`)
- Metadata JSON (`metadata.json` → `outputs`, `output_profile`, `table_profiles`, `transition_profiles`)
- Raw profile (`_profile/raw_profile.json` → `row_count`)
- Preflight (da `run full` → reachability, quality score)
- Review readiness (5 check: config, raw, clean, mart, run record)

### Modificato: `toolkit/cli/cmd_run.py`

Integrazione in `run full`: generazione best-effort (try/except, non fa fallire il run),
eseguita anche con candidate bloccato o run fallito. README aggregato con stato
derivato da tutti i report storici.

### Campi del report JSON

```json
{
  "dataset": "str", "config_path": "str", "year": int,
  "run_id": "str", "run_mode": "full|smoke",
  "toolkit_version": "str", "status": "SUCCESS|FAILED",
  "duration_seconds": float, "config_hash": "str (sha256)",
  "source_urls": ["https://..."],
  "readiness": "ready|needs-review|incomplete",
  "readiness_checks": {"total": 5, "ok": 5, "fail": 0},
  "preflight": {"config_ok": bool, "sources_reachable": int,
                "sources_total": int, "quality_score_avg": int|null},
  "layers": {"raw": {...}, "clean": {...}, "mart": {...}},
  "support_datasets": [{"name", "year", "status"}]
}
```

### README aggregato (markdown)

| Anno | Status | Readiness | Qualità | Raw | Clean | Mart | Durata |
|------|--------|-----------|---------|-----|-------|------|--------|
| 2023 | ✅ SUCCESS | ✅ ready | - | utf-8 · 14.7KB | 22 righe (2w) · 13.5KB | 2 tabelle (20 righe) (2w) | 2.9s |

Include sezioni: Preflight, Warning ed errori per anno, Review Readiness,
stato complessivo aggregato da tutti i run.

## Verifica

```bash
pytest tests/ -x -q --tb=short -k "run_full or preflight or validation_gate or report"
ruff check toolkit/cli/inspect/report_ops.py toolkit/cli/cmd_run.py

# Run reale multi-anno
toolkit run full --config dataset-incubator/candidates/openga-ricorsi-appalto/dataset.yml

# Run su smoke
toolkit run full --config toolkit/smoke/local_file_csv/dataset.yml --years 2022
```

- [x] `pytest -k "run_full or preflight or validation_gate or report"` — 47 pass
- [x] `ruff check .` — passa
- [x] `mypy toolkit/cli/inspect/report_ops.py` — passa
- [x] Run reale su openga-ricorsi-appalto (4 anni: 2023-2026)
- [x] Run su smoke local_file_csv

## Checklist PR

- [x] Perimetro stretto: una PR = report di run
- [x] Verifiche eseguite

## Note per chi revisiona

- **Best-effort**: la generazione è wrappata in try/except — se fallisce, il run continua
- **Multi-anno**: il README legge tutti i JSON su disco e li unisce. Ogni `run full` aggiunge, non sovrascrive
- **Mart-only**: raw/clean non eseguiti hanno validation=None (non False)
- **Stato aggregato**: `_derive_overall_status()` deriva "failed" se anche un solo report storico è FAILED
- **Nessun side effect**: non scrive più in `candidates/`
- `quality_score_avg` può essere null (fonti CKAN)
- `raw_rows` può essere null se raw_profile.json non ha row_count
