### PR TITLE
feat(clean): abilita httpfs in safe_connect per S3 glob patterns

### DIFF
--- a/toolkit/clean/sql_execute.py
+++ b/toolkit/clean/sql_execute.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from lab_connectors.duckdb import safe_connect
+from lab_connectors.duckdb import GCS_S3_CONFIG, safe_connect
 
 from toolkit.core.duckdb_read import read_raw_to_relation
 from toolkit.core.input_file import RawInputFile
@@ -45,7 +45,7 @@ def _run_sql(
     Returns:
         tuple of (source, params_used, output_profile)
     """
-    with safe_connect() as con:
+    with safe_connect(extensions=["httpfs"], config=GCS_S3_CONFIG) as con:
         read_info = read_raw_to_relation(con, input_files, read_cfg, read_mode, logger)
         if sample_rows is not None:
             # Strip trailing semicolons: clean.sql spesso termina con ;


### PR DESCRIPTION
## Sintesi

Abilita httpfs + GCS_S3_CONFIG in `safe_connect` per permettere ai clean SQL
di leggere parquet multi-anno da GCS via `s3://` glob patterns.

## Contesto

Necessario per `candidates/unified-comuni/` in dataset-incubator, che legge
direttamente da GCS i parquet di popolazione, IRPEF, rifiuti ecc. usando
`read_parquet('s3://dataciviclab-clean/.../*/..._clean.parquet')`.

## Cosa cambia

- `toolkit/clean/sql_execute.py`: import `GCS_S3_CONFIG` + passa
  `extensions=["httpfs"], config=GCS_S3_CONFIG` a `safe_connect()`

## Impatto

- [x] Modifica un modulo core del toolkit

Rischio: httpfs caricato su OGNI clean SQL. Overhead minimo (extension
già installata). Testato su unified-comuni: 52k righe, 6 fonti, 7 anni.
