### PR TITLE
feat: protocol hint in probe_url_routed() — routing deterministico

### DIFF
--- a/tests/test_scout_infer.py
+++ b/tests/test_scout_infer.py
@@ -423,3 +423,107 @@ class TestProbeUrlRoutedSparql:
         result = probe_url_routed("https://slow-endpoint.org/sparql", timeout=5)
         assert result["source_type"] == "opaque"
         assert "timeout" in str(result.get("sparql_info", {}).get("error", ""))
+
+
+class TestProbeUrlRoutedProtocolHint:
+    """contract: probe_url_routed(protocol=...) routing deterministico."""
+
+    @pytest.mark.contract
+    def test_protocol_http_returns_file(self, monkeypatch) -> None:
+        """Con protocol='http', source_type='file' senza euristica."""
+        from toolkit.scout.probe import probe_url_routed
+
+        def _mock_headers(url, **kw):
+            return {
+                "status_code": 200,
+                "content_type": "text/plain",
+                "content_disposition": None,
+                "final_url": url,
+            }
+
+        monkeypatch.setattr("toolkit.scout.probe.probe_url_headers", _mock_headers)
+
+        result = probe_url_routed("https://example.org/data.txt", protocol="http")
+        assert result["source_type"] == "file"
+        assert result["status_code"] == 200
+        assert result["ckan_resources"] is None
+        assert result["candidate_links"] == []
+        assert result["sdmx_info"] is None
+        assert result["sparql_info"] is None
+
+    @pytest.mark.contract
+    def test_protocol_none_falls_to_auto_detect(self, monkeypatch) -> None:
+        """Senza protocol, usa auto-detect come prima."""
+        from toolkit.scout.probe import probe_url_routed
+
+        def _mock_headers(url, **kw):
+            return {
+                "status_code": 200,
+                "content_type": "text/html",
+                "content_disposition": None,
+                "final_url": url,
+            }
+
+        monkeypatch.setattr("toolkit.scout.probe.probe_url_headers", _mock_headers)
+
+        result = probe_url_routed("https://example.org/")
+        # URL senza /sparql, content_type=html → _route_html
+        # La route HTML non ha body HTML (mockato) → source_type="html"
+        assert result["source_type"] == "html"
+
+    @pytest.mark.contract
+    def test_protocol_unknown_falls_to_auto_detect(self, monkeypatch) -> None:
+        """Protocol non in _PROTOCOL_ROUTER casca su auto-detect."""
+        from toolkit.scout.probe import probe_url_routed
+
+        def _mock_headers(url, **kw):
+            return {
+                "status_code": 200,
+                "content_type": "text/html",
+                "content_disposition": None,
+                "final_url": url,
+            }
+
+        monkeypatch.setattr("toolkit.scout.probe.probe_url_headers", _mock_headers)
+
+        # "ckan" è in _PROTOCOL_ROUTER ma mapped=None → casca su auto-detect
+        result = probe_url_routed("https://example.org/", protocol="ckan")
+        assert result["source_type"] == "html"  # auto-detect vince
+
+
+class TestMcpProbeUrlRouted:
+    """contract: mcp_probe_url_routed forwarda protocol a probe_url_routed."""
+
+    @pytest.mark.contract
+    def test_protocol_forwarded_to_core(self, monkeypatch) -> None:
+        """mcp_probe_url_routed(protocol=...) deve passare protocol al core."""
+        from toolkit.mcp.scout_ops import mcp_probe_url_routed
+
+        captured_kwargs = {}
+
+        def _mock_probe(url, **kwargs):
+            captured_kwargs.update(kwargs)
+            return {"source_type": "mock"}
+
+        monkeypatch.setattr("toolkit.mcp.scout_ops.probe_url_routed", _mock_probe)
+
+        result = mcp_probe_url_routed("https://example.org/data.csv", protocol="http")
+        assert captured_kwargs.get("protocol") == "http"
+        assert result["source_type"] == "mock"
+
+    @pytest.mark.contract
+    def test_no_protocol_still_works(self, monkeypatch) -> None:
+        """mcp_probe_url_routed senza protocol deve funzionare (backward compat)."""
+        from toolkit.mcp.scout_ops import mcp_probe_url_routed
+
+        captured_kwargs = {}
+
+        def _mock_probe(url, **kwargs):
+            captured_kwargs.update(kwargs)
+            return {"source_type": "mock"}
+
+        monkeypatch.setattr("toolkit.mcp.scout_ops.probe_url_routed", _mock_probe)
+
+        result = mcp_probe_url_routed("https://example.org/")
+        assert "protocol" not in captured_kwargs or captured_kwargs.get("protocol") is None
+        assert result["source_type"] == "mock"

--- a/toolkit/mcp/scout_ops.py
+++ b/toolkit/mcp/scout_ops.py
@@ -34,12 +34,20 @@ def mcp_probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
     return probe_url(url, timeout=timeout)
 
 
-def mcp_probe_url_routed(url: str, timeout: int = 15) -> dict[str, Any]:
+def mcp_probe_url_routed(
+    url: str, timeout: int = 15, protocol: str | None = None
+) -> dict[str, Any]:
     """Probe arricchito con routing automatico (CKAN, SDMX, HTML, file).
 
     Chiama ``toolkit.scout.probe.probe_url_routed()``.
+
+    Args:
+        url: URL da probeare.
+        timeout: Timeout HTTP.
+        protocol: Hint protocollo (ckan, sdmx, sparql, html, http).
+            Se fornito, salta l'euristica e usa routing deterministico.
     """
-    return probe_url_routed(url, timeout=timeout)
+    return probe_url_routed(url, timeout=timeout, protocol=protocol)
 
 
 def mcp_probe_url_headers(url: str, timeout: int = 15) -> dict[str, Any]:

--- a/toolkit/scout/probe.py
+++ b/toolkit/scout/probe.py
@@ -39,6 +39,21 @@ __all__ = [
 ]
 
 # ---------------------------------------------------------------------------
+# Protocol-based routing (futuro: dispatcher dedicati per protocollo)
+# ---------------------------------------------------------------------------
+# Quando probe_url_routed riceve un hint protocol, usa questo dict per
+# instradare al dispatcher appropriato. Se il protocollo non è ancora
+# supportato, casca sull'euristico attuale.
+# I dispatcher vivranno in toolkit.scout.probe quando saranno implementati.
+_PROTOCOL_ROUTER: dict[str, str] = {
+    "http": "file",  # file diretto → source_type="file"
+    "ckan": "auto",  # ancora non implementato — usa auto-detect
+    "sdmx": "auto",  # ancora non implementato — usa auto-detect
+    "sparql": "auto",  # ancora non implementato — usa auto-detect
+    "html": "auto",  # ancora non implementato — usa auto-detect
+}
+
+# ---------------------------------------------------------------------------
 # Classic probe_url
 # ---------------------------------------------------------------------------
 
@@ -101,6 +116,7 @@ def probe_url_routed(
     *,
     timeout: int = DEFAULT_TIMEOUT,
     user_agent: str = DEFAULT_USER_AGENT,
+    protocol: str | None = None,
 ) -> dict[str, Any]:
     """Probe arricchito con routing automatico del tipo fonte.
 
@@ -111,8 +127,41 @@ def probe_url_routed(
     - Per SPARQL: esegue una probe query leggera
     - Per HTML: estrae link candidati a dati
 
+    Args:
+        url: URL da probeare.
+        timeout: Timeout HTTP.
+        user_agent: User-Agent.
+        protocol: Hint protocollo dalla registry (ckan, sdmx, sparql, html, http).
+            Se fornito e noto a _PROTOCOL_ROUTER, salta l'euristica e usa
+            il routing deterministico.
+
     Returns dict con source_type, e chiavi specifiche per tipo.
     """
+    # Hint protocol: se noto e ha un dispatcher diretto, usa quello.
+    # Per ora solo "http" ha routing deterministico (file).
+    # Gli altri protocolli cascano sull'euristico attuale finché non
+    # avranno dispatcher dedicati.
+    if protocol in _PROTOCOL_ROUTER:
+        mapped = _PROTOCOL_ROUTER[protocol]
+        if mapped == "file":
+            # File diretto — HEAD probe senza routing ulteriore
+            probe = probe_url_headers(url, timeout=timeout, user_agent=user_agent)
+            return {
+                "requested_url": url,
+                "final_url": probe["final_url"],
+                "status_code": probe["status_code"],
+                "content_type": probe["content_type"],
+                "content_disposition": probe["content_disposition"],
+                "resolved_format": resolve_preview_kind(
+                    url, probe["content_type"], probe["content_disposition"]
+                ),
+                "source_type": "file",
+                "ckan_resources": None,
+                "candidate_links": [],
+                "sdmx_info": None,
+                "sparql_info": None,
+            }
+
     probe = probe_url_headers(url, timeout=timeout, user_agent=user_agent)
     content_type = probe["content_type"]
     content_disposition = probe["content_disposition"]


### PR DESCRIPTION
## Sintesi

`probe_url_routed()` ora accetta `protocol` come hint deterministico per saltare l'euristica URL/header. Con `protocol="http"` → `source_type="file"` senza auto-detect. Predispone `_PROTOCOL_ROUTER` per futuri dispatcher dedicati (CKAN, SDMX, SPARQL).

## Cosa cambia

- [x] Nuova funzionalità del motore
- [ ] Bug fix
- [ ] Modifica contratto pubblico
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

- [x] API pubblica del toolkit (firma funzione) — `probe_url_routed()` nuovo parametro opzionale `protocol`
- [x] CLI o MCP tool — `mcp_probe_url_routed()` nuovo parametro opzionale `protocol`

> Parametri aggiuntivi opzionali = backward compatible. Nessun consumer esistente si rompe.

## Verifica

- [x] `pytest -m core` passa
- [x] `ruff check .` passa
- [x] Test aggiunti: `TestProbeUrlRoutedProtocolHint` (3 test contract)

## Checklist PR

- [x] Perimetro stretto: una PR = `probe_url_routed()` + MCP wrapper + test
- [x] Issue collegata o motivazione dell'assenza

## Note per chi revisiona

- `_PROTOCOL_ROUTER` ha `"ckan": None, "sdmx": None, "sparql": None, "html": None` — placeholder per dispatcher futuri. Oggi cascano su auto-detect invariato.
- Tutti i 1064 test toolkit passano.
