### PR TITLE
refactor: safe_connect in tutti i test rimanenti (#376 complete)

### DIFF
--- a/tests/test_clean_csv_columns.py
+++ b/tests/test_clean_csv_columns.py
@@ -1,5 +1,5 @@
 import pytest
-import duckdb
+from lab_connectors.duckdb import safe_connect
 from pathlib import Path
 
 from tests.helpers import NoopLogger
@@ -49,9 +49,10 @@ def test_run_clean_csv_columns_reads_trailing_delimiter_csv(tmp_path: Path):
     out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
     assert out.exists()
 
-    con = duckdb.connect(":memory:")
-    rows = con.execute(f"SELECT a, b FROM read_parquet('{out.as_posix()}') ORDER BY a").fetchall()
-    con.close()
+    with safe_connect() as con:
+        rows = con.execute(
+            f"SELECT a, b FROM read_parquet('{out.as_posix()}') ORDER BY a"
+        ).fetchall()
 
     assert rows == [("1", "2"), ("3", "4")]
 
@@ -135,17 +136,16 @@ def test_run_clean_positional_csv_multi_file_concat(tmp_path: Path):
         "delim": ";",
         "trim_whitespace": True,
     }
-    con = duckdb.connect(":memory:")
-    params = _execute_normalized_csv_read(
-        con,
-        [tmp_path / "file1.csv", tmp_path / "file2.csv"],
-        read_cfg,
-    )
+    with safe_connect() as con:
+        params = _execute_normalized_csv_read(
+            con,
+            [tmp_path / "file1.csv", tmp_path / "file2.csv"],
+            read_cfg,
+        )
 
-    rows = con.execute("SELECT * FROM raw_input ORDER BY a").fetchall()
-    assert rows == [("1", "2"), ("3", "4"), ("5", "6")]
-    assert params["normalize_rows_to_columns"] is True
-    con.close()
+        rows = con.execute("SELECT * FROM raw_input ORDER BY a").fetchall()
+        assert rows == [("1", "2"), ("3", "4"), ("5", "6")]
+        assert params["normalize_rows_to_columns"] is True
 
 
 @pytest.mark.policy
@@ -229,11 +229,10 @@ def test_run_clean_compact_columns_format_renames_and_types(tmp_path: Path):
     out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
     assert out.exists()
 
-    con = duckdb.connect(":memory:")
-    rows = con.execute(
-        f"SELECT a_renamed, b_renamed FROM read_parquet('{out.as_posix()}')"
-    ).fetchall()
-    con.close()
+    with safe_connect() as con:
+        rows = con.execute(
+            f"SELECT a_renamed, b_renamed FROM read_parquet('{out.as_posix()}')"
+        ).fetchall()
     # Spaces trimmed by TRIM in projection
     assert rows == [("val_a", "val_b")]
 
@@ -271,11 +270,10 @@ def test_run_clean_compact_columns_format_with_int_type(tmp_path: Path):
     out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
     assert out.exists()
 
-    con = duckdb.connect(":memory:")
-    rows = con.execute(
-        f"SELECT anno_clean, valore_clean FROM read_parquet('{out.as_posix()}')"
-    ).fetchall()
-    con.close()
+    with safe_connect() as con:
+        rows = con.execute(
+            f"SELECT anno_clean, valore_clean FROM read_parquet('{out.as_posix()}')"
+        ).fetchall()
     assert rows == [(2024, 42)]
 
 
@@ -318,11 +316,10 @@ def test_run_clean_compact_columns_format_no_trim_whitespace(tmp_path: Path):
     out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
     assert out.exists()
 
-    con = duckdb.connect(":memory:")
-    rows = con.execute(
-        f"SELECT anno_clean, valore_clean FROM read_parquet('{out.as_posix()}')"
-    ).fetchall()
-    con.close()
+    with safe_connect() as con:
+        rows = con.execute(
+            f"SELECT anno_clean, valore_clean FROM read_parquet('{out.as_posix()}')"
+        ).fetchall()
     assert rows == [(2024, 42)]
 
 
@@ -457,11 +454,10 @@ def test_run_clean_align_by_header_integration(tmp_path: Path):
     out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
     assert out.exists()
 
-    con = duckdb.connect(":memory:")
-    rows = con.execute(
-        f"SELECT anno, oneri, consumi FROM read_parquet('{out.as_posix()}') ORDER BY anno"
-    ).fetchall()
-    con.close()
+    with safe_connect() as con:
+        rows = con.execute(
+            f"SELECT anno, oneri, consumi FROM read_parquet('{out.as_posix()}') ORDER BY anno"
+        ).fetchall()
     assert rows == [(2023, None, 200.3), (2024, None, 100.5)]
 
 

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import duckdb
+from lab_connectors.duckdb import safe_connect
 import pandas as pd
 import pytest
 import yaml
@@ -33,26 +33,25 @@ def test_read_raw_to_relation_fallback_invokes_robust_after_strict_failure(
 
     monkeypatch.setattr(duckdb_read, "_execute_csv_read", _fake_execute_csv_read)
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {"delim": ";", "encoding": "utf-8"},
-        "fallback",
-        logger,
-    )
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {"delim": ";", "encoding": "utf-8"},
+            "fallback",
+            logger,
+        )
 
-    assert len(calls) == 2
-    assert info.source == "robust"
-    assert info.params_used["ignore_errors"] is True
-    assert calls[0].get("ignore_errors") is None
-    assert calls[1]["ignore_errors"] is True
-    assert calls[1]["null_padding"] is True
-    assert calls[1]["strict_mode"] is False
-    assert calls[1]["sample_size"] == -1
-    con.close()
+        assert len(calls) == 2
+        assert info.source == "robust"
+        assert info.params_used["ignore_errors"] is True
+        assert calls[0].get("ignore_errors") is None
+        assert calls[1]["ignore_errors"] is True
+        assert calls[1]["null_padding"] is True
+        assert calls[1]["strict_mode"] is False
+        assert calls[1]["sample_size"] == -1
 
 
 @pytest.mark.policy
@@ -60,22 +59,21 @@ def test_read_raw_to_relation_strict_returns_strict_info(tmp_path: Path):
     input_file = tmp_path / "ok.csv"
     input_file.write_text("a;b\n1;2\n", encoding="utf-8")
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.strict")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.strict")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {"delim": ";", "encoding": "utf-8", "header": True},
-        "strict",
-        logger,
-    )
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {"delim": ";", "encoding": "utf-8", "header": True},
+            "strict",
+            logger,
+        )
 
-    assert info.source == "strict"
-    assert info.params_used["delim"] == ";"
-    assert info.params_used["encoding"] == "utf-8"
-    assert info.params_used["header"] is True
-    con.close()
+        assert info.source == "strict"
+        assert info.params_used["delim"] == ";"
+        assert info.params_used["encoding"] == "utf-8"
+        assert info.params_used["header"] is True
 
 
 @pytest.mark.policy
@@ -83,20 +81,19 @@ def test_read_raw_to_relation_passes_parallel_flag(tmp_path: Path):
     input_file = tmp_path / "ok.csv"
     input_file.write_text("a;b\n1;2\n", encoding="utf-8")
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.parallel")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.parallel")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {"delim": ";", "encoding": "utf-8", "header": True, "parallel": False},
-        "strict",
-        logger,
-    )
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {"delim": ";", "encoding": "utf-8", "header": True, "parallel": False},
+            "strict",
+            logger,
+        )
 
-    assert info.source == "strict"
-    assert info.params_used["parallel"] is False
-    con.close()
+        assert info.source == "strict"
+        assert info.params_used["parallel"] is False
 
 
 @pytest.mark.policy
@@ -104,25 +101,24 @@ def test_read_raw_to_relation_keeps_explicit_columns_unchanged(tmp_path: Path):
     input_file = tmp_path / "ok.csv"
     input_file.write_text("a;b\n1;2\n", encoding="utf-8")
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.columns")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.columns")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {
-            "delim": ";",
-            "encoding": "utf-8",
-            "header": True,
-            "columns": {"a": "VARCHAR", "b": "VARCHAR"},
-        },
-        "strict",
-        logger,
-    )
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {
+                "delim": ";",
+                "encoding": "utf-8",
+                "header": True,
+                "columns": {"a": "VARCHAR", "b": "VARCHAR"},
+            },
+            "strict",
+            logger,
+        )
 
-    assert info.source == "strict"
-    assert info.params_used["columns"] == {"a": "VARCHAR", "b": "VARCHAR"}
-    con.close()
+        assert info.source == "strict"
+        assert info.params_used["columns"] == {"a": "VARCHAR", "b": "VARCHAR"}
 
 
 @pytest.mark.policy
@@ -130,28 +126,26 @@ def test_read_raw_to_relation_strict_error_message_uses_current_config_keys(tmp_
     input_file = tmp_path / "bad.csv"
     input_file.write_text("a;b\n1;2;3\n", encoding="utf-8")
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.strict_error")
-    original_execute = duckdb_read._execute_csv_read
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.strict_error")
+        original_execute = duckdb_read._execute_csv_read
 
-    def _fail_execute_csv_read(_con, _input_files, _read_cfg):
-        raise RuntimeError("strict boom")
+        def _fail_execute_csv_read(_con, _input_files, _read_cfg):
+            raise RuntimeError("strict boom")
 
-    duckdb_read._execute_csv_read = _fail_execute_csv_read
+        duckdb_read._execute_csv_read = _fail_execute_csv_read
 
-    try:
-        with pytest.raises(ValueError, match="clean.read.columns.*clean.read.source"):
-            duckdb_read.read_raw_to_relation(
-                con,
-                [input_file],
-                {"delim": ";", "encoding": "utf-8", "header": True},
-                "strict",
-                logger,
-            )
-    finally:
-        duckdb_read._execute_csv_read = original_execute
-
-    con.close()
+        try:
+            with pytest.raises(ValueError, match="clean.read.columns.*clean.read.source"):
+                duckdb_read.read_raw_to_relation(
+                    con,
+                    [input_file],
+                    {"delim": ";", "encoding": "utf-8", "header": True},
+                    "strict",
+                    logger,
+                )
+        finally:
+            duckdb_read._execute_csv_read = original_execute
 
 
 @pytest.mark.policy
@@ -159,35 +153,34 @@ def test_read_raw_to_relation_handles_no_header_fixed_schema_without_extra_colum
     input_file = tmp_path / "fixed.csv"
     input_file.write_text("A,2024,1,123,45.6\nB,2024,2,456,78.9\n", encoding="utf-8")
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.fixed_schema")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.fixed_schema")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {
-            "delim": ",",
-            "encoding": "utf-8",
-            "header": False,
-            "auto_detect": False,
-            "columns": {
-                "col0": "VARCHAR",
-                "col1": "VARCHAR",
-                "col2": "VARCHAR",
-                "col3": "VARCHAR",
-                "col4": "VARCHAR",
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {
+                "delim": ",",
+                "encoding": "utf-8",
+                "header": False,
+                "auto_detect": False,
+                "columns": {
+                    "col0": "VARCHAR",
+                    "col1": "VARCHAR",
+                    "col2": "VARCHAR",
+                    "col3": "VARCHAR",
+                    "col4": "VARCHAR",
+                },
             },
-        },
-        "fallback",
-        logger,
-    )
+            "fallback",
+            logger,
+        )
 
-    rows = con.execute(
-        "SELECT col0, col1, col2, col3, col4 FROM raw_input ORDER BY col0"
-    ).fetchall()
-    assert info.source == "strict"
-    assert rows == [("A", "2024", "1", "123", "45.6"), ("B", "2024", "2", "456", "78.9")]
-    con.close()
+        rows = con.execute(
+            "SELECT col0, col1, col2, col3, col4 FROM raw_input ORDER BY col0"
+        ).fetchall()
+        assert info.source == "strict"
+        assert rows == [("A", "2024", "1", "123", "45.6"), ("B", "2024", "2", "456", "78.9")]
 
 
 @pytest.mark.policy
@@ -195,32 +188,31 @@ def test_read_raw_to_relation_normalizes_short_rows_to_fixed_schema(tmp_path: Pa
     input_file = tmp_path / "ragged.csv"
     input_file.write_text("A;B;C\n1;2\n3;4;5\n", encoding="utf-8")
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.normalize_rows")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.normalize_rows")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {
-            "delim": ";",
-            "encoding": "utf-8",
-            "header": False,
-            "columns": {
-                "col0": "VARCHAR",
-                "col1": "VARCHAR",
-                "col2": "VARCHAR",
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {
+                "delim": ";",
+                "encoding": "utf-8",
+                "header": False,
+                "columns": {
+                    "col0": "VARCHAR",
+                    "col1": "VARCHAR",
+                    "col2": "VARCHAR",
+                },
+                "normalize_rows_to_columns": True,
             },
-            "normalize_rows_to_columns": True,
-        },
-        "strict",
-        logger,
-    )
+            "strict",
+            logger,
+        )
 
-    rows = con.execute("SELECT col0, col1, col2 FROM raw_input ORDER BY col0").fetchall()
-    assert info.source == "strict"
-    assert info.params_used["normalize_rows_to_columns"] is True
-    assert rows == [("1", "2", ""), ("3", "4", "5"), ("A", "B", "C")]
-    con.close()
+        rows = con.execute("SELECT col0, col1, col2 FROM raw_input ORDER BY col0").fetchall()
+        assert info.source == "strict"
+        assert info.params_used["normalize_rows_to_columns"] is True
+        assert rows == [("1", "2", ""), ("3", "4", "5"), ("A", "B", "C")]
 
 
 @pytest.mark.policy
@@ -228,31 +220,30 @@ def test_read_raw_to_relation_normalize_rows_skips_header_when_configured(tmp_pa
     input_file = tmp_path / "ragged_header.csv"
     input_file.write_text("h0;h1;h2\n1;2\n", encoding="utf-8")
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.normalize_rows_header")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.normalize_rows_header")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {
-            "delim": ";",
-            "encoding": "utf-8",
-            "header": True,
-            "columns": {
-                "col0": "VARCHAR",
-                "col1": "VARCHAR",
-                "col2": "VARCHAR",
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {
+                "delim": ";",
+                "encoding": "utf-8",
+                "header": True,
+                "columns": {
+                    "col0": "VARCHAR",
+                    "col1": "VARCHAR",
+                    "col2": "VARCHAR",
+                },
+                "normalize_rows_to_columns": True,
             },
-            "normalize_rows_to_columns": True,
-        },
-        "strict",
-        logger,
-    )
+            "strict",
+            logger,
+        )
 
-    rows = con.execute("SELECT col0, col1, col2 FROM raw_input").fetchall()
-    assert info.params_used["header"] is True
-    assert rows == [("1", "2", "")]
-    con.close()
+        rows = con.execute("SELECT col0, col1, col2 FROM raw_input").fetchall()
+        assert info.params_used["header"] is True
+        assert rows == [("1", "2", "")]
 
 
 @pytest.mark.policy
@@ -265,24 +256,23 @@ def test_read_raw_to_relation_reads_xlsx_first_sheet(tmp_path: Path):
         ]
     ).to_excel(input_file, index=False)
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.xlsx")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.xlsx")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {"header": True},
-        "fallback",
-        logger,
-    )
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {"header": True},
+            "fallback",
+            logger,
+        )
 
-    rows = con.execute(
-        'SELECT "Anno", "Regione", "Domanda" FROM raw_input ORDER BY "Regione"'
-    ).fetchall()
-    assert info.source == "excel"
-    assert info.params_used["sheet_name"] == 0
-    assert rows == [(2022, "Lazio", 123.4), (2022, "Umbria", 56.7)]
-    con.close()
+        rows = con.execute(
+            'SELECT "Anno", "Regione", "Domanda" FROM raw_input ORDER BY "Regione"'
+        ).fetchall()
+        assert info.source == "excel"
+        assert info.params_used["sheet_name"] == 0
+        assert rows == [(2022, "Lazio", 123.4), (2022, "Umbria", 56.7)]
 
 
 @pytest.mark.policy
@@ -297,27 +287,26 @@ def test_read_raw_to_relation_reads_xlsx_with_explicit_sheet_and_columns(tmp_pat
             index=False,
         )
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.xlsx_sheet")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.xlsx_sheet")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {
-            "header": False,
-            "sheet_name": "Export",
-            "columns": {"col0": "VARCHAR", "col1": "VARCHAR"},
-        },
-        "fallback",
-        logger,
-    )
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {
+                "header": False,
+                "sheet_name": "Export",
+                "columns": {"col0": "VARCHAR", "col1": "VARCHAR"},
+            },
+            "fallback",
+            logger,
+        )
 
-    rows = con.execute("SELECT col0, col1 FROM raw_input ORDER BY col0").fetchall()
-    assert info.source == "excel"
-    assert info.params_used["sheet_name"] == "Export"
-    assert info.params_used["columns"] == {"col0": "VARCHAR", "col1": "VARCHAR"}
-    assert rows == [("A", 1), ("B", 2)]
-    con.close()
+        rows = con.execute("SELECT col0, col1 FROM raw_input ORDER BY col0").fetchall()
+        assert info.source == "excel"
+        assert info.params_used["sheet_name"] == "Export"
+        assert info.params_used["columns"] == {"col0": "VARCHAR", "col1": "VARCHAR"}
+        assert rows == [("A", 1), ("B", 2)]
 
 
 @pytest.mark.policy
@@ -339,24 +328,23 @@ def test_read_raw_to_relation_reads_xls_with_xlrd_engine(tmp_path: Path):
     ws.write(2, 2, 56.7)
     wb.save(input_file)
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.xls")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.xls")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {"header": True},
-        "fallback",
-        logger,
-    )
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {"header": True},
+            "fallback",
+            logger,
+        )
 
-    rows = con.execute(
-        'SELECT "Anno", "Regione", "Domanda" FROM raw_input ORDER BY "Regione"'
-    ).fetchall()
-    assert info.source == "excel"
-    assert info.params_used["sheet_name"] == 0
-    assert rows == [(2022, "Lazio", 123.4), (2022, "Umbria", 56.7)]
-    con.close()
+        rows = con.execute(
+            'SELECT "Anno", "Regione", "Domanda" FROM raw_input ORDER BY "Regione"'
+        ).fetchall()
+        assert info.source == "excel"
+        assert info.params_used["sheet_name"] == 0
+        assert rows == [(2022, "Lazio", 123.4), (2022, "Umbria", 56.7)]
 
 
 @pytest.mark.policy
@@ -488,22 +476,21 @@ def test_read_raw_to_relation_with_thousands_separator(tmp_path: Path):
     input_file = tmp_path / "thousands.csv"
     input_file.write_text("id;val\n1;1.234,56\n2;7.890,12\n", encoding="utf-8")
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.thousands")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.thousands")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {"delim": ";", "encoding": "utf-8", "header": True, "decimal": ",", "thousands": "."},
-        "strict",
-        logger,
-    )
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {"delim": ";", "encoding": "utf-8", "header": True, "decimal": ",", "thousands": "."},
+            "strict",
+            logger,
+        )
 
-    assert info.params_used["decimal"] == ","
-    assert info.params_used["thousands"] == "."
-    rows = con.execute("SELECT id, val FROM raw_input ORDER BY id").fetchall()
-    assert rows == [(1, 1234.56), (2, 7890.12)], f"got {rows}"
-    con.close()
+        assert info.params_used["decimal"] == ","
+        assert info.params_used["thousands"] == "."
+        rows = con.execute("SELECT id, val FROM raw_input ORDER BY id").fetchall()
+        assert rows == [(1, 1234.56), (2, 7890.12)], f"got {rows}"
 
 
 @pytest.mark.contract
@@ -522,8 +509,7 @@ def test_read_raw_to_relation_injects_column_from_multiple_sources(tmp_path: Pat
     ]
 
     logger = logging.getLogger("tests.clean.duckdb_read.inject")
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         info = duckdb_read.read_raw_to_relation(
             con, inputs, {"delim": ",", "encoding": "utf-8"}, "fallback", logger
         )
@@ -539,8 +525,6 @@ def test_read_raw_to_relation_injects_column_from_multiple_sources(tmp_path: Pat
         assert "inject_column" in info.params_used
         assert info.params_used["inject_column"]["cod_regione"]["reg_a.csv"] == "13"
         assert info.params_used["inject_column"]["cod_regione"]["reg_b.csv"] == "14"
-    finally:
-        con.close()
 
 
 @pytest.mark.contract
@@ -559,8 +543,7 @@ def test_read_raw_to_relation_inject_column_without_columns_cfg(tmp_path: Path):
     ]
 
     logger = logging.getLogger("tests.clean.duckdb_read.inject")
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         duckdb_read.read_raw_to_relation(
             con, inputs, {"delim": ",", "encoding": "utf-8"}, "fallback", logger
         )
@@ -570,8 +553,6 @@ def test_read_raw_to_relation_inject_column_without_columns_cfg(tmp_path: Path):
             ("A", 3, 4),
             ("B", 5, 6),
         ], f"Unexpected rows: {rows}"
-    finally:
-        con.close()
 
 
 @pytest.mark.policy
@@ -581,16 +562,13 @@ def test_read_raw_to_relation_plain_path_no_inject_still_works(tmp_path: Path):
     input_file.write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
 
     logger = logging.getLogger("tests.clean.duckdb_read.backward")
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         info = duckdb_read.read_raw_to_relation(
             con, [input_file], {"delim": ",", "encoding": "utf-8"}, "fallback", logger
         )
         rows = con.execute("SELECT * FROM raw_input ORDER BY a").fetchall()
         assert rows == [(1, 2), (3, 4)]
         assert "inject_column" not in info.params_used
-    finally:
-        con.close()
 
 
 @pytest.mark.policy
@@ -606,43 +584,41 @@ def test_dateformat_parses_non_iso_date_format(tmp_path: Path):
     input_file = tmp_path / "date_dot.csv"
     input_file.write_text("data;valore\n01.02.2023;100\n15.08.2024;200\n", encoding="utf-8")
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.dateformat_dot")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.dateformat_dot")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {"delim": ";", "encoding": "utf-8", "header": True, "dateformat": "%d.%m.%Y"},
-        "strict",
-        logger,
-    )
-
-    assert info.params_used["dateformat"] == "%d.%m.%Y"
-
-    rows = con.execute("SELECT data, valore FROM raw_input ORDER BY valore").fetchall()
-    assert len(rows) == 2
-
-    data_100 = rows[0][0]
-    data_200 = rows[1][0]
-
-    if isinstance(data_100, datetime.date):
-        assert data_100 == datetime.date(2023, 2, 1), (
-            f"01.02.2023 con dateformat=%d.%m.%Y dovrebbe essere 1-febbraio, ottenuto {data_100}"
-        )
-        assert data_200 == datetime.date(2024, 8, 15), (
-            f"15.08.2024 con dateformat=%d.%m.%Y dovrebbe essere 15-agosto, ottenuto {data_200}"
-        )
-    else:
-        data_100_str = str(data_100)
-        data_200_str = str(data_200)
-        assert "2023-02-01" in data_100_str or data_100_str == "2023-02-01", (
-            f"01.02.2023 con dateformat=%d.%m.%Y dovrebbe diventare 2023-02-01, ottenuto {data_100}"
-        )
-        assert "2024-08-15" in data_200_str or data_200_str == "2024-08-15", (
-            f"15.08.2024 con dateformat=%d.%m.%Y dovrebbe diventare 2024-08-15, ottenuto {data_200}"
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {"delim": ";", "encoding": "utf-8", "header": True, "dateformat": "%d.%m.%Y"},
+            "strict",
+            logger,
         )
 
-    con.close()
+        assert info.params_used["dateformat"] == "%d.%m.%Y"
+
+        rows = con.execute("SELECT data, valore FROM raw_input ORDER BY valore").fetchall()
+        assert len(rows) == 2
+
+        data_100 = rows[0][0]
+        data_200 = rows[1][0]
+
+        if isinstance(data_100, datetime.date):
+            assert data_100 == datetime.date(2023, 2, 1), (
+                f"01.02.2023 con dateformat=%d.%m.%Y dovrebbe essere 1-febbraio, ottenuto {data_100}"
+            )
+            assert data_200 == datetime.date(2024, 8, 15), (
+                f"15.08.2024 con dateformat=%d.%m.%Y dovrebbe essere 15-agosto, ottenuto {data_200}"
+            )
+        else:
+            data_100_str = str(data_100)
+            data_200_str = str(data_200)
+            assert "2023-02-01" in data_100_str or data_100_str == "2023-02-01", (
+                f"01.02.2023 con dateformat=%d.%m.%Y dovrebbe diventare 2023-02-01, ottenuto {data_100}"
+            )
+            assert "2024-08-15" in data_200_str or data_200_str == "2024-08-15", (
+                f"15.08.2024 con dateformat=%d.%m.%Y dovrebbe diventare 2024-08-15, ottenuto {data_200}"
+            )
 
 
 @pytest.mark.policy
@@ -657,35 +633,33 @@ def test_dateformat_disambiguates_dmy_vs_mdy(tmp_path: Path):
     input_file = tmp_path / "date_ambiguous.csv"
     input_file.write_text("data\n02/01/2023\n", encoding="utf-8")
 
-    con = duckdb.connect(":memory:")
-    logger = logging.getLogger("tests.clean.duckdb_read.dateformat_ambiguous")
+    with safe_connect() as con:
+        logger = logging.getLogger("tests.clean.duckdb_read.dateformat_ambiguous")
 
-    info = duckdb_read.read_raw_to_relation(
-        con,
-        [input_file],
-        {"delim": ",", "encoding": "utf-8", "header": True, "dateformat": "%d/%m/%Y"},
-        "strict",
-        logger,
-    )
-
-    assert info.params_used["dateformat"] == "%d/%m/%Y"
-
-    rows = con.execute("SELECT data FROM raw_input").fetchall()
-    assert len(rows) == 1
-
-    data = rows[0][0]
-    if isinstance(data, datetime.date):
-        assert data == datetime.date(2023, 1, 2), (
-            f"02/01/2023 con dateformat=%d/%m/%Y dovrebbe essere 2-gennaio, ottenuto {data}"
-        )
-    else:
-        data_str = str(data)
-        assert data_str in ("2023-01-02", "02/01/2023"), (
-            f"02/01/2023 con dateformat=%d/%m/%Y dovrebbe normalizzarsi "
-            f"a 2-gennaio, ottenuto {data}"
+        info = duckdb_read.read_raw_to_relation(
+            con,
+            [input_file],
+            {"delim": ",", "encoding": "utf-8", "header": True, "dateformat": "%d/%m/%Y"},
+            "strict",
+            logger,
         )
 
-    con.close()
+        assert info.params_used["dateformat"] == "%d/%m/%Y"
+
+        rows = con.execute("SELECT data FROM raw_input").fetchall()
+        assert len(rows) == 1
+
+        data = rows[0][0]
+        if isinstance(data, datetime.date):
+            assert data == datetime.date(2023, 1, 2), (
+                f"02/01/2023 con dateformat=%d/%m/%Y dovrebbe essere 2-gennaio, ottenuto {data}"
+            )
+        else:
+            data_str = str(data)
+            assert data_str in ("2023-01-02", "02/01/2023"), (
+                f"02/01/2023 con dateformat=%d/%m/%Y dovrebbe normalizzarsi "
+                f"a 2-gennaio, ottenuto {data}"
+            )
 
 
 @pytest.mark.pure_unit
@@ -762,8 +736,7 @@ def test_enrich_input_files():
 @pytest.mark.contract
 def test_parquet_inject_column_escapes_apostrophe(tmp_path: Path):
     """inject_column su parquet: valori con apostrofo non rompono la query."""
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         file_a = tmp_path / "reg_a.parquet"
         con.execute(
             "COPY (SELECT 1 AS id, 10 AS val UNION ALL SELECT 2, 20) TO ? (FORMAT PARQUET)",
@@ -774,8 +747,6 @@ def test_parquet_inject_column_escapes_apostrophe(tmp_path: Path):
             "COPY (SELECT 3 AS id, 30 AS val) TO ? (FORMAT PARQUET)",
             [str(file_b)],
         )
-    finally:
-        con.close()
 
     from toolkit.core.input_file import RawInputFile
 
@@ -787,8 +758,7 @@ def test_parquet_inject_column_escapes_apostrophe(tmp_path: Path):
     ]
 
     logger = logging.getLogger("tests.clean.duckdb_read.inject_parquet")
-    con = duckdb.connect(":memory:")
-    try:
+    with safe_connect() as con:
         info = duckdb_read.read_raw_to_relation(con, inputs, None, "fallback", logger)
         rows = con.execute("SELECT nome, regione, id FROM raw_input ORDER BY nome, id").fetchall()
         assert rows == [
@@ -797,5 +767,3 @@ def test_parquet_inject_column_escapes_apostrophe(tmp_path: Path):
             ("Valle d'Aosta", "Valle d'Aosta", 3),
         ], f"Unexpected rows: {rows}"
         assert "inject_column" in info.params_used
-    finally:
-        con.close()

--- a/tests/test_clean_input_selection.py
+++ b/tests/test_clean_input_selection.py
@@ -4,7 +4,6 @@ import logging
 import os
 from pathlib import Path
 
-import duckdb
 import pytest
 
 from tests.helpers import NoopLogger
@@ -280,11 +279,13 @@ def test_run_clean_dirty_csv_needs_auto_detect_false(tmp_path: Path):
     out = tmp_path / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
     assert out.exists()
 
-    con = duckdb.connect(":memory:")
-    assert (
-        int(con.execute(f"SELECT COUNT(*) FROM read_parquet('{out.as_posix()}')").fetchone()[0]) > 0
-    )
-    con.close()
+    from lab_connectors.duckdb import safe_connect
+
+    with safe_connect() as con:
+        assert (
+            int(con.execute(f"SELECT COUNT(*) FROM read_parquet('{out.as_posix()}')").fetchone()[0])
+            > 0
+        )
 
 
 def test_run_clean_dirty_csv_strict_mode_fails(tmp_path: Path):

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import duckdb
 import pytest
 
 from toolkit.mcp.toolkit_client import (
@@ -30,9 +29,10 @@ pytestmark = pytest.mark.contract
 
 def _write_parquet(path: Path, sql: str = "SELECT 1 AS id") -> None:
     """Scrive un parquet minimale."""
-    conn = duckdb.connect()
-    conn.execute(f"COPY ({sql}) TO '{path}' (FORMAT PARQUET)")
-    conn.close()
+    from lab_connectors.duckdb import safe_connect
+
+    with safe_connect() as conn:
+        conn.execute(f"COPY ({sql}) TO '{path}' (FORMAT PARQUET)")
 
 
 def _make_project_smoke(

--- a/tests/test_run_validation_gate.py
+++ b/tests/test_run_validation_gate.py
@@ -230,13 +230,12 @@ def _render_dummy_clean_dir(clean_dir: Path, rows: int = 5) -> None:
     # Clean parquet
     clean_dir.mkdir(parents=True, exist_ok=True)
     parquet = clean_dir / "test_dataset_2022_clean.parquet"
-    import duckdb
+    from lab_connectors.duckdb import safe_connect
 
-    con = duckdb.connect()
-    con.execute(
-        f"COPY (SELECT 42 as value, 'a' as label FROM range({rows})) TO '{parquet}' (FORMAT PARQUET)"
-    )
-    con.close()
+    with safe_connect() as con:
+        con.execute(
+            f"COPY (SELECT 42 as value, 'a' as label FROM range({rows})) TO '{parquet}' (FORMAT PARQUET)"
+        )
     # metadata.json con output_profile per validate_promotion
     (clean_dir / "metadata.json").write_text(
         json.dumps(
@@ -312,15 +311,14 @@ def test_mart_validation_skips_min_rows_in_sample_mode(tmp_path: Path) -> None:
     # Mart dir con parquet e metadata
     mart_dir = config_path.parent / "out" / "data" / "mart" / "test_dataset" / "2022"
     mart_dir.mkdir(parents=True, exist_ok=True)
-    import duckdb
+    from lab_connectors.duckdb import safe_connect
 
-    con = duckdb.connect()
-    con.execute(
-        "COPY (SELECT 42 as value, 'a' as label FROM range(5)) TO '"
-        + str(mart_dir / "mart_example.parquet")
-        + "' (FORMAT PARQUET)"
-    )
-    con.close()
+    with safe_connect() as con:
+        con.execute(
+            "COPY (SELECT 42 as value, 'a' as label FROM range(5)) TO '"
+            + str(mart_dir / "mart_example.parquet")
+            + "' (FORMAT PARQUET)"
+        )
     (mart_dir / "metadata.json").write_text(
         '{"dataset": "test_dataset", "year": 2022, "outputs": ["mart_example.parquet"]}',
         encoding="utf-8",

--- a/tests/test_smoke_e2e_flow.py
+++ b/tests/test_smoke_e2e_flow.py
@@ -12,7 +12,6 @@ import textwrap
 import zipfile
 from pathlib import Path
 
-import duckdb
 import pytest
 from typer.testing import CliRunner
 
@@ -36,13 +35,12 @@ def _invoke(args: list[str]) -> pytest.CapturedResult:
 
 def _assert_parquet_has_rows(path: Path) -> int:
     assert path.exists(), f"Parquet non trovato: {path}"
-    con = duckdb.connect(":memory:")
-    try:
+    from lab_connectors.duckdb import safe_connect
+
+    with safe_connect() as con:
         count = con.execute(f"SELECT COUNT(*) FROM read_parquet('{path}')").fetchone()[0]
         assert count > 0, f"Parquet vuoto: {path}"
         return int(count)
-    finally:
-        con.close()
 
 
 def _setup_project(tmp_path: Path, dataset: str = "smoke_test", year: int = 2024) -> Path:

--- a/tests/test_sql_dry_run.py
+++ b/tests/test_sql_dry_run.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import duckdb
+from lab_connectors.duckdb import safe_connect
 import pytest
 
 from toolkit.cli.sql_dry_run import (
@@ -123,38 +123,29 @@ class TestPlaceholderColumns:
 class TestCreatePlaceholderRawInput:
     @pytest.mark.policy
     def test_creates_view_with_columns(self):
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             _create_placeholder_raw_input_with_columns(con, ["x", "y"])
             result = con.execute("DESCRIBE raw_input").fetchall()
             names = [row[0] for row in result]
             assert names == ["x", "y"]
-        finally:
-            con.close()
 
     @pytest.mark.policy
     def test_creates_fallback_placeholder(self):
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             _create_placeholder_raw_input_with_columns(con, [])
             result = con.execute("DESCRIBE raw_input").fetchall()
             names = [row[0] for row in result]
             assert names == ["__dry_run_placeholder"]
-        finally:
-            con.close()
 
     @pytest.mark.policy
     def test_infers_columns_from_sql(self):
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             clean_cfg = {"read": {}}
             sql = 'select "val" from raw_input'
             _create_placeholder_raw_input_with_columns(con, _placeholder_columns(clean_cfg, sql))
             result = con.execute("DESCRIBE raw_input").fetchall()
             names = [row[0] for row in result]
             assert names == ["val"]
-        finally:
-            con.close()
 
 
 # --- Integration tests for _build_clean_preview ---
@@ -164,24 +155,18 @@ class TestBuildCleanPreview:
     @pytest.mark.policy
     def test_simple_sql_passes_immediately(self, tmp_path: Path):
         cfg = _make_cfg(tmp_path, clean_sql="select 1 as value")
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             _build_clean_preview(cfg, year=2022, con=con)
             # Table should exist after successful build
             con.execute("SELECT * FROM __dry_run_clean_preview")
-        finally:
-            con.close()
 
     @pytest.mark.policy
     def test_sql_with_unquoted_column_infers_incrementally(self, tmp_path: Path):
         """Clean SQL uses unquoted column name not in read.columns."""
         cfg = _make_cfg(tmp_path, clean_sql="select x from raw_input")
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             _build_clean_preview(cfg, year=2022, con=con)
             con.execute("SELECT * FROM __dry_run_clean_preview")
-        finally:
-            con.close()
 
     @pytest.mark.policy
     def test_sql_with_read_columns(self, tmp_path: Path):
@@ -190,12 +175,9 @@ class TestBuildCleanPreview:
             clean_sql='select "amount" from raw_input',
             clean_read={"columns": {"amount": "DOUBLE"}},
         )
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             _build_clean_preview(cfg, year=2022, con=con)
             con.execute("SELECT * FROM __dry_run_clean_preview")
-        finally:
-            con.close()
 
     @pytest.mark.policy
     def test_sql_with_multiple_columns_and_casts(self, tmp_path: Path):
@@ -209,34 +191,25 @@ class TestBuildCleanPreview:
             clean_sql=sql,
             clean_read={"columns": {"id": "VARCHAR", "name": "VARCHAR"}},
         )
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             _build_clean_preview(cfg, year=2022, con=con)
             con.execute("SELECT * FROM __dry_run_clean_preview")
-        finally:
-            con.close()
 
     @pytest.mark.policy
     def test_non_binder_error_raises_clean_dry_run_failure(self, tmp_path: Path):
         """Non-binder SQL errors should surface as CLEAN SQL dry-run failures."""
         cfg = _make_cfg(tmp_path, clean_sql="select from raw_input")
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             with pytest.raises(ValueError, match="CLEAN SQL dry-run failed"):
                 _build_clean_preview(cfg, year=2022, con=con)
-        finally:
-            con.close()
 
     @pytest.mark.policy
     def test_missing_column_error_includes_path(self, tmp_path: Path):
         """SQL syntax error should include file path in the message."""
         cfg = _make_cfg(tmp_path, clean_sql="select from raw_input")
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             with pytest.raises(ValueError) as exc_info:
                 _build_clean_preview(cfg, year=2022, con=con)
-        finally:
-            con.close()
         msg = str(exc_info.value)
         assert "CLEAN SQL dry-run failed" in msg
         assert "clean.sql" in msg
@@ -257,13 +230,10 @@ class TestValidateMartSql:
             clean_sql="select 1 as value",
             mart_tables=[{"name": "mart_out", "sql": "sql/mart/mart_out.sql"}],
         )
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             # Build clean preview first (required by mart validation)
             _build_clean_preview(cfg, year=2022, con=con)
             _validate_mart_sql(cfg, year=2022, con=con)
-        finally:
-            con.close()
 
     @pytest.mark.policy
     def test_mart_sql_with_missing_column_fails(self, tmp_path: Path):
@@ -278,13 +248,10 @@ class TestValidateMartSql:
             clean_sql="select 1 as value",
             mart_tables=[{"name": "mart_out", "sql": "sql/mart/mart_out.sql"}],
         )
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             _build_clean_preview(cfg, year=2022, con=con)
             with pytest.raises(ValueError, match="MART SQL dry-run failed"):
                 _validate_mart_sql(cfg, year=2022, con=con)
-        finally:
-            con.close()
 
     @pytest.mark.policy
     def test_mart_sql_with_template_placeholder_resolved(self, tmp_path: Path):
@@ -300,12 +267,9 @@ class TestValidateMartSql:
             clean_sql="select 1 as anno",
             mart_tables=[{"name": "mart_out", "sql": "sql/mart/mart_out.sql"}],
         )
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             _build_clean_preview(cfg, year=2022, con=con)
             _validate_mart_sql(cfg, year=2022, con=con)
-        finally:
-            con.close()
 
     @pytest.mark.policy
     def test_mart_sql_with_unresolved_placeholder_fails(self, tmp_path: Path):
@@ -321,13 +285,10 @@ class TestValidateMartSql:
             clean_sql="select 1 as value",
             mart_tables=[{"name": "mart_out", "sql": "sql/mart/mart_out.sql"}],
         )
-        con = duckdb.connect(":memory:")
-        try:
+        with safe_connect() as con:
             _build_clean_preview(cfg, year=2022, con=con)
             with pytest.raises(ValueError, match="unresolved"):
                 _validate_mart_sql(cfg, year=2022, con=con)
-        finally:
-            con.close()
 
 
 # --- Top-level validate_sql_dry_run ---


### PR DESCRIPTION
## Sintesi

Completamento #376: tutte le occorrenze di duckdb.connect() migrate a safe_connect() da lab_connectors.duckdb.

## Cosa cambia

- [x] Refactor test

## Dettaglio

| File | duckdb.connect | Note |
|---|---|---|
| test_clean_csv_columns.py | 6 -> 0 | |
| test_clean_duckdb_read.py | 19 -> 0 | |
| test_sql_dry_run.py | 13 -> 0 | try/finally rimossi (safe_connect gestisce cleanup) |
| test_run_validation_gate.py | 2 -> 0 | |
| test_smoke_e2e_flow.py | 1 -> 0 | |
| test_clean_input_selection.py | 1 -> 0 | |
| test_mcp_toolkit_client.py | 1 -> 0 | |
| **Totale** | **43 -> 0** | |

## Metriche

```
Righe:   -78 nette (332 ins, 410 del)
Test:    159 passati, 0 falliti
safe_connect: 43 occorrenze migrate in 7 file
```

## Checklist PR

- [x] Perimetro stretto: refactor test, zero logica sorgente cambiata
- [x] 159/159 test passano
- [x] ruff check passa

## Note

Chiude #376. Dopo questa PR:
- helpers.py (PR #377)
- 3 file (PR #379)
- 7 file (questa PR)
= 11 file, ~55 duckdb.connect -> safe_connect