### PR TITLE
feat: compressione ZSTD per tutti i parquet (clean + mart)

### DIFF
--- a/toolkit/clean/sql_execute.py
+++ b/toolkit/clean/sql_execute.py
@@ -82,5 +82,7 @@ def _run_sql(
         con.execute(f"CREATE TABLE clean_out AS {sql_query}")
         output_profile = profile_relation(con, "clean_out")
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        con.execute(f"COPY clean_out TO '{sql_path(output_path)}' (FORMAT PARQUET);")
+        con.execute(
+            f"COPY clean_out TO '{sql_path(output_path)}' (FORMAT PARQUET, COMPRESSION ZSTD);"
+        )
         return read_info.source, read_info.params_used, output_profile

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -129,7 +129,7 @@ def run_mart_multi_year(
             total_rows += row_count
 
             out = multi_year_dir / f"{name}.parquet"
-            con.execute(f"COPY {name} TO '{out}' (FORMAT PARQUET);")
+            con.execute(f"COPY {name} TO '{out}' (FORMAT PARQUET, COMPRESSION ZSTD);")
 
             written.append(out)
             executed.append(
@@ -299,7 +299,7 @@ def _run_hierarchy_levels(
         total_rows += row_count
 
         out = mart_dir / f"{table_name}.parquet"
-        con.execute(f"COPY \"{table_name}\" TO '{out}' (FORMAT PARQUET);")
+        con.execute(f"COPY \"{table_name}\" TO '{out}' (FORMAT PARQUET, COMPRESSION ZSTD);")
         written.append(out)
 
         executed.append(
@@ -434,7 +434,7 @@ def run_mart(
             total_rows += row_count
 
             out = mart_dir / f"{name}.parquet"
-            con.execute(f"COPY {name} TO '{out}' (FORMAT PARQUET);")
+            con.execute(f"COPY {name} TO '{out}' (FORMAT PARQUET, COMPRESSION ZSTD);")
 
             written.append(out)
             table_profiles[name] = output_profile


### PR DESCRIPTION
## Sintesi

Aggiunge `COMPRESSION ZSTD` a tutte le 4 COPY PARQUET del toolkit (1 clean + 3 mart). DuckDB ha ZSTD built-in — zero nuove dipendenze.

ZSTD dà il **30-50% di risparmio storage** rispetto allo Snappy di default, con prestazioni di lettura/scrittura comparabili.

## Contesto collegato

Nessuna issue — ottimizzazione emersa da analisi storage.

## Cosa cambia

- [ ] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

Nessuno. Il formato Parquet rimane identico, cambia solo il codec di compressione interno. Qualsiasi reader legge i file senza modifiche.

- [ ] Struttura `dataset.yml` (nuovo campo, cambio obbligatorietà)
- [ ] Path output (nuovo layer, cambio percorso artifact)
- [ ] Schema parquet (nuova colonna, rename, cambio tipo)
- [ ] CLI o MCP tool (nuovo comando, cambio parametro)
- [ ] API pubblica del toolkit (firma funzione, classe, eccezione)

## Verifica

```bash
# Test su campo reale: anac_bandi_gara 2024
# Snappy (GCS): 276 MB → ZSTD: 152 MB (-45%)
python -m pytest toolkit/tests/ -x -q --tb=short
```

- [x] `pytest -m core` passa (125 test, solo 1 errore pre-esistente su fixture project-example)
- [x] `ruff check .` passa
- [ ] `mypy toolkit/` passa (o motiva le eccezioni)
- [ ] Modificato o aggiunto test con marker appropriato

## Checklist PR

- [x] Perimetro stretto: una PR = un layer o un fix mirato
- [ ] Se nuovo plugin: test + docs inclusi
- [ ] Issue collegata o motivazione dell'assenza
- [ ] **Se rimuovo un modulo/funzione pubblica**: ho verificato l'assenza di import con `rg` su tutta l'org
  e lasciato shim backward compat con `DeprecationWarning` (vedi deprecation policy in CONTRIBUTING)

## Note per chi revisiona

Modifica minima: 4 righe aggiungono `, COMPRESSION ZSTD` alle COPY PARQUET esistenti. Nessun cambiamento di contratto — i file restano Parquet standard aperti da qualsiasi tool.

Risultato test su anac_bandi_gara 2024:
- 276 MB (Snappy) → 152 MB (ZSTD) = **-45%**
- Pipeline completa raw→clean→mart eseguita senza errori
- Compression ratio del clean: 33.4%
