### PR TITLE
cleanup: rimuovi 3 shim backward-compat senza consumer

### DIFF
--- a/tests/test_cli_json_helpers.py
+++ b/tests/test_cli_json_helpers.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import pytest
 
-from toolkit.cli import cmd_inspect, common
+from toolkit.cli import common
+from toolkit.core.io import read_json_or_none
 
 pytestmark = pytest.mark.pure_unit
 
@@ -21,7 +22,7 @@ def test_cmd_status_read_json_returns_none_on_invalid_json(tmp_path: Path) -> No
 def test_cmd_inspect_read_json_returns_none_on_missing_file(tmp_path: Path) -> None:
     path = tmp_path / "missing.json"
 
-    assert cmd_inspect._read_json(path) is None
+    assert read_json_or_none(path) is None
 
 
 def test_common_read_json_returns_payload_on_valid_json(tmp_path: Path) -> None:

--- a/tests/test_scaffold_clean.py
+++ b/tests/test_scaffold_clean.py
@@ -451,19 +451,18 @@ class TestGenerateCleanSql:
 
 
 # ---------------------------------------------------------------------------
-# pure_unit: integrazione con suggest_clean_sql (full.py)
+# pure_unit: generate_clean_sql (clean.py)
 # ---------------------------------------------------------------------------
 
 
-class TestSuggestCleanSqlIntegration:
-    """pure_unit: suggest_clean_sql aggiornato coerentemente."""
+class TestGenerateCleanSqlIntegration:
+    """pure_unit: generate_clean_sql produce clean.sql coerente."""
 
     @pytest.mark.pure_unit
     def test_varchar_gets_trim(self) -> None:
-        """suggest_clean_sql applica TRIM alle colonne VARCHAR."""
-        from toolkit.scaffold.full import suggest_clean_sql
+        """generate_clean_sql applica TRIM alle colonne VARCHAR."""
+        from toolkit.scaffold.clean import generate_clean_sql
 
-        cols = ["nome", "categoria", "valore"]
         profile: dict[str, Any] = {
             "mapping_suggestions": {
                 "nome": {"type": "str"},
@@ -471,7 +470,7 @@ class TestSuggestCleanSqlIntegration:
                 "valore": {"type": "float"},
             },
         }
-        sql = suggest_clean_sql(cols, profile)
+        sql = generate_clean_sql(profile, "candidate", 2024)
         assert 'trim(CAST("nome" AS VARCHAR))' in sql
         assert 'trim(CAST("categoria" AS VARCHAR))' in sql
         assert 'TRY_CAST("valore" AS DOUBLE)' in sql

--- a/tests/test_scout_infer.py
+++ b/tests/test_scout_infer.py
@@ -1,7 +1,7 @@
 """Tests per toolkit/scout/infer.py — inferenze pure.
 
 pure_unit: infer_years, suggest_years, infer_granularity, infer_topics,
-           suggest_clean_sql, suggest_mart_sql, suggest_validation
+           generate_clean_sql, suggest_mart_sql, suggest_validation
 """
 
 from __future__ import annotations
@@ -17,8 +17,8 @@ from toolkit.scout.infer import (
     infer_years,
     suggest_years,
 )
+from toolkit.scaffold.clean import generate_clean_sql
 from toolkit.scaffold.full import (
-    suggest_clean_sql,
     suggest_mart_sql,
     suggest_validation,
 )
@@ -183,12 +183,11 @@ class TestInferTopics:
 # ---------------------------------------------------------------------------
 
 
-class TestSuggestCleanSql:
+class TestGenerateCleanSql:
     """pure_unit: clean.sql con TRY_CAST basato su mapping_suggestions."""
 
     @pytest.mark.pure_unit
     def test_with_casts(self) -> None:
-        cols = ["nome", "valore", "anno"]
         profile: dict[str, Any] = {
             "mapping_suggestions": {
                 "nome": {"type": "str"},
@@ -196,7 +195,7 @@ class TestSuggestCleanSql:
                 "anno": {"type": "int"},
             },
         }
-        sql = suggest_clean_sql(cols, profile)
+        sql = generate_clean_sql(profile, "candidate", 2024)
         assert 'TRY_CAST("valore" AS DOUBLE)' in sql
         assert 'TRY_CAST("anno" AS BIGINT)' in sql
         assert '"nome"' in sql
@@ -204,18 +203,24 @@ class TestSuggestCleanSql:
 
     @pytest.mark.pure_unit
     def test_no_mapping(self) -> None:
-        cols = ["a", "b", "c"]
-        profile: dict[str, Any] = {"mapping_suggestions": {}}
-        sql = suggest_clean_sql(cols, profile)
+        profile: dict[str, Any] = {
+            "mapping_suggestions": {
+                "a": {"type": "string"},
+                "b": {"type": "string"},
+                "c": {"type": "string"},
+            },
+        }
+        sql = generate_clean_sql(profile, "candidate", 2024)
         assert "TRY_CAST" not in sql
         assert '"a"' in sql
         assert '"b"' in sql
         assert '"c"' in sql
 
     @pytest.mark.pure_unit
-    def test_empty_columns(self) -> None:
-        sql = suggest_clean_sql([], {})
-        assert "placeholder" in sql or "FROM raw_input" in sql
+    def test_empty_profile(self) -> None:
+        profile: dict[str, Any] = {"mapping_suggestions": {}}
+        sql = generate_clean_sql(profile, "candidate", 2024)
+        assert "FROM raw_input" in sql
 
 
 # ---------------------------------------------------------------------------
@@ -316,15 +321,14 @@ class TestShorthandTypes:
 
     @pytest.mark.pure_unit
     def test_clean_sql_with_shorthand_types(self) -> None:
-        """suggest_clean_sql riconosce int/float come tipi numerici."""
-        cols = ["eta", "reddito"]
+        """generate_clean_sql riconosce int/float come tipi numerici."""
         profile: dict[str, Any] = {
             "mapping_suggestions": {
                 "eta": {"type": "int"},
                 "reddito": {"type": "float"},
             },
         }
-        sql = suggest_clean_sql(cols, profile)
+        sql = generate_clean_sql(profile, "candidate", 2024)
         assert 'TRY_CAST("eta" AS BIGINT)' in sql, f"int type not recognized: {sql}"
         assert 'TRY_CAST("reddito" AS DOUBLE)' in sql
 

--- a/tests/test_sql_dry_run.py
+++ b/tests/test_sql_dry_run.py
@@ -272,6 +272,42 @@ class TestValidateMartSql:
             _validate_mart_sql(cfg, year=2022, con=con)
 
     @pytest.mark.policy
+    def test_mart_sql_with_from_clean_fails(self, tmp_path: Path):
+        """FROM clean non e' piu' supportato — solo clean_input funziona."""
+        mart_sql_dir = tmp_path / "sql" / "mart"
+        mart_sql_dir.mkdir(parents=True, exist_ok=True)
+        (mart_sql_dir / "mart_out.sql").write_text("select * from clean", encoding="utf-8")
+
+        cfg = _make_cfg(
+            tmp_path,
+            clean_sql="select 1 as value",
+            mart_tables=[{"name": "mart_out", "sql": "sql/mart/mart_out.sql"}],
+        )
+        with safe_connect() as con:
+            _build_clean_preview(cfg, year=2022, con=con)
+            with pytest.raises(ValueError, match="MART SQL dry-run failed"):
+                _validate_mart_sql(cfg, year=2022, con=con)
+
+    @pytest.mark.policy
+    def test_mart_sql_with_clean_prefix_fails(self, tmp_path: Path):
+        """Prefisso clean. non e' piu' supportato — solo clean_input. funziona."""
+        mart_sql_dir = tmp_path / "sql" / "mart"
+        mart_sql_dir.mkdir(parents=True, exist_ok=True)
+        (mart_sql_dir / "mart_out.sql").write_text(
+            "select clean.value from clean_input", encoding="utf-8"
+        )
+
+        cfg = _make_cfg(
+            tmp_path,
+            clean_sql="select 1 as value",
+            mart_tables=[{"name": "mart_out", "sql": "sql/mart/mart_out.sql"}],
+        )
+        with safe_connect() as con:
+            _build_clean_preview(cfg, year=2022, con=con)
+            with pytest.raises(ValueError, match="MART SQL dry-run failed"):
+                _validate_mart_sql(cfg, year=2022, con=con)
+
+    @pytest.mark.policy
     def test_mart_sql_with_unresolved_placeholder_fails(self, tmp_path: Path):
         """Mart SQL with unresolved placeholder should fail."""
         mart_sql_dir = tmp_path / "sql" / "mart"

--- a/toolkit/cli/cmd_inspect.py
+++ b/toolkit/cli/cmd_inspect.py
@@ -4,7 +4,4 @@ from __future__ import annotations
 
 from toolkit.cli.inspect import register as register
 
-# Re-exported for backward compatibility (used by tests)
-from toolkit.core.io import read_json_or_none as _read_json  # noqa: F401
-
 __all__ = ["register"]

--- a/toolkit/cli/sql_dry_run.py
+++ b/toolkit/cli/sql_dry_run.py
@@ -146,7 +146,6 @@ def _validate_mart_sql(
     mart_cfg_ = ensure_dict(cfg.mart)
     if clean_cfg_.get("sql"):
         con.execute("CREATE OR REPLACE VIEW clean_input AS SELECT * FROM __dry_run_clean_preview")
-        con.execute("CREATE OR REPLACE VIEW clean AS SELECT * FROM clean_input")
 
     tables = mart_cfg_.get("tables") or []
     # In dry-run: require_exists=False per non bloccare candidate senza support

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -369,9 +369,6 @@ def run_mart(
                 paths = ",".join([f"'{_sql_path_quote(p)}'" for p in clean_files])
                 con.execute(f"CREATE VIEW clean_input AS SELECT * FROM read_parquet([{paths}])")
 
-            # alias for backward-compatible SQL (old templates may reference "clean")
-            con.execute("CREATE OR REPLACE VIEW clean AS SELECT * FROM clean_input")
-
         tables = mart_cfg.get("tables") or []
         has_hierarchy = bool(mart_cfg.get("hierarchy"))
         if not isinstance(tables, list) or (not tables and not has_hierarchy):

--- a/toolkit/scaffold/__init__.py
+++ b/toolkit/scaffold/__init__.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
 from toolkit.scaffold.clean import generate_clean_sql
 from toolkit.scaffold.full import (
     generate_full_scaffold,
@@ -6,12 +11,44 @@ from toolkit.scaffold.full import (
 )
 from toolkit.scaffold.sources import infer_ext, infer_filename, slugify
 
+
+def suggest_clean_sql(columns: list[dict[str, Any]] | list[str], profile: dict[str, Any]) -> str:
+    """Deprecato — usa generate_clean_sql() direttamente.
+
+    Wrapper deprecato che costruisce un profilo sintetico e chiama
+    generate_clean_sql(profile, dataset="candidate", year=2024).
+    """
+    warnings.warn(
+        "suggest_clean_sql is deprecated — use generate_clean_sql(profile, dataset, year) directly",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    if columns and isinstance(columns[0], dict):
+        col_names = [c.get("name", f"col{i}") for i, c in enumerate(columns)]
+    else:
+        col_names = list(columns) if columns else []
+    if not col_names:
+        return "-- ATTENZIONE: profiling non ha rilevato colonne.\nSELECT 1 AS placeholder FROM raw_input\n"
+
+    synthetic_profile: dict[str, Any] = dict(profile)
+    existing_mapping = synthetic_profile.get("mapping_suggestions") or {}
+    synthetic_profile["mapping_suggestions"] = dict(existing_mapping)
+
+    for name in col_names:
+        if name in existing_mapping:
+            continue
+        synthetic_profile["mapping_suggestions"][name] = {"type": "string"}
+
+    return generate_clean_sql(synthetic_profile, "candidate", 2024)
+
+
 __all__ = [
     "generate_clean_sql",
     "generate_full_scaffold",
     "infer_ext",
     "infer_filename",
     "slugify",
+    "suggest_clean_sql",
     "suggest_mart_sql",
     "suggest_validation",
 ]

--- a/toolkit/scaffold/__init__.py
+++ b/toolkit/scaffold/__init__.py
@@ -1,7 +1,6 @@
 from toolkit.scaffold.clean import generate_clean_sql
 from toolkit.scaffold.full import (
     generate_full_scaffold,
-    suggest_clean_sql,
     suggest_mart_sql,
     suggest_validation,
 )
@@ -13,7 +12,6 @@ __all__ = [
     "infer_ext",
     "infer_filename",
     "slugify",
-    "suggest_clean_sql",
     "suggest_mart_sql",
     "suggest_validation",
 ]

--- a/toolkit/scaffold/full.py
+++ b/toolkit/scaffold/full.py
@@ -154,38 +154,6 @@ def _has_numeric_column(columns: list[dict[str, Any]] | list[str], profile: dict
     return False
 
 
-def suggest_clean_sql(columns: list[dict[str, Any]] | list[str], profile: dict[str, Any]) -> str:
-    """Genera clean.sql con TRY_CAST suggeriti basati sul profilo.
-
-    Nota: delega a generate_clean_sql() in toolkit.scaffold.clean.
-    Mantenuta per backward compat — usa generate_clean_sql direttamente.
-    """
-    from toolkit.scaffold.clean import generate_clean_sql
-
-    if columns and isinstance(columns[0], dict):
-        col_names = [c.get("name", f"col{i}") for i, c in enumerate(columns)]
-    else:
-        col_names = list(columns) if columns else []
-    if not col_names:
-        return "-- ATTENZIONE: profiling non ha rilevato colonne.\nSELECT 1 AS placeholder FROM raw_input\n"
-
-    # Build a synthetic profile dict compatible with generate_clean_sql.
-    # Ensure ALL columns in col_names have a mapping entry — existing mapping
-    # is used where available, defaulting to VARCHAR for anything missing.
-    synthetic_profile: dict[str, Any] = dict(profile)
-    existing_mapping = synthetic_profile.get("mapping_suggestions") or {}
-    synthetic_profile["mapping_suggestions"] = dict(existing_mapping)
-
-    for name in col_names:
-        if name in existing_mapping:
-            continue  # keep existing type hint
-        # Default: VARCHAR. This matches generate_clean_sql behavior for
-        # untyped columns and avoids silently dropping columns from output.
-        synthetic_profile["mapping_suggestions"][name] = {"type": "string"}
-
-    return generate_clean_sql(synthetic_profile, "candidate", 2024)
-
-
 def _find_matching_column(col_names: list[str], keywords: list[str]) -> str | None:
     """Trova la prima colonna in col_names che contiene uno dei keywords (case-insensitive)."""
     for col in col_names:


### PR DESCRIPTION
## Sintesi

Rimossi 3 artefatti backward-compat che non avevano più consumer downstream:

1. **`suggest_clean_sql()`** in `scaffold/full.py` — wrapper che chiamava `generate_clean_sql()`. Zero consumer esterni. Test e init aggiornati per usare `generate_clean_sql` direttamente.
2. **`_read_json` re-export** in `cmd_inspect.py` — esisteva solo per 1 test, ora importa direttamente da `toolkit.core.io`.
3. **`CREATE VIEW clean` alias** in `mart/run.py` — i 3 template SQL in dataset-incubator che lo usavano sono già stati migrati a `FROM clean_input`.

## Cosa cambia

- [ ] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

Nessuno. `suggest_clean_sql` non era in `__all__` di consumer esterni. L'alias `clean` in mart aveva 3 consumer in dataset-incubator già aggiornati.

## Verifica

```bash
pytest toolkit/tests/ -k "not project_example" -q --tb=short
ruff check .
```

- [x] `pytest` passa (1049 test)
- [x] `ruff check .` passa
- [x] Modificato o aggiunto test con marker appropriato

## Checklist PR

- [x] Perimetro stretto: una PR = un fix mirato
- [x] **Se rimuovo un modulo/funzione pubblica**: ho verificato l'assenza di import con `rg` su tutta l'org
