### PR TITLE
feat: placeholder {support.X.clean} per compose SQL

### DIFF
--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -9,6 +9,7 @@ from toolkit.core.support import (
     flatten_support_template_ctx,
     resolve_support_payloads,
     _support_expected_mart_outputs,
+    _support_expected_clean_output,
 )
 
 pytestmark = pytest.mark.policy
@@ -36,6 +37,7 @@ def _make_support_dataset(
     years: list[int] | None = None,
     mart_tables: list[str] | None = None,
     create_mart_outputs: bool = False,
+    create_clean_output: bool = False,
 ) -> Path:
     """Create a minimal support dataset project with config, mart dir, and optional parquet outputs."""
     years = years or [2024]
@@ -65,6 +67,12 @@ def _make_support_dataset(
             mart_dir.mkdir(parents=True, exist_ok=True)
             for table in mart_tables:
                 (mart_dir / f"{table}.parquet").write_bytes(b"")
+
+    if create_clean_output:
+        for year in years:
+            clean_dir = ds_dir / "data" / "clean" / name / str(year)
+            clean_dir.mkdir(parents=True, exist_ok=True)
+            (clean_dir / f"{name}_{year}_clean.parquet").write_bytes(b"")
 
     return config_path
 
@@ -127,6 +135,33 @@ class TestSupportExpectedMartOutputs:
         assert outputs == []
 
 
+# --- _support_expected_clean_output ---
+
+
+class TestSupportExpectedCleanOutput:
+    def test_single_year(self, tmp_path: Path):
+        ds_dir = tmp_path / "ds"
+        ds_dir.mkdir()
+        cfg = _fake_cfg(
+            root=ds_dir,
+            dataset="ds",
+            years=[2024],
+            mart={"tables": [{"name": "t", "sql": "sql/t.sql"}]},
+        )
+        path = _support_expected_clean_output(cfg, 2024)
+        assert path.name == "ds_2024_clean.parquet"
+        assert "clean" in str(path)
+
+    def test_path_contains_dataset_and_year(self, tmp_path: Path):
+        ds_dir = tmp_path / "myds"
+        ds_dir.mkdir()
+        cfg = _fake_cfg(root=ds_dir, dataset="myds", years=[2023], mart={"tables": []})
+        path = _support_expected_clean_output(cfg, 2023)
+        assert "myds" in str(path)
+        assert "2023" in str(path)
+        assert path.suffix == ".parquet"
+
+
 # --- resolve_support_payloads: happy paths ---
 
 
@@ -187,6 +222,33 @@ class TestResolveSupportPayloadsHappy:
         assert len(yr["outputs"]) == 1
         assert yr["existing_outputs"] == []
         assert yr["all_outputs_exist"] is False
+
+    def test_support_payload_includes_clean(self, tmp_path: Path):
+        """resolve_support_payloads deve includere il campo clean."""
+        config_path = _make_support_dataset(
+            tmp_path, create_mart_outputs=True, create_clean_output=True
+        )
+        entries = [_make_support_entry(config_path)]
+        result = resolve_support_payloads(entries, require_exists=True)
+
+        assert len(result) == 1
+        payload = result[0]
+        assert "clean" in payload
+        assert payload["clean"] is not None
+        assert payload["clean"].endswith("support_ds_2024_clean.parquet")
+
+    def test_support_payload_clean_is_none_when_missing(self, tmp_path: Path):
+        """Senza clean output, clean deve essere None."""
+        config_path = _make_support_dataset(
+            tmp_path, create_mart_outputs=True, create_clean_output=False
+        )
+        entries = [_make_support_entry(config_path)]
+        result = resolve_support_payloads(entries, require_exists=True)
+
+        assert len(result) == 1
+        payload = result[0]
+        assert "clean" in payload
+        assert payload["clean"] is None
 
     def test_none_entries_returns_empty(self):
         result = resolve_support_payloads(None, require_exists=True)
@@ -261,11 +323,13 @@ class TestFlattenSupportTemplateCtx:
                 "name": "my_support",
                 "outputs": ["/path/table_a.parquet"],
                 "mart": "/path/table_a.parquet",
+                "clean": "/path/clean.parquet",
             }
         ]
         ctx = flatten_support_template_ctx(payloads)
         assert ctx["support.my_support.outputs"] == ["/path/table_a.parquet"]
         assert ctx["support.my_support.mart"] == "/path/table_a.parquet"
+        assert ctx["support.my_support.clean"] == "/path/clean.parquet"
 
     def test_multiple_payloads(self):
         payloads = [
@@ -273,18 +337,22 @@ class TestFlattenSupportTemplateCtx:
                 "name": "alpha",
                 "outputs": ["/a/table.parquet"],
                 "mart": "/a/table.parquet",
+                "clean": "/a/clean.parquet",
             },
             {
                 "name": "beta",
                 "outputs": ["/b/t1.parquet", "/b/t2.parquet"],
                 "mart": "/b/t1.parquet",
+                "clean": None,
             },
         ]
         ctx = flatten_support_template_ctx(payloads)
         assert ctx["support.alpha.outputs"] == ["/a/table.parquet"]
         assert ctx["support.alpha.mart"] == "/a/table.parquet"
+        assert ctx["support.alpha.clean"] == "/a/clean.parquet"
         assert ctx["support.beta.outputs"] == ["/b/t1.parquet", "/b/t2.parquet"]
         assert ctx["support.beta.mart"] == "/b/t1.parquet"
+        assert ctx["support.beta.clean"] is None
 
     def test_empty_payloads(self):
         ctx = flatten_support_template_ctx([])
@@ -296,11 +364,13 @@ class TestFlattenSupportTemplateCtx:
                 "name": "empty_support",
                 "outputs": [],
                 "mart": None,
+                "clean": None,
             }
         ]
         ctx = flatten_support_template_ctx(payloads)
         assert ctx["support.empty_support.outputs"] == []
         assert ctx["support.empty_support.mart"] is None
+        assert ctx["support.empty_support.clean"] is None
 
 
 # --- Integration: resolve + flatten ---
@@ -308,15 +378,19 @@ class TestFlattenSupportTemplateCtx:
 
 class TestResolveAndFlatten:
     def test_end_to_end(self, tmp_path: Path):
-        config_path = _make_support_dataset(tmp_path, create_mart_outputs=True)
+        config_path = _make_support_dataset(
+            tmp_path, create_mart_outputs=True, create_clean_output=True
+        )
         entries = [_make_support_entry(config_path)]
         resolved = resolve_support_payloads(entries, require_exists=True)
         ctx = flatten_support_template_ctx(resolved)
 
         assert "support.my_support.outputs" in ctx
         assert "support.my_support.mart" in ctx
+        assert "support.my_support.clean" in ctx
         assert len(ctx["support.my_support.outputs"]) == 1
         assert ctx["support.my_support.mart"].endswith("table_a.parquet")
+        assert ctx["support.my_support.clean"].endswith("support_ds_2024_clean.parquet")
 
     def test_no_flatten_on_empty_resolve(self):
         resolved = resolve_support_payloads(None, require_exists=True)

--- a/toolkit/core/support.py
+++ b/toolkit/core/support.py
@@ -13,6 +13,11 @@ def _support_expected_mart_outputs(cfg, year: int) -> list[Path]:
     return [mart_dir / f"{name}.parquet" for name in table_names]
 
 
+def _support_expected_clean_output(cfg, year: int) -> Path:
+    clean_dir = layer_year_dir(cfg.root, "clean", cfg.dataset, year)
+    return clean_dir / f"{cfg.dataset}_{year}_clean.parquet"
+
+
 def resolve_support_payloads(
     support_entries: list[dict[str, Any]] | None,
     *,
@@ -37,6 +42,7 @@ def resolve_support_payloads(
             expected_paths = _support_expected_mart_outputs(support_cfg, year)
             output_paths = [str(path) for path in expected_paths]
             existing_paths = [str(path) for path in expected_paths if path.exists()]
+            clean_path_expected = _support_expected_clean_output(support_cfg, year)
             all_outputs_exist = len(output_paths) > 0 and len(existing_paths) == len(output_paths)
             if require_exists and not output_paths:
                 raise ValueError(
@@ -61,9 +67,13 @@ def resolve_support_payloads(
                     "outputs": output_paths,
                     "existing_outputs": existing_paths,
                     "all_outputs_exist": all_outputs_exist,
+                    "clean": str(clean_path_expected) if clean_path_expected.exists() else None,
                 }
             )
             all_outputs.extend(existing_paths if require_exists else output_paths)
+
+        # Primo clean disponibile tra gli anni risolti (per template)
+        first_clean = next((yp["clean"] for yp in year_payloads if yp["clean"] is not None), None)
 
         resolved.append(
             {
@@ -74,6 +84,7 @@ def resolve_support_payloads(
                 "years_resolved": year_payloads,
                 "outputs": all_outputs,
                 "mart": all_outputs[0] if all_outputs else None,
+                "clean": first_clean,
             }
         )
     return resolved
@@ -85,4 +96,5 @@ def flatten_support_template_ctx(payloads: list[dict[str, Any]]) -> dict[str, An
         name = payload["name"]
         ctx[f"support.{name}.outputs"] = payload["outputs"]
         ctx[f"support.{name}.mart"] = payload["mart"]
+        ctx[f"support.{name}.clean"] = payload["clean"]
     return ctx


### PR DESCRIPTION
## Sintesi

Nuovo placeholder `{support.X.clean}` nei template SQL dei compose, che risolve al path del clean parquet di un dataset di supporto.

## Contesto

I compose (`compose/`) possono referenziare altri dataset tramite `support:`. Finora esistevano solo `{support.X.mart}` (primo mart) e `{support.X.outputs}` (tutti i mart). Manca il clean, che invece serve per:
- Fare JOIN nel **clean** di un compose (e pushato su GCS)
- Non dover creare mart pass-through solo per avere il path del clean

## Cosa cambia

- [ ] altro

**`toolkit/core/support.py`:**
- Nuova `_support_expected_clean_output()` — calcola `{root}/data/clean/{dataset}/{year}/{dataset}_{year}_clean.parquet`
- `resolve_support_payloads()` ora include `"clean"` nel payload (`None` se il file non esiste)
- `flatten_support_template_ctx()` espone `{support.X.clean}` nel context

**`tests/test_support.py`:**
- Test per `_support_expected_clean_output`
- Test per `clean` in `resolve_support_payloads` (presente e None se mancante)
- Test per `clean` in `flatten_support_template_ctx`
- Test end-to-end resolve+flatten con clean

## Verifica

```bash
pytest tests/test_support.py -v        # 25 passati
pytest tests/test_*.py                  # nessuna regressione (49 test passati)
```

## Esempio d'uso in un compose

```yaml
# compose/comuni-master/dataset.yml
support:
  - name: istat
    config: "../../support_datasets/istat-elenco-comuni/dataset.yml"
    years: [2026]
  - name: ipa
    config: "../../support_datasets/ipa-istat-mapping/dataset.yml"
    years: [2026]

clean:
  sql: "sql/clean.sql"
```

```sql
-- sql/clean.sql
SELECT i.*, ip.codice_ipa, ip.codice_fiscale
FROM read_parquet('{support.istat.clean}') i
LEFT JOIN read_parquet('{support.ipa.clean}') ip
    ON i.codice_istat = ip.codice_istat
```

## Note

- `{support.X.clean}` è opzionale: se il clean parquet non esiste, vale `None`
- Il nome del file clean segue la convenzione standard `{dataset}_{year}_clean.parquet`
- I compose esistenti (solo mart) continuano a funzionare senza modifiche
