### PR TITLE
fix(mcp): toolkit_list_candidates e toolkit_ckan_package_show — bug MCP

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -363,13 +363,16 @@ def test_toolkit_list_candidates_passes_stage_and_filter(monkeypatch: pytest.Mon
 
     # Test con status_filter
     result = mcp_server.toolkit_list_candidates("candidates", "SUCCESS")
-    assert result[0]["stage"] == "candidates"
-    assert result[0]["status"] == "SUCCESS"
+    assert isinstance(result, dict), f"expected dict, got {type(result)}"
+    assert "candidates" in result, f"expected 'candidates' key, got {list(result.keys())}"
+    assert result["candidates"][0]["stage"] == "candidates"
+    assert result["candidates"][0]["status"] == "SUCCESS"
+    assert result["count"] == 1
     assert calls == {"stage": "candidates", "status_filter": "SUCCESS"}
 
     # Test con status_filter=None
     result2 = mcp_server.toolkit_list_candidates("all", None)
-    assert result2[0]["status"] is None
+    assert result2["candidates"][0]["status"] is None
 
 
 def test_toolkit_dataset_info_passes_config_path(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -122,14 +122,21 @@ def toolkit_review_readiness(config_path: str, year: int = 0) -> dict[str, Any]:
 
 
 @mcp.tool(
-    description="Elenca tutti i dataset disponibili in dataset-incubator (candidates e support_datasets). Opzionalmente filtra per last_run_status.",
+    description="Elenca tutti i dataset disponibili in dataset-incubator (candidates e support_datasets). "
+    "Opzionalmente filtra per last_run_status. "
+    "Restituisce un dict con chiave 'candidates' contenente la lista.",
     structured_output=True,
 )
 def toolkit_list_candidates(
     stage: str = "all",
     status_filter: str | None = None,
 ) -> dict[str, Any]:
-    return guard_timed(list_candidates_impl, "toolkit_list_candidates", stage, status_filter)
+    result = guard_timed(list_candidates_impl, "toolkit_list_candidates", stage, status_filter)
+    # Se guard_timed restituisce un errore (dict con chiave "error"), passalo attraverso
+    if isinstance(result, dict) and "error" in result:
+        return result
+    # Altrimenti wrappa la lista in un dict per structured_output=True
+    return {"candidates": result, "count": len(result) if isinstance(result, list) else 0}
 
 
 @mcp.tool(

--- a/toolkit/scout/http.py
+++ b/toolkit/scout/http.py
@@ -519,6 +519,50 @@ def extract_ckan_dataset_id(url: str, html_text: str = "") -> str | None:
     return None
 
 
+def _ckan_portal_base(url: str) -> str:
+    """Estrae il base path del portale CKAN da un URL qualsiasi.
+
+    Normalizza URL nella forma:
+      - ``https://portale.it/opendata/dataset/slug`` → ``https://portale.it/opendata``
+      - ``https://portale.it/opendata/api/3/action/package_show?id=...`` → ``https://portale.it/opendata``
+      - ``https://portale.it/dataset/slug`` → ``https://portale.it``
+      - ``https://dati.gov.it/opendata`` → ``https://dati.gov.it/opendata``
+
+    Returns:
+        URL base del portale (schema + netloc + path), senza trailing slash.
+    """
+    parsed = urlparse(url)
+    root = f"{parsed.scheme}://{parsed.netloc}"
+    path = parsed.path.rstrip("/")
+
+    # Toglie /dataset/{slug} o /dataset/...  (es. /opendata/dataset/foo → /opendata)
+    ds_match = re.search(r"^(.*?)/dataset/", path)
+    if ds_match:
+        path = ds_match.group(1).rstrip("/")
+        return f"{root}{path}" if path else root
+
+    # Toglie /api/3/action/package_show (es. /opendata/api/3/action/package_show → /opendata)
+    api_match = re.search(r"^(.*?)/api/3/action/package_show/?$", path)
+    if api_match:
+        path = api_match.group(1).rstrip("/")
+        return f"{root}{path}" if path else root
+
+    # Toglie /api/3/action (es. /opendata/api/3/action → /opendata)
+    api_match = re.search(r"^(.*?)/api/3/action/?$", path)
+    if api_match:
+        path = api_match.group(1).rstrip("/")
+        return f"{root}{path}" if path else root
+
+    # Toglie /api/3 o /api
+    api_match = re.search(r"^(.*?)/api(/[123])?/?$", path)
+    if api_match:
+        path = api_match.group(1).rstrip("/")
+        return f"{root}{path}" if path else root
+
+    # Nessun pattern CKAN riconosciuto — usa il path così com'è
+    return f"{root}{path}" if path else root
+
+
 def fetch_ckan_package(
     portal_url: str,
     dataset_id: str,
@@ -528,19 +572,28 @@ def fetch_ckan_package(
 ) -> dict[str, Any] | None:
     """Fetch CKAN package_show via API.
 
+    Normalizza automaticamente il base path del portale CKAN,
+    quindi funziona con qualsiasi URL: homepage, pagina dataset, endpoint API.
+
     Args:
         client: HttpClient opzionale. Se fornito, lo usa invece di crearne uno.
     """
     parsed = urlparse(portal_url)
     root = f"{parsed.scheme}://{parsed.netloc}"
-    api_bases: list[str] = []
-    if parsed.path.startswith("/api/3/action"):
-        api_bases.append(f"{root}/api/3/action/package_show")
-    elif parsed.path.startswith("/dataset/"):
-        api_bases.append(f"{root}/api/3/action/package_show")
-    else:
-        api_bases.append(f"{root}/api/3/action/package_show")
-        api_bases.append(f"{root}/package_show")
+
+    # Normalizza il base path del portale CKAN
+    portal_base = _ckan_portal_base(portal_url)
+
+    api_bases: list[str] = [
+        f"{portal_base}/api/3/action/package_show",
+    ]
+
+    # Fallback: API alla radice (per portali che ignorano il path prefix)
+    api_base_root = f"{root}/api/3/action/package_show"
+    if api_base_root != api_bases[0]:
+        api_bases.append(api_base_root)
+    # Ultimo fallback: package_show alla radice
+    api_bases.append(f"{root}/package_show")
 
     client = client or _mk_client(timeout=timeout)
     for api_base in api_bases:


### PR DESCRIPTION
## Sintesi

Due bug nei tool MCP del toolkit che impedivano il funzionamento di `toolkit_list_candidates` e `toolkit_ckan_package_show` via protocollo MCP.

## Contesto collegato

Nessuna issue aperta — trovati durante sessione di verifica sistematica dei tool MCP del Lab.

## Cosa cambia

- [x] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Dettaglio fix

### Bug 1: `toolkit_list_candidates` — errore di validazione Pydantic

**Problema**: `list_candidates_impl()` restituisce `list[dict]`, ma il wrapper MCP dichiarava `-> dict[str, Any]` con `structured_output=True`. Il framework MCP rifiutava la lista con errore `Input should be a valid dictionary`.

**Fix**: wrapping del risultato in `{"candidates": list, "count": N}` in `toolkit/mcp/server.py`.

### Bug 2: `toolkit_ckan_package_show` — URL API CKAN mal costruito

**Problema**: `fetch_ckan_package()` in `toolkit/scout/http.py` costruiva l'URL dell'API CKAN come `{root}/api/3/action/package_show` perdendo il path base del portale (es. `/opendata`). Per `https://dati.gov.it/opendata` chiamava `https://dati.gov.it/api/...` invece di `https://dati.gov.it/opendata/api/...`.

**Fix**: ora preserva `parsed.path` nella costruzione: `{root}{path}/api/3/action/package_show`, con fallback alla radice per portali senza path prefix.

## Impatto su contratti pubblici

- [x] CLI o MCP tool (nuovo comando, cambio parametro)
  - `toolkit_list_candidates`: **cambio contratto** — l'output ora è un dict con chiave `"candidates"` invece di una lista nuda. I consumer MCP devono accedere a `result.candidates` invece di `result[0]`.

## Verifica

```bash
pytest toolkit/tests/test_mcp_server.py -v --tb=short  # 26/26 passano
pytest toolkit/tests/test_ckan_plugin.py -v --tb=short  # 24/24 passano
```

Verifica manuale:
- `fetch_ckan_package('https://dati.gov.it/opendata', 'percentuale-raccolta-differenziata1')` → ora restituisce il dataset (prima era `None`)
- `toolkit_list_candidates('all')` → via Python diretto restituisce `{"candidates": [...], "count": 49}`

- [x] `pytest -m contract` passa
- [x] `ruff check .` passa (pre-commit hook)
- [x] Modificato test con marker appropriato (`contract`)

## Checklist PR

- [x] Perimetro stretto: una PR = fix mirati su due tool MCP
- [ ] Se nuovo plugin: test + docs inclusi
- [ ] Issue collegata o motivazione dell'assenza
- [x] **Se rimuovo un modulo/funzione pubblica**: N/A

## Note per chi revisiona

- Il server MCP va riavviato per caricare i fix (il server in esecuzione usa ancora il vecchio codice)
- `toolkit/raw/_fetch_utils.py` è risultato modificato nel worktree ma NON è incluso in questa PR (modifica non nostra)
- Entrambi i fix sono backward-compatible a livello di implementazione interna; solo l'output di `list_candidates` cambia formato
