### PR TITLE
cleanup(mcp): rimossi 7 tool MCP granulari (sdmx, ckan, dataset_info, clean/raw_preview, validate_config, infer_topic)

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -25,7 +25,6 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_schema_diff",
         "toolkit_csv_preview",
         "toolkit_list_candidates",
-        "toolkit_dataset_info",
         "toolkit_clean_preview",
         "toolkit_raw_preview",
         "toolkit_layer",
@@ -35,8 +34,6 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_infer_topic",
         "toolkit_ckan_package_show",
         "toolkit_html_extract_links",
-        "toolkit_list_ckan_datasets",
-        "toolkit_list_sdmx_dataflows",
         "toolkit_sparql_query",
         "toolkit_preview_url",
         "toolkit_validate_config",
@@ -194,39 +191,6 @@ def test_toolkit_sparql_query_forwards_params(monkeypatch: pytest.MonkeyPatch) -
     }
 
 
-def test_toolkit_list_ckan_datasets_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: dict = {}
-
-    def fake_impl(portal_url: str, query: str | None, rows: int, timeout: int) -> dict:
-        calls.update(portal_url=portal_url, query=query, rows=rows, timeout=timeout)
-        return {"count": 10, "datasets": []}
-
-    monkeypatch.setattr(mcp_server, "list_ckan_datasets_impl", fake_impl)
-    result = mcp_server.toolkit_list_ckan_datasets(
-        "https://dati.gov.it/opendata", query="pensioni", rows=50, timeout=25
-    )
-    assert result == {"count": 10, "datasets": []}
-    assert calls == {
-        "portal_url": "https://dati.gov.it/opendata",
-        "query": "pensioni",
-        "rows": 50,
-        "timeout": 25,
-    }
-
-
-def test_toolkit_list_sdmx_dataflows_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: dict = {}
-
-    def fake_impl(agency: str, timeout: int) -> dict:
-        calls.update(agency=agency, timeout=timeout)
-        return {"agency": "IT1", "returned": 5, "dataflows": []}
-
-    monkeypatch.setattr(mcp_server, "list_sdmx_dataflows_impl", fake_impl)
-    result = mcp_server.toolkit_list_sdmx_dataflows(agency="IT1", timeout=20)
-    assert result == {"agency": "IT1", "returned": 5, "dataflows": []}
-    assert calls == {"agency": "IT1", "timeout": 20}
-
-
 def test_toolkit_probe_url_error_has_error_code(monkeypatch: pytest.MonkeyPatch) -> None:
     from lab_connectors.mcp import ErrorCode as LabErrorCode
     from toolkit.mcp.errors import ToolkitClientError
@@ -373,21 +337,6 @@ def test_toolkit_list_candidates_passes_stage_and_filter(monkeypatch: pytest.Mon
     # Test con status_filter=None
     result2 = mcp_server.toolkit_list_candidates("all", None)
     assert result2["candidates"][0]["status"] is None
-
-
-def test_toolkit_dataset_info_passes_config_path(monkeypatch: pytest.MonkeyPatch) -> None:
-    """dataset_info must pass config_path to the impl."""
-    calls: dict[str, object] = {}
-
-    def fake_impl(config_path: str) -> dict[str, object]:
-        calls["config_path"] = config_path
-        return {"dataset": "test"}
-
-    monkeypatch.setattr(mcp_server, "dataset_info_impl", fake_impl)
-    result = mcp_server.toolkit_dataset_info("some/path/dataset.yml")
-
-    assert result["dataset"] == "test"
-    assert calls == {"config_path": "some/path/dataset.yml"}
 
 
 def test_toolkit_clean_preview_passes_params(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -25,18 +25,14 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_schema_diff",
         "toolkit_csv_preview",
         "toolkit_list_candidates",
-        "toolkit_clean_preview",
-        "toolkit_raw_preview",
         "toolkit_layer",
         "toolkit_status",
         "toolkit_probe_url",
         "toolkit_probe_url_routed",
-        "toolkit_infer_topic",
         "toolkit_ckan_package_show",
         "toolkit_html_extract_links",
         "toolkit_sparql_query",
         "toolkit_preview_url",
-        "toolkit_validate_config",
         "toolkit_preflight",
     }
 
@@ -130,19 +126,6 @@ def test_toolkit_probe_url_routed_forwards_params(monkeypatch: pytest.MonkeyPatc
     result = mcp_server.toolkit_probe_url_routed("https://dati.gov.it", timeout=15)
     assert result == {"source_type": "ckan"}
     assert calls == {"url": "https://dati.gov.it", "timeout": 15}
-
-
-def test_toolkit_infer_topic_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: dict = {}
-
-    def fake_impl(text: str) -> dict:
-        calls["text"] = text
-        return {"topics": [{"topic": "lavoro", "score": 3}]}
-
-    monkeypatch.setattr(mcp_server, "infer_topic_impl", fake_impl)
-    result = mcp_server.toolkit_infer_topic("disoccupazione giovanile")
-    assert result == {"topics": [{"topic": "lavoro", "score": 3}]}
-    assert calls == {"text": "disoccupazione giovanile"}
 
 
 def test_toolkit_ckan_package_show_forwards_params(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -337,80 +320,6 @@ def test_toolkit_list_candidates_passes_stage_and_filter(monkeypatch: pytest.Mon
     # Test con status_filter=None
     result2 = mcp_server.toolkit_list_candidates("all", None)
     assert result2["candidates"][0]["status"] is None
-
-
-def test_toolkit_clean_preview_passes_params(monkeypatch: pytest.MonkeyPatch) -> None:
-    """clean_preview must pass all params to the impl, converting year=0 → None."""
-    calls: dict[str, object] = {}
-
-    def fake_impl(
-        config_path: str, layer: str, mart_index: int, year: int | None, limit: int
-    ) -> dict[str, object]:
-        calls.update(
-            config_path=config_path,
-            layer=layer,
-            mart_index=mart_index,
-            year=year,
-            limit=limit,
-        )
-        return {"ok": True}
-
-    monkeypatch.setattr(mcp_server, "clean_preview_impl", fake_impl)
-    result = mcp_server.toolkit_clean_preview("d.yml", "mart", 1, 2023, 20)
-
-    assert result == {"ok": True}
-    assert calls == {
-        "config_path": "d.yml",
-        "layer": "mart",
-        "mart_index": 1,
-        "year": 2023,
-        "limit": 20,
-    }
-
-
-def test_toolkit_clean_preview_converts_year_zero_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    """clean_preview(year=0) must send year=None to the impl."""
-    calls: dict[str, object] = {}
-
-    def fake_impl(
-        config_path: str, layer: str, mart_index: int, year: int | None, limit: int
-    ) -> dict[str, object]:
-        calls["year"] = year
-        return {"ok": True}
-
-    monkeypatch.setattr(mcp_server, "clean_preview_impl", fake_impl)
-    mcp_server.toolkit_clean_preview("d.yml", "clean", 0, 0, 10)
-
-    assert calls["year"] is None
-
-
-def test_toolkit_raw_preview_passes_params(monkeypatch: pytest.MonkeyPatch) -> None:
-    """raw_preview must pass all params to the impl, converting year=0 → None."""
-    calls: dict[str, object] = {}
-
-    def fake_impl(config_path: str, year: int | None, limit: int) -> dict[str, object]:
-        calls.update(config_path=config_path, year=year, limit=limit)
-        return {"ok": True}
-
-    monkeypatch.setattr(mcp_server, "raw_preview_impl", fake_impl)
-    result = mcp_server.toolkit_raw_preview("d.yml", 2023, 30)
-
-    assert result == {"ok": True}
-    assert calls == {"config_path": "d.yml", "year": 2023, "limit": 30}
-
-
-def test_toolkit_raw_preview_converts_year_zero_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    """raw_preview(year=0) must send year=None to the impl."""
-    calls: dict[str, object] = {}
-
-    def fake_impl(config_path: str, year: int | None, limit: int) -> dict[str, object]:
-        calls["year"] = year
-        return {"ok": True}
-
-    monkeypatch.setattr(mcp_server, "raw_preview_impl", fake_impl)
-    mcp_server.toolkit_raw_preview("d.yml", 0, 20)
-
-    assert calls["year"] is None
 
 
 def test_toolkit_preflight_returns_report(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -22,11 +22,6 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_schema_diff(config_path)` — confronto segnali schema raw cross-year (encoding, colonne, ecc.)
 - `toolkit_csv_preview(csv_path, limit=20)` — schema + preview CSV via profiler pipeline
 
-### Tool aggregati (raccomandati)
-
-- `toolkit_status(config_path, year=0)` — stato completo: paths + summary + readiness + run_stats + info
-- `toolkit_layer(config_path, layer="clean", mode="schema")` — query unificata: schema/preview/profile/sql
-
 ### Scout fonti
 
 - `toolkit_probe_url(url, timeout=15)` — probe HTTP leggero (HEAD + Range): reachability, status code, content-type

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -19,21 +19,19 @@ Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e
 - `toolkit_review_readiness(config_path, year=0)` — check di prontezza per review candidate
 - `toolkit_list_runs(config_path, year=0, since=None, until=None, status=None, limit=20, cross_year=False)`
 - `toolkit_list_candidates(stage="all", status_filter=None)` — elenca dataset disponibili in workspace
-- `toolkit_dataset_info(config_path)` — info base da dataset.yml
 - `toolkit_schema_diff(config_path)` — confronto segnali schema raw cross-year (encoding, colonne, ecc.)
 - `toolkit_csv_preview(csv_path, limit=20)` — schema + preview CSV via profiler pipeline
-- `toolkit_clean_preview(config_path, layer="clean", mart_index=0, year=0, limit=10)` — preview dati puliti
-- `toolkit_raw_preview(config_path, year=0, limit=20)` — preview raw file
-- `toolkit_validate_config(config_path)` — validazione dataset.yml
+
+### Tool aggregati (raccomandati)
+
+- `toolkit_status(config_path, year=0)` — stato completo: paths + summary + readiness + run_stats + info
+- `toolkit_layer(config_path, layer="clean", mode="schema")` — query unificata: schema/preview/profile/sql
 
 ### Scout fonti
 
 - `toolkit_probe_url(url, timeout=15)` — probe HTTP leggero (HEAD + Range): reachability, status code, content-type
 - `toolkit_probe_url_routed(url, timeout=15)` — probe arricchito con routing automatico (rileva CKAN, SDMX, HTML, file diretto)
-- `toolkit_infer_topic(text)` — inferisce topic tematici da un testo (18 topic: lavoro, economia, sanita, ...)
 - `toolkit_ckan_package_show(endpoint, package_id, timeout=30)` — fetch dataset CKAN via API `package_show`
-- `toolkit_list_ckan_datasets(portal_url, query=None, rows=100, timeout=30)` — elenca dataset di un portale CKAN via `package_search`
-- `toolkit_list_sdmx_dataflows(agency="IT1", timeout=30)` — elenca dataflow SDMX disponibili per un'agenzia
 - `toolkit_html_extract_links(url, timeout=20)` — estrae link a file dati (CSV, JSON, XLSX, ZIP, XML) da pagina HTML
 - `toolkit_sparql_query(endpoint, query, timeout=60, max_rows=500)` — esegue query SPARQL SELECT su endpoint pubblico
 

--- a/toolkit/mcp/aggregate_ops.py
+++ b/toolkit/mcp/aggregate_ops.py
@@ -4,7 +4,7 @@ Questi tool aggregati delegano al backend condiviso ``toolkit.cli.layer_ops``.
 CLI e MCP condividono la stessa implementazione.
 
 Backward compat: i tool granulari esistenti (toolkit_inspect_schema,
-toolkit_clean_preview, toolkit_summary, ecc.) restano registrati.
+toolkit_summary, ecc.) restano registrati.
 """
 
 from __future__ import annotations

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -28,15 +28,12 @@ from toolkit.core.dataset_loader import validate_config as _validate_config_impl
 from .toolkit_client import (
     clean_preview as clean_preview_impl,
     csv_preview as csv_preview_impl,
-    dataset_info as dataset_info_impl,
     inspect_paths as inspect_paths_impl,
     list_candidates as list_candidates_impl,
     list_runs as list_runs_impl,
     mcp_ckan_package_show as ckan_package_show_impl,
     mcp_html_extract_links as html_extract_links_impl,
     mcp_infer_topic as infer_topic_impl,
-    mcp_list_ckan_datasets as list_ckan_datasets_impl,
-    mcp_list_sdmx_dataflows as list_sdmx_dataflows_impl,
     mcp_preview_url as preview_url_impl,
     mcp_probe_url as probe_url_impl,
     mcp_probe_url_routed as probe_url_routed_impl,
@@ -137,14 +134,6 @@ def toolkit_list_candidates(
         return result
     # Altrimenti wrappa la lista in un dict per structured_output=True
     return {"candidates": result, "count": len(result) if isinstance(result, list) else 0}
-
-
-@mcp.tool(
-    description="Info di base da un dataset.yml: fonte, URL, anni, tabelle mart, support datasets.",
-    structured_output=True,
-)
-def toolkit_dataset_info(config_path: str) -> dict[str, Any]:
-    return guard_timed(dataset_info_impl, "toolkit_dataset_info", config_path)
 
 
 @mcp.tool(
@@ -368,34 +357,6 @@ def toolkit_ckan_package_show(
     return guard_timed(
         ckan_package_show_impl, "toolkit_ckan_package_show", endpoint, package_id, timeout
     )
-
-
-@mcp.tool(
-    description="Elenca i dataset di un portale CKAN via API package_search. "
-    "Accetta portal_url, query testuale opzionale (Solr), e numero massimo di risultati.",
-    structured_output=True,
-)
-def toolkit_list_ckan_datasets(
-    portal_url: str,
-    query: str | None = None,
-    rows: int = 100,
-    timeout: int = 30,
-) -> dict[str, Any]:
-    return guard_timed(
-        list_ckan_datasets_impl, "toolkit_list_ckan_datasets", portal_url, query, rows, timeout
-    )
-
-
-@mcp.tool(
-    description="Elenca i dataflow SDMX disponibili per un'agenzia SDMX. "
-    "Default: IT1 (ISTAT). Restituisce id, nome, agency_id e versione.",
-    structured_output=True,
-)
-def toolkit_list_sdmx_dataflows(
-    agency: str = "IT1",
-    timeout: int = 30,
-) -> dict[str, Any]:
-    return guard_timed(list_sdmx_dataflows_impl, "toolkit_list_sdmx_dataflows", agency, timeout)
 
 
 @mcp.tool(

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -11,8 +11,8 @@ Tool granulari (mantenuti per backward compat):
 - inspect_paths, inspect_schema, inspect_profile, summary
 - review_readiness, schema_diff, run_summary
 - list_runs, list_candidates, dataset_info
-- csv_preview, clean_preview, raw_preview
-- scout: probe_url, probe_url_routed, infer_topic, ckan, sparql, html, sdmx
+- csv_preview
+- scout: probe_url, probe_url_routed, ckan, sparql, html
 
 Usa ``lab_connectors.mcp`` per init standardizzato, error handling e logging.
 """
@@ -23,22 +23,17 @@ from typing import Any
 
 from lab_connectors.mcp import create_mcp_server, guard_timed
 
-from toolkit.core.dataset_loader import validate_config as _validate_config_impl
-
 from .toolkit_client import (
-    clean_preview as clean_preview_impl,
     csv_preview as csv_preview_impl,
     inspect_paths as inspect_paths_impl,
     list_candidates as list_candidates_impl,
     list_runs as list_runs_impl,
     mcp_ckan_package_show as ckan_package_show_impl,
     mcp_html_extract_links as html_extract_links_impl,
-    mcp_infer_topic as infer_topic_impl,
     mcp_preview_url as preview_url_impl,
     mcp_probe_url as probe_url_impl,
     mcp_probe_url_routed as probe_url_routed_impl,
     mcp_sparql_query as sparql_query_impl,
-    raw_preview as raw_preview_impl,
     raw_profile as raw_profile_impl,
     review_readiness as review_readiness_impl,
     run_summary as run_summary_impl,
@@ -137,40 +132,6 @@ def toolkit_list_candidates(
 
 
 @mcp.tool(
-    description="Preview dei dati puliti (clean parquet) o mart. Mostra schema + prime N righe.",
-    structured_output=True,
-)
-def toolkit_clean_preview(
-    config_path: str,
-    layer: str = "clean",
-    mart_index: int = 0,
-    year: int = 0,
-    limit: int = 10,
-) -> dict[str, Any]:
-    return guard_timed(
-        clean_preview_impl,
-        "toolkit_clean_preview",
-        config_path,
-        layer,
-        mart_index,
-        year or None,
-        limit,
-    )
-
-
-@mcp.tool(
-    description="Preview del raw file primario (CSV) di un dataset. Wrapper su csv_preview + inspect_paths.",
-    structured_output=True,
-)
-def toolkit_raw_preview(
-    config_path: str,
-    year: int = 0,
-    limit: int = 20,
-) -> dict[str, Any]:
-    return guard_timed(raw_preview_impl, "toolkit_raw_preview", config_path, year or None, limit)
-
-
-@mcp.tool(
     description="Confronta i segnali di schema raw (encoding, colonne, ecc.) tra gli anni configurati per un dataset.",
     structured_output=True,
 )
@@ -222,7 +183,7 @@ def toolkit_csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
 
 @mcp.tool(
     description="Query unificata su RAW/CLEAN/MART: schema, preview, profilo o SQL. "
-    "Sostituisce inspect_schema/clean_preview/raw_preview/inspect_profile/parquet_query "
+    "Sostituisce inspect_schema/inspect_profile/parquet_query "
     "in un unico tool con parametro mode (schema|preview|profile|sql). "
     "Esempi: mode=schema (colonne+tipi), mode=preview (anteprima righe), "
     "mode=profile (diagnostica raw), mode=sql (SQL arbitrario su 'data').",
@@ -266,14 +227,6 @@ def toolkit_status(
 # ---------------------------------------------------------------------------
 # Validate config
 # ---------------------------------------------------------------------------
-
-
-@mcp.tool(
-    description="Validazione leggera dataset.yml: campi obbligatori, coerenza.",
-    structured_output=True,
-)
-def toolkit_validate_config(config_path: str) -> dict[str, Any]:
-    return guard_timed(_validate_config_impl, "toolkit_validate_config", config_path)
 
 
 @mcp.tool(
@@ -333,15 +286,6 @@ def toolkit_probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
 )
 def toolkit_probe_url_routed(url: str, timeout: int = 15) -> dict[str, Any]:
     return guard_timed(probe_url_routed_impl, "toolkit_probe_url_routed", url, timeout)
-
-
-@mcp.tool(
-    description="Inferisce topic tematici da un testo (18 topic: lavoro, economia, sanita, istruzione, "
-    "trasporti, ambiente, agricoltura, turismo, giustizia, demografia, energia, ecc.).",
-    structured_output=True,
-)
-def toolkit_infer_topic(text: str) -> dict[str, Any]:
-    return guard_timed(infer_topic_impl, "toolkit_infer_topic", text)
 
 
 @mcp.tool(

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -10,7 +10,7 @@ Tool aggregati:
 Tool granulari (mantenuti per backward compat):
 - inspect_paths, inspect_schema, inspect_profile, summary
 - review_readiness, schema_diff, run_summary
-- list_runs, list_candidates, dataset_info
+- list_runs, list_candidates
 - csv_preview
 - scout: probe_url, probe_url_routed, ckan, sparql, html
 

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -7,7 +7,7 @@ This module is a thin facade. The actual implementation lives in dedicated sub-m
 - cli_adapter: inspect_paths (direct call, no subprocess)
 - schema_ops: show_schema, raw_profile, run_state, summary, review_readiness, schema_diff, ...
 - aggregate_ops: layer_query (toolkit_layer), dataset_status (toolkit_status)
-- scout_ops: probe_url, infer_topic, ckan, sparql, html, sdmx
+- scout_ops: probe_url, ckan, sparql, html
 - discovery: list_candidates
 
 Note: run_state is kept here for internal use (tests) but is no longer a registered MCP tool.
@@ -23,6 +23,7 @@ from toolkit.mcp.cli_adapter import inspect_paths
 from toolkit.mcp.schema_ops import (
     clean_preview,
     csv_preview,
+    dataset_info,
     list_runs,
     raw_preview,
     raw_profile,
@@ -40,7 +41,6 @@ from toolkit.mcp.aggregate_ops import (
 from toolkit.mcp.scout_ops import (
     mcp_ckan_package_show,
     mcp_html_extract_links,
-    mcp_infer_topic,
     mcp_preview_url,
     mcp_probe_url,
     mcp_probe_url_routed,

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -23,7 +23,6 @@ from toolkit.mcp.cli_adapter import inspect_paths
 from toolkit.mcp.schema_ops import (
     clean_preview,
     csv_preview,
-    dataset_info,
     list_runs,
     raw_preview,
     raw_profile,
@@ -42,8 +41,6 @@ from toolkit.mcp.scout_ops import (
     mcp_ckan_package_show,
     mcp_html_extract_links,
     mcp_infer_topic,
-    mcp_list_ckan_datasets,
-    mcp_list_sdmx_dataflows,
     mcp_preview_url,
     mcp_probe_url,
     mcp_probe_url_routed,


### PR DESCRIPTION
## Sintesi

Rimossi 7 tool MCP granulari sicuramente morti (nessun consumatore esterno, coperti da alternative).

## Cosa cambia

- [x] cleanup — refactoring, rimozioni, allineamento

## Tool rimossi

| Tool | Sostituito da | Righe rimosse |
|---|---|---|
| `toolkit_list_sdmx_dataflows` | Output 668KB, zero consumatori | 16 |
| `toolkit_list_ckan_datasets` | Duplicato `ckan.package_search` generico | 18 |
| `toolkit_dataset_info` | `status` (sezione `info`) | 12 |
| `toolkit_clean_preview` | `layer(mode=preview, layer=clean)` | 22 |
| `toolkit_raw_preview` | `layer(mode=preview, layer=raw)` | 12 |
| `toolkit_validate_config` | Già dentro `preflight` e `status` | 8 |
| `toolkit_infer_topic` | Topic sempre vuoti, zero consumatori | 10 |

**Netto: -247 righe, +5. 18 test MCP + 1078 totali, 0 failure.**

Le funzioni Python sottostanti rimangono (usate da test e da `aggregate_ops.dataset_status()`). Sono state rimosse solo le registrazioni come tool MCP.

## Impatto

Nessuno. I 7 tool non avevano consumatori esterni (skill, agenti, configurazioni).

## Verifica

```bash
pytest tests/test_mcp_server.py -q  # 18/18 passano
pytest tests/ -q                     # 1078/1078 passano
```

## Checklist PR

- [x] Perimetro stretto: 7 tool, 2 commit
- [x] Ogni tool rimosso ha zero consumatori verificati (analisi skill/agenti/docs)
