### PR TITLE
refactor: rimuovi suggested_read.yml da run raw, deriva da raw_profile.json

### DIFF
--- a/project-example/sql/clean.sql
+++ b/project-example/sql/clean.sql
@@ -1,24 +1,24 @@
 WITH base AS (
   SELECT
-    COALESCE("Regione", "REGIONE") AS regione,
-    COALESCE("Provincia", "PROVINCIA") AS provincia,
-    COALESCE("Comune", "COMUNE") AS comune,
+    CAST(COALESCE("Regione", "REGIONE") AS VARCHAR) AS regione,
+    CAST(COALESCE("Provincia", "PROVINCIA") AS VARCHAR) AS provincia,
+    CAST(COALESCE("Comune", "COMUNE") AS VARCHAR) AS comune,
 
     COALESCE(
-      "Raccolta differenziata (%)",
-      "Raccolta differenziata %",
-      "RD (%)",
-      "RD%",
+      CAST("Raccolta differenziata (%)" AS VARCHAR),
+      CAST("Raccolta differenziata %" AS VARCHAR),
+      CAST("RD (%)" AS VARCHAR),
+      CAST("RD%" AS VARCHAR),
 
       -- varianti strane viste in giro
-      "Raccolta differenziata ( % )"
+      CAST("Raccolta differenziata ( % )" AS VARCHAR)
     ) AS pct_rd_raw,
 
     COALESCE(
-      "Rifiuti urbani totali (t)",
-      "Rifiuti urbani totali t",
-      "RU totali (t)",
-      "RU totali t"
+      CAST("Rifiuti urbani totali (t)" AS VARCHAR),
+      CAST("Rifiuti urbani totali t" AS VARCHAR),
+      CAST("RU totali (t)" AS VARCHAR),
+      CAST("RU totali t" AS VARCHAR)
     ) AS ru_tot_t_raw
 
   FROM raw_input
@@ -54,4 +54,4 @@ SELECT
 FROM base
 WHERE regione  IS NOT NULL AND TRIM(regione)  <> ''
   AND provincia IS NOT NULL AND TRIM(provincia) <> ''
-  AND comune   IS NOT NULL AND TRIM(comune)   <> '';
+  AND comune   IS NOT NULL AND TRIM(comune)   <> ''

--- a/tests/test_clean_duckdb_read.py
+++ b/tests/test_clean_duckdb_read.py
@@ -9,7 +9,7 @@ import pytest
 import yaml
 
 from toolkit.core import duckdb_read
-from toolkit.clean.read_config import resolve_clean_read_cfg
+from toolkit.clean.read_config import load_suggested_read, resolve_clean_read_cfg
 
 
 @pytest.mark.policy
@@ -767,3 +767,41 @@ def test_parquet_inject_column_escapes_apostrophe(tmp_path: Path):
             ("Valle d'Aosta", "Valle d'Aosta", 3),
         ], f"Unexpected rows: {rows}"
         assert "inject_column" in info.params_used
+
+
+@pytest.mark.regression
+def test_load_suggested_read_raw_profile_wins_over_suggested_yml(tmp_path: Path):
+    """Con entrambi raw_profile.json (con decimal) e suggested_read.yml (senza decimal)
+    presenti, raw_profile.json deve vincere: decimal deve essere presente."""
+    profile_dir = tmp_path / "_profile"
+    profile_dir.mkdir(parents=True)
+
+    # suggested_read.yml — versione POVERA, senza decimal
+    (profile_dir / "suggested_read.yml").write_text(
+        yaml.dump({"clean": {"read": {"delim": ";", "encoding": "utf-8"}}}),
+        encoding="utf-8",
+    )
+
+    # raw_profile.json — versione RICCA, con decimal
+    (profile_dir / "raw_profile.json").write_text(
+        __import__("json").dumps(
+            {
+                "delim_suggested": ";",
+                "encoding_suggested": "utf-8",
+                "decimal_suggested": ",",
+                "skip_suggested": 0,
+                "robust_read_suggested": False,
+                "date_raw_values": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = load_suggested_read(tmp_path)
+
+    assert result is not None, "load_suggested_read deve restituire un dict"
+    assert result.get("decimal") == ",", (
+        f"Decimal deve venire da raw_profile.json, got: {result.get('decimal')}"
+    )
+    assert result.get("delim") == ";"
+    assert result.get("encoding") == "utf-8"

--- a/tests/test_cli_inspect_paths.py
+++ b/tests/test_cli_inspect_paths.py
@@ -59,7 +59,7 @@ def test_inspect_paths_reports_dataset_repo_layout_from_other_cwd(
     )
     assert "raw_hints:" in result.output
     assert "primary_output_file:" in result.output
-    assert "suggested_read_exists: True" in result.output
+    assert "suggested_read_exists: False" in result.output
     assert "latest_run_status: SUCCESS" in result.output
 
 

--- a/tests/test_cli_path_contract.py
+++ b/tests/test_cli_path_contract.py
@@ -137,7 +137,7 @@ def test_cli_commands_use_dataset_yml_dir_as_path_base(tmp_path: Path, monkeypat
     mart_dir = root / "data" / "mart" / "project_example" / "2022"
 
     assert (raw_dir / "ispra_dettaglio_comunale_2022.csv").exists()
-    assert (raw_dir / "_profile" / "suggested_read.yml").exists()
+    assert (raw_dir / "_profile" / "raw_profile.json").exists()
     assert (clean_dir / "project_example_2022_clean.parquet").exists()
     assert (mart_dir / "rd_by_regione.parquet").exists()
     assert (mart_dir / "rd_by_provincia.parquet").exists()

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -130,7 +130,7 @@ def test_artifacts_policy_standard_keeps_expected_artifacts(
     mart_dir = root / "data" / "mart" / cfg.dataset / str(year)
 
     assert (profile_dir / "raw_profile.json").exists()
-    assert (profile_dir / "suggested_read.yml").exists()
+    # suggested_read.yml non è più scritto da run raw — deriva da raw_profile.json al volo
     assert (clean_dir / "_run" / "clean_rendered.sql").exists()
     assert any((mart_dir / "_run").glob("*_rendered.sql"))
 

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -55,6 +55,17 @@ def _split_read_cfg(explicit_cfg: dict[str, Any]) -> tuple[dict[str, Any], dict[
 
 
 def load_suggested_read(raw_year_dir: Path) -> dict[str, Any] | None:
+    # 1. raw_profile.json (ricco, da DuckDB profiling) — priorità massima
+    raw_profile_path = raw_year_dir / RAW_PROFILE_DIR / RAW_PROFILE
+    raw_profile = read_json_or_none(raw_profile_path) if raw_profile_path.exists() else None
+    if raw_profile is not None:
+        from toolkit.profile.raw import build_suggested_read_cfg
+
+        derived = build_suggested_read_cfg(raw_profile)
+        if derived:
+            return dict(derived)
+
+    # 2. Fallback legacy: suggested_read.yml (versione povera, sniff leggero)
     suggested_path = raw_year_dir / RAW_PROFILE_DIR / RAW_SUGGESTED_READ
     if suggested_path.exists():
         payload = read_yaml(suggested_path)
@@ -64,16 +75,6 @@ def load_suggested_read(raw_year_dir: Path) -> dict[str, Any] | None:
                 read_cfg = clean_cfg.get("read")
                 if isinstance(read_cfg, dict):
                     return dict(read_cfg)
-
-    # Fallback: deriva da raw_profile.json (elimina la dipendenza da suggested_read.yml
-    # scritto durante run raw, che era una versione povera basata su sniff leggero).
-    raw_profile_path = raw_year_dir / RAW_PROFILE_DIR / RAW_PROFILE
-    raw_profile = read_json_or_none(raw_profile_path) if raw_profile_path.exists() else None
-    if raw_profile is not None:
-        from toolkit.profile.raw import build_suggested_read_cfg
-
-        derived = build_suggested_read_cfg(raw_profile)
-        return dict(derived) if derived else None
 
     return None
 
@@ -93,8 +94,14 @@ def resolve_clean_read_cfg(
     suggested_cfg = load_suggested_read(raw_year_dir)
     filtered_suggested = filter_suggested_read(suggested_cfg)
     if normalized_source == "auto" and filtered_suggested and logger is not None:
+        _src = (
+            "raw_profile.json"
+            if (raw_year_dir / RAW_PROFILE_DIR / RAW_PROFILE).exists()
+            else "suggested_read.yml"
+        )
         logger.info(
-            "CLEAN read hints loaded from suggested_read.yml: %s",
+            "CLEAN read hints loaded from %s: %s",
+            _src,
             json.dumps(filtered_suggested, ensure_ascii=False, sort_keys=True),
         )
 

--- a/toolkit/clean/read_config.py
+++ b/toolkit/clean/read_config.py
@@ -2,7 +2,7 @@
 
 Responsible for resolving clean.read contract from:
 - explicit clean.read config
-- suggested_read.yml hints from raw profiling
+- suggested_read.yml hints from raw profiling (o derivato da raw_profile.json)
 - merging and normalising into a unified read config
 
 Does NOT handle runtime read execution (see duckdb_read.py).
@@ -14,14 +14,14 @@ import json
 from pathlib import Path
 from typing import Any
 
-from toolkit.core.io import read_yaml
+from toolkit.core.io import read_json_or_none, read_yaml
 from toolkit.core.csv_read import (
     READ_SELECTION_KEYS,
     READ_SOURCE_MODES,
     filter_suggested_format_keys,
     merge_read_cfg,
 )
-from toolkit.core.paths import RAW_PROFILE_DIR, RAW_SUGGESTED_READ
+from toolkit.core.paths import RAW_PROFILE, RAW_PROFILE_DIR, RAW_SUGGESTED_READ
 
 
 def _read_source_mode(clean_cfg: dict[str, Any], logger=None) -> tuple[str, dict[str, Any]]:
@@ -56,22 +56,26 @@ def _split_read_cfg(explicit_cfg: dict[str, Any]) -> tuple[dict[str, Any], dict[
 
 def load_suggested_read(raw_year_dir: Path) -> dict[str, Any] | None:
     suggested_path = raw_year_dir / RAW_PROFILE_DIR / RAW_SUGGESTED_READ
-    if not suggested_path.exists():
-        return None
+    if suggested_path.exists():
+        payload = read_yaml(suggested_path)
+        if isinstance(payload, dict):
+            clean_cfg = payload.get("clean")
+            if isinstance(clean_cfg, dict):
+                read_cfg = clean_cfg.get("read")
+                if isinstance(read_cfg, dict):
+                    return dict(read_cfg)
 
-    payload = read_yaml(suggested_path)
-    if not isinstance(payload, dict):
-        return None
+    # Fallback: deriva da raw_profile.json (elimina la dipendenza da suggested_read.yml
+    # scritto durante run raw, che era una versione povera basata su sniff leggero).
+    raw_profile_path = raw_year_dir / RAW_PROFILE_DIR / RAW_PROFILE
+    raw_profile = read_json_or_none(raw_profile_path) if raw_profile_path.exists() else None
+    if raw_profile is not None:
+        from toolkit.profile.raw import build_suggested_read_cfg
 
-    clean_cfg = payload.get("clean")
-    if not isinstance(clean_cfg, dict):
-        return None
+        derived = build_suggested_read_cfg(raw_profile)
+        return dict(derived) if derived else None
 
-    read_cfg = clean_cfg.get("read")
-    if not isinstance(read_cfg, dict):
-        return None
-
-    return dict(read_cfg)
+    return None
 
 
 def filter_suggested_read(cfg: dict[str, Any] | None) -> dict[str, Any]:

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -18,7 +18,6 @@ from toolkit.profile.raw import (
     sniff_source_file,
     profile_raw,
     write_raw_profile,
-    write_suggested_read_yml,
 )
 from toolkit.scaffold.clean import scaffold_clean_if_missing
 from toolkit.raw._fetch_utils import (
@@ -168,12 +167,6 @@ def run_raw(
     }:
         try:
             profile_hints = sniff_source_file(primary_output_path)
-            if should_write("profile", "suggested_read", profile_ctx):
-                conservative_hints = dict(profile_hints)
-                conservative_hints["decimal_suggested"] = None
-                suggested_path = write_suggested_read_yml(out_dir / "_profile", conservative_hints)
-                logger.info("RAW suggested_read -> %s", suggested_path)
-
             if should_write("profile", "raw_profile", profile_ctx):
                 raw_profile = profile_raw(
                     out_dir,


### PR DESCRIPTION
## Sintesi

`suggested_read.yml` veniva scritto in `run raw` PRIMA del profiling DuckDB completo,
producendo una versione conservativa (es. `decimal_suggested=None`). Il clean runtime
leggeva questa versione povera, perdendo hint importanti.

Ora il clean runtime deriva la config di lettura al volo da `raw_profile.json`
tramite `build_suggested_read_cfg()`, utility pura già esistente.

## Cosa cambia

- `raw/run.py`: rimossa scrittura `suggested_read.yml` (~10 righe in meno)
- `clean/read_config.py`: `load_suggested_read()` fallback a `raw_profile.json` → `build_suggested_read_cfg()`
- `project-example/sql/clean.sql`: CAST espliciti in COALESCE (il decimal è ora correttamente rilevato,
  prima era mascherato dalla versione conservativa di suggested_read.yml)

## Impatto

- `build_suggested_read_cfg()` e `write_suggested_read_yml()` rimangono nell'API pubblica
- `toolkit inspect profile` scrive ancora `suggested_read.yml` per chi lo vuole
- Il clean runtime ora ha sempre la versione RICCA degli hint (con decimal, dateformat, robust flags)

## Verifica

```bash
pytest tests/test_validate_layers.py tests/test_clean_duckdb_read.py tests/test_profile_sniff.py tests/test_public_api_contracts.py -q
toolkit run full -c project-example/dataset.yml  # verifica assenza suggested_read.yml, lettura da raw_profile.json
```