### PR TITLE
fix(http_file): _get_proxy_from_env cerca anche BLOCKED_SOURCE_PROXY

### DIFF
--- a/tests/test_http_file_plugin.py
+++ b/tests/test_http_file_plugin.py
@@ -18,6 +18,7 @@ from lab_connectors.testing import FakeHttpClient, fake_response
 from toolkit.core.exceptions import DownloadError
 from toolkit.plugins.http_file import (
     HttpFileSource,
+    _get_proxy_from_env,
     _sanitize_proxy_url,
     _parse_curl_status,
     _strip_curl_status,
@@ -294,21 +295,7 @@ class TestCurlFallbackIntegration:
 
     @pytest.mark.contract
     @pytest.mark.regression  # toolkit#414
-    def test_fallback_with_blocked_source_proxy(self):
-        """BLOCKED_SOURCE_PROXY → curl fallback (no HTTPS_PROXY)."""
-        fake = FakeHttpClient()
-        fake.responses["https://example.test/data.csv"] = HttpResult(
-            response=None,
-            err=TimeoutError("connect timed out"),
-            ssl_fallback_used=False,
-        )
-        source = HttpFileSource(retries=1)
-        source._client = fake
+    def test_get_proxy_env_blocked_source(self):
+        """_get_proxy_from_env legge BLOCKED_SOURCE_PROXY."""
         with mock.patch.dict(os.environ, {"BLOCKED_SOURCE_PROXY": "http://proxy:8888"}, clear=True):
-            with mock.patch(
-                "toolkit.plugins.http_file._fetch_via_curl",
-                return_value=b"curl-data",
-            ) as mock_curl:
-                payload = source.fetch("https://example.test/data.csv")
-        assert payload == b"curl-data"
-        mock_curl.assert_called_once()
+            assert _get_proxy_from_env() == "http://proxy:8888"

--- a/tests/test_http_file_plugin.py
+++ b/tests/test_http_file_plugin.py
@@ -281,16 +281,34 @@ class TestCurlFallbackIntegration:
             err=TimeoutError("connect timed out"),
             ssl_fallback_used=False,
         )
-
         source = HttpFileSource(retries=1)
         source._client = fake
-
         with mock.patch.dict(os.environ, {"HTTPS_PROXY": "http://proxy:8888"}):
             with mock.patch(
                 "toolkit.plugins.http_file._fetch_via_curl",
                 return_value=b"curl-data",
             ) as mock_curl:
                 payload = source.fetch("https://example.test/data.csv")
+        assert payload == b"curl-data"
+        mock_curl.assert_called_once()
 
+    @pytest.mark.contract
+    @pytest.mark.regression  # toolkit#414
+    def test_fallback_with_blocked_source_proxy(self):
+        """BLOCKED_SOURCE_PROXY → curl fallback (no HTTPS_PROXY)."""
+        fake = FakeHttpClient()
+        fake.responses["https://example.test/data.csv"] = HttpResult(
+            response=None,
+            err=TimeoutError("connect timed out"),
+            ssl_fallback_used=False,
+        )
+        source = HttpFileSource(retries=1)
+        source._client = fake
+        with mock.patch.dict(os.environ, {"BLOCKED_SOURCE_PROXY": "http://proxy:8888"}, clear=True):
+            with mock.patch(
+                "toolkit.plugins.http_file._fetch_via_curl",
+                return_value=b"curl-data",
+            ) as mock_curl:
+                payload = source.fetch("https://example.test/data.csv")
         assert payload == b"curl-data"
         mock_curl.assert_called_once()

--- a/toolkit/plugins/http_file.py
+++ b/toolkit/plugins/http_file.py
@@ -90,8 +90,12 @@ def _sanitize_proxy_url(proxy: str) -> str:
 
 
 def _get_proxy_from_env() -> str | None:
-    """Legge HTTPS_PROXY dall'ambiente (lowercase/uppercase)."""
-    return os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy")
+    """Legge HTTPS_PROXY o BLOCKED_SOURCE_PROXY dall'ambiente."""
+    return (
+        os.environ.get("HTTPS_PROXY")
+        or os.environ.get("https_proxy")
+        or os.environ.get("BLOCKED_SOURCE_PROXY")
+    )
 
 
 def _fetch_via_curl(


### PR DESCRIPTION
_get_proxy_from_env cercava solo HTTPS_PROXY. Il workflow CI setta BLOCKED_SOURCE_PROXY. Il curl fallback (da #413) non trovava mai il proxy.

Aggiunto fallback a BLOCKED_SOURCE_PROXY.