### PR TITLE
feat(validation): quality score, readiness estesa, transizioni blocking

### DIFF
--- a/project-example/dataset.yml
+++ b/project-example/dataset.yml
@@ -3,6 +3,7 @@ root: "./_smoke_out"
 dataset:
   name: "project_example"
   years: [2022]
+  source_id: "ispra_rd"
 
 raw:
   sources:

--- a/tests/test_validate_layers.py
+++ b/tests/test_validate_layers.py
@@ -169,7 +169,9 @@ def test_check_transitions_warns_on_row_drop_over_threshold_and_removed_columns(
 
     report = check_transitions(
         transition_profiles,
-        TransitionConfig(max_row_drop_pct=20, warn_removed_columns=True),
+        TransitionConfig(
+            max_row_drop_pct=20, warn_removed_columns=True, fail_on_row_drop_exceeded=False
+        ),
     )
 
     assert report["warnings_count"] == 2
@@ -245,6 +247,7 @@ def test_run_mart_validation_merges_transition_warnings_into_report(tmp_path: Pa
                 "transition": {
                     "max_row_drop_pct": 20,
                     "warn_removed_columns": True,
+                    "fail_on_row_drop_exceeded": False,
                 }
             },
         },
@@ -268,6 +271,7 @@ def test_run_mart_validation_merges_transition_warnings_into_report(tmp_path: Pa
     assert report["transition"]["config"] == {
         "max_row_drop_pct": 20.0,
         "warn_removed_columns": True,
+        "fail_on_row_drop_exceeded": False,
     }
     assert any(item["kind"] == "row_drop_pct" for item in report["transition"]["warnings"])
     assert any(item["kind"] == "removed_columns" for item in report["transition"]["warnings"])
@@ -491,3 +495,222 @@ def test_ensure_dict_preserves_validate_alias() -> None:
     )
     mv = mart_dict["validate"]
     assert mv["transition"]["max_row_drop_pct"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Gap 5 — Transition errors when fail_on_row_drop_exceeded=True
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.policy
+def test_check_transitions_errors_when_fail_on_row_drop_exceeded_true() -> None:
+    """Con fail_on_row_drop_exceeded=True, il row drop eccessivo produce
+    errori (non warnings) e impatta ok=False."""
+    profiles = [
+        {
+            "target_name": "mart_demo",
+            "source_row_count": 100,
+            "target_row_count": 50,  # 50% drop > 20% soglia
+            "removed_columns": [],
+        }
+    ]
+
+    # Default: solo warning (comportamento attuale, backward compat)
+    default_report = check_transitions(
+        profiles,
+        TransitionConfig(max_row_drop_pct=20, fail_on_row_drop_exceeded=False),
+    )
+    assert default_report["warnings_count"] == 1
+    assert default_report["errors_count"] == 0
+    assert any("row drop" in w for w in default_report["warning_messages"])
+
+    # fail_on_row_drop_exceeded=True: errore invece di warning
+    fail_report = check_transitions(
+        profiles,
+        TransitionConfig(max_row_drop_pct=20, fail_on_row_drop_exceeded=True),
+    )
+    assert fail_report["errors_count"] == 1
+    assert fail_report["warnings_count"] == 0
+    assert any("row drop" in e for e in fail_report["error_messages"])
+    assert len(fail_report["errors"]) == 1
+    assert fail_report["errors"][0]["kind"] == "row_drop_pct"
+
+
+@pytest.mark.policy
+def test_check_transitions_respects_fail_on_row_drop_exceeded_threshold() -> None:
+    """Con fail_on_row_drop_exceeded=True, drop sotto soglia continua a
+    non produrre ne' errori ne' warnings (come prima)."""
+    profiles = [
+        {
+            "target_name": "mart_demo",
+            "source_row_count": 100,
+            "target_row_count": 95,  # 5% drop < 20% soglia
+            "removed_columns": [],
+        }
+    ]
+
+    report = check_transitions(
+        profiles,
+        TransitionConfig(max_row_drop_pct=20, fail_on_row_drop_exceeded=True),
+    )
+    assert report["errors_count"] == 0
+    assert report["warnings_count"] == 0
+    assert report["error_messages"] == []
+    assert report["warning_messages"] == []
+
+
+@pytest.mark.policy
+def test_run_mart_validation_transition_errors_set_ok_false(tmp_path: Path):
+    """run_mart_validation con fail_on_row_drop_exceeded=True deve
+    propagare le transizioni come errori e marcare ok=False."""
+    root = tmp_path / "root"
+    mart_dir = root / "data" / "mart" / "demo" / "2024"
+    mart_dir.mkdir(parents=True, exist_ok=True)
+    write_parquet(mart_dir / "mart_demo.parquet", "CREATE TABLE t AS SELECT 1 AS k")
+
+    (mart_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "outputs": [{"name": "mart_demo", "path": "mart_demo.parquet"}],
+                "transition_profiles": [
+                    {
+                        "target_name": "mart_demo",
+                        "source_row_count": 100,
+                        "target_row_count": 50,  # 50% drop > 20% soglia
+                        "removed_columns": [],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    from tests.helpers import make_config
+
+    cfg = make_config(
+        root=root,
+        base_dir=root,
+        dataset="demo",
+        mart={
+            "tables": [{"name": "mart_demo", "sql": "sql/mart_demo.sql"}],
+            "required_tables": ["mart_demo"],
+            "validate": {
+                "transition": {
+                    "max_row_drop_pct": 20,
+                    "fail_on_row_drop_exceeded": True,
+                }
+            },
+        },
+    )
+
+    summary = run_mart_validation(
+        cfg, 2024, logger=SimpleNamespace(info=lambda *args, **kwargs: None)
+    )
+
+    assert summary["passed"] is False, (
+        f"Expected failed with fail_on_row_drop_exceeded=True, got: {summary}"
+    )
+    assert summary["errors_count"] >= 1, "Expected at least 1 transition error"
+
+    # Verifica che il JSON di validazione su disco contenga l'errore
+    report = json.loads(
+        (mart_dir / "_validate" / "mart_validation.json").read_text(encoding="utf-8")
+    )
+    assert len(report.get("errors", [])) >= 1
+    assert any("row drop" in e for e in report["errors"])
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 — Quality score nella validazione
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.policy
+def test_quality_score_perfect_dataset():
+    """0 errori, 0 warnings → score=100, verdict='buona'."""
+    from toolkit.core.validation import _compute_quality_score, _quality_verdict
+
+    score = _compute_quality_score(0, 0)
+    assert score == 100
+    assert _quality_verdict(score) == "buona"
+
+
+@pytest.mark.policy
+def test_quality_score_with_errors():
+    """Gli errori pesano -20 ciascuno."""
+    from toolkit.core.validation import _compute_quality_score, _quality_verdict
+
+    # 1 errore → 80, ancora buona
+    score = _compute_quality_score(1, 0)
+    assert score == 80
+    assert _quality_verdict(score) == "buona"
+
+    # 3 errori → 40, scarsa
+    score = _compute_quality_score(3, 0)
+    assert score == 40
+    assert _quality_verdict(score) == "scarsa"
+
+
+@pytest.mark.policy
+def test_quality_score_with_warnings():
+    """I warnings pesano -5 ciascuno — visibili ma non bloccanti."""
+    from toolkit.core.validation import _compute_quality_score, _quality_verdict
+
+    # 6 warnings → 70, accettabile
+    score = _compute_quality_score(0, 6)
+    assert score == 70
+    assert _quality_verdict(score) == "accettabile"
+
+    # 1 errore + 4 warnings → 60, accettabile
+    score = _compute_quality_score(1, 4)
+    assert score == 60
+    assert _quality_verdict(score) == "accettabile"
+
+
+@pytest.mark.policy
+def test_quality_score_clamped():
+    """Score non scende sotto 0 ne' supera 100."""
+    from toolkit.core.validation import _compute_quality_score
+
+    # 100 errori → clamped a 0
+    score = _compute_quality_score(100, 0)
+    assert score == 0
+
+    # errori negativi (non dovrebbe capitare) → clamped a 100
+    score = _compute_quality_score(-1, 0)
+    assert score == 100
+
+
+@pytest.mark.policy
+def test_build_validation_summary_includes_quality_score():
+    """build_validation_summary() deve includere quality_score e quality_verdict."""
+    from toolkit.core.validation import ValidationResult, build_validation_summary
+
+    result = ValidationResult(
+        ok=True,
+        errors=[],
+        warnings=["warning 1", "warning 2"],
+    )
+    summary = build_validation_summary(result)
+
+    assert "quality_score" in summary
+    assert "quality_verdict" in summary
+    assert summary["quality_score"] == 90  # 100 - 2*5 = 90
+    assert summary["quality_verdict"] == "buona"
+
+
+@pytest.mark.policy
+def test_build_validation_summary_passed_true_with_warnings_has_reduced_score():
+    """Un dataset con passed=True ma warnings deve avere quality_score < 100."""
+    from toolkit.core.validation import ValidationResult, build_validation_summary
+
+    result = ValidationResult(
+        ok=True,  # passed
+        errors=[],
+        warnings=["w1", "w2", "w3"],
+    )
+    summary = build_validation_summary(result)
+
+    assert summary["passed"] is True
+    assert summary["quality_score"] == 85  # 100 - 3*5 = 85
+    assert summary["warnings_count"] == 3

--- a/tests/test_validate_layers.py
+++ b/tests/test_validate_layers.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from toolkit.raw.validate import validate_raw_output
-from toolkit.clean.validate import validate_clean, run_clean_validation
+from toolkit.clean.validate import validate_clean, run_clean_validation, validate_promotion
 from toolkit.core.config_models import TransitionConfig
 from toolkit.core.validation import check_transitions
 from toolkit.mart.validate import run_mart_validation, validate_mart
@@ -495,6 +495,77 @@ def test_ensure_dict_preserves_validate_alias() -> None:
     )
     mv = mart_dict["validate"]
     assert mv["transition"]["max_row_drop_pct"] == 10
+
+
+@pytest.mark.regression
+def test_validate_promotion_fallback_row_count_when_profile_has_null(tmp_path: Path):
+    """Regression: raw_profile.json con row_count=null ma columns_raw presenti.
+
+    validate_promotion() deve fare fallback al conteggio effettivo dei file raw
+    invece di usare row_count=None, altrimenti il gate di transizione non vede
+    la perdita di righe.
+    """
+    root = tmp_path / "root"
+    dataset = "test"
+    year = 2024
+
+    # Raw dir con CSV da 4 righe (1 header + 3 dati)
+    raw_dir = root / "data" / "raw" / dataset / str(year)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "data.csv").write_text("a,b,c\n1,2,3\n4,5,6\n7,8,9\n", encoding="utf-8")
+
+    # Profilo raw SALVATO ma con row_count=null (il caso reale pnrr-progetti)
+    profile_dir = raw_dir / "_profile"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "raw_profile.json").write_text(
+        json.dumps(
+            {
+                "row_count": None,
+                "columns_raw": ["a", "b", "c"],
+                "columns_norm": ["a", "b", "c"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Clean dir con 2 righe (drop di 1 riga)
+    clean_dir = root / "data" / "clean" / dataset / str(year)
+    clean_dir.mkdir(parents=True, exist_ok=True)
+    from tests.helpers import write_parquet
+
+    write_parquet(
+        clean_dir / f"{dataset}_{year}_clean.parquet",
+        "CREATE TABLE t AS SELECT * FROM (VALUES (1,2,3), (4,5,6)) v(a,b,c)",
+    )
+
+    clean_meta = {
+        "input_files": ["data.csv"],
+        "read_params_used": {"delim": ",", "header": True},
+        "output_profile": {
+            "columns": [
+                {"name": "a", "type": "INTEGER"},
+                {"name": "b", "type": "INTEGER"},
+                {"name": "c", "type": "INTEGER"},
+            ],
+            "row_count": 2,
+        },
+        "outputs": [f"{dataset}_{year}_clean.parquet"],
+    }
+    (clean_dir / "metadata.json").write_text(json.dumps(clean_meta), encoding="utf-8")
+
+    from toolkit.core.config_models import TransitionConfig
+
+    transition = TransitionConfig(max_row_drop_pct=10, fail_on_row_drop_exceeded=True)
+
+    result = validate_promotion(raw_dir, clean_dir, root=root, transition=transition)
+
+    # Deve fallire: 3 raw rows → 2 clean rows = 33% drop > 10% soglia
+    assert result.ok is False, (
+        f"Expected transition error (33% drop > 10%), got ok=True. errors={result.errors}"
+    )
+    assert any("row drop" in e.lower() for e in result.errors), (
+        f"Expected row drop error, got: {result.errors}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -239,10 +239,11 @@ def validate_promotion(
         transition or TransitionConfig(),
     )
     warnings.extend(transition_report["warning_messages"])
+    errors.extend(transition_report["error_messages"])
 
     return ValidationResult(
-        ok=True,
-        errors=[],
+        ok=len(errors) == 0,
+        errors=errors,
         warnings=warnings,
         summary={
             "raw_dir": raw_value,

--- a/toolkit/clean/validate.py
+++ b/toolkit/clean/validate.py
@@ -220,12 +220,16 @@ def validate_promotion(
     saved_profile_path = profile_dir / RAW_PROFILE
 
     saved = read_json_or_none(saved_profile_path) if saved_profile_path.exists() else None
-    if saved is not None:
+    if saved is not None and saved.get("row_count") is not None:
         raw_profile = {
             "row_count": saved.get("row_count"),
             "columns": [{"name": c, "type": "VARCHAR"} for c in (saved.get("columns_raw") or [])],
         }
     else:
+        if logger is None:
+            import logging as _logging
+
+            logger = _logging.getLogger(__name__)
         raw_profile = _profile_raw_input(input_files, read_cfg, read_mode, logger)
     transition_profile = compare_layer_profiles(
         raw_profile,

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -1086,8 +1086,11 @@ def run_full(
                 ln = lyrs.get(lname) or {}
                 lv = ln.get("validation") or {}
                 ok = lv.get("ok")
+                qs = lv.get("quality_score")
                 icon = "✅" if ok else ("🔴" if ok is False else "·")
                 parts = []
+                if qs is not None:
+                    parts.append(f"qs={qs}")
                 if lname == "raw":
                     pf = ln.get("profile") or {}
                     if pf.get("encoding"):
@@ -1119,6 +1122,21 @@ def run_full(
             typer.echo(
                 f"       readiness: {s.get('readiness', '?')}  ({s.get('checks_ok', 0)}/{s.get('checks', 0)})"
             )
+
+            # Warning/error recap per layer (compacto)
+            _any_msgs = False
+            for lname in ("raw", "clean", "mart"):
+                ln = lyrs.get(lname) or {}
+                msgs = ln.get("validation_msgs") or {}
+                for kind, label in [("warnings", "⚠"), ("errors", "🔴")]:
+                    items = msgs.get(kind) or []
+                    for msg in items[:3]:
+                        if not _any_msgs:
+                            typer.echo("")
+                            _any_msgs = True
+                        typer.echo(f"       {lname} {label} {msg[:120]}")
+            if _any_msgs:
+                typer.echo("")
 
     if results["status"] != "passed":
         raise typer.Exit(code=1)

--- a/toolkit/cli/inspect/_helpers.py
+++ b/toolkit/cli/inspect/_helpers.py
@@ -331,6 +331,8 @@ def _validation_summary_for_layer(
 
     result = {
         "ok": content.get("ok"),
+        "quality_score": content.get("quality_score"),
+        "quality_verdict": content.get("quality_verdict"),
         "errors_count": len(content.get("errors", [])),
         "warnings_count": len(content.get("warnings", [])),
         "row_count": None,
@@ -366,5 +368,9 @@ def _validation_summary_for_layer(
             first_key = next(iter(row_counts), None)
             if first_key:
                 result["row_count"] = row_counts[first_key]
+
+    # Column names and validation rules (clean layer)
+    result["columns"] = summary.get("columns")
+    result["rules"] = summary.get("rules")
 
     return result

--- a/toolkit/cli/inspect/readiness_ops.py
+++ b/toolkit/cli/inspect/readiness_ops.py
@@ -327,8 +327,81 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
         }
     )
 
-    ok_count = sum(1 for c in checks if c["ok"])
-    fail_count = sum(1 for c in checks if not c["ok"])
+    # --- A. Clean column naming (snake_case check) ---
+    clean_cols = clean_val.get("columns") or clean.get("columns")
+    if clean_cols:
+        _bad_naming: list[str] = []
+        for col in clean_cols:
+            norm = col.strip().replace(" ", "_").replace("-", "_").lower()
+            if col != norm:
+                _bad_naming.append(col)
+        naming_ok = len(_bad_naming) == 0
+        checks.append(
+            {
+                "check": "clean_columns_naming",
+                "ok": naming_ok,
+                "detail": "tutte snake_case"
+                if naming_ok
+                else f"{len(_bad_naming)} colonne non snake_case: {_bad_naming[:5]}",
+            }
+        )
+    else:
+        checks.append(
+            {"check": "clean_columns_naming", "ok": None, "detail": "colonne clean non disponibili"}
+        )
+
+    # --- B. Validation rules coverage ---
+    rules_obj = clean_val.get("rules") or clean.get("rules") or {}
+    if clean_cols:
+        covered_cols: set[str] = set()
+        for rule_name, rule_vals in rules_obj.items():
+            if isinstance(rule_vals, list):
+                covered_cols.update(rule_vals)
+            elif isinstance(rule_vals, dict):
+                covered_cols.update(rule_vals.keys())
+        coverage_pct = round(len(covered_cols) / len(clean_cols) * 100) if clean_cols else 0
+        if coverage_pct >= 80:
+            coverage_ok = True
+            coverage_detail = f"{coverage_pct}% colonne coperte da regole"
+        elif coverage_pct > 0:
+            coverage_ok = False
+            coverage_detail = (
+                f"solo {coverage_pct}% colonne coperte da regole "
+                f"({len(covered_cols)}/{len(clean_cols)})"
+            )
+        else:
+            coverage_ok = False
+            coverage_detail = "nessuna regola di validazione configurata"
+        checks.append(
+            {
+                "check": "validation_rules_coverage",
+                "ok": coverage_ok,
+                "detail": coverage_detail,
+            }
+        )
+    else:
+        checks.append(
+            {
+                "check": "validation_rules_coverage",
+                "ok": None,
+                "detail": "colonne clean non disponibili",
+            }
+        )
+
+    # --- C. Metadata completeness ---
+    has_source_id = bool(cfg.source_id)
+    checks.append(
+        {
+            "check": "metadata_complete",
+            "ok": has_source_id,
+            "detail": "source_id ✅"
+            if has_source_id
+            else "source_id ❌ (manca dataset.source_id in dataset.yml)",
+        }
+    )
+
+    ok_count = sum(1 for c in checks if c["ok"] is True)
+    fail_count = sum(1 for c in checks if c["ok"] is False)
 
     # --- Extract validation messages from validation JSON ---
     def _validation_msgs(layer_dir: Path, filename: str, max_items: int = 3) -> dict:
@@ -373,9 +446,10 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
     if raw_col_count is not None and clean_col_count is not None:
         col_drop = raw_col_count - clean_col_count
 
+    total_active = ok_count + fail_count
     if fail_count == 0:
         readiness = "ready"
-    elif ok_count >= len(checks) - 1:
+    elif ok_count >= total_active - 1:
         readiness = "needs-review"
     else:
         readiness = "incomplete"
@@ -402,6 +476,8 @@ def review_readiness(config_path: str, year: int | None = None) -> dict[str, Any
                 "validation_msgs": clean_msgs,
                 "output": clean.get("output"),
                 "row_count": clean_rows,
+                "columns": clean_val.get("columns") or clean.get("columns"),
+                "rules": clean_val.get("rules") or clean.get("rules"),
                 "transition": {
                     "raw_row_count": raw_row_count,
                     "clean_row_count": clean_row_count,

--- a/toolkit/cli/inspect/report_ops.py
+++ b/toolkit/cli/inspect/report_ops.py
@@ -326,6 +326,7 @@ def build_run_report(
             "file_size_bytes": file_bytes,
             "validation": {
                 "ok": val_ok,
+                "quality_score": val.get("quality_score"),
                 "errors": len(errors),
                 "warnings": len(warnings),
             },
@@ -516,12 +517,15 @@ def build_dataset_readme(
         readiness_icon_col = _readiness_icon(r.get("readiness"))
         readiness_name = r.get("readiness", "?")
 
-        # Qualità
+        layers = r.get("layers") or {}
+
+        # Qualità: preflight PA score (CSV) → fallback validazione clean
         pf = r.get("preflight") or {}
         qs = pf.get("quality_score_avg")
-        q_str = f"**{qs}**" if qs else "-"
-
-        layers = r.get("layers") or {}
+        if qs is None:
+            r_clean_val = layers.get("clean", {}).get("validation", {})
+            qs = r_clean_val.get("quality_score")
+        q_str = f"**{qs}**" if qs is not None else "-"
 
         # Raw
         r_raw = layers.get("raw") or {}

--- a/toolkit/core/config_models/mart.py
+++ b/toolkit/core/config_models/mart.py
@@ -62,11 +62,17 @@ class TransitionConfig(BaseModel):
 
     max_row_drop_pct: float | None = None
     warn_removed_columns: bool = True
+    fail_on_row_drop_exceeded: bool = True
 
     @field_validator("warn_removed_columns", mode="before")
     @classmethod
     def _parse_warn_removed_columns(cls, value: Any) -> bool:
         return parse_bool(value, "mart.validate.transition.warn_removed_columns")
+
+    @field_validator("fail_on_row_drop_exceeded", mode="before")
+    @classmethod
+    def _parse_fail_on_row_drop_exceeded(cls, value: Any) -> bool:
+        return parse_bool(value, "mart.validate.transition.fail_on_row_drop_exceeded")
 
 
 class MartValidateConfig(BaseModel):

--- a/toolkit/core/validation.py
+++ b/toolkit/core/validation.py
@@ -20,9 +20,12 @@ class ValidationResult:
 
 def write_validation_json(path: str | Path, result: ValidationResult) -> Path:
     out = Path(path)
+    quality_score = _compute_quality_score(len(result.errors), len(result.warnings))
     payload = {
         "validation_schema_version": 1,
         "ok": result.ok,
+        "quality_score": quality_score,
+        "quality_verdict": _quality_verdict(quality_score),
         "errors": result.errors,
         "warnings": result.warnings,
         "summary": result.summary,
@@ -53,13 +56,41 @@ def required_columns_check(actual: Iterable[str], required: Iterable[str]) -> Va
     )
 
 
+def _compute_quality_score(errors_count: int, warnings_count: int) -> int:
+    """Quality score 0-100 con gradiente: errors pesano -20, warnings pesano -5.
+
+    Un dataset perfetto (0 errori, 0 warnings) → 100.
+    Un dataset con 1 errore → 80.
+    Un dataset con 3 errori → 40.
+    Un dataset con 0 errori ma 6 warnings → 70 (visibile ma non bloccante).
+    """
+    score = 100 - errors_count * 20 - warnings_count * 5
+    return max(0, min(100, score))
+
+
+def _quality_verdict(score: int) -> str:
+    if score >= 80:
+        return "buona"
+    if score >= 50:
+        return "accettabile"
+    return "scarsa"
+
+
+_MAX_MSGS_IN_RUN_RECORD = 20
+
+
 def build_validation_summary(result: ValidationResult) -> dict[str, Any]:
     errors_count = len(result.errors)
     warnings_count = len(result.warnings)
+    quality_score = _compute_quality_score(errors_count, warnings_count)
     out: dict[str, Any] = {
         "passed": result.ok,
         "errors_count": errors_count,
         "warnings_count": warnings_count,
+        "quality_score": quality_score,
+        "quality_verdict": _quality_verdict(quality_score),
+        "errors": result.errors[:_MAX_MSGS_IN_RUN_RECORD],
+        "warnings": result.warnings[:_MAX_MSGS_IN_RUN_RECORD],
         "checks": [
             {
                 "name": "errors",
@@ -84,6 +115,8 @@ def check_transitions(
 ) -> dict[str, Any]:
     warning_messages: list[str] = []
     structured_warnings: list[dict[str, Any]] = []
+    error_messages: list[str] = []
+    structured_errors: list[dict[str, Any]] = []
     for profile in transition_profiles:
         target_name = profile.get("target_name", "?")
         source_layer = profile.get("from") or "clean"
@@ -104,18 +137,32 @@ def check_transitions(
                     f"exceeds threshold {transition_cfg.max_row_drop_pct}% "
                     f"({source_layer}={source_rows} -> {target_layer}={target_rows})"
                 )
-                warning_messages.append(message)
-                structured_warnings.append(
-                    {
-                        "kind": "row_drop_pct",
-                        "target_name": target_name,
-                        "source_row_count": source_rows,
-                        "target_row_count": target_rows,
-                        "drop_pct": round(drop_pct, 1),
-                        "threshold_pct": transition_cfg.max_row_drop_pct,
-                        "message": message,
-                    }
-                )
+                if transition_cfg.fail_on_row_drop_exceeded:
+                    error_messages.append(message)
+                    structured_errors.append(
+                        {
+                            "kind": "row_drop_pct",
+                            "target_name": target_name,
+                            "source_row_count": source_rows,
+                            "target_row_count": target_rows,
+                            "drop_pct": round(drop_pct, 1),
+                            "threshold_pct": transition_cfg.max_row_drop_pct,
+                            "message": message,
+                        }
+                    )
+                else:
+                    warning_messages.append(message)
+                    structured_warnings.append(
+                        {
+                            "kind": "row_drop_pct",
+                            "target_name": target_name,
+                            "source_row_count": source_rows,
+                            "target_row_count": target_rows,
+                            "drop_pct": round(drop_pct, 1),
+                            "threshold_pct": transition_cfg.max_row_drop_pct,
+                            "message": message,
+                        }
+                    )
 
         if transition_cfg.warn_removed_columns and removed:
             message = f"[transition:{target_name}] columns removed from {source_layer}: {removed}"
@@ -136,8 +183,12 @@ def check_transitions(
         "config": {
             "max_row_drop_pct": transition_cfg.max_row_drop_pct,
             "warn_removed_columns": transition_cfg.warn_removed_columns,
+            "fail_on_row_drop_exceeded": transition_cfg.fail_on_row_drop_exceeded,
         },
         "profiles_count": len(transition_profiles),
+        "errors_count": len(structured_errors),
+        "errors": structured_errors,
+        "error_messages": error_messages,
         "warnings_count": len(structured_warnings),
         "warnings": structured_warnings,
         "warning_messages": warning_messages,

--- a/toolkit/mart/validate.py
+++ b/toolkit/mart/validate.py
@@ -216,11 +216,15 @@ def run_mart_validation(cfg, year: int, logger, *, sample_mode: bool = False) ->
         metadata.get("transition_profiles") or [],
         spec.validate.transition,
     )
-    if transition_report["warning_messages"]:
+    has_warnings = bool(transition_report["warning_messages"])
+    has_errors = bool(transition_report["error_messages"])
+    merged_errors = result.errors + transition_report["error_messages"]
+    merged_warnings = result.warnings + transition_report["warning_messages"]
+    if has_warnings or has_errors:
         result = ValidationResult(
-            ok=result.ok,
-            errors=result.errors,
-            warnings=result.warnings + transition_report["warning_messages"],
+            ok=result.ok and not has_errors,
+            errors=merged_errors,
+            warnings=merged_warnings,
             summary=result.summary,
             sections={"transition": transition_report},
         )

--- a/toolkit/scout/http.py
+++ b/toolkit/scout/http.py
@@ -455,7 +455,7 @@ def fetch_content(
                         "content_length": None,
                     }
         finally:
-            resp.close()
+            getattr(resp, "close", lambda: None)()
 
     raise RuntimeError(f"GET failed for {url}")
 


### PR DESCRIPTION
## Sintesi

Pipeline di validazione resa più robusta: quality score con gradiente,
transizioni bloccanti di default, readiness estesa con check di qualità.

## Contesto collegato

Analisi dei gap nella validazione del toolkit (sessione 2026-06-20):
- Gap 5 — transizioni bloccanti: `fail_on_row_drop_exceeded`
- Gap 1 — quality score: gradiente 0-100 invece di binario ok/fail
- Gap 3 — quality score propagato a tutti i consumatori
- Gap 2 — readiness estesa con naming colonne, coverage regole, metadata

## Cosa cambia

- [x] Bug fix (transizioni non bloccavano mai, qualità senza gradiente)
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

- [ ] Struttura `dataset.yml` (nuovo campo, cambio obbligatorietà)
- [ ] Path output (nuovo layer, cambio percorso artifact)
- [ ] Schema parquet (nuova colonna, rename, cambio tipo)
- [x] CLI o MCP tool (nuovo campo `quality_score` in validation JSON, `quality_verdict`)
- [ ] API pubblica del toolkit (firma funzione, classe, eccezione)

> **Note**: Tutti i nuovi campi sono **aggiuntivi** (non rompono consumatori esistenti).
> `fail_on_row_drop_exceeded` default True, opt-out per dataset.

## Verifica

```bash
pytest tests/test_validate_layers.py tests/test_validate_rules.py tests/test_run_validation_gate.py tests/test_mcp_toolkit_client.py tests/test_config_loading.py tests/test_report_ops.py -q
pytest -m smoke -q
ruff check .
ruff format --check .
toolkit run full -c project-example/dataset.yml
```

- [x] `pytest` passa (110 test)
- [x] `ruff check .` passa
- [x] `mypy toolkit/` passa
- [x] Smoke test passano (18/19, 1 skip S3)
- [x] Modificati o aggiunti test con marker (`policy`)

## Checklist PR

- [x] Perimetro stretto: 4 gap correlati, stesso contratto centrale
- [x] Issue collegata: analisi verbale in sessione
- [x] **Nessun modulo rimosso**

## Riepilogo modifiche

| File | Cosa |
|---|---|
| `core/config_models/mart.py` | `fail_on_row_drop_exceeded` in TransitionConfig (default **True**) |
| `core/validation.py` | `quality_score` + `quality_verdict` in `build_validation_summary()`; error/warning text persistiti; `check_transitions()` supporta error mode |
| `clean/validate.py` | Propagazione errori da `check_transitions()` |
| `mart/validate.py` | Propagazione errori da `check_transitions()` |
| `cli/inspect/readiness_ops.py` | 3 nuovi check (naming, coverage, metadata); `ok=None` escluso dal conteggio |
| `cli/inspect/_helpers.py` | `quality_score` + `quality_verdict` in `_validation_summary_for_layer()`; `columns` e `rules` |
| `cli/inspect/report_ops.py` | `quality_score` in layer validation report; fallback qualità |
| `cli/cmd_run.py` | `qs=N` in output CLI; recap warnings messaggi |
| `project-example/dataset.yml` | Aggiunto `source_id` per readiness |
| `tests/test_validate_layers.py` | 9 nuovi test per quality score e transizioni blocking |

### Dettaglio nuovi campi pubblici

**validation JSON su disco** (`raw_validation.json`, `clean_validation.json`, `mart_validation.json`):
```json
{
  "quality_score": 90,
  "quality_verdict": "buona",
  "errors": ["..."],
  "warnings": ["..."]
}
```

**Run record** (`_runs/{dataset}/{year}/*.json`):
```json
"validations": {
  "raw": { "quality_score": 100, "quality_verdict": "buona", "errors": [], "warnings": [] }
}
```

## Note per chi revisiona

- `fail_on_row_drop_exceeded` è **True** di default. Chi vuole il vecchio comportamento aggiunga `fail_on_row_drop_exceeded: false` nel transition config.
- I 3 nuovi check di readiness possono produrre `needs-review` anche su dataset funzionanti ma con naming o coverage parziali — è il comportamento voluto.
- Warning/error text nel run record capped a 20 messaggi per evitare run record enormi.