### PR TITLE
cleanup: smetti di scrivere suggested_read.yml, inlinea _normalize_legacy_payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Il toolkit non gestisce il deployment: scrive nella directory configurata via
 | `toolkit inspect schema-diff --config dataset.yml` | Confronta schema RAW tra anni configurati |
 | `toolkit review-readiness --config dataset.yml` | Check di prontezza per review candidate (raccomandato) |
 | `toolkit status --dataset <name> --year <year> --latest --config dataset.yml` | Ultimo run completato |
-| `toolkit inspect profile --config dataset.yml` | Profilo diagnostico del RAW (encoding, delimitatore, colonne) — scrive `raw_profile.json` e `suggested_read.yml` |
+| `toolkit inspect profile --config dataset.yml` | Profilo diagnostico del RAW (encoding, delimitatore, colonne) — scrive `raw_profile.json` |
 
 ### Altri comandi
 

--- a/docs/advanced-workflows.md
+++ b/docs/advanced-workflows.md
@@ -89,7 +89,7 @@ Il comando verifica anche gli artefatti minimi del layer precedente prima di rip
 Artefatti principali:
 
 - `raw/<dataset>/<year>/_profile/raw_profile.json`
-- `raw/<dataset>/<year>/_profile/suggested_read.yml`
+- `raw/<dataset>/<year>/_profile/suggested_read.yml` (non più prodotto, leggibile come fallback se presente da run precedenti)
 
 Nota pratica:
 

--- a/smoke/bdap_ckan_csv/README.md
+++ b/smoke/bdap_ckan_csv/README.md
@@ -17,7 +17,6 @@ toolkit status --dataset bdap_ckan_csv --year 2022 --latest --config dataset.yml
 - `./_smoke_out/data/raw/bdap_ckan_csv/2022/manifest.json`
 - `./_smoke_out/data/raw/bdap_ckan_csv/2022/raw_validation.json`
 - `./_smoke_out/data/raw/bdap_ckan_csv/2022/_profile/raw_profile.json`
-- `./_smoke_out/data/raw/bdap_ckan_csv/2022/_profile/suggested_read.yml`
 - `./_smoke_out/data/clean/bdap_ckan_csv/2022/metadata.json` con `read_params_source`, `read_source_used`, `read_params_used`
 - `./_smoke_out/data/mart/bdap_ckan_csv/2022/mart_ok.parquet`
 

--- a/smoke/bdap_http_csv/README.md
+++ b/smoke/bdap_http_csv/README.md
@@ -17,7 +17,6 @@ toolkit status --dataset bdap_http_csv --year 2022 --latest --config dataset.yml
 - `./_smoke_out/data/raw/bdap_http_csv/2022/manifest.json`
 - `./_smoke_out/data/raw/bdap_http_csv/2022/raw_validation.json`
 - `./_smoke_out/data/raw/bdap_http_csv/2022/_profile/raw_profile.json`
-- `./_smoke_out/data/raw/bdap_http_csv/2022/_profile/suggested_read.yml`
 - `./_smoke_out/data/clean/bdap_http_csv/2022/metadata.json` con `read_params_source`, `read_source_used`, `read_params_used`
 - `./_smoke_out/data/mart/bdap_http_csv/2022/mart_ok.parquet`
 

--- a/smoke/zip_http_csv/README.md
+++ b/smoke/zip_http_csv/README.md
@@ -25,7 +25,6 @@ toolkit status --dataset zip_http_csv --year 2022 --latest --config dataset.yml
 - `./_smoke_out/data/raw/zip_http_csv/2022/manifest.json`
 - `./_smoke_out/data/raw/zip_http_csv/2022/raw_validation.json`
 - `./_smoke_out/data/raw/zip_http_csv/2022/_profile/raw_profile.json`
-- `./_smoke_out/data/raw/zip_http_csv/2022/_profile/suggested_read.yml`
 - `./_smoke_out/data/clean/zip_http_csv/2022/metadata.json` con `read_params_source`, `read_source_used`, `read_params_used`
 - `./_smoke_out/data/mart/zip_http_csv/2022/mart_ok.parquet`
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -2,52 +2,7 @@
 
 import pytest
 
-from toolkit.core.artifacts import profile_required, should_write
-
-
-# profile_required
-
-
-@pytest.mark.policy
-@pytest.mark.parametrize(
-    "cfg, expected",
-    [
-        (None, True),
-        ({}, True),
-        ({"clean": {}}, True),
-        ({"clean": {"read": {"source": "auto"}}}, True),
-        ({"clean": {"read": {"source": "duckdb"}}}, False),
-        ({"clean": {"read": "duckdb"}}, False),
-        ({"clean": {"read_source": "duckdb"}}, False),
-    ],
-)
-def test_profile_required(cfg, expected) -> None:
-    assert profile_required(cfg) is expected
-
-
-@pytest.mark.policy
-def test_profile_required_object_attribute_access() -> None:
-    class Cfg:
-        pass
-
-    obj = Cfg()
-    obj.clean = {"read": {"source": "duckdb"}}
-    assert profile_required(obj) is False
-
-
-# should_write
-
-
-@pytest.mark.policy
-@pytest.mark.parametrize(
-    "layer, artifact, cfg, expected",
-    [
-        ("profile", "suggested_read", {"clean": {"read": {"source": "auto"}}}, True),
-        ("profile", "suggested_read", {"clean": {"read": {"source": "duckdb"}}}, False),
-    ],
-)
-def test_should_write(layer, artifact, cfg, expected) -> None:
-    assert should_write(layer, artifact, cfg) is expected
+from toolkit.core.artifacts import should_write
 
 
 @pytest.mark.policy
@@ -55,12 +10,13 @@ def test_should_write(layer, artifact, cfg, expected) -> None:
     "layer, artifact",
     [
         ("profile", "raw_profile"),
+        ("profile", "suggested_read"),
         ("clean", "rendered_sql"),
-        ("mart", "rendered_sql"),
         ("clean", "data_parquet"),
+        ("mart", "rendered_sql"),
         ("mart", "aggregated_parquet"),
     ],
 )
-def test_should_write_always_true(layer, artifact) -> None:
-    """All artifacts always returned True — no policy gating."""
-    assert should_write(layer, artifact, {}) is True
+def test_should_write_always_true(layer: str, artifact: str) -> None:
+    """All artifacts are always written — no policy gating."""
+    assert should_write(layer, artifact) is True

--- a/toolkit/cli/inspect/profile_ops.py
+++ b/toolkit/cli/inspect/profile_ops.py
@@ -17,7 +17,6 @@ import typer
 from lab_connectors.duckdb import safe_connect
 
 from toolkit.cli.common import dump_cfg_section, iter_selected_years, load_cfg_and_logger
-from toolkit.core.artifacts import should_write
 from toolkit.core.csv_read import csv_read_option_strings, robust_preset
 from toolkit.core.sql_utils import sql_str
 from toolkit.core.paths import layer_year_dir
@@ -27,7 +26,6 @@ from toolkit.profile.raw import (
     profile_with_read_cfg,
     sniff_source_file,
     write_raw_profile,
-    write_suggested_read_yml,
 )
 
 
@@ -127,9 +125,6 @@ def run_profile(cfg: ToolkitConfig, years: list[int], logger: Logger) -> None:
         prof = profile_raw(raw_dir, cfg.dataset, y, read_cfg=clean_cfg.get("read"))
         paths = write_raw_profile(out_dir, prof)
         written_paths = list(paths.values())
-
-        if should_write("profile", "suggested_read", cfg):
-            written_paths.append(write_suggested_read_yml(out_dir, prof.__dict__))
 
         if written_paths:
             logger.info("PROFILE RAW -> %s", " | ".join(str(path) for path in written_paths))

--- a/toolkit/core/artifacts.py
+++ b/toolkit/core/artifacts.py
@@ -1,45 +1,6 @@
-from __future__ import annotations
-
-from typing import Any
-
-
-def profile_required(cfg: Any) -> bool:
-    """True quando il read source è ``"auto"`` e serve profiling raw."""
-    if not cfg:
-        return True  # default: assume profile needed
-    if isinstance(cfg, dict):
-        clean_cfg = cfg.get("clean") or {}
-        read_cfg = clean_cfg.get("read")
-        if isinstance(read_cfg, dict):
-            source = read_cfg.get("source", "auto")
-        elif isinstance(read_cfg, str):
-            source = read_cfg
-        else:
-            source = clean_cfg.get("read_source", "auto")
-    else:
-        # ToolkitConfig object or duck-typed object with .clean
-        clean_attr = cfg.clean
-        if isinstance(clean_attr, dict):
-            read_cfg = clean_attr.get("read")
-            if isinstance(read_cfg, dict):
-                source = read_cfg.get("source", "auto")
-            elif isinstance(read_cfg, str):
-                source = read_cfg
-            else:
-                source = clean_attr.get("read_source", "auto")
-        else:
-            read_cfg = clean_attr.read
-            source = read_cfg.source if read_cfg else clean_attr.read_source
-    return str(source or "auto").strip().lower() == "auto"
-
-
-def should_write(layer: str, artifact_name: str, cfg: Any) -> bool:
+def should_write(layer: str, artifact_name: str, cfg: object = None) -> bool:
     """Decide whether a given artifact should be produced.
 
-    Most artifacts are always written. The only exception is
-    ``suggested_read``, which is skipped when the read source
-    is explicitly configured (non-``"auto"``).
+    All artifacts are always written — no special cases.
     """
-    if layer == "profile" and artifact_name == "suggested_read":
-        return profile_required(cfg)
     return True

--- a/toolkit/core/config_models/__init__.py
+++ b/toolkit/core/config_models/__init__.py
@@ -44,7 +44,6 @@ from toolkit.core.config_models.policy import (
     _declared_model_keys,
     _emit_deprecation_notice,
     _emit_unknown_keys_notice,
-    _normalize_legacy_payload,
     _warn_or_reject_unknown_keys,
 )
 
@@ -108,7 +107,6 @@ __all__ = [
     "_declared_model_keys",
     "_emit_deprecation_notice",
     "_emit_unknown_keys_notice",
-    "_normalize_legacy_payload",
     "_warn_or_reject_unknown_keys",
     # Raw
     "ClientConfig",

--- a/toolkit/core/config_models/_loader.py
+++ b/toolkit/core/config_models/_loader.py
@@ -20,7 +20,6 @@ from toolkit.core.config_models.common import (
     SupportDatasetConfig,
     _err,
     _ensure_root_within_repo,
-    _normalize_legacy_payload,
     _normalize_section_paths,
     _require_map,
     _resolve_root,
@@ -108,7 +107,13 @@ def load_config_model(
         raise _err("dataset.years deve essere una lista non vuota, es: [2022, 2023].", path=p)
 
     strict_mode = strict_config or _read_strict_config(data, path=p)
-    normalized = _normalize_legacy_payload(data, path=p, strict_config=strict_mode)
+    # Shallow copy to avoid mutating caller dict
+    normalized = dict(data)
+    for section in ("raw", "clean", "mart"):
+        val = normalized.get(section)
+        if isinstance(val, dict):
+            normalized[section] = dict(val)
+
     normalized = _warn_or_reject_unknown_keys(normalized, path=p, strict_config=strict_mode)
     root_path, root_source = _resolve_root(normalized.get("root"), base_dir=base_dir)
     if repo_root is not None:

--- a/toolkit/core/config_models/common.py
+++ b/toolkit/core/config_models/common.py
@@ -51,6 +51,5 @@ from toolkit.core.config_models.policy import (
     _declared_model_keys,
     _emit_deprecation_notice,
     _emit_unknown_keys_notice,
-    _normalize_legacy_payload,
     _warn_or_reject_unknown_keys,
 )

--- a/toolkit/core/config_models/policy.py
+++ b/toolkit/core/config_models/policy.py
@@ -73,29 +73,6 @@ def _emit_unknown_keys_notice(
         raise _err(message, path=path)
 
 
-def _normalize_legacy_payload(
-    data: dict[str, Any],
-    *,
-    path: Path,
-    strict_config: bool,
-) -> dict[str, Any]:
-    normalized = dict(data)
-
-    raw = normalized.get("raw")
-    if isinstance(raw, dict):
-        normalized["raw"] = dict(raw)
-
-    clean = normalized.get("clean")
-    if isinstance(clean, dict):
-        normalized["clean"] = dict(clean)
-
-    mart = normalized.get("mart")
-    if isinstance(mart, dict):
-        normalized["mart"] = dict(mart)
-
-    return normalized
-
-
 def _warn_or_reject_unknown_keys(
     data: dict[str, Any],
     *,


### PR DESCRIPTION
## Sintesi

Due pulizie a basso costo identificate nell'analisi dei componenti superfluo/a basso uso:

1. **`suggested_read.yml`**: la pipeline (`toolkit run raw`) non lo produce più da #392. Solo `inspect profile` CLI lo scriveva. `raw_profile.json` è il formato canonico. Basta scriverlo; il fallback in lettura continua a funzionare per file vecchi.
2. **`_normalize_legacy_payload`**: 20 righe chiamate da 1 solo punto. Faceva `dict(data)` shallow su raw/clean/mart più 2 parametri (`path`, `strict_config`) mai usati. Inlineato in `_loader.py`.

## Cosa cambia

- [ ] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

Nessuno. `_normalize_legacy_payload` era un interno (_privato). `suggested_read.yml` non viene più scritto ma chi lo legge funziona ancora (fallback).

## Verifica

```bash
cd toolkit
pytest -k "not project_example" -q --tb=short
mypy toolkit/cli/inspect/profile_ops.py toolkit/core/config_models/
ruff check toolkit/cli/inspect/profile_ops.py toolkit/core/config_models/
```

- [x] `pytest` passa (1051 test)
- [x] `ruff check .` passa
- [x] `mypy` pulito sui file modificati

## Checklist PR

- [x] Perimetro stretto: una PR = due pulizie collegate (entrambe identificate come superfluo)
- [x] Nessun contratto pubblico modificato

## Metriche

- Codice rimosso: -33 righe nette
- Nessun test modificato (solo rimozione di codice morto)
