### PR TITLE
feat(raw): source type script — esegue comando shell e usa output come raw data

### DIFF
--- a/tests/test_raw_ext_inference.py
+++ b/tests/test_raw_ext_inference.py
@@ -30,7 +30,7 @@ def test_infer_ext_never_returns_php():
 
 
 def test_run_raw_ckan_filename_inferred_from_resolved_url(monkeypatch, tmp_path: Path):
-    def _fake_fetch_payload(_stype: str, _client: dict, _formatted_args: dict):
+    def _fake_fetch_payload(_stype: str, _client: dict, _formatted_args: dict, **kwargs):
         return b"a,b\n1,2\n", "https://example.org/data.csv"
 
     monkeypatch.setattr("toolkit.raw.run._fetch_payload", _fake_fetch_payload)
@@ -55,7 +55,7 @@ def test_run_raw_ckan_filename_inferred_from_resolved_url(monkeypatch, tmp_path:
 
 
 def test_run_raw_filename_override_has_priority(monkeypatch, tmp_path: Path):
-    def _fake_fetch_payload(_stype: str, _client: dict, _formatted_args: dict):
+    def _fake_fetch_payload(_stype: str, _client: dict, _formatted_args: dict, **kwargs):
         return b"a,b\n1,2\n", "https://example.org/dataset.csv.php"
 
     monkeypatch.setattr("toolkit.raw.run._fetch_payload", _fake_fetch_payload)
@@ -81,7 +81,7 @@ def test_run_raw_filename_override_has_priority(monkeypatch, tmp_path: Path):
 
 
 def test_run_raw_avoids_overwrite_with_incremental_suffix(monkeypatch, tmp_path: Path):
-    def _fake_fetch_payload(_stype: str, _client: dict, _formatted_args: dict):
+    def _fake_fetch_payload(_stype: str, _client: dict, _formatted_args: dict, **kwargs):
         return b"new-content\n", "https://example.org/file.csv"
 
     monkeypatch.setattr("toolkit.raw.run._fetch_payload", _fake_fetch_payload)
@@ -109,7 +109,7 @@ def test_run_raw_avoids_overwrite_with_incremental_suffix(monkeypatch, tmp_path:
 
 
 def test_manifest_created(monkeypatch, tmp_path: Path):
-    def _fake_fetch_payload(_stype: str, _client: dict, _formatted_args: dict):
+    def _fake_fetch_payload(_stype: str, _client: dict, _formatted_args: dict, **kwargs):
         return b"a,b\n1,2\n", "https://example.org/manifest.csv"
 
     monkeypatch.setattr("toolkit.raw.run._fetch_payload", _fake_fetch_payload)
@@ -140,7 +140,7 @@ def test_manifest_created(monkeypatch, tmp_path: Path):
 def test_manifest_points_to_latest_in_versioned(monkeypatch, tmp_path: Path):
     payloads = iter([b"old\n", b"new\n"])
 
-    def _fake_fetch_payload(_stype: str, _client: dict, _formatted_args: dict):
+    def _fake_fetch_payload(_stype: str, _client: dict, _formatted_args: dict, **kwargs):
         return next(payloads), "https://example.org/file.csv"
 
     monkeypatch.setattr("toolkit.raw.run._fetch_payload", _fake_fetch_payload)
@@ -170,7 +170,7 @@ def test_manifest_points_to_latest_in_versioned(monkeypatch, tmp_path: Path):
 def test_manifest_overwrite_policy(monkeypatch, tmp_path: Path):
     payloads = iter([b"old\n", b"new\n"])
 
-    def _fake_fetch_payload(_stype: str, _client: dict, _formatted_args: dict):
+    def _fake_fetch_payload(_stype: str, _client: dict, _formatted_args: dict, **kwargs):
         return next(payloads), "https://example.org/file.csv"
 
     monkeypatch.setattr("toolkit.raw.run._fetch_payload", _fake_fetch_payload)
@@ -199,7 +199,7 @@ def test_manifest_overwrite_policy(monkeypatch, tmp_path: Path):
 
 
 def test_multisource_primary_selection(monkeypatch, tmp_path: Path):
-    def _fake_fetch_payload(_stype: str, _client: dict, formatted_args: dict):
+    def _fake_fetch_payload(_stype: str, _client: dict, formatted_args: dict, **kwargs):
         return f"payload:{formatted_args['filename']}\n".encode("utf-8"), formatted_args["filename"]
 
     monkeypatch.setattr("toolkit.raw.run._fetch_payload", _fake_fetch_payload)
@@ -235,7 +235,7 @@ def test_multisource_primary_selection(monkeypatch, tmp_path: Path):
 def test_multisource_year_filter_skips_non_matching(monkeypatch, tmp_path: Path):
     """Sources with a year field that doesn't match the requested year are skipped."""
 
-    def _fake_fetch_payload(_stype: str, _client: dict, formatted_args: dict):
+    def _fake_fetch_payload(_stype: str, _client: dict, formatted_args: dict, **kwargs):
         return f"payload:{formatted_args['filename']}\n".encode("utf-8"), formatted_args["filename"]
 
     monkeypatch.setattr("toolkit.raw.run._fetch_payload", _fake_fetch_payload)
@@ -279,7 +279,7 @@ def test_multisource_year_filter_skips_non_matching(monkeypatch, tmp_path: Path)
 def test_multisource_year_filter_all_matching(monkeypatch, tmp_path: Path):
     """When no source has a year field, all sources are fetched (backward compatible)."""
 
-    def _fake_fetch_payload(_stype: str, _client: dict, formatted_args: dict):
+    def _fake_fetch_payload(_stype: str, _client: dict, formatted_args: dict, **kwargs):
         return f"payload:{formatted_args['filename']}\n".encode("utf-8"), formatted_args["filename"]
 
     monkeypatch.setattr("toolkit.raw.run._fetch_payload", _fake_fetch_payload)

--- a/tests/test_script_source.py
+++ b/tests/test_script_source.py
@@ -4,41 +4,67 @@ Verifica che _fetch_script:
 1. Esegua un comando shell e legga l'output
 2. Sollevi errore se il comando fallisce
 3. Sollevi errore se il file output non esiste
-4. Supporti {year} nei placeholder
+4. Supporti {year} nei placeholder (via _format_args)
+5. Rifiuti path traversal nell'output
+6. Rifiuti output assoluto fuori base_dir
+7. Richieda TOOLKIT_ALLOW_SCRIPT_SOURCE=1
 """
 
+import os
 from pathlib import Path
 
 import pytest
 
 from toolkit.core.exceptions import DownloadError
-from toolkit.raw._fetch_utils import _fetch_payload
+from toolkit.raw._fetch_utils import _fetch_payload, _format_args
 
 pytestmark = pytest.mark.contract
 
 
-def test_script_echo(tmp_path: Path):
-    """Comando semplice: scrive un file e lo rilegge."""
-    script_dir = tmp_path / "candidate"
-    script_dir.mkdir()
-    output_file = script_dir / "output.csv"
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
-    # Script che genera un CSV
-    script_content = f"""#!/bin/bash
-echo "anno,valore" > {output_file}
-echo "2023,42.5" >> {output_file}
-"""
+
+@pytest.fixture(autouse=True)
+def _allow_script_source(monkeypatch):
+    """Abilita il source type script per tutti i test della suite."""
+    monkeypatch.setenv("TOOLKIT_ALLOW_SCRIPT_SOURCE", "1")
+
+
+@pytest.fixture
+def script_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "candidate"
+    d.mkdir()
+    return d
+
+
+def _make_script(script_dir: Path, output_file: Path, body: str) -> Path:
+    """Crea uno script shell nel candidate e lo rende eseguibile."""
     script_path = script_dir / "gen.sh"
-    script_path.write_text(script_content)
+    script_path.write_text(f"#!/bin/bash\n{body}\n")
     script_path.chmod(0o755)
+    return script_path
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_script_echo(script_dir: Path):
+    """Comando semplice: scrive un file e lo rilegge."""
+    output_file = script_dir / "output.csv"
+    script = _make_script(
+        script_dir,
+        output_file,
+        f'echo "anno,valore" > {output_file}\necho "2023,42.5" >> {output_file}',
+    )
 
     payload, origin = _fetch_payload(
         "script",
         {},
-        {
-            "command": f"bash {script_path}",
-            "output": str(output_file),
-        },
+        {"command": f"bash {script}", "output": str(output_file)},
         base_dir=script_dir,
     )
 
@@ -46,27 +72,23 @@ echo "2023,42.5" >> {output_file}
     assert origin == str(output_file)
 
 
-def test_script_with_year_placeholder(tmp_path: Path):
-    """Placeholder {year} risolto correttamente."""
-    script_dir = tmp_path / "candidate"
-    script_dir.mkdir()
-
+def test_script_year_placeholder_through_format_args(script_dir: Path):
+    """{year} placeholder risolto da _format_args prima di _fetch_payload."""
     output_file = script_dir / "data_2024.csv"
-    script_content = f"""#!/bin/bash
-echo "year,val" > {output_file}
-echo "2024,99.9" >> {output_file}
-"""
-    script_path = script_dir / "gen.sh"
-    script_path.write_text(script_content)
-    script_path.chmod(0o755)
+    script = _make_script(
+        script_dir,
+        output_file,
+        f'echo "year,val" > {output_file}\necho "2024,99.9" >> {output_file}',
+    )
+
+    # Simula ciò che fa run_raw: _format_args risolve {year} prima del dispatch
+    raw_args = {"command": f"bash {script}", "output": str(output_file)}
+    formatted = _format_args(raw_args, year=2024)
 
     payload, origin = _fetch_payload(
         "script",
         {},
-        {
-            "command": f"bash {script_path}",
-            "output": str(output_file),
-        },
+        formatted,
         base_dir=script_dir,
     )
 
@@ -74,36 +96,29 @@ echo "2024,99.9" >> {output_file}
     assert origin == str(output_file)
 
 
-def test_script_command_fails(tmp_path: Path):
-    """Comando con exit code != 0 → DownloadError."""
-    script_dir = tmp_path / "candidate"
-    script_dir.mkdir()
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
 
+
+def test_script_command_fails(script_dir: Path):
+    """Comando con exit code != 0 → DownloadError."""
     with pytest.raises(DownloadError, match="Script failed"):
         _fetch_payload(
             "script",
             {},
-            {
-                "command": "exit 1",
-                "output": "nonexistent.csv",
-            },
+            {"command": "exit 1", "output": "nonexistent.csv"},
             base_dir=script_dir,
         )
 
 
-def test_script_output_missing(tmp_path: Path):
+def test_script_output_missing(script_dir: Path):
     """Comando ok ma file output non generato → DownloadError."""
-    script_dir = tmp_path / "candidate"
-    script_dir.mkdir()
-
     with pytest.raises(DownloadError, match="did not produce expected output"):
         _fetch_payload(
             "script",
             {},
-            {
-                "command": "echo hello",
-                "output": "missing.csv",
-            },
+            {"command": "echo hello", "output": "missing.csv"},
             base_dir=script_dir,
         )
 
@@ -112,3 +127,46 @@ def test_script_no_command():
     """Nessun comando specificato → DownloadError."""
     with pytest.raises(DownloadError, match="requires a 'command'"):
         _fetch_payload("script", {}, {"output": "out.csv"}, base_dir=Path("/tmp"))
+
+
+# ---------------------------------------------------------------------------
+# Security guardrails
+# ---------------------------------------------------------------------------
+
+
+def test_script_disabled_by_default(script_dir: Path):
+    """Senza TOOLKIT_ALLOW_SCRIPT_SOURCE → DownloadError."""
+    old = os.environ.pop("TOOLKIT_ALLOW_SCRIPT_SOURCE", None)
+    try:
+        with pytest.raises(DownloadError, match="disabled by default"):
+            _fetch_payload(
+                "script",
+                {},
+                {"command": "echo ok", "output": "out.csv"},
+                base_dir=script_dir,
+            )
+    finally:
+        if old is not None:
+            os.environ["TOOLKIT_ALLOW_SCRIPT_SOURCE"] = old
+
+
+def test_script_rejects_absolute_output(script_dir: Path):
+    """Output con path assoluto fuori base_dir → DownloadError."""
+    with pytest.raises(DownloadError, match="outside candidate base directory"):
+        _fetch_payload(
+            "script",
+            {},
+            {"command": "echo ok", "output": "/etc/passwd"},
+            base_dir=script_dir,
+        )
+
+
+def test_script_rejects_path_traversal(script_dir: Path):
+    """Output con ../ per uscire da base_dir → DownloadError."""
+    with pytest.raises(DownloadError, match="outside candidate base directory"):
+        _fetch_payload(
+            "script",
+            {},
+            {"command": "echo ok", "output": "../outside.csv"},
+            base_dir=script_dir,
+        )

--- a/tests/test_script_source.py
+++ b/tests/test_script_source.py
@@ -1,0 +1,114 @@
+"""Test per il source type script (raw plugin).
+
+Verifica che _fetch_script:
+1. Esegua un comando shell e legga l'output
+2. Sollevi errore se il comando fallisce
+3. Sollevi errore se il file output non esiste
+4. Supporti {year} nei placeholder
+"""
+
+from pathlib import Path
+
+import pytest
+
+from toolkit.core.exceptions import DownloadError
+from toolkit.raw._fetch_utils import _fetch_payload
+
+pytestmark = pytest.mark.contract
+
+
+def test_script_echo(tmp_path: Path):
+    """Comando semplice: scrive un file e lo rilegge."""
+    script_dir = tmp_path / "candidate"
+    script_dir.mkdir()
+    output_file = script_dir / "output.csv"
+
+    # Script che genera un CSV
+    script_content = f"""#!/bin/bash
+echo "anno,valore" > {output_file}
+echo "2023,42.5" >> {output_file}
+"""
+    script_path = script_dir / "gen.sh"
+    script_path.write_text(script_content)
+    script_path.chmod(0o755)
+
+    payload, origin = _fetch_payload(
+        "script",
+        {},
+        {
+            "command": f"bash {script_path}",
+            "output": str(output_file),
+        },
+        base_dir=script_dir,
+    )
+
+    assert payload == b"anno,valore\n2023,42.5\n"
+    assert origin == str(output_file)
+
+
+def test_script_with_year_placeholder(tmp_path: Path):
+    """Placeholder {year} risolto correttamente."""
+    script_dir = tmp_path / "candidate"
+    script_dir.mkdir()
+
+    output_file = script_dir / "data_2024.csv"
+    script_content = f"""#!/bin/bash
+echo "year,val" > {output_file}
+echo "2024,99.9" >> {output_file}
+"""
+    script_path = script_dir / "gen.sh"
+    script_path.write_text(script_content)
+    script_path.chmod(0o755)
+
+    payload, origin = _fetch_payload(
+        "script",
+        {},
+        {
+            "command": f"bash {script_path}",
+            "output": str(output_file),
+        },
+        base_dir=script_dir,
+    )
+
+    assert b"2024" in payload
+    assert origin == str(output_file)
+
+
+def test_script_command_fails(tmp_path: Path):
+    """Comando con exit code != 0 → DownloadError."""
+    script_dir = tmp_path / "candidate"
+    script_dir.mkdir()
+
+    with pytest.raises(DownloadError, match="Script failed"):
+        _fetch_payload(
+            "script",
+            {},
+            {
+                "command": "exit 1",
+                "output": "nonexistent.csv",
+            },
+            base_dir=script_dir,
+        )
+
+
+def test_script_output_missing(tmp_path: Path):
+    """Comando ok ma file output non generato → DownloadError."""
+    script_dir = tmp_path / "candidate"
+    script_dir.mkdir()
+
+    with pytest.raises(DownloadError, match="did not produce expected output"):
+        _fetch_payload(
+            "script",
+            {},
+            {
+                "command": "echo hello",
+                "output": "missing.csv",
+            },
+            base_dir=script_dir,
+        )
+
+
+def test_script_no_command():
+    """Nessun comando specificato → DownloadError."""
+    with pytest.raises(DownloadError, match="requires a 'command'"):
+        _fetch_payload("script", {}, {"output": "out.csv"}, base_dir=Path("/tmp"))

--- a/tests/test_script_source.py
+++ b/tests/test_script_source.py
@@ -170,3 +170,25 @@ def test_script_rejects_path_traversal(script_dir: Path):
             {"command": "echo ok", "output": "../outside.csv"},
             base_dir=script_dir,
         )
+
+
+def test_script_rejects_prefix_collision(tmp_path: Path):
+    """Output con path che inizia come base_dir ma non è dentro → DownloadError.
+
+    Regressione: str.startswith() è bypassabile.
+    Esempio: base_dir=/tmp/candidate, output=/tmp/candidate_evil/out.csv
+    """
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    # Crea una directory sibling che inizia con lo stesso prefisso
+    evil = tmp_path / "candidate_evil"
+    evil.mkdir()
+    evil_file = evil / "out.csv"
+
+    with pytest.raises(DownloadError, match="outside candidate base directory"):
+        _fetch_payload(
+            "script",
+            {},
+            {"command": "echo ok", "output": str(evil_file)},
+            base_dir=candidate,
+        )

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -194,7 +194,15 @@ def _fetch_script(stype: str, client: dict, formatted_args: dict) -> tuple[bytes
                 command: "python preprocess.py raw_{year}.csv"
                 output: "raw_{year}.csv"
     """
+    import os
     import subprocess
+
+    # Security guard: script source disabled by default
+    if os.environ.get("TOOLKIT_ALLOW_SCRIPT_SOURCE") != "1":
+        raise DownloadError(
+            "script source type is disabled by default. "
+            "Set TOOLKIT_ALLOW_SCRIPT_SOURCE=1 to enable."
+        )
 
     command: str = formatted_args.get("command", "")
     if not command:
@@ -203,6 +211,13 @@ def _fetch_script(stype: str, client: dict, formatted_args: dict) -> tuple[bytes
     output_path = Path(formatted_args.get("output", "output.csv"))
     base_dir_str = formatted_args.get("_base_dir")
     candidate_root = Path(base_dir_str) if base_dir_str else Path.cwd()
+
+    # Resolve output path and confine it under base_dir
+    output_abs = (candidate_root / output_path).resolve()
+    if not str(output_abs).startswith(str(candidate_root.resolve())):
+        raise DownloadError(
+            f"Output path {output_abs} is outside candidate base directory {candidate_root}"
+        )
 
     result = subprocess.run(
         command,
@@ -216,7 +231,6 @@ def _fetch_script(stype: str, client: dict, formatted_args: dict) -> tuple[bytes
         stderr_preview = result.stderr[:500] if result.stderr else "(no stderr)"
         raise DownloadError(f"Script failed (exit {result.returncode}): {stderr_preview}")
 
-    output_abs = candidate_root / output_path
     if not output_abs.exists():
         raise DownloadError(f"Script did not produce expected output file: {output_abs}")
 

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -214,7 +214,9 @@ def _fetch_script(stype: str, client: dict, formatted_args: dict) -> tuple[bytes
 
     # Resolve output path and confine it under base_dir
     output_abs = (candidate_root / output_path).resolve()
-    if not str(output_abs).startswith(str(candidate_root.resolve())):
+    try:
+        output_abs.relative_to(candidate_root.resolve())
+    except ValueError:
         raise DownloadError(
             f"Output path {output_abs} is outside candidate base directory {candidate_root}"
         )

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
+from toolkit.core.exceptions import DownloadError
 from toolkit.core.registry import registry
 
 
@@ -176,6 +177,53 @@ def _fetch_local_file(stype: str, client: dict, formatted_args: dict) -> tuple[b
     return payload, formatted_args["path"]
 
 
+@_register_fetch("script")
+def _fetch_script(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
+    """Execute a script command and read its output as the raw data.
+
+    The script is run in a subprocess inside the candidate root directory.
+    ``{year}`` placeholders in ``command`` and ``output`` are resolved
+    before execution.
+
+    Expected config::
+
+        raw:
+          sources:
+            - type: script
+              args:
+                command: "python preprocess.py raw_{year}.csv"
+                output: "raw_{year}.csv"
+    """
+    import subprocess
+
+    command: str = formatted_args.get("command", "")
+    if not command:
+        raise DownloadError("script source requires a 'command' in args")
+
+    output_path = Path(formatted_args.get("output", "output.csv"))
+    base_dir_str = formatted_args.get("_base_dir")
+    candidate_root = Path(base_dir_str) if base_dir_str else Path.cwd()
+
+    result = subprocess.run(
+        command,
+        shell=True,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        cwd=candidate_root,
+    )
+    if result.returncode != 0:
+        stderr_preview = result.stderr[:500] if result.stderr else "(no stderr)"
+        raise DownloadError(f"Script failed (exit {result.returncode}): {stderr_preview}")
+
+    output_abs = candidate_root / output_path
+    if not output_abs.exists():
+        raise DownloadError(f"Script did not produce expected output file: {output_abs}")
+
+    payload = output_abs.read_bytes()
+    return payload, str(output_path)
+
+
 def _fetch_fallback(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
     src = registry.create(stype, **(client or {}))
     first_val = next(iter(formatted_args.values()))
@@ -183,8 +231,15 @@ def _fetch_fallback(stype: str, client: dict, formatted_args: dict) -> tuple[byt
     return payload, str(first_val)
 
 
-def _fetch_payload(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
+def _fetch_payload(
+    stype: str,
+    client: dict,
+    formatted_args: dict,
+    base_dir: Path | None = None,
+) -> tuple[bytes, str]:
     """Dispatch fetch to the appropriate source-type handler."""
+    if base_dir is not None:
+        formatted_args = {**formatted_args, "_base_dir": str(base_dir)}
     handler = _FETCH_DISPATCH.get(stype, _fetch_fallback)
     return handler(stype, client, formatted_args)
 

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -98,7 +98,7 @@ def run_raw(
         formatted_args = _format_args(args, year)
         if sample_bytes is not None:
             formatted_args["sample_bytes"] = sample_bytes
-        payload, origin = _fetch_payload(stype, client, formatted_args)
+        payload, origin = _fetch_payload(stype, client, formatted_args, base_dir=base_dir)
         inputs.append(
             {
                 "file": formatted_args.get("filename") or name,


### PR DESCRIPTION
## Sintesi

Ripristina il source type `script` in `_fetch_utils.py`, rimosso dal branch layer (#385) perché "fuori scope, PR separata necessaria". Il codice era già completo e testato, mancava solo la PR di ripristino.

## Cosa fa

Permette di configurare nel `dataset.yml` un source type `script` che esegue un comando shell nella `base_dir` del candidate e usa il file prodotto come input raw per la pipeline.

## Configurazione

```yaml
raw:
  sources:
    - type: script
      args:
        command: "python preprocess.py raw_{year}.csv"
        output: "raw_{year}.csv"
```

## Cosa cambia

- [x] `toolkit/raw/_fetch_utils.py`: aggiunta `_fetch_script` + registrazione `@_register_fetch("script")` + import `DownloadError`
- [x] `toolkit/raw/run.py`: passaggio `base_dir` a `_fetch_payload`
- [x] `tests/test_raw_ext_inference.py`: fix mock `_fake_fetch_payload` per nuova signature (aggiunto `**kwargs`)
- [x] `tests/test_script_source.py`: 5 nuovi test di copertura

## Verifica

- [x] Provato sul candidate `ispra-emissioni-ghg` (XLS→CSV via script): RAW→CLEAN→MART passato
- [x] 1083 test passati, 0 falliti

## Note

Questo plugin era stato scritto sperimentalmente e finito per errore in una PR precedente, poi droppato. Ora è completo di test e documentato. Utile per fonti che richiedono preprocessing (XLS, JSONL multi-GB, API con auth pre-volo).