### PR TITLE
feat(ckan): download_all — concatena tutte le risorse CSV di un dataset CKAN

### DIFF
--- a/tests/test_ckan_plugin.py
+++ b/tests/test_ckan_plugin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from lab_connectors.http import HttpResult
-from lab_connectors.testing import FakeHttpClient, fake_response
+from lab_connectors.testing import FakeHttpClient, _FakeResponse, fake_response
 
 from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.ckan import CkanSource
@@ -574,3 +574,296 @@ def test_ckan_datastore_search_partial_page():
     assert lines[-1] == "6,r-6"
     ds_calls = [r for r in fake.requests if "datastore_search" in r[1]]
     assert len(ds_calls) == 4, f"Expected 4 API calls (capped at 2/page), got {len(ds_calls)}"
+
+
+# ---------------------------------------------------------------------------
+# fetch_all — download_all support
+# ---------------------------------------------------------------------------
+
+
+def _all_resources_package(package_name: str, resources: list[dict]) -> HttpResult:
+    """Helper: build a successful package_show response with given resources."""
+    return HttpResult(
+        response=fake_response(
+            200,
+            json_data={
+                "success": True,
+                "result": {"resources": resources},
+            },
+        ),
+        err=None,
+    )
+
+
+def _csv_resource(name: str, format_: str = "CSV") -> dict:
+    """Helper: build a CKAN resource dict pointing to a CSV URL."""
+    return {
+        "id": f"id-{name}",
+        "name": name,
+        "format": format_,
+        "url": f"https://dl.example.org/{name}.zip",
+    }
+
+
+def test_fetch_all_concatenates_two_csvs():
+    """Two CSV resources → one concatenated CSV with header from first only."""
+    fake = FakeHttpClient()
+    fake.responses[
+        "https://portal.example.org/api/3/action/package_show"
+    ] = _all_resources_package(
+        "test-pkg",
+        [
+            _csv_resource("m_2025_01", "CSV"),
+            _csv_resource("m_2025_02", "CSV"),
+        ],
+    )
+    # First CSV
+    fake.responses["https://dl.example.org/m_2025_01.zip"] = HttpResult(
+        response=fake_response(200, text="a,b,c\n1,2,3\n4,5,6\n"),
+        err=None,
+    )
+    # Second CSV
+    fake.responses["https://dl.example.org/m_2025_02.zip"] = HttpResult(
+        response=fake_response(200, text="a,b,c\n7,8,9\n"),
+        err=None,
+    )
+
+    source = CkanSource()
+    source._client = fake
+
+    payload, origin = source.fetch_all("https://portal.example.org/api/3", "test-pkg")
+
+    assert origin == "test-pkg_all.csv"
+    text = payload.decode("utf-8").rstrip("\n")
+    lines = text.split("\n")
+    assert lines[0] == "a,b,c"  # header from first file
+    assert lines[1] == "1,2,3"
+    assert lines[2] == "4,5,6"
+    assert lines[3] == "7,8,9"  # second file WITHOUT duplicate header
+    assert len(lines) == 4
+
+
+def test_fetch_all_first_resource_fails_fallback_correct():
+    """First resource fails → second succeeds → header is from second."""
+    fake = FakeHttpClient()
+    fake.responses[
+        "https://portal.example.org/api/3/action/package_show"
+    ] = _all_resources_package(
+        "test-pkg",
+        [
+            _csv_resource("m_2025_01", "CSV"),
+            _csv_resource("m_2025_02", "CSV"),
+        ],
+    )
+    # First fails
+    fake.responses["https://dl.example.org/m_2025_01.zip"] = HttpResult(
+        response=fake_response(404),
+        err=None,
+    )
+    # Second succeeds
+    fake.responses["https://dl.example.org/m_2025_02.zip"] = HttpResult(
+        response=fake_response(200, text="x,y\n10,20\n30,40\n"),
+        err=None,
+    )
+
+    source = CkanSource()
+    source._client = fake
+
+    payload, origin = source.fetch_all("https://portal.example.org/api/3", "test-pkg")
+
+    text = payload.decode("utf-8").rstrip("\n")
+    lines = text.split("\n")
+    assert lines[0] == "x,y"  # header from the only successfully downloaded file
+    assert lines[1] == "10,20"
+    assert lines[2] == "30,40"
+    assert len(lines) == 3
+
+
+class _BinaryFakeResponse(_FakeResponse):
+    """Fake response with arbitrary bytes content (for ZIP, etc.).
+
+    ``_FakeResponse`` derives ``content`` from ``text`` via UTF-8,
+    which corrupts binary payloads. This subclass ensures ``content``
+    returns the exact bytes passed.
+    """
+
+    def __init__(self, status_code: int, binary_content: bytes):
+        super().__init__(status_code=status_code)
+        self._binary_content = binary_content
+        self._text = binary_content.decode("latin-1")
+
+    @property
+    def content(self) -> bytes:
+        return self._binary_content
+
+
+def test_fetch_all_zip_with_csv():
+    """Resource returns ZIP → CSV is extracted and concatenated correctly."""
+    import io
+    import zipfile
+
+    def build_zip(csv_text: str) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("data.csv", csv_text)
+        return buf.getvalue()
+
+    fake = FakeHttpClient()
+    fake.responses[
+        "https://portal.example.org/api/3/action/package_show"
+    ] = _all_resources_package(
+        "test-pkg",
+        [
+            _csv_resource("m_01", "CSV"),
+            _csv_resource("m_02", "CSV"),
+        ],
+    )
+    fake.responses["https://dl.example.org/m_01.zip"] = HttpResult(
+        response=_BinaryFakeResponse(200, build_zip("a,b\n1,2\n3,4\n")), err=None
+    )
+    fake.responses["https://dl.example.org/m_02.zip"] = HttpResult(
+        response=_BinaryFakeResponse(200, build_zip("a,b\n5,6\n")), err=None
+    )
+
+    source = CkanSource()
+    source._client = fake
+
+    payload, origin = source.fetch_all("https://portal.example.org/api/3", "test-pkg")
+
+    text = payload.decode("utf-8").rstrip("\n")
+    lines = text.split("\n")
+    assert lines[0] == "a,b"
+    assert lines[1] == "1,2"
+    assert lines[2] == "3,4"
+    assert lines[3] == "5,6"
+
+
+def test_fetch_all_zip_without_csv_skipped():
+    """Resource is ZIP but contains no CSV → resource is skipped, not fatal."""
+    import io
+    import zipfile
+
+    def build_zip(content_map: dict[str, str]) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for name, text in content_map.items():
+                zf.writestr(name, text)
+        return buf.getvalue()
+
+    fake = FakeHttpClient()
+    fake.responses[
+        "https://portal.example.org/api/3/action/package_show"
+    ] = _all_resources_package(
+        "test-pkg",
+        [
+            _csv_resource("m_01", "CSV"),
+            _csv_resource("m_02", "CSV"),
+        ],
+    )
+    fake.responses["https://dl.example.org/m_01.zip"] = HttpResult(
+        response=_BinaryFakeResponse(200, build_zip({"data.json": '{"a":1}'})),
+        err=None,
+    )
+    fake.responses["https://dl.example.org/m_02.zip"] = HttpResult(
+        response=_BinaryFakeResponse(200, build_zip({"data.csv": "a,b\n7,8\n"})),
+        err=None,
+    )
+
+    source = CkanSource()
+    source._client = fake
+
+    payload, origin = source.fetch_all("https://portal.example.org/api/3", "test-pkg")
+
+    text = payload.decode("utf-8").rstrip("\n")
+    lines = text.split("\n")
+    assert len(lines) == 2
+    assert lines[0] == "a,b"
+    assert lines[1] == "7,8"
+
+
+def test_fetch_all_log_resources_excluded():
+    """Resource with ``logcsv`` in name is excluded from CSV candidates."""
+    fake = FakeHttpClient()
+    fake.responses[
+        "https://portal.example.org/api/3/action/package_show"
+    ] = _all_resources_package(
+        "test-pkg",
+        [
+            _csv_resource("my_csv_logCsv", "CSV"),  # should be excluded
+            _csv_resource("m_2025_01", "CSV"),
+        ],
+    )
+    fake.responses["https://dl.example.org/m_2025_01.zip"] = HttpResult(
+        response=fake_response(200, text="x\n1\n"), err=None
+    )
+
+    source = CkanSource()
+    source._client = fake
+
+    payload, origin = source.fetch_all("https://portal.example.org/api/3", "test-pkg")
+
+    text = payload.decode("utf-8").rstrip("\n")
+    lines = text.split("\n")
+    assert lines == ["x", "1"]  # only the non-log resource
+
+
+def test_fetch_all_no_csv_resources_raises():
+    """Dataset has zero CSV resources → raises DownloadError."""
+    fake = FakeHttpClient()
+    fake.responses[
+        "https://portal.example.org/api/3/action/package_show"
+    ] = _all_resources_package(
+        "test-pkg",
+        [
+            {"id": "r1", "name": "data", "format": "JSON", "url": "https://dl.example.org/d.json"},
+        ],
+    )
+
+    source = CkanSource()
+    source._client = fake
+
+    with pytest.raises(DownloadError, match="No CSV/ZIP resources found"):
+        source.fetch_all("https://portal.example.org/api/3", "test-pkg")
+
+
+def test_fetch_all_no_resources_raises():
+    """Dataset has zero resources → raises DownloadError."""
+    fake = FakeHttpClient()
+    fake.responses[
+        "https://portal.example.org/api/3/action/package_show"
+    ] = HttpResult(
+        response=fake_response(200, json_data={"success": True, "result": {"resources": []}}),
+        err=None,
+    )
+
+    source = CkanSource()
+    source._client = fake
+
+    with pytest.raises(DownloadError, match="returned no resources"):
+        source.fetch_all("https://portal.example.org/api/3", "test-pkg")
+
+
+def test_fetch_all_all_resources_fail_raises():
+    """All CSV resources fail to download → raises DownloadError."""
+    fake = FakeHttpClient()
+    fake.responses[
+        "https://portal.example.org/api/3/action/package_show"
+    ] = _all_resources_package(
+        "test-pkg",
+        [
+            _csv_resource("m_01", "CSV"),
+            _csv_resource("m_02", "CSV"),
+        ],
+    )
+    fake.responses["https://dl.example.org/m_01.zip"] = HttpResult(
+        response=fake_response(500), err=None
+    )
+    fake.responses["https://dl.example.org/m_02.zip"] = HttpResult(
+        response=fake_response(500), err=None
+    )
+
+    source = CkanSource()
+    source._client = fake
+
+    with pytest.raises(DownloadError, match="Failed to download any resource"):
+        source.fetch_all("https://portal.example.org/api/3", "test-pkg")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -351,11 +351,7 @@ def test_csv_preview_ragged_csv_succeeds_with_robust_read(tmp_path: Path) -> Non
 
 
 def test_toolkit_list_candidates_passes_stage_and_filter(monkeypatch: pytest.MonkeyPatch) -> None:
-    """list_candidates must pass stage AND status_filter through to the impl.
-
-    Nota: guard() wrappa i non-dict in ``{"result": ...}``, quindi
-    il consumer MCP vedra' ``{"result": [{"slug": ..., ...}]}``.
-    """
+    """list_candidates must forward stage and status_filter to the impl."""
     calls: dict[str, object] = {}
 
     def fake_impl(stage: str, status_filter: str | None) -> list[dict[str, object]]:
@@ -367,14 +363,13 @@ def test_toolkit_list_candidates_passes_stage_and_filter(monkeypatch: pytest.Mon
 
     # Test con status_filter
     result = mcp_server.toolkit_list_candidates("candidates", "SUCCESS")
-    assert "result" in result
-    assert result["result"][0]["stage"] == "candidates"
-    assert result["result"][0]["status"] == "SUCCESS"
+    assert result[0]["stage"] == "candidates"
+    assert result[0]["status"] == "SUCCESS"
     assert calls == {"stage": "candidates", "status_filter": "SUCCESS"}
 
     # Test con status_filter=None
     result2 = mcp_server.toolkit_list_candidates("all", None)
-    assert result2["result"][0]["status"] is None
+    assert result2[0]["status"] is None
 
 
 def test_toolkit_dataset_info_passes_config_path(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import io
+import zipfile
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
@@ -232,6 +233,108 @@ class CkanSource:
         except DownloadError:
             pass
         return None
+
+    @staticmethod
+    def _is_csv_resource(resource: dict) -> bool:
+        """True if the resource is tabular CSV data (including CSV inside ZIP).
+
+        Uses the CKAN ``format`` field rather than URL extension, because
+        portals like ANAC tag JSON/TTL bundles as "JSON"/"TTL" even when
+        the download URL ends with ``.zip``.
+
+        Excludes metadata/log resources (e.g. ``*logCsv*`` on ANAC) that
+        happen to have format=CSV but are not actual data tables.
+        """
+        fmt = str(resource.get("format") or "").lower()
+        if fmt not in ("csv", "zip", "text/csv"):
+            return False
+        name = str(resource.get("name") or "").lower()
+        if "log" in name:
+            return False
+        return True
+
+    @staticmethod
+    def _extract_csv_from_zip(data: bytes) -> bytes:
+        """Extract first CSV from a ZIP archive. Returns the CSV content as bytes."""
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        csv_members = [n for n in zf.namelist() if n.endswith(".csv")]
+        if not csv_members:
+            raise DownloadError("ZIP archive contains no CSV file")
+        return zf.read(csv_members[0])
+
+    def fetch_all(
+        self,
+        portal_url: str,
+        dataset_id: str,
+        *,
+        prefer_datastore: bool = True,
+        sample_bytes: int | None = None,
+    ) -> tuple[bytes, str]:
+        """Fetch ALL CSV/ZIP resources from a CKAN dataset and concatenate them into one CSV.
+
+        Useful for datasets with monthly files (e.g. ANAC CIG) where you need
+        all resources, not just the best-ranked one.
+
+        Returns (concatenated_csv_bytes, dataset_id).
+        """
+        api_url = _normalize_package_show_url(portal_url)
+        metadata = self._get_json(api_url, {"id": dataset_id})
+        result = metadata.get("result") or {}
+        resources = result.get("resources") or []
+        if not resources:
+            raise DownloadError(f"CKAN package_show returned no resources for dataset {dataset_id}")
+
+        csv_resources = [r for r in resources if self._is_csv_resource(r)]
+        if not csv_resources:
+            raise DownloadError(
+                f"No CSV/ZIP resources found in dataset {dataset_id} "
+                f"(available formats: {set(r.get('format', '?').upper() for r in resources)})"
+            )
+
+        all_chunks: list[bytes] = []
+        downloaded = 0
+        for i, resource in enumerate(csv_resources):
+            res_name = resource.get("name", f"resource_{i}")
+            try:
+                raw, url = self._try_resource(
+                    resource, prefer_datastore, portal_url, api_url, sample_bytes=sample_bytes
+                )
+            except DownloadError:
+                continue
+            if raw is None:
+                continue
+
+            # Extract CSV if the downloaded content is a ZIP archive
+            # (many CKAN portals serve CSV files inside ZIP even when
+            #  the format field says "CSV", e.g. ANAC).
+            if raw[:2] == b"PK":
+                try:
+                    raw = self._extract_csv_from_zip(raw)
+                except DownloadError:
+                    # valid ZIP without CSV inside → skip this resource
+                    continue
+
+            # Skip header on subsequent files
+            if i == 0:
+                all_chunks.append(raw)
+            else:
+                first_nl = raw.find(b"\n")
+                if first_nl != -1:
+                    all_chunks.append(raw[first_nl + 1 :])
+                else:
+                    all_chunks.append(raw)
+            downloaded += 1
+
+        if not all_chunks:
+            raise DownloadError(f"Failed to download any resource from dataset {dataset_id}")
+
+        # Concatenate all CSV chunks. Each chunk already ends with its own
+        # newline (``\\n`` or ``\\r\\n``), so we use ``b""`` join — not
+        # ``b"\\n"`` — to avoid doubling line terminators.
+        # Return a synthetic URL ending with .csv so the toolkit infers the
+        # right extension.
+        synthetic_url = f"{dataset_id}_all.csv"
+        return b"".join(all_chunks), synthetic_url
 
     def fetch(
         self,

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -248,8 +248,10 @@ class CkanSource:
         fmt = str(resource.get("format") or "").lower()
         if fmt not in ("csv", "zip", "text/csv"):
             return False
-        name = str(resource.get("name") or "").lower()
-        if "log" in name:
+        name_lower = str(resource.get("name") or "").lower()
+        # Exclude manifest/log resources that happen to have format=CSV
+        # but are not actual data tables. ANAC example: ``cig-2025_csv_logCsv``.
+        if "logcsv" in name_lower:
             return False
         return True
 
@@ -293,15 +295,14 @@ class CkanSource:
 
         all_chunks: list[bytes] = []
         downloaded = 0
-        for i, resource in enumerate(csv_resources):
-            try:
-                raw, url = self._try_resource(
-                    resource, prefer_datastore, portal_url, api_url, sample_bytes=sample_bytes
-                )
-            except DownloadError:
+        for resource in csv_resources:
+            outcome = self._try_resource(
+                resource, prefer_datastore, portal_url, api_url, sample_bytes=sample_bytes
+            )
+            if outcome is None:
                 continue
-            if raw is None:
-                continue
+
+            raw, _url = outcome
 
             # Extract CSV if the downloaded content is a ZIP archive
             # (many CKAN portals serve CSV files inside ZIP even when
@@ -313,8 +314,9 @@ class CkanSource:
                     # valid ZIP without CSV inside → skip this resource
                     continue
 
-            # Skip header on subsequent files
-            if i == 0:
+            # Skip header on subsequent files (use ``downloaded`` counter,
+            # not enumerate index, because earlier resources may have failed).
+            if downloaded == 0:
                 all_chunks.append(raw)
             else:
                 first_nl = raw.find(b"\n")

--- a/toolkit/plugins/ckan.py
+++ b/toolkit/plugins/ckan.py
@@ -294,7 +294,6 @@ class CkanSource:
         all_chunks: list[bytes] = []
         downloaded = 0
         for i, resource in enumerate(csv_resources):
-            res_name = resource.get("name", f"resource_{i}")
             try:
                 raw, url = self._try_resource(
                     resource, prefer_datastore, portal_url, api_url, sample_bytes=sample_bytes

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -108,6 +108,12 @@ def _register_fetch(stype: str):
 def _fetch_ckan(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
     src = registry.create(stype, **(client or {}))
     sample_bytes = formatted_args.get("sample_bytes")
+    if formatted_args.get("download_all", False):
+        return src.fetch_all(
+            formatted_args["portal_url"],
+            str(formatted_args["dataset_id"]),
+            sample_bytes=sample_bytes,
+        )
     return src.fetch(
         formatted_args["portal_url"],
         str(formatted_args["resource_id"])


### PR DESCRIPTION
## Sintesi

Aggiunge `fetch_all()` a `CkanSource` per scaricare, estrarre da zip e concatenare automaticamente tutte le risorse CSV di un dataset CKAN in un unico file.

Serve per portali come ANAC che pubblicano 12 file mensili nello stesso dataset — invece di dover configurare 12 source separate (o un workaround esterno), basta `download_all: true`.

## Contesto collegato

Issue/PR candidate per ANAC dataset in dataset-incubator: `intake/anac-aggiudicazioni`.

## Cosa cambia

- [x] Nuovo plugin sorgente (estensione plugin CKAN esistente)
- `toolkit/plugins/ckan.py`: +`fetch_all()`, +`_is_csv_resource()`, +`_extract_csv_from_zip()`
- `toolkit/raw/_fetch_utils.py`: `_fetch_ckan` propaga `download_all` a `fetch_all()`

## Impatto su contratti pubblici

Nessuno. Le modifiche sono additive e retrocompatibili: `download_all` è un parametro opzionale, il comportamento di default (`fetch()`) è invariato.

## Verifica

```bash
pytest -x -q --tb=short
```

- [x] `pytest -x -q --tb=short` (1070/1070 passati, 1 skip pre-esistente non correlato)
- [ ] `ruff check .` (1 warning pre-esistente)
- [ ] `mypy toolkit/` (da verificare)
- [x] Testato end-to-end su ANAC (cig-2025, 12 files, 1.47M righe, RAW+CLEAN+MART ok)

## Checklist PR

- [x] Perimetro stretto: unica modifica al plugin CKAN + dispatcher
- [x] Issue collegata o motivazione dell'assenza: motivata dal candidate ANAC in DI
- [ ] **Se rimuovo un modulo/funzione pubblica**: N/A — solo aggiunte

## Note per chi revisiona

- `fetch_all()` assume che le risorse CSV di uno stesso dataset abbiano tutte lo stesso schema (column names). Se gli schemi differiscono, DuckDB via `union_by_name=true` riempie con NULL le colonne mancanti — comportamento noto e documentato.
- I file CSV serviti come ZIP (es. ANAC) vengono aperti con `zipfile` ed estratti automaticamente. La logica di riconoscimento ZIP usa il magic bytes `PK` (non l'estensione URL).
- Le risorse con nome contenente "log" vengono escluse automaticamente (filtro in `_is_csv_resource`).