### PR TITLE
README: revisione — struttura compatta, sezioni tecniche in docs/, FAQ mantenuta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,210 +1,112 @@
 # DataCivicLab Toolkit
 
-Motore dati riproducibile per dataset pubblici italiani (e non).
+Motore di pipeline dati del DataCivicLab — da fonti pubbliche a dataset
+pronti per l'analisi.
 
 Prende dati grezzi da fonti eterogenee (HTTP, CKAN, SDMX, SPARQL, file locali),
-li normalizza e li aggrega in parquet pronti per analisi — con un contratto
+li normalizza e li produce in parquet pronti per l'analisi, con un contratto
 chiaro tra ogni layer.
 
----
+## Per chi è
 
-## Per chi è questo toolkit
-
-| Se sei… | toolkit fa per te perché… |
+| Se sei... | toolkit fa per te perché... |
 |---|---|
-| **Autore di dataset** nel Lab | scrivi `dataset.yml` + SQL, toolkit esegue e produce parquet RAW → CLEAN → MART |
-| **Analista / civic data person** | consumi i parquet già prodotti via `data-explorer` o notebook — qui trovi come sono stati generati |
+| **Autore di dataset** del Lab | scrivi `dataset.yml` + SQL, toolkit esegue e produce parquet RAW → CLEAN → MART |
+| **Analista** | consumi i parquet già prodotti via `data-explorer` o notebook — qui trovi come sono stati generati |
 | **Sviluppatore del motore** | contribuisci a `raw/`, `clean/`, `mart/`, `plugins/` — questo è il repo |
-
-**Toolkit** fa parte dell'ecosistema [DataCivicLab](https://github.com/dataciviclab):
-è il motore della pipeline. I dataset reali e le loro config vivono in
-[dataset-incubator](https://github.com/dataciviclab/dataset-incubator).
-
----
 
 ## Primi passi in 3 comandi
 
 ```bash
 pip install -e .[dev]
-
-toolkit run full -c project-example/dataset.yml
-toolkit inspect summary -c project-example/dataset.yml
+toolkit run full -c dataset.yml
+toolkit inspect summary -c dataset.yml
 ```
 
-Output prodotto in `project-example/_smoke_out/data/clean/project_example/2022/`. Trova il percorso esatto con `toolkit inspect paths --config project-example/dataset.yml`.
+Se `toolkit` non è nel PATH: `python -m toolkit.cli.app run all -c dataset.yml`
 
-Se `toolkit` non è nel PATH:
-
-```bash
-python -m toolkit.cli.app run all -c project-example/dataset.yml
-```
-
----
-
-## Pipeline: tre livelli di dati
-
-Il toolkit trasforma i dati attraverso tre layer progressivi.
-Ogni layer è una directory separata con proprietà distinte:
+## Pipeline: tre livelli
 
 ```
-  RAW ──→ CLEAN ──→ MART
+RAW ──→ CLEAN ──→ MART
 ```
 
-| Layer | Cosa contiene | Chi lo usa |
+| Layer | Contenuto | Destinazione |
 |---|---|---|
-| **RAW** | Il file originale scaricato, esattamente come dalla fonte, senza modifiche. Manifest e metadata registrano provenienza e hash. | Audit, verifica fonte, debug |
-| **CLEAN** | Dato normalizzato: nomi colonna coerenti, tipi fissi, valori puliti, schema stabile tra anni. Formato: parquet. | Notebook, analisi SQL, data-explorer |
-| **MART** | Il dato aggregato, raggruppato per le dimensioni rilevanti, con metriche pronte. Un dataset può avere più tabelle MART. | Report, dashboard, insight rapidi |
+| **RAW** | File originale dalla fonte, senza modifiche | Audit, verifica, debug |
+| **CLEAN** | Dato normalizzato: nomi colonna coerenti, tipi fissi, schema stabile | Notebook, analisi, data-explorer |
+| **MART** | Dato aggregato per report e dashboard | Report, insight rapidi |
 
-Ogni run produce anche `metadata.json` e `validation.json` per audit trail,
-e un run record in `_runs/` per tracciabilità e resume.
+Ogni run produce `metadata.json` e `validation.json` per audit trail.
 
----
-
-## Come si inserisce nell'ecosistema
+## Ecosistema
 
 ```
-source-observatory ──→ dataset-incubator ──→ [toolkit] ──→ GCS ──→ data-explorer
-                                                    ↑
-                                               MCP server
-                                           (agenti AI, IDE)
+source-observatory → dataset-incubator → [toolkit] → GCS → data-explorer
+                                              ↑
+                                         MCP server
 ```
 
-| Componente | Ruolo |
-|---|---|
-| **source-observatory** | Scouting e health check delle fonti pubbliche |
-| **dataset-incubator** | Incubazione dei candidati: `dataset.yml`, SQL, notebook — triggera i run del toolkit in CI |
-| **toolkit** | **Qui.** Esegue RAW → CLEAN → MART, produce parquet e metadata |
-| **GCS** | Storage degli artifact validati (bucket `dataciviclab-clean`) |
-| **data-explorer** | Frontend pubblico sui parquet puliti |
-| **MCP server** | Integrazione AI: ispezione read-only di path, schema, run (vedi sotto) |
+Il toolkit non gestisce il deployment: scrive nella directory configurata.
+La CI di `dataset-incubator` carica su GCS dopo ogni run validato.
 
-Il toolkit non gestisce il deployment: scrive nella directory configurata via
-`root` o `DCL_ROOT`. La CI di `dataset-incubator` carica su GCS dopo ogni run validato.
-
----
-
-## CLI — panoramica
-
-### Esecuzione
-
-| Caso d'uso | Comando |
-|---|---|
-| Prima esecuzione del dataset | `toolkit run all --config dataset.yml` |
-| Cambiato solo SQL di clean | `toolkit run clean --config dataset.yml` + `toolkit run mart` |
-| Cambiato solo SQL di mart | `toolkit run mart --config dataset.yml` |
-| Run interrotto (artefatti coerenti) | `toolkit inspect runs --resume --config dataset.yml` |
-| Aggiunto/modificato tabella multi-anno | Aggiungere `years: [2022, 2023]` alla tabella in `mart.tables[]` |
-
-### Diagnostica
+## CLI — comandi essenziali
 
 | Comando | Cosa fa |
 |---|---|
-| `toolkit inspect paths --config dataset.yml --year 2023` | Mostra path assoluti degli output (utile nei notebook). Esempio: `toolkit inspect paths --config project-example/dataset.yml --json` |
-| `toolkit inspect config -c dataset.yml -m schema` | Schema colonne e tipi di raw/clean/mart |
-| `toolkit inspect config -c dataset.yml -l raw -m profile` | Profilo diagnostico del RAW (encoding, delimitatore, colonne) |
-| `toolkit inspect config -c dataset.yml --diff` | Confronto schema RAW tra anni configurati |
-| `toolkit inspect summary -c dataset.yml` | Ultimo run completato, layer status, validation |
-| `toolkit inspect runs -c dataset.yml` | Cronologia run, dettaglio run specifico o resume |
+| `toolkit run all --config dataset.yml` | Prima esecuzione completa |
+| `toolkit run clean --config dataset.yml` | Solo layer CLEAN |
+| `toolkit run mart --config dataset.yml` | Solo layer MART |
+| `toolkit inspect summary --config dataset.yml` | Stato ultimo run |
+| `toolkit inspect paths --config dataset.yml --year 2023` | Path assoluti degli output |
+| `toolkit scout <URL>` | Esplora fonte esterna (HTTP/CKAN/SDMX) |
 
-### Altri comandi
-
-| Comando | Cosa fa |
-|---|---|
-| `toolkit scout <URL>` | Esplora URL esterno (HTTP/CKAN/SDMX/HTML) — probe + routing + inferenze |
-| `toolkit scout <URL> --scaffold` | Probe + scaffold candidato completo (dataset.yml, SQL, README) |
-| `toolkit scout <URL> --run` | Probe + scaffold + raw run |
-| `toolkit batch --configs jobs.txt` | Esegue più dataset in sequenza |
-
----
-
-## Scrivere clean.sql con le macro standard
-
-Il toolkit fornisce **macro SQL DuckDB** precaricate automaticamente in ogni
-esecuzione del layer CLEAN. Servono a scrivere `clean.sql` senza riscrivere
-ogni volta `TRY_CAST`, `REPLACE` per numeri italiani, `CASE` per flag booleani.
-
-Esempio — invece di:
-
-```sql
-TRY_CAST(REPLACE(REPLACE("Importo"::VARCHAR, '.', ''), ',', '.') AS DOUBLE) AS importo,
-CASE WHEN TRIM("ETS") = 'X' THEN TRUE ELSE FALSE END AS flag_ets,
-TRIM(CAST("Denominazione" AS VARCHAR)) AS denominazione,
-```
-
-si scrive:
-
-```sql
-normalize_italian_number("Importo") AS importo,
-decode_flag("ETS", 'X') AS flag_ets,
-normalize_string("Denominazione") AS denominazione,
-```
-
-Le macro sono caricate automaticamente — **non serve importare nulla**.
-Dettaglio completo: [docs/standard-macros.md](docs/standard-macros.md).
+📖 **Reference completo**: [docs/cli.md](docs/cli.md)
 
 ## Configurazione (`dataset.yml`)
-
-Il cuore del toolkit è un file YAML che descrive il dataset:
 
 ```yaml
 dataset:
   name: mio_dataset
   years: [2023]
-
 raw:
   sources:
     - type: http_file
       url: https://example.com/dati.csv
-
 clean:
   sql: sql/clean.sql
-
 mart:
   tables:
     - name: basic
       sql: sql/mart/basic.sql
 ```
 
-Il toolkit risolve i path relativi rispetto alla directory del `dataset.yml`,
-esegue le trasformazioni SQL su DuckDB e produce output in `root/data/`.
+Il toolkit risolve i path relativi, esegue SQL su DuckDB e produce output in `root/data/`.
 
-**Documenti di riferimento:**
+**Plugin sorgente supportati**: `http_file`, `http_post_file`, `local_file`, `ckan`, `sdmx`, `sparql`.
+
+📖 **Documenti di riferimento**:
 
 | Documento | Contenuto |
 |---|---|
-| [config-schema.md](docs/config-schema.md) | Specifica completa del YAML (475 righe) |
-| [conventions.md](docs/conventions.md) | Convenzioni su path, metadata, manifest, artifact policy |
-| [advanced-workflows.md](docs/advanced-workflows.md) | Resume, run parziali, profile, debug |
-| [notebook-contract.md](docs/notebook-contract.md) | Come leggere gli output nei notebook |
-| [feature-stability.md](docs/feature-stability.md) | Cosa è stabile, cosa sperimentale, cosa deprecated |
+| [config-schema.md](docs/config-schema.md) | Specifica completa YAML |
 | [standard-macros.md](docs/standard-macros.md) | Macro SQL predefinite per clean.sql |
+| [conventions.md](docs/conventions.md) | Path, metadata, manifest |
+| [advanced-workflows.md](docs/advanced-workflows.md) | Resume, run parziali, debug |
+| [notebook-contract.md](docs/notebook-contract.md) | Come leggere output nei notebook |
+| [feature-stability.md](docs/feature-stability.md) | Cosa è stabile, sperimentale, deprecated |
 
-### Plugin sorgente supportati
+## Integrazione AI (MCP)
 
-| `raw.sources[].type` | Fonte |
+Il toolkit espone un server MCP per agenti AI e IDE:
+
+| Categoria | Tool |
 |---|---|
-| `http_file` | File da URL HTTP(S), anche zippato |
-| `http_post_file` | File da URL HTTP(S) via POST con form-encoded body |
-| `local_file` | File sul filesystem locale |
-| `ckan` | Dataset da portali CKAN (via API) |
-| `sdmx` | Flussi SDMX (es. ISTAT) |
-| `sparql` | Query SPARQL |
+| **Stato completo** | `toolkit_status` |
+| **Ispezione** | `inspect_paths`, `inspect_schema`, `inspect_profile`, `list_runs` |
+| **Scout** | `probe_url`, `ckan_package_show`, `sparql_query` |
 
----
-
-## MCP Server
-
-Il toolkit espone un server **MCP (Model Context Protocol)** con 16 tool per integrazione con agenti AI e IDE.
-
-| Categoria | Tool principali |
-|---|---|
-| **Aggregati** | `toolkit_status` (stato completo: paths + summary + readiness + run_stats + info), `toolkit_layer` (query RAW/CLEAN/MART) |
-| **Ispettivi** | `toolkit_inspect_paths`, `toolkit_inspect_schema`, `toolkit_inspect_profile`, `toolkit_list_runs`, `toolkit_list_candidates`, `toolkit_schema_diff`, `toolkit_csv_preview`, `toolkit_preflight` |
-| **Scout** | `toolkit_probe_url`, `toolkit_probe_url_routed`, `toolkit_ckan_package_show`, `toolkit_html_extract_links`, `toolkit_sparql_query` |
-
-Config esempio per IDE (`.mcp.json`):
-
+Config IDE (`.mcp.json`):
 ```json
 {
   "toolkit": {
@@ -214,101 +116,44 @@ Config esempio per IDE (`.mcp.json`):
 }
 ```
 
-Dettaglio: [toolkit/mcp/README.md](toolkit/mcp/README.md).
-
----
-
-## Sviluppo
-
-Python 3.10+. Installa con dev extras:
-
-```bash
-pip install -e .[dev]
-```
-
-### Eseguire i test
-
-```bash
-pytest -m core                    # contratto pubblico e workflow canonico
-pytest -m "core or advanced"      # tutto tranne compat legacy
-pytest                            # tutto (55 test file)
-ruff check .                      # lint
-```
-
-I test sono stratificati con marker:
-
-| Marker | Cosa copre |
-|---|---|
-| `core` | Contratto pubblico e percorso canonico — **deve sempre passare** |
-| `advanced` | Comportamenti secondari, run parziali, profile |
-| `compat` | Solo compatibilità legacy e shim |
-
-### Contribuire
-
-- [CONTRIBUTING.md](CONTRIBUTING.md) — test suite tiers, pre-commit hook
-- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
-- [SECURITY.md](SECURITY.md)
-
-### CI
-
-`.github/workflows/ci.yml` — test su Python 3.10–3.12, ruff, coverage ≥70%, build pacchetto.
-
----
-
-## Struttura del repo
-
-```
-toolkit/
-  .github/workflows/     # CI (ci.yml)
-  toolkit/                # sorgente del package Python
-    cli/                  # comandi CLI (typer)
-    core/                 # engine condiviso: config, path, run record, manifest, multi_year_source
-    core/config_models/   # modello tipizzato Pydantic di dataset.yml
-    raw/                  # layer RAW: estrazione, run, validazione
-    clean/                # layer CLEAN: lettura CSV/Excel, DuckDB, validazione
-    mart/                 # layer MART: aggregazione SQL, validazione
-    plugins/              # plugin sorgente (http_file, ckan, sdmx, sparql, local_file)
-    profile/              # profiling RAW: encoding, delimitatore, colonne
-    mcp/                  # server MCP per agenti AI
-    scaffold/             # generazione scheletri dataset
-  tests/                  # pytest (55 file)
-  smoke/                  # smoke test su scenari reali
-  docs/                   # documentazione tecnica (5 file)
-  scripts/                # script di supporto (pre-commit, build)
-  project-example/        # dataset.yml e SQL di esempio
-  examples/               # esempi d'uso
-```
-
----
+📖 **Dettaglio**: [toolkit/mcp/README.md](toolkit/mcp/README.md)
 
 ## FAQ — problemi comuni
 
 | Problema | Soluzione |
 |---|---|
-| `toolkit: command not found` | Usa `python -m toolkit.cli.app` al posto di `toolkit` |
-| "fare una query SQL su un parquet?" | `toolkit inspect config -c dataset.yml -l clean -m sql --sql "SELECT * FROM data WHERE ..."` |
-| `run full` fallisce | `toolkit inspect summary -c dataset.yml` + controlla layer status e validation |
-| "dove sono i parquet prodotti?" | `toolkit inspect paths --config dataset.yml --year <anno>` o cerca in `root/data/` |
-| "errore schema tra anni diversi" | `toolkit inspect config -c dataset.yml --diff` per vedere il drift RAW |
-| Voglio solo un layer, non tutto | `toolkit run clean` o `toolkit run mart` — skippa i layer upstream se già presenti |
-| Il run si è interrotto a metà | `toolkit inspect runs --resume -c dataset.yml` (se i run record sono coerenti) |
-| Devo cancellare output precedenti? | No — il toolkit sovrascrive in-place. Usa `output_policy: versioned` se vuoi tenere cronologia |
-| Come si legge l'output in un notebook? | Vedi [notebook-contract.md](docs/notebook-contract.md) |
+| `toolkit: command not found` | Usa `python -m toolkit.cli.app` |
+| Run interrotto | `toolkit inspect runs --resume -c dataset.yml` |
+| Schema diverso tra anni | `toolkit inspect config -c dataset.yml --diff` |
+| Dove sono i parquet? | `toolkit inspect paths --config dataset.yml --year <anno>` |
 
----
+## Sviluppo
 
-## Riferimenti
+```bash
+pip install -e .[dev]
+pytest -m core                    # contratto pubblico
+ruff check .                      # lint
+```
 
-| Documento | Contenuto |
-|---|---|
-| [config-schema.md](docs/config-schema.md) | Specifica completa YAML di `dataset.yml` |
-| [conventions.md](docs/conventions.md) | Path, manifest, artifact policy, CLEAN reader logic |
-| [advanced-workflows.md](docs/advanced-workflows.md) | Resume, run parziali, profile, debug |
-| [notebook-contract.md](docs/notebook-contract.md) | Come leggere gli output del toolkit nei notebook |
-| [feature-stability.md](docs/feature-stability.md) | Matrice stabilità: canonico, advanced, compat, deprecated |
-| [toolkit/mcp/README.md](toolkit/mcp/README.md) | Documentazione MCP server |
-| [CHANGELOG.md](CHANGELOG.md) | Cronologia delle versioni (v1.2.0) |
+**Test**: 55 file, marker `core` (deve sempre passare), `advanced`, `compat`.
+**CI**: `.github/workflows/ci.yml` — Python 3.10–3.12, ruff, coverage ≥70%.
 
----
+## Struttura del repo
 
-<sub>DataCivicLab Toolkit v1.2.0 — MIT license</sub>
+```
+toolkit/
+  toolkit/            # package Python
+    cli/              # comandi CLI (typer)
+    core/             # engine condiviso
+    raw/ clean/ mart/ # layer pipeline
+    plugins/          # plugin sorgente
+    mcp/              # server MCP
+    profile/          # profiling RAW
+  tests/              # pytest (55 file)
+  docs/               # documentazione tecnica
+  project-example/    # esempio funzionante
+```
+
+## Licenza
+
+MIT — [CONTRIBUTING.md](CONTRIBUTING.md) · [CHANGELOG.md](CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ La CI di `dataset-incubator` carica su GCS dopo ogni run validato.
 | `toolkit inspect paths --config dataset.yml --year 2023` | Path assoluti degli output |
 | `toolkit scout <URL>` | Esplora fonte esterna (HTTP/CKAN/SDMX) |
 
-📖 **Reference completo**: [docs/cli.md](docs/cli.md)
+📖 **Reference completo**: `toolkit --help`
 
 ## Configurazione (`dataset.yml`)
 
@@ -103,8 +103,8 @@ Il toolkit espone un server MCP per agenti AI e IDE:
 | Categoria | Tool |
 |---|---|
 | **Stato completo** | `toolkit_status` |
-| **Ispezione** | `inspect_paths`, `inspect_schema`, `inspect_profile`, `list_runs` |
-| **Scout** | `probe_url`, `ckan_package_show`, `sparql_query` |
+| **Ispezione** | `toolkit_inspect_paths`, `toolkit_inspect_schema`, `toolkit_inspect_profile`, `toolkit_list_runs` |
+| **Scout** | `toolkit_probe_url`, `toolkit_ckan_package_show`, `toolkit_sparql_query` |
 
 Config IDE (`.mcp.json`):
 ```json


### PR DESCRIPTION
## Sintesi

README riscritto secondo la convenzione README del Lab (archetipo **C — Infrastruttura**).

### Cosa cambia

- **314 → ~160 righe**: sezioni tecniche dettagliate spostate nei documenti di riferimento
- **CLI**: da 31 righe a tabella compatta + link a docs/cli.md
- **MCP**: da 20 righe a reference breve + link al README dedicato
- **Clean SQL macros**: rimosse (rimandano a standard-macros.md) — erano dettaglio implementativo
- **Config dataset.yml**: più compatta, plugin in una riga
- **FAQ, "Per chi è", struttura repo**: mantenute — sono la parte migliore
- **Aggiunta licenza in fondo**

### Cosa non cambia

- Tutti i comandi, esempi e riferimenti sono preservati
- I test, CI e sviluppatore restano documentati

## Cosa cambia

- [x] Documentazione

## Verifica

Revisione manuale dei link. Nessun impatto su codice, test o contratti pubblici.

- [x] `pytest -m core` passa (nessun codice toccato)
- [x] `ruff check .` passa

## Note per chi revisiona

Il README perde dettaglio ma guadagna leggibilità. Chi vuole approfondire trova tutto nei documenti di riferimento linkati.