### PR TITLE
feat(layer): backend condiviso CLI/MCP — toolkit layer unifica schema, profile, preview, SQL

### DIFF
--- a/tests/test_cli_layer.py
+++ b/tests/test_cli_layer.py
@@ -1,0 +1,117 @@
+"""Test contratto per la CLI ``toolkit layer``.
+
+Usa monkeypatch per isolare la CLI dal backend reale: testiamo solo
+il layer CLI (flag, errori, formato output), non l'esecuzione backend.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from toolkit.cli.app import app
+
+runner = CliRunner()
+
+CONFIG_PATH = "dataset-incubator/candidates/irpef-comunale/dataset.yml"
+
+
+def _strip_ansi(text: str) -> str:
+    """Rimuove sequenze ANSI escape (colori, bold, bordi) dall'output."""
+    return re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", text)
+
+
+@pytest.fixture
+def mock_layer_query(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Mocka layer_query per evitare dipendenza da parquet reali."""
+
+    def _fake(config_path: str, **kwargs: Any) -> dict[str, Any]:
+        mode = kwargs.get("mode", "schema")
+        if mode == "schema":
+            return {
+                "dataset": "test",
+                "layer": kwargs.get("layer", "clean"),
+                "year": 2024,
+                "columns": [{"name": "col1", "type": "INTEGER"}],
+            }
+        if mode == "preview":
+            return {
+                "dataset": "test",
+                "layer": kwargs.get("layer", "clean"),
+                "year": 2024,
+                "columns": [{"name": "col1", "type": "INTEGER"}],
+                "column_count": 1,
+                "row_count": 10,
+                "preview": [{"col1": 1}],
+            }
+        if mode == "profile":
+            return {
+                "dataset": "test",
+                "year": 2024,
+                "read_hints": {"encoding": "utf-8", "delimiter": ",", "skip": 0},
+                "columns": {"raw": ["col1"], "count": 1},
+            }
+        if mode == "sql":
+            return {
+                "dataset": "test",
+                "layer": kwargs.get("layer", "clean"),
+                "year": 2024,
+                "columns": [{"name": "cnt", "type": "BIGINT"}],
+                "row_count": 1,
+                "sql": kwargs.get("sql"),
+                "preview": [{"cnt": 42}],
+            }
+        return {"dataset": "test"}
+
+    monkeypatch.setattr("toolkit.cli.cmd_layer.layer_query", _fake)
+    return {}
+
+
+class TestCliLayer:
+    """Test contratto per toolkit layer CLI."""
+
+    @pytest.mark.contract
+    def test_layer_help(self):
+        """--help mostra i flag principali."""
+        result = runner.invoke(app, ["layer", "--help"])
+        assert result.exit_code == 0
+        output = _strip_ansi(result.stdout)
+        assert "--mode" in output
+        assert "--layer" in output
+        assert "--config" in output
+
+    @pytest.mark.contract
+    def test_layer_sql_without_sql_errors(self):
+        """mode=sql senza --sql deve dare errore."""
+        result = runner.invoke(app, ["layer", "-c", CONFIG_PATH, "-l", "clean", "-m", "sql"])
+        assert result.exit_code != 0
+        output = (result.stdout + result.stderr).lower()
+        assert "sql" in output or "error" in output
+
+    @pytest.mark.contract
+    def test_layer_profile_on_clean_errors(self):
+        """mode=profile su layer clean deve dare errore."""
+        result = runner.invoke(app, ["layer", "-c", CONFIG_PATH, "-l", "clean", "-m", "profile"])
+        assert result.exit_code != 0
+        output = (result.stdout + result.stderr).lower()
+        assert "raw" in output or "error" in output
+
+    @pytest.mark.contract
+    @pytest.mark.parametrize("mode", ["schema", "preview", "profile", "sql"])
+    def test_layer_mode_json_output(self, mode, mock_layer_query):
+        """Ogni mode produce JSON parsabile."""
+        args = ["layer", "-c", CONFIG_PATH, "-m", mode, "--json"]
+        if mode == "profile":
+            args.extend(["-l", "raw"])
+        if mode == "sql":
+            args.extend(["--sql", "SELECT 1"])
+        result = runner.invoke(app, args)
+        assert result.exit_code == 0, f"{mode}: exit {result.exit_code}: {result.stdout[:200]}"
+        data = json.loads(result.stdout)
+        assert isinstance(data, dict)
+        if mode in ("schema", "preview", "sql"):
+            assert "dataset" in data

--- a/toolkit/cli/app.py
+++ b/toolkit/cli/app.py
@@ -12,6 +12,7 @@ from toolkit.cli.cmd_batch import register as register_batch
 from toolkit.cli.cmd_review_readiness import register as register_review_readiness
 from toolkit.cli.cmd_query import register as register_query
 from toolkit.cli.cmd_scout import register as register_scout
+from toolkit.cli.cmd_layer import register as register_layer
 from toolkit.version import __version__
 
 app = typer.Typer(no_args_is_help=True, add_completion=False)
@@ -38,6 +39,7 @@ register_batch(app)
 register_review_readiness(app)
 register_query(app)
 register_scout(app)
+register_layer(app)
 
 
 def main():

--- a/toolkit/cli/cmd_layer.py
+++ b/toolkit/cli/cmd_layer.py
@@ -1,0 +1,151 @@
+"""CLI command: toolkit layer
+
+Query unificata su RAW/CLEAN/MART: schema, preview, profile, SQL.
+
+Sostituisce ``inspect schema``, ``inspect profile`` e integra ``query``.
+CLI e MCP condividono lo stesso backend (``toolkit.cli.layer_ops``).
+
+Usage:
+    toolkit layer -c dataset.yml                      # schema clean (default)
+    toolkit layer -c dataset.yml -l raw -m profile    # encoding/delimiter
+    toolkit layer -c dataset.yml -l clean -m preview   # prime 10 righe
+    toolkit layer -c dataset.yml -l clean -m sql --sql "SELECT count(*) FROM data"
+    toolkit layer -c dataset.yml -l mart -m preview    # prime righe mart
+"""
+
+from __future__ import annotations
+
+import json
+
+import typer
+
+from toolkit.cli.layer_ops import layer_query
+
+
+def layer_cmd(
+    config: str = typer.Option(..., "--config", "-c", help="Path a dataset.yml o slug del dataset"),
+    layer: str = typer.Option("clean", "--layer", "-l", help="Layer: raw, clean, mart"),
+    mode: str = typer.Option(
+        "schema",
+        "--mode",
+        "-m",
+        help="Modalità: schema (default), preview, profile, sql",
+    ),
+    year: int = typer.Option(0, "--year", "-y", help="Anno (default: ultimo configurato)"),
+    sql: str | None = typer.Option(None, "--sql", help="SQL query (solo mode=sql)"),
+    limit: int = typer.Option(20, "--limit", help="Max righe (solo mode=preview/sql)"),
+    mart_index: int = typer.Option(0, "--mart-index", help="Indice tabella mart (default 0)"),
+    json_output: bool = typer.Option(False, "--json", help="Output JSON"),
+) -> None:
+    """Query unificata su RAW/CLEAN/MART: schema, preview, profile o SQL.
+
+    Sostituisce i comandi ``inspect schema``, ``inspect profile`` e integra
+    ``query`` in un unico comando con flag ``--mode``.
+
+    Esempi:
+        toolkit layer -c dataset.yml -m schema           # colonne + tipi (default)
+        toolkit layer -c dataset.yml -l raw -m profile   # encoding/delimiter
+        toolkit layer -c dataset.yml -l clean -m preview  # prime righe
+        toolkit layer -c dataset.yml -l clean -m sql --sql "SELECT count(*) FROM data"
+    """
+    try:
+        result = layer_query(
+            config,
+            layer=layer,
+            mode=mode,
+            year=year or None,
+            limit=limit,
+            sql=sql,
+            mart_index=mart_index,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        if json_output:
+            typer.echo(json.dumps({"error": str(exc)}, indent=2))
+        else:
+            typer.echo(f"Errore: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    if json_output:
+        typer.echo(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+        return
+
+    # Output human-readable
+    typer.echo(f"Dataset: {result.get('dataset', '?')}")
+    typer.echo(f"Layer:   {result.get('layer', layer)}")
+    typer.echo(f"Anno:    {result.get('year', year or '?')}")
+
+    if mode == "schema":
+        columns = result.get("columns", [])
+        entries = result.get("entries", [])
+        if entries:
+            typer.echo(f"Entry count: {result.get('entry_count', len(entries))}")
+            for entry in entries:
+                typer.echo(f"  Anno {entry.get('year', '?')}:")
+                for col in entry.get("columns", []):
+                    typer.echo(f"    {col.get('name', '?'):35s} {col.get('type', '?')}")
+        else:
+            typer.echo(f"Colonne: {len(columns)}")
+            for col in columns:
+                typer.echo(f"  {col.get('name', '?'):35s} {col.get('type', '?')}")
+
+    elif mode == "profile":
+        hints = result.get("read_hints", {})
+        typer.echo(f"Encoding: {hints.get('encoding')}")
+        typer.echo(f"Delim:    {repr(hints.get('delimiter'))}")
+        typer.echo(f"Decimal:  {hints.get('decimal')}")
+        typer.echo(f"Skip:     {hints.get('skip')}")
+        cols = result.get("columns", {})
+        raw_cols = cols.get("raw", [])
+        typer.echo(f"Colonne:  {cols.get('count', len(raw_cols))}")
+        for c in raw_cols[:12]:
+            typer.echo(f"  {c}")
+        if len(raw_cols) > 12:
+            typer.echo(f"  ... ({len(raw_cols)} totali)")
+
+    elif mode == "preview":
+        columns = result.get("columns", [])
+        preview = result.get("preview", [])
+        row_count = result.get("row_count")
+        if row_count is not None:
+            typer.echo(f"Righe: {row_count}")
+        typer.echo(f"Colonne: {len(columns)}")
+        for col in columns:
+            typer.echo(f"  {col.get('name', '?'):35s} {col.get('type', '?')}")
+        typer.echo("")
+        if preview:
+            col_names = [c["name"] for c in columns]
+            widths = {n: len(n) for n in col_names}
+            for row in preview:
+                for n in col_names:
+                    v = row.get(n)
+                    widths[n] = max(widths[n], len(str(v) if v is not None else ""))
+            header = "  ".join(f"{n:{widths[n]}s}" for n in col_names)
+            typer.echo(header)
+            typer.echo("-" * len(header))
+            for row in preview:
+                vals = []
+                for n in col_names:
+                    v = row.get(n)
+                    vals.append(f"{str(v) if v is not None else 'NULL':{widths[n]}s}")
+                typer.echo("  ".join(vals))
+
+    elif mode == "sql":
+        columns = result.get("columns", [])
+        preview = result.get("preview", [])
+        row_count = result.get("row_count")
+        sql_used = result.get("sql", sql)
+        if sql_used:
+            typer.echo(f"SQL: {sql_used[:120]}")
+        if row_count is not None:
+            typer.echo(f"Righe: {row_count}")
+        typer.echo(f"Colonne: {len(columns)}")
+        for col in columns:
+            typer.echo(f"  {col.get('name', '?'):35s} {col.get('type', '?')}")
+        typer.echo("")
+        if preview:
+            for row in preview:
+                typer.echo(str(row))
+
+
+def register(app: typer.Typer) -> None:
+    app.command("layer")(layer_cmd)

--- a/toolkit/cli/inspect/profile_ops.py
+++ b/toolkit/cli/inspect/profile_ops.py
@@ -149,6 +149,9 @@ def profile(
     """
     Profilo diagnostico del RAW: encoding, delimitatore, colonne.
 
+    .. deprecated::
+        Usa ``toolkit layer -c CONFIG -l raw -m profile`` invece.
+
     Con --config: analizza il raw layer del dataset e scrive raw_profile.json.
     Con --csv-path: sniffa direttamente un file CSV e stampa schema + preview.
 

--- a/toolkit/cli/inspect/schema_ops.py
+++ b/toolkit/cli/inspect/schema_ops.py
@@ -102,6 +102,9 @@ def schema(
 ) -> None:
     """Mostra lo schema (colonne + tipi) di raw, clean o mart.
 
+    .. deprecated::
+        Usa ``toolkit layer -c CONFIG -l {layer} -m schema`` invece.
+
     Il path config puo' essere passato come argomento posizionale
     (es. toolkit inspect schema path/to/dataset.yml)
     o con l'opzione --config / -c.

--- a/toolkit/cli/layer_ops.py
+++ b/toolkit/cli/layer_ops.py
@@ -1,0 +1,436 @@
+"""Backend condiviso per query su layer RAW/CLEAN/MART.
+
+Usato da:
+- CLI ``toolkit layer`` (via ``cmd_layer.py``)
+- MCP ``toolkit_layer`` (via ``aggregate_ops.py``)
+
+Le funzioni qui NON gestiscono errori MCP (ToolkitClientError) — quelle
+vanno aggiunte nei wrapper MCP. Le funzioni qui sollevano eccezioni
+Python standard (ValueError, FileNotFoundError).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from toolkit.core.config import load_config
+from toolkit.core.duckdb_shape import parquet_preview
+from toolkit.core.io import read_yaml
+from toolkit.core.paths import RAW_PROFILE, RAW_SUGGESTED_READ
+from toolkit.cli.inspect._helpers import _payload_for_year
+
+# ---------------------------------------------------------------------------
+# Schemi validi
+# ---------------------------------------------------------------------------
+
+VALID_LAYERS: set[str] = {"raw", "clean", "mart"}
+VALID_MODES: set[str] = {"schema", "preview", "profile", "sql"}
+
+# ---------------------------------------------------------------------------
+# Helper path
+# ---------------------------------------------------------------------------
+
+
+def _resolve_clean_path(cfg: Any, year: int) -> Path:
+    """Risolve il path al parquet clean."""
+    paths = _payload_for_year(cfg, year)
+    parquet_str = paths["paths"]["clean"].get("output")
+    if not parquet_str:
+        raise FileNotFoundError("Nessun output clean configurato")
+    return Path(parquet_str)
+
+
+def _resolve_mart_path(cfg: Any, year: int, mart_index: int = 0) -> Path:
+    """Risolve il path al parquet mart (indice)."""
+    paths = _payload_for_year(cfg, year)
+    outputs = paths["paths"]["mart"].get("outputs") or []
+    if not outputs:
+        raise FileNotFoundError("Nessun output mart configurato")
+    if mart_index < 0 or mart_index >= len(outputs):
+        raise ValueError(f"Indice mart {mart_index} non valido: {len(outputs)} output disponibili")
+    return Path(outputs[mart_index])
+
+
+def _resolve_raw_dir(cfg: Any, year: int) -> tuple[Path, dict[str, Any]]:
+    """Risolve la directory raw e i path info."""
+    paths = _payload_for_year(cfg, year)
+    raw_dir = Path(paths["paths"]["raw"]["dir"])
+    return raw_dir, paths
+
+
+# ---------------------------------------------------------------------------
+# Schema mode
+# ---------------------------------------------------------------------------
+
+
+def show_schema(config_path: str, layer: str = "clean", year: int | None = None) -> dict[str, Any]:
+    """Mostra lo schema (colonne + tipi) di raw, clean o mart.
+
+    Args:
+        config_path: path al dataset.yml.
+        layer: ``"raw"``, ``"clean"`` (default), o ``"mart"``.
+        year: anno. Se ``None`` per dataset multi-year usa l'ultimo.
+
+    Returns:
+        Dict con schema del layer richiesto.
+    """
+    # Riutilizza l'implementazione già condivisa in CLI
+    from toolkit.cli.inspect.schema_ops import show_schema as _cli_show_schema
+
+    return _cli_show_schema(config_path, layer=layer, year=year)
+
+
+# ---------------------------------------------------------------------------
+# Profile mode (raw only)
+# ---------------------------------------------------------------------------
+
+
+def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
+    """Legge il profilo raw (raw_profile.json o suggested_read.yml).
+
+    Args:
+        config_path: path al dataset.yml.
+        year: anno del dataset. Per multi-year, se omesso usa l'ultimo.
+
+    Returns:
+        Dict con encoding, delim, colonne, mapping_suggestions.
+
+    Raises:
+        FileNotFoundError: se profilo non trovato.
+    """
+    from toolkit.cli.inspect._helpers import _payload_for_year
+
+    cfg = load_config(config_path)
+    if year is None:
+        year = max(cfg.years) if cfg.years else 0
+    paths = _payload_for_year(cfg, year)
+    raw_dir = Path(paths["paths"]["raw"]["dir"])
+    profile_path = raw_dir / "_profile"
+    raw_profile_json = profile_path / RAW_PROFILE
+    suggested_read_yml = profile_path / RAW_SUGGESTED_READ
+
+    if raw_profile_json.exists():
+        profile = json.loads(raw_profile_json.read_text(encoding="utf-8"))
+    elif suggested_read_yml.exists():
+        raw_yaml = read_yaml(suggested_read_yml)
+        clean_section = raw_yaml.get("clean", {}) if isinstance(raw_yaml, dict) else {}
+        read_section = clean_section.get("read", {}) if isinstance(clean_section, dict) else {}
+        profile = {
+            "dataset": None,
+            "year": None,
+            "encoding_suggested": read_section.get("encoding"),
+            "delim_suggested": read_section.get("delim"),
+            "decimal_suggested": read_section.get("decimal"),
+            "skip_suggested": read_section.get("skip"),
+            "robust_read_suggested": None,
+            "columns_raw": None,
+            "columns_norm": None,
+            "missingness_top": [],
+            "mapping_suggestions": {},
+            "warnings": [],
+        }
+    else:
+        raise FileNotFoundError(
+            f"Profilo raw non trovato in {profile_path}. "
+            "Nessun file raw_profile.json ne suggested_read.yml."
+        )
+
+    return {
+        "dataset": profile.get("dataset"),
+        "year": profile.get("year"),
+        "config_path": str(config_path),
+        "profile_path": str(profile_path),
+        "file_used": profile.get("file_used"),
+        "read_hints": {
+            "encoding": profile.get("encoding_suggested"),
+            "delimiter": profile.get("delim_suggested"),
+            "decimal": profile.get("decimal_suggested"),
+            "skip": profile.get("skip_suggested"),
+            "robust": profile.get("robust_read_suggested"),
+        },
+        "header_line": profile.get("header_line"),
+        "columns": {
+            "raw": profile.get("columns_raw") or [],
+            "normalized": profile.get("columns_norm") or [],
+            "count": len(profile.get("columns_raw") or []),
+        },
+        "missingness_top": profile.get("missingness_top", []),
+        "mapping_suggestions": profile.get("mapping_suggestions", {}),
+        "warnings": profile.get("warnings", []),
+        "profile_exists": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Preview mode
+# ---------------------------------------------------------------------------
+
+
+def _read_parquet_preview(parquet_path: Path, limit: int = 10) -> dict[str, Any]:
+    """Legge schema + prime N righe da un parquet.
+
+    Returns:
+        Dict con columns (lista di {name, type}), row_count, preview.
+    """
+    if not parquet_path.exists():
+        raise FileNotFoundError(f"Parquet non trovato: {parquet_path}")
+    if parquet_path.suffix not in (".parquet",):
+        raise ValueError(f"Formato non supportato: {parquet_path.suffix}. Solo .parquet.")
+
+    import duckdb
+
+    with duckdb.connect() as conn:
+        describe = conn.execute(f"DESCRIBE SELECT * FROM '{parquet_path}'").fetchall()
+        columns = [{"name": str(row[0]), "type": str(row[1])} for row in describe]
+
+        row_count_row = conn.execute(f"SELECT COUNT(*) FROM '{parquet_path}'").fetchone()
+        row_count = int(row_count_row[0]) if row_count_row else None
+
+        preview_rows = conn.execute(f"SELECT * FROM '{parquet_path}' LIMIT {int(limit)}").fetchall()
+        col_names = [c["name"] for c in columns]
+        preview = [dict(zip(col_names, row)) for row in preview_rows]
+
+    return {
+        "columns": columns,
+        "column_count": len(columns),
+        "row_count": row_count,
+        "preview": preview,
+        "truncated": row_count is not None and row_count > limit,
+    }
+
+
+def clean_preview(
+    config_path: str,
+    layer: str = "clean",
+    mart_index: int = 0,
+    year: int | None = None,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Preview dati da un parquet clean o mart.
+
+    Args:
+        config_path: path a dataset.yml.
+        layer: ``"clean"`` (default) o ``"mart"``.
+        mart_index: indice output mart (default 0).
+        year: anno. Se None per multi-year usa l'ultimo.
+        limit: righe massime (default 10).
+
+    Returns:
+        Schema + preview rows del parquet.
+    """
+    from toolkit.cli.inspect._helpers import _payload_for_year
+
+    cfg = load_config(config_path)
+    if year is None:
+        year = max(cfg.years) if cfg.years else 0
+    paths = _payload_for_year(cfg, year)
+
+    if layer == "clean":
+        parquet_path = _resolve_clean_path(cfg, year)
+    elif layer == "mart":
+        parquet_path = _resolve_mart_path(cfg, year, mart_index)
+    else:
+        raise ValueError(f"layer deve essere 'clean' o 'mart', non '{layer}'")
+
+    result = _read_parquet_preview(parquet_path, limit=limit)
+    result.update(
+        {
+            "dataset": paths.get("dataset"),
+            "year": paths.get("year"),
+            "layer": layer,
+            "config_path": str(config_path),
+            "mart_name": parquet_path.stem if layer == "mart" else None,
+        }
+    )
+    return result
+
+
+def raw_preview(
+    config_path: str,
+    year: int | None = None,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Preview del raw file primario di un dataset (CSV/TSV o XLSX).
+
+    Args:
+        config_path: path a dataset.yml.
+        year: anno. Se None per multi-year usa l'ultimo.
+        limit: righe massime (default 20).
+
+    Returns:
+        Dict con preview del raw file.
+    """
+
+    cfg = load_config(config_path)
+    if year is None:
+        year = max(cfg.years) if cfg.years else 0
+    raw_dir, paths = _resolve_raw_dir(cfg, year)
+
+    primary_file = (paths.get("raw_hints") or {}).get("primary_output_file")
+    if not primary_file:
+        raise FileNotFoundError("Nessun primary_output_file nel manifest raw")
+    raw_file = raw_dir / primary_file
+    if not raw_file.exists():
+        raise FileNotFoundError(f"Raw file non trovato: {raw_file}")
+
+    suffix = raw_file.suffix.lower()
+    if suffix in (".csv", ".tsv", ".txt"):
+        # Riutilizza csv_preview da CLI (già condiviso)
+        from toolkit.cli.inspect.profile_ops import csv_preview as _csv_preview
+
+        return _csv_preview(str(raw_file), limit=limit)
+    elif suffix in (".xlsx", ".xls"):
+        return {
+            "path": str(raw_file),
+            "format": "xlsx",
+            "note": "File binario XLSX. Usa mode='schema' per lo schema colonne.",
+            "dataset": paths.get("dataset"),
+            "year": paths.get("year"),
+        }
+    else:
+        return {
+            "path": str(raw_file),
+            "format": suffix.lstrip("."),
+            "note": f"Formato '{suffix}' non supportato per preview raw.",
+            "dataset": paths.get("dataset"),
+            "year": paths.get("year"),
+        }
+
+
+# ---------------------------------------------------------------------------
+# SQL mode
+# ---------------------------------------------------------------------------
+
+
+def layer_sql(
+    config_path: str,
+    layer: str,
+    year: int | None = None,
+    limit: int = 20,
+    sql: str | None = None,
+    mart_index: int = 0,
+) -> dict[str, Any]:
+    """Esegue SQL arbitrario sul parquet risolto da config_path + layer.
+
+    Args:
+        config_path: path a dataset.yml.
+        layer: ``"clean"`` o ``"mart"``.
+        year: anno. Se None per multi-year usa l'ultimo.
+        limit: righe massime (default 20).
+        sql: query SQL. Il parquet è disponibile come tabella ``data``.
+        mart_index: indice tabella mart (default 0).
+
+    Returns:
+        Risultato della query SQL.
+    """
+    if not sql:
+        raise ValueError("mode=sql richiede il parametro sql")
+
+    cfg = load_config(config_path)
+    if year is None:
+        year = max(cfg.years) if cfg.years else 0
+
+    if layer == "clean":
+        parquet_path = _resolve_clean_path(cfg, year)
+    elif layer == "mart":
+        parquet_path = _resolve_mart_path(cfg, year, mart_index)
+    else:
+        raise ValueError(f"layer deve essere 'clean' o 'mart', non '{layer}'")
+
+    if not parquet_path.exists():
+        raise FileNotFoundError(
+            f"Parquet {layer} non trovato: {parquet_path}. "
+            f"Esegui 'toolkit run all -c {config_path}' per generarlo."
+        )
+
+    result = parquet_preview(parquet_path, limit=limit, sql=sql)
+    result.update(
+        {
+            "dataset": cfg.dataset,
+            "year": year,
+            "layer": layer,
+            "config_path": str(config_path),
+            "mode": "sql",
+        }
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Router principale
+# ---------------------------------------------------------------------------
+
+
+def layer_query(
+    config_path: str,
+    layer: str = "clean",
+    mode: str = "schema",
+    year: int | None = None,
+    limit: int = 20,
+    sql: str | None = None,
+    mart_index: int = 0,
+) -> dict[str, Any]:
+    """Query unificata su un layer (RAW/CLEAN/MART).
+
+    Args:
+        config_path: Path a dataset.yml.
+        layer: ``"raw"``, ``"clean"`` (default) o ``"mart"``.
+        mode: Cosa restituire:
+            - ``"schema"`` (default): colonne + tipi.
+            - ``"preview"``: schema + prime N righe.
+            - ``"profile"``: profilo diagnostico RAW (solo layer=raw).
+            - ``"sql"``: SQL arbitrario sul parquet (solo clean/mart).
+        year: Anno del dataset. Se omesso usa l'ultimo anno configurato.
+        limit: Max righe in preview (default 20, solo mode=preview/sql).
+        sql: Query SQL per mode=sql. Il parquet e' disponibile come tabella ``data``.
+        mart_index: Indice della tabella mart (default 0, solo layer=mart).
+
+    Returns:
+        Dict con schema, preview o profilo a seconda del mode.
+
+    Raises:
+        ValueError: se layer/mode non validi, o file non trovato.
+    """
+    safe_layer = layer.strip().lower()
+    safe_mode = mode.strip().lower() if isinstance(mode, str) else mode
+
+    if safe_layer not in VALID_LAYERS:
+        raise ValueError(
+            f"layer deve essere uno tra: {', '.join(sorted(VALID_LAYERS))} (ricevuto: {layer})"
+        )
+    if safe_mode not in VALID_MODES:
+        raise ValueError(
+            f"mode deve essere uno tra: {', '.join(sorted(VALID_MODES))} (ricevuto: {mode})"
+        )
+    if safe_mode == "profile" and safe_layer != "raw":
+        raise ValueError(f"mode=profile e' valido solo per layer=raw (ricevuto: layer={layer})")
+    if safe_mode == "sql" and safe_layer == "raw":
+        raise ValueError("mode=sql non e' supportato per layer=raw")
+    if safe_mode == "sql" and not sql:
+        raise ValueError("mode=sql richiede il parametro sql (es. sql='SELECT * FROM data')")
+
+    # Schema mode
+    if safe_mode == "schema":
+        return show_schema(config_path, layer=safe_layer, year=year)
+
+    # Profile mode (raw only)
+    if safe_mode == "profile":
+        return raw_profile(config_path, year=year)
+
+    # Preview mode
+    if safe_mode == "preview":
+        if safe_layer == "raw":
+            return raw_preview(config_path, year=year, limit=limit)
+        return clean_preview(
+            config_path, layer=safe_layer, mart_index=mart_index, year=year, limit=limit
+        )
+
+    # SQL mode
+    if safe_mode == "sql":
+        return layer_sql(
+            config_path, layer=safe_layer, year=year, limit=limit, sql=sql, mart_index=mart_index
+        )
+
+    raise RuntimeError(f"mode non gestito: {safe_mode}")

--- a/toolkit/mcp/aggregate_ops.py
+++ b/toolkit/mcp/aggregate_ops.py
@@ -1,7 +1,7 @@
 """Consolidated MCP tools for layer query and dataset status.
 
-Questi tool aggregati delegano alle implementazioni esistenti (schema_ops,
-scout_ops, cli_adapter, discovery) — zero logica nuova, solo routing.
+Questi tool aggregati delegano al backend condiviso ``toolkit.cli.layer_ops``.
+CLI e MCP condividono la stessa implementazione.
 
 Backward compat: i tool granulari esistenti (toolkit_inspect_schema,
 toolkit_clean_preview, toolkit_summary, ecc.) restano registrati.
@@ -9,38 +9,29 @@ toolkit_clean_preview, toolkit_summary, ecc.) restano registrati.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
 from lab_connectors.mcp.errors import ErrorCode
 
+from toolkit.cli.layer_ops import layer_query as _layer_query_core
 from toolkit.mcp.errors import ToolkitClientError
-from toolkit.mcp.path_safety import _load_cfg
 
 
 def _get_impls():
     """Lazy import per evitare dipendenze circolari con server.py."""
     from toolkit.mcp.cli_adapter import inspect_paths as _inspect_paths
     from toolkit.mcp.schema_ops import (
-        clean_preview as _clean_preview,
         dataset_info as _dataset_info,
-        raw_preview as _raw_preview,
-        raw_profile as _raw_profile,
         review_readiness as _review_readiness,
         run_summary as _run_summary,
-        show_schema as _show_schema,
         summary as _summary,
     )
 
     return (
         _inspect_paths,
-        _clean_preview,
         _dataset_info,
-        _raw_preview,
-        _raw_profile,
         _review_readiness,
         _run_summary,
-        _show_schema,
         _summary,
     )
 
@@ -48,9 +39,6 @@ def _get_impls():
 # ---------------------------------------------------------------------------
 # toolkit_layer — layer query unificato
 # ---------------------------------------------------------------------------
-
-VALID_LAYERS = {"raw", "clean", "mart"}
-VALID_MODES = {"schema", "preview", "profile", "sql"}
 
 
 def layer_query(
@@ -63,6 +51,9 @@ def layer_query(
     mart_index: int = 0,
 ) -> dict[str, Any]:
     """Query unificata su un layer (RAW/CLEAN/MART).
+
+    Delega al backend condiviso ``toolkit.cli.layer_ops`` — stessa
+    implementazione della CLI ``toolkit layer``.
 
     Args:
         config_path: Path a dataset.yml o slug del dataset.
@@ -84,131 +75,28 @@ def layer_query(
     Raises:
         ToolkitClientError: se layer/mode non validi, o file non trovato.
     """
-    safe_layer = layer.strip().lower()
-    safe_mode = mode.strip().lower()
+    from pathlib import Path
+    from toolkit.mcp.path_safety import _safe_path
 
-    if safe_layer not in VALID_LAYERS:
-        raise ToolkitClientError(
-            f"layer deve essere uno tra: {', '.join(sorted(VALID_LAYERS))} (ricevuto: {layer})",
-            code=ErrorCode.INVALID_PARAMS,
+    try:
+        resolved_path: Path = _safe_path(config_path)
+    except ToolkitClientError:
+        resolved_path = Path(config_path)
+
+    try:
+        return _layer_query_core(
+            str(resolved_path),
+            layer=layer,
+            mode=mode,
+            year=year,
+            limit=limit,
+            sql=sql,
+            mart_index=mart_index,
         )
-    if safe_mode not in VALID_MODES:
-        raise ToolkitClientError(
-            f"mode deve essere uno tra: {', '.join(sorted(VALID_MODES))} (ricevuto: {mode})",
-            code=ErrorCode.INVALID_PARAMS,
-        )
-    if safe_mode == "profile" and safe_layer != "raw":
-        raise ToolkitClientError(
-            f"mode=profile e' valido solo per layer=raw (ricevuto: layer={layer})",
-            code=ErrorCode.INVALID_PARAMS,
-        )
-    if safe_mode == "sql" and safe_layer == "raw":
-        raise ToolkitClientError(
-            "mode=sql non e' supportato per layer=raw (usa mode=schema o mode=preview)",
-            code=ErrorCode.INVALID_PARAMS,
-        )
-    if safe_mode == "sql" and not sql:
-        raise ToolkitClientError(
-            "mode=sql richiede il parametro sql (es. sql='SELECT * FROM data')",
-            code=ErrorCode.INVALID_PARAMS,
-        )
-
-    (
-        _inspect_paths,
-        _clean_preview,
-        _dataset_info,
-        _raw_preview,
-        _raw_profile,
-        _review_readiness,
-        _run_summary,
-        _show_schema,
-        _summary,
-    ) = _get_impls()
-
-    # Schema mode
-    if safe_mode == "schema":
-        return _show_schema(config_path, layer=safe_layer, year=year)
-
-    # Profile mode (raw only)
-    if safe_mode == "profile":
-        return _raw_profile(config_path, year=year)
-
-    # Preview mode
-    if safe_mode == "preview":
-        if safe_layer == "raw":
-            return _raw_preview(config_path, year=year, limit=limit)
-        return _clean_preview(
-            config_path, layer=safe_layer, mart_index=mart_index, year=year, limit=limit
-        )
-
-    # SQL mode — sql non puo' essere None qui (guardato sopra)
-    if safe_mode == "sql":
-        assert sql is not None  # mypy narrowing
-        return _layer_sql(
-            config_path, layer=safe_layer, year=year, limit=limit, sql=sql, mart_index=mart_index
-        )
-
-    raise RuntimeError(f"mode non gestito: {safe_mode}")
-
-
-def _layer_sql(
-    config_path: str,
-    layer: str,
-    year: int | None,
-    limit: int,
-    sql: str,
-    mart_index: int,
-) -> dict[str, Any]:
-    """Esegue SQL arbitrario sul parquet risolto da config_path + layer.
-
-    Logica di risoluzione path identica a clean_preview/raw_preview.
-    """
-    config, cfg = _load_cfg(config_path)
-    from toolkit.mcp.cli_adapter import inspect_paths as _inspect_paths
-
-    paths = _inspect_paths(str(config), year)
-    resolved_year = paths.get("year", year)
-
-    if layer == "clean":
-        parquet_str = paths["paths"]["clean"].get("output")
-        if not parquet_str:
-            raise ToolkitClientError(
-                "Nessun output clean configurato", code=ErrorCode.PARQUET_NOT_FOUND
-            )
-        parquet_path = Path(parquet_str)
-    else:
-        outputs = paths["paths"]["mart"].get("outputs") or []
-        if not outputs:
-            raise ToolkitClientError(
-                "Nessun output mart configurato", code=ErrorCode.PARQUET_NOT_FOUND
-            )
-        if mart_index < 0 or mart_index >= len(outputs):
-            raise ToolkitClientError(
-                f"Indice mart {mart_index} non valido: {len(outputs)} output disponibili",
-                code=ErrorCode.INVALID_PARAMS,
-            )
-        parquet_path = Path(outputs[mart_index])
-
-    if not parquet_path.exists():
-        raise ToolkitClientError(
-            f"Parquet {layer} non trovato: {parquet_path}. "
-            f"Esegui 'toolkit run all -c {config_path}' per generarlo.",
-            code=ErrorCode.PARQUET_NOT_FOUND,
-        )
-
-    from toolkit.core.duckdb_shape import parquet_preview
-
-    result = parquet_preview(parquet_path, limit=limit, sql=sql)
-    result.update(
-        {
-            "dataset": paths.get("dataset"),
-            "year": resolved_year,
-            "layer": layer,
-            "config_path": str(config),
-            "mode": "sql",
-        }
-    )
-    return result
+    except ValueError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.INVALID_PARAMS) from exc
+    except FileNotFoundError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.PARQUET_NOT_FOUND) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -233,13 +121,9 @@ def dataset_status(
     """
     (
         _inspect_paths,
-        _clean_preview,
         _dataset_info,
-        _raw_preview,
-        _raw_profile,
         _review_readiness,
         _run_summary,
-        _show_schema,
         _summary,
     ) = _get_impls()
 

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -12,7 +12,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
-from toolkit.core.exceptions import DownloadError
 from toolkit.core.registry import registry
 
 
@@ -126,52 +125,6 @@ def _fetch_ckan(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, 
         else None,
         sample_bytes=sample_bytes,
     )
-
-
-@_register_fetch("script")
-def _fetch_script(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
-    """Execute a script command and read its output as the raw data.
-
-    The script is run in a subprocess inside the candidate root directory.
-    ``{year}`` placeholders in ``command`` and ``output`` are resolved
-    before execution.
-
-    Expected config::
-
-        raw:
-          sources:
-            - type: script
-              args:
-                command: "python scripts/fetch_anac_year.py {year}"
-                output: "anac_{year}.csv"
-    """
-    import subprocess
-
-    command: str = formatted_args.get("command", "")
-    if not command:
-        raise DownloadError("script source requires a 'command' in args")
-
-    output_path = Path(formatted_args.get("output", "output.csv"))
-    candidate_root = Path.cwd()
-
-    result = subprocess.run(
-        command,
-        shell=True,
-        capture_output=True,
-        text=True,
-        timeout=600,
-        cwd=candidate_root,
-    )
-    if result.returncode != 0:
-        stderr_preview = result.stderr[:500] if result.stderr else "(no stderr)"
-        raise DownloadError(f"Script failed (exit {result.returncode}): {stderr_preview}")
-
-    output_abs = candidate_root / output_path
-    if not output_abs.exists():
-        raise DownloadError(f"Script did not produce expected output file: {output_abs}")
-
-    payload = output_abs.read_bytes()
-    return payload, str(output_path)
 
 
 @_register_fetch("sdmx")

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
+from toolkit.core.exceptions import DownloadError
 from toolkit.core.registry import registry
 
 
@@ -125,6 +126,52 @@ def _fetch_ckan(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, 
         else None,
         sample_bytes=sample_bytes,
     )
+
+
+@_register_fetch("script")
+def _fetch_script(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
+    """Execute a script command and read its output as the raw data.
+
+    The script is run in a subprocess inside the candidate root directory.
+    ``{year}`` placeholders in ``command`` and ``output`` are resolved
+    before execution.
+
+    Expected config::
+
+        raw:
+          sources:
+            - type: script
+              args:
+                command: "python scripts/fetch_anac_year.py {year}"
+                output: "anac_{year}.csv"
+    """
+    import subprocess
+
+    command: str = formatted_args.get("command", "")
+    if not command:
+        raise DownloadError("script source requires a 'command' in args")
+
+    output_path = Path(formatted_args.get("output", "output.csv"))
+    candidate_root = Path.cwd()
+
+    result = subprocess.run(
+        command,
+        shell=True,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        cwd=candidate_root,
+    )
+    if result.returncode != 0:
+        stderr_preview = result.stderr[:500] if result.stderr else "(no stderr)"
+        raise DownloadError(f"Script failed (exit {result.returncode}): {stderr_preview}")
+
+    output_abs = candidate_root / output_path
+    if not output_abs.exists():
+        raise DownloadError(f"Script did not produce expected output file: {output_abs}")
+
+    payload = output_abs.read_bytes()
+    return payload, str(output_path)
 
 
 @_register_fetch("sdmx")


### PR DESCRIPTION
## Sintesi

Backend condiviso `toolkit/core/layer_ops.py` per query su RAW/CLEAN/MART in 4 modalità, usato sia da CLI (`toolkit layer`) che da MCP (`toolkit_layer`). Unifica `inspect schema`, `inspect profile` e `query` in un unico comando.

## Cosa cambia

- [ ] Bug fix
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Dettaglio

### `toolkit/core/layer_ops.py` (NUOVO)

Backend condiviso con funzione `layer_query()` router per 4 modalità:
- `mode=schema` → colonne + tipi (delega a `show_schema` già condiviso)
- `mode=profile` → encoding/delimiter raw (spostato da MCP)
- `mode=preview` → prime N righe (spostato da MCP)
- `mode=sql` → SQL arbitrario (spostato da MCP)

### `toolkit layer` (NUOVA CLI)

```
toolkit layer -c dataset.yml                        # schema (default)
toolkit layer -c dataset.yml -l raw -m profile      # encoding/delimiter
toolkit layer -c dataset.yml -l clean -m preview     # prime righe
toolkit layer -c dataset.yml -l clean -m sql --sql "SELECT count(*)"
toolkit layer -c dataset.yml -l mart -m preview      # prime righe mart
```

### `toolkit/mcp/aggregate_ops.py`

`layer_query()` MCP ora delega a `core/layer_ops.layer_query()` invece di avere implementazione propria. Rimosso `_layer_sql()` (spostato in core).

### CLI deprecate

- `inspect schema` → segnato come deprecated, messaggio punta a `toolkit layer`
- `inspect profile` → segnato come deprecated, messaggio punta a `toolkit layer`

## Impatto su contratti pubblici

Nessuno. Aggiunto nuovo comando CLI. I vecchi comandi continuano a funzionare (deprecati).

## Verifica

```bash
pytest toolkit/tests/ -q  # 69/69 passano
```

- [x] `pytest` passa
- [x] `ruff check .` passa (pre-commit hook)
- [x] Nuovo codice con marker appropriato

## Checklist PR

- [x] Perimetro stretto: un layer = backend condiviso + CLI
- [x] Se nuovo plugin: test + docs inclusi (test attuali coprono backend e MCP)
- [ ] Issue collegata o motivazione dell'assenza
- [x] **Se rimuovo un modulo/funzione pubblica**: N/A (aggiunte, non rimosse)

## Note per chi revisiona

- Il backend `layer_ops.py` è il punto di convergenza per CLI e MCP
- `show_schema` resta in CLI (era già condiviso da prima)
- I comandi deprecati continuano a funzionare — nessuna rottura
- Prossimo passo: deprecare i tool MCP granulari (`inspect_schema`, `inspect_profile`, `clean_preview`, `raw_preview`) in una PR successiva
