### PR TITLE
fix(http_file): prova curl -x su qualsiasi fallimento, non solo SSL

### DIFF
--- a/tests/test_http_file_plugin.py
+++ b/tests/test_http_file_plugin.py
@@ -270,3 +270,27 @@ class TestCurlFallbackIntegration:
         with mock.patch.dict(os.environ, {}, clear=True):
             with pytest.raises(DownloadError, match="fallback failed"):
                 source.fetch("https://example.test/data.csv")
+
+    @pytest.mark.contract
+    @pytest.mark.regression  # toolkit#413
+    def test_fallback_on_timeout_with_proxy(self):
+        """Timeout/ConnError + proxy → curl fallback chiamato (non solo SSL)."""
+        fake = FakeHttpClient()
+        fake.responses["https://example.test/data.csv"] = HttpResult(
+            response=None,
+            err=TimeoutError("connect timed out"),
+            ssl_fallback_used=False,
+        )
+
+        source = HttpFileSource(retries=1)
+        source._client = fake
+
+        with mock.patch.dict(os.environ, {"HTTPS_PROXY": "http://proxy:8888"}):
+            with mock.patch(
+                "toolkit.plugins.http_file._fetch_via_curl",
+                return_value=b"curl-data",
+            ) as mock_curl:
+                payload = source.fetch("https://example.test/data.csv")
+
+        assert payload == b"curl-data"
+        mock_curl.assert_called_once()

--- a/toolkit/plugins/http_file.py
+++ b/toolkit/plugins/http_file.py
@@ -51,15 +51,17 @@ class HttpFileSource:
                 content = truncate_at_line(content, sample_bytes)
             return content
 
-        # Fallback a curl via proxy quando Python requests fallisce con SSL
-        # (noto: GitHub Actions + tinyproxy da SSLV3_ALERT_HANDSHAKE_FAILURE
-        #  con dati.salute.gov.it — curl invece funziona)
-        if result.is_ssl_fallback_failed:
+        # Fallback a curl via proxy quando requests fallisce (SSL o timeout)
+        # (noto: GitHub Actions + proxy HTTP → requests non invia CONNECT,
+        #  curl -x invece funziona. Squid/tinyproxy: stesso comportamento.)
+        if not result.is_ok:
             proxy = _get_proxy_from_env()
             if proxy:
                 logger.warning(
-                    "SSL fallback failed for %s — riprovo con curl via proxy",
+                    "Requests failed for %s (%s) — riprovo con curl via proxy",
                     url,
+                    result.err
+                    or f"HTTP {result.response.status_code if result.response else 'no response'}",
                 )
                 return _fetch_via_curl(url, proxy, self.timeout, self.user_agent, sample_bytes)
 


### PR DESCRIPTION
## Problema

`HttpFileSource.fetch()` prova `curl -x` solo quando `result.is_ssl_fallback_failed`. Per timeout/connection error (MUR blocca GHA), il fallback non scatta. 

`requests` via proxy HTTP da GHA non completa il CONNECT (sia tinyproxy che squid) — ma `curl -x` funziona.

## Fix

Cambia la condizione da `is_ssl_fallback_failed` a `not is_ok`: qualsiasi fallimento (SSL, timeout, conn error) attiva il fallback curl con proxy se `BLOCKED_SOURCE_PROXY` è configurato.

## Verifica

```bash
python -m pytest tests/ -k http_file -q
```
32 passati, 0 falliti.
