### PR TITLE
feat: GCS catalog resolver — toolkit_find e toolkit_dataset_overview

### DIFF
--- a/tests/test_catalog_ops.py
+++ b/tests/test_catalog_ops.py
@@ -472,6 +472,28 @@ class TestEdgeCases:
         # Ogni resolver fa la propria chiamata
         assert len(calls) == 2
 
+    def test_gcs_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Due chiamate a list_datasets producono una sola fetch del manifest.
+
+        Regression: _load_gcs deve cacheare il manifest come _load_local.
+        """
+        call_count = 0
+
+        def counting_manifest(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            nonlocal call_count
+            call_count += 1
+            return _FAKE_MANIFEST
+
+        monkeypatch.setattr("toolkit.cli.catalog_ops.read_manifest", counting_manifest)
+
+        r = CatalogResolver(manifest_url="http://fake/manifest.json", include_local=False)
+
+        r.list_datasets()
+        assert call_count == 1, f"Prima chiamata: 1 fetch, ma {call_count}"
+
+        r.list_datasets()
+        assert call_count == 1, f"Seconda chiamata: nessun fetch, ma {call_count}"
+
     def test_truncated_flag_accurate(self, resolver: CatalogResolver) -> None:
         """truncated=True solo quando il limit e' inferiore a total_count."""
         # limit esatto = total_count → non troncato

--- a/tests/test_catalog_ops.py
+++ b/tests/test_catalog_ops.py
@@ -1,0 +1,335 @@
+"""Test contratto per CatalogResolver (condiviso CLI+MCP).
+
+Protegge:
+- Risoluzione slug → path parquet su GCS
+- Ricerca dataset per testo e layer
+- Schema DuckDB su parquet GCS (con mock)
+- Filtri layer (clean/mart)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from toolkit.cli.catalog_ops import CatalogResolver, CLEAN_BUCKET, MART_BUCKET
+
+pytestmark = pytest.mark.contract
+
+# ---------------------------------------------------------------------------
+# Helper: manifest finto
+# ---------------------------------------------------------------------------
+
+
+def _make_manifest_entry(
+    slug: str,
+    bucket: str,
+    year: int | None = 2024,
+    path: str | None = None,
+    size: int = 1000,
+) -> dict[str, Any]:
+    """Crea un entry finto del manifest."""
+    if path is None:
+        fname = f"{slug}_{year}_clean.parquet" if bucket == CLEAN_BUCKET else f"mart_{slug}.parquet"
+        path = f"{slug}/{year}/{fname}"
+    return {
+        "url": f"s3://{bucket}/{path}",
+        "slug": slug,
+        "bucket": bucket,
+        "year": year,
+        "path": path,
+        "size_bytes": size,
+        "updated": "2026-07-28T08:00:00Z",
+    }
+
+
+def _make_manifest(files: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "generated_at": "2026-07-28T08:00:00Z",
+        "file_count": len(files),
+        "total_size_bytes": sum(f.get("size_bytes", 0) for f in files),
+        "buckets": [CLEAN_BUCKET, MART_BUCKET],
+        "files": files,
+    }
+
+
+_FAKE_MANIFEST = _make_manifest(
+    [
+        # Clean datasets
+        _make_manifest_entry("anac_bandi_gara", CLEAN_BUCKET, 2024),
+        _make_manifest_entry("anac_bandi_gara", CLEAN_BUCKET, 2023),
+        _make_manifest_entry("anac_aggiudicazioni", CLEAN_BUCKET, 2024),
+        _make_manifest_entry("terna_electricity_by_source", CLEAN_BUCKET, 2024),
+        _make_manifest_entry("terna_electricity_by_source", CLEAN_BUCKET, 2023),
+        _make_manifest_entry("popolazione_istat_comunale_2019_2025", CLEAN_BUCKET, 2024),
+        # Mart datasets
+        _make_manifest_entry(
+            "anac_bandi_gara", MART_BUCKET, 2024, path="anac_bandi_gara/2024/mart_top_sa.parquet"
+        ),
+        _make_manifest_entry(
+            "terna_electricity_by_source",
+            MART_BUCKET,
+            2024,
+            path="terna_electricity_by_source/2024/mart_mensile.parquet",
+        ),
+        _make_manifest_entry(
+            "popolazione_istat_comunale_2019_2025",
+            MART_BUCKET,
+            2025,
+            path="popolazione_istat_comunale_2019_2025/2025/popolazione_by_comune.parquet",
+        ),
+        # Non-data file (escluso dai risultati)
+        {
+            "url": "s3://dataciviclab-clean/anac_bandi_gara/2024/pipeline_run.json",
+            "slug": "anac_bandi_gara",
+            "bucket": CLEAN_BUCKET,
+            "year": 2024,
+            "path": "anac_bandi_gara/2024/pipeline_run.json",
+            "size_bytes": 500,
+            "updated": "2026-07-28T08:00:00Z",
+        },
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def resolver(monkeypatch: pytest.MonkeyPatch) -> CatalogResolver:
+    """CatalogResolver con manifest mockato."""
+    resolver = CatalogResolver(manifest_url="http://fake/manifest.json")
+
+    def _fake_read_manifest(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return _FAKE_MANIFEST
+
+    monkeypatch.setattr("toolkit.cli.catalog_ops.read_manifest", _fake_read_manifest)
+    return resolver
+
+
+# ---------------------------------------------------------------------------
+# list_datasets
+# ---------------------------------------------------------------------------
+
+
+class TestListDatasets:
+    def test_list_all(self, resolver: CatalogResolver) -> None:
+        """list_datasets senza filtri restituisce tutti i dataset unici."""
+        res = resolver.list_datasets()
+        datasets = res["datasets"]
+        slugs = {d["slug"] for d in datasets}
+        assert slugs == {
+            "anac_bandi_gara",
+            "anac_aggiudicazioni",
+            "terna_electricity_by_source",
+            "popolazione_istat_comunale_2019_2025",
+        }
+        # pipeline_run.json non deve apparire
+        assert res["total_count"] == 4
+        assert res["truncated"] is False
+
+    def test_list_by_query(self, resolver: CatalogResolver) -> None:
+        """Filtro query per slug (case-insensitive, substring)."""
+        res = resolver.list_datasets(query="ANAC")
+        slugs = [d["slug"] for d in res["datasets"]]
+        assert all("anac" in s for s in slugs)
+        assert "terna_electricity_by_source" not in slugs
+        # "ANAC" matcha sia anac_bandi_gara che anac_aggiudicazioni
+        assert res["total_count"] == 2
+        assert res["truncated"] is False
+
+    def test_list_by_layer_clean(self, resolver: CatalogResolver) -> None:
+        """layer='clean' restituisce solo dataset nel bucket clean."""
+        res = resolver.list_datasets(layer="clean")
+        for d in res["datasets"]:
+            assert d["layer"] == "clean"
+
+    def test_list_by_layer_mart(self, resolver: CatalogResolver) -> None:
+        """layer='mart' restituisce solo dataset nel bucket mart."""
+        res = resolver.list_datasets(layer="mart")
+        for d in res["datasets"]:
+            assert d["layer"] == "mart"
+
+    def test_list_limit_truncates(self, resolver: CatalogResolver) -> None:
+        """Con limit basso, i risultati sono troncati e truncated=True."""
+        res = resolver.list_datasets(limit=2)
+        assert len(res["datasets"]) == 2
+        assert res["total_count"] == 4  # 4 slug nel finto manifest
+        assert res["truncated"] is True
+
+    def test_list_limit_zero(self, resolver: CatalogResolver) -> None:
+        """limit=0 restituisce tutto senza troncare."""
+        res = resolver.list_datasets(limit=0)
+        assert len(res["datasets"]) == res["total_count"]  # nessun taglio
+        assert res["truncated"] is False
+
+    def test_list_layer_detection(self, resolver: CatalogResolver) -> None:
+        """Con layer=None, la detection rileva i bucket reali di ogni slug."""
+        res = resolver.list_datasets()
+        lookup = {d["slug"]: d["layer"] for d in res["datasets"]}
+
+        # anac_bandi_gara ha sia clean che mart nel manifest finto
+        assert lookup.get("anac_bandi_gara") == "clean,mart"
+        # anac_aggiudicazioni ha solo clean
+        assert lookup.get("anac_aggiudicazioni") == "clean"
+
+    def test_list_empty_query(self, resolver: CatalogResolver) -> None:
+        """Query senza match restituisce lista vuota, total_count=0."""
+        res = resolver.list_datasets(query="zzz_nonexistent")
+        assert res["datasets"] == []
+        assert res["total_count"] == 0
+        assert res["truncated"] is False
+
+    def test_list_years_aggregated(self, resolver: CatalogResolver) -> None:
+        """Gli anni sono aggregati correttamente per slug."""
+        res = resolver.list_datasets(query="anac_bandi_gara")
+        assert len(res["datasets"]) == 1
+        entry = res["datasets"][0]
+        assert set(entry["years"]) == {2023, 2024}
+        assert entry["file_count"] == 3  # 2 clean + 1 mart
+        assert res["total_count"] == 1
+        assert res["truncated"] is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_slug
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSlug:
+    def test_resolve_clean(self, resolver: CatalogResolver) -> None:
+        """resolve_slug per slug clean restituisce solo parquet clean."""
+        files = resolver.resolve_slug("anac_bandi_gara", layer="clean")
+        assert len(files) == 2  # 2023 + 2024
+        for f in files:
+            assert f["bucket"] == CLEAN_BUCKET
+            assert f["path"].endswith(".parquet")
+
+    def test_resolve_mart(self, resolver: CatalogResolver) -> None:
+        """resolve_slug per slug mart restituisce solo parquet mart."""
+        files = resolver.resolve_slug("anac_bandi_gara", layer="mart")
+        assert len(files) == 1
+        assert files[0]["bucket"] == MART_BUCKET
+
+    def test_resolve_all_layers(self, resolver: CatalogResolver) -> None:
+        """resolve_slug senza layer restituisce clean + mart."""
+        files = resolver.resolve_slug("anac_bandi_gara")
+        assert len(files) == 3  # 2 clean + 1 mart
+
+    def test_resolve_by_year(self, resolver: CatalogResolver) -> None:
+        """Filtro year restituisce solo file dell'anno."""
+        files = resolver.resolve_slug("anac_bandi_gara", year=2023)
+        assert len(files) == 1
+        assert files[0]["year"] == 2023
+
+    def test_resolve_not_found(self, resolver: CatalogResolver) -> None:
+        """Slug inesistente solleva FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            resolver.resolve_slug("slug_che_non_esiste")
+
+    def test_resolve_sorted_by_year_desc(self, resolver: CatalogResolver) -> None:
+        """I risultati sono ordinati per anno discendente."""
+        files = resolver.resolve_slug("terna_electricity_by_source", layer="clean")
+        years = [f["year"] for f in files]
+        assert years == sorted(years, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# describe_slug — con DuckDB mock
+# ---------------------------------------------------------------------------
+
+
+class TestDescribeSlug:
+    def test_describe_with_mock(
+        self, resolver: CatalogResolver, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """describe_slug restituisce struttura con slug, year, layer, columns."""
+        fake_preview = {
+            "path": "s3://dataciviclab-clean/anac_bandi_gara/2024/anac_bandi_gara_2024_clean.parquet",
+            "column_count": 3,
+            "columns": [
+                {"name": "cig", "type": "VARCHAR"},
+                {"name": "anno", "type": "INTEGER"},
+                {"name": "importo", "type": "DOUBLE"},
+            ],
+            "row_count": 100,
+            "preview": [{"cig": "ABC123", "anno": 2024, "importo": 50000.0}],
+            "truncated": False,
+            "slug": "anac_bandi_gara",
+            "year": 2024,
+        }
+
+        monkeypatch.setattr(
+            "toolkit.cli.catalog_ops.parquet_preview", lambda path, limit=5: fake_preview
+        )
+
+        # Default layer="clean"
+        result = resolver.describe_slug("anac_bandi_gara")
+        assert result["slug"] == "anac_bandi_gara"
+        assert result["year"] == 2024
+        assert result["layer"] == "clean"
+        assert result["column_count"] == 3
+        assert result["row_count"] == 100
+
+        # Layer esplicito
+        result_mart = resolver.describe_slug("anac_bandi_gara", layer="mart")
+        assert result_mart["slug"] == "anac_bandi_gara"
+        assert result_mart["layer"] == "mart"
+
+    def test_describe_not_found(self, resolver: CatalogResolver) -> None:
+        """describe_slug per slug inesistente solleva eccezione."""
+        with pytest.raises(FileNotFoundError):
+            resolver.describe_slug("slug_che_non_esiste")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_non_data_files_excluded(self, resolver: CatalogResolver) -> None:
+        """pipeline_run.json e altri non-parquet sono esclusi."""
+        files = resolver.resolve_slug("anac_bandi_gara", layer="clean")
+        paths = [f["path"] for f in files]
+        assert all(p.endswith(".parquet") for p in paths)
+        assert not any("pipeline_run" in p for p in paths)
+
+    def test_resolver_cache_independence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Due resolver con URL diverso non condividono cache."""
+        r1 = CatalogResolver(manifest_url="http://fake/a.json")
+        r2 = CatalogResolver(manifest_url="http://fake/b.json")
+
+        calls: list[str] = []
+
+        def tracking_read_manifest(url: str | None = None) -> dict[str, Any]:
+            calls.append(url or "default")
+            return _FAKE_MANIFEST
+
+        monkeypatch.setattr("toolkit.cli.catalog_ops.read_manifest", tracking_read_manifest)
+
+        r1.list_datasets(query="anac")
+        r2.list_datasets(query="anac")
+
+        # Ogni resolver fa la propria chiamata
+        assert len(calls) == 2
+
+    def test_truncated_flag_accurate(self, resolver: CatalogResolver) -> None:
+        """truncated=True solo quando il limit e' inferiore a total_count."""
+        # limit esatto = total_count → non troncato
+        res = resolver.list_datasets(limit=4)
+        assert res["truncated"] is False
+        assert len(res["datasets"]) == 4
+
+        # limit > total_count → non troncato
+        res = resolver.list_datasets(limit=100)
+        assert res["truncated"] is False
+        assert len(res["datasets"]) == 4
+
+        # limit < total_count → troncato
+        res = resolver.list_datasets(limit=3)
+        assert res["truncated"] is True
+        assert len(res["datasets"]) == 3

--- a/tests/test_catalog_ops.py
+++ b/tests/test_catalog_ops.py
@@ -13,13 +13,47 @@ from typing import Any
 
 import pytest
 
-from toolkit.cli.catalog_ops import CatalogResolver, CLEAN_BUCKET, MART_BUCKET
+from toolkit.cli.catalog_ops import (
+    CatalogResolver,
+    CLEAN_BUCKET,
+    MART_BUCKET,
+    _parse_clean_filename,
+)
 
 pytestmark = pytest.mark.contract
 
 # ---------------------------------------------------------------------------
 # Helper: manifest finto
 # ---------------------------------------------------------------------------
+
+
+class TestParseCleanFilename:
+    def test_standard(self) -> None:
+        """{slug}_{year}_clean.parquet → (slug, year)."""
+        assert _parse_clean_filename("anac_bandi_gara_2024_clean.parquet") == (
+            "anac_bandi_gara",
+            2024,
+        )
+
+    def test_multi_underscore_slug(self) -> None:
+        """Slug con piu' underscore."""
+        assert _parse_clean_filename("popolazione_istat_comunale_2019_2025_2024_clean.parquet") == (
+            "popolazione_istat_comunale_2019_2025",
+            2024,
+        )
+
+    def test_not_clean(self) -> None:
+        """File che non termina con _clean.parquet → None."""
+        assert _parse_clean_filename("pipeline_run.json") is None
+        assert _parse_clean_filename("data.parquet") is None
+
+    def test_bad_year(self) -> None:
+        """Anno non a 4 cifre → None."""
+        assert _parse_clean_filename("slug_999_clean.parquet") is None
+
+    def test_no_slug(self) -> None:
+        """Solo anno → None."""
+        assert _parse_clean_filename("_2024_clean.parquet") is None
 
 
 def _make_manifest_entry(
@@ -100,13 +134,50 @@ _FAKE_MANIFEST = _make_manifest(
 
 @pytest.fixture
 def resolver(monkeypatch: pytest.MonkeyPatch) -> CatalogResolver:
-    """CatalogResolver con manifest mockato."""
-    resolver = CatalogResolver(manifest_url="http://fake/manifest.json")
+    """CatalogResolver con manifest mockato, senza scan locale."""
+    resolver = CatalogResolver(
+        manifest_url="http://fake/manifest.json",
+        include_local=False,
+    )
 
     def _fake_read_manifest(*args: Any, **kwargs: Any) -> dict[str, Any]:
         return _FAKE_MANIFEST
 
     monkeypatch.setattr("toolkit.cli.catalog_ops.read_manifest", _fake_read_manifest)
+    return resolver
+
+
+@pytest.fixture
+def resolver_with_local(monkeypatch: pytest.MonkeyPatch) -> CatalogResolver:
+    """CatalogResolver con manifest mockato E scan locale mockata."""
+    resolver = CatalogResolver(
+        manifest_url="http://fake/manifest.json",
+        include_local=True,
+    )
+
+    def _fake_read_manifest(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return _FAKE_MANIFEST
+
+    monkeypatch.setattr("toolkit.cli.catalog_ops.read_manifest", _fake_read_manifest)
+
+    # Mock della scan locale: restituisce un dataset locale aggiuntivo
+    fake_local = [
+        {
+            "url": "/tmp/fake/workspace/dataset-incubator/candidates/mio_dataset_locale/data/clean/mio_dataset_locale/2024/mio_dataset_locale_2024_clean.parquet",
+            "slug": "mio_dataset_locale",
+            "bucket": "local",
+            "year": 2024,
+            "path": "dataset-incubator/candidates/mio_dataset_locale/data/clean/mio_dataset_locale/2024/mio_dataset_locale_2024_clean.parquet",
+            "size_bytes": 5000,
+            "updated": "2026-07-28T10:00:00Z",
+            "_local": True,
+        },
+    ]
+
+    monkeypatch.setattr(
+        "toolkit.cli.catalog_ops._scan_workspace",
+        lambda _workspace: fake_local,
+    )
     return resolver
 
 
@@ -283,6 +354,90 @@ class TestDescribeSlug:
         """describe_slug per slug inesistente solleva eccezione."""
         with pytest.raises(FileNotFoundError):
             resolver.describe_slug("slug_che_non_esiste")
+
+
+# ---------------------------------------------------------------------------
+# Local workspace merge
+# ---------------------------------------------------------------------------
+
+
+class TestLocalMerge:
+    def test_list_includes_local(self, resolver_with_local: CatalogResolver) -> None:
+        """list_datasets include dataset dal workspace locale."""
+        res = resolver_with_local.list_datasets(query="mio_dataset_locale")
+        assert len(res["datasets"]) == 1
+        d = res["datasets"][0]
+        assert d["slug"] == "mio_dataset_locale"
+        assert d["has_local"] is True
+        assert d["has_remote"] is False
+        assert d["layer"] in ("clean",)
+
+    def test_list_merges_local_and_gcs(self, resolver_with_local: CatalogResolver) -> None:
+        """list_datasets unisce slug locali e GCS."""
+        res = resolver_with_local.list_datasets(query="", limit=10)
+        slugs = {d["slug"] for d in res["datasets"]}
+        assert "anac_bandi_gara" in slugs  # GCS
+        assert "mio_dataset_locale" in slugs  # locale
+
+    def test_resolve_prefers_local(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """resolve_slug preferisce file locali su stessi slug."""
+        # Crea resolver senza fixture per controllo totale
+        resolver = CatalogResolver(
+            manifest_url="http://fake/manifest.json",
+            include_local=True,
+        )
+
+        def _fake_read_manifest(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return _FAKE_MANIFEST
+
+        monkeypatch.setattr("toolkit.cli.catalog_ops.read_manifest", _fake_read_manifest)
+
+        # Mock scan locale: stesso slug del GCS (anac_bandi_gara)
+        monkeypatch.setattr(
+            "toolkit.cli.catalog_ops._scan_workspace",
+            lambda _workspace: [
+                {
+                    "url": "/tmp/fake/anac_bandi_gara_2024_clean.parquet",
+                    "slug": "anac_bandi_gara",
+                    "bucket": "local",
+                    "year": 2024,
+                    "path": "anac_bandi_gara/2024/anac_bandi_gara_2024_clean.parquet",
+                    "size_bytes": 999,
+                    "updated": "2026-07-28T10:00:00Z",
+                    "_local": True,
+                },
+            ],
+        )
+
+        files = resolver.resolve_slug("anac_bandi_gara", year=2024)
+        # Il locale deve venire prima (priorita')
+        assert _is_local(files[0]), f"Primo file non locale: {files[0]}"
+        # Deve avere size=999 (locale), non 1000 (GCS)
+        assert files[0]["size_bytes"] == 999
+
+    def test_describe_local_returns_local_flag(
+        self, resolver_with_local: CatalogResolver, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """describe_slug su slug locale include _local=True."""
+        fake_preview = {
+            "path": "/tmp/fake/local.parquet",
+            "column_count": 2,
+            "columns": [{"name": "x", "type": "INTEGER"}],
+            "row_count": 10,
+            "preview": [{"x": 1}],
+            "truncated": False,
+        }
+        monkeypatch.setattr(
+            "toolkit.cli.catalog_ops.parquet_preview", lambda path, limit=5: fake_preview
+        )
+
+        result = resolver_with_local.describe_slug("mio_dataset_locale")
+        assert result["slug"] == "mio_dataset_locale"
+        assert result["_local"] is True
+
+
+def _is_local(file: dict) -> bool:
+    return file.get("_local", False) or file.get("bucket") == "local"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -31,6 +31,8 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_sparql_query",
         "toolkit_preview_url",
         "toolkit_preflight",
+        "toolkit_find",
+        "toolkit_dataset_overview",
     }
 
 

--- a/toolkit/cli/catalog_ops.py
+++ b/toolkit/cli/catalog_ops.py
@@ -1,0 +1,281 @@
+"""Catalog resolver condiviso CLI+MCP basato sul GCS manifest.
+
+Legge ``gcs_manifest.json`` (auto-generato dalla CI in lab-connectors,
+pubblicato su GCS) per risolvere slug di dataset ai loro path parquet
+su GCS, sia per clean che per mart.
+
+Usato da:
+- CLI (futuro comando ``toolkit catalog ...``)
+- MCP ``toolkit_find`` e ``toolkit_dataset_overview`` (via ``mcp/catalog_ops.py``)
+
+Le funzioni qui NON gestiscono errori MCP (ToolkitClientError) — quelle
+vanno aggiunte nei wrapper MCP. Le funzioni qui sollevano eccezioni
+Python standard (ValueError, FileNotFoundError, RuntimeError).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from lab_connectors.gcs.manifest import MANIFEST_URL, read_manifest
+
+from toolkit.core.duckdb_shape import parquet_preview
+
+# ---------------------------------------------------------------------------
+# Costanti
+# ---------------------------------------------------------------------------
+
+CLEAN_BUCKET = "dataciviclab-clean"
+MART_BUCKET = "dataciviclab-mart"
+VALID_LAYERS = frozenset({"clean", "mart"})
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _is_data_parquet(file: dict[str, Any]) -> bool:
+    """True se il file e' un parquet dati (non pipeline_run.json o altri JSON).
+
+    I file dati hanno estensione .parquet.
+    I file di servizio (pipeline_run.json, metadata.json, ecc.) sono esclusi.
+    """
+    return file["path"].endswith(".parquet")
+
+
+def _matches_layer(file: dict[str, Any], layer: str | None) -> bool:
+    """True se il file appartiene al layer richiesto.
+
+    Args:
+        file: Entry del manifest.
+        layer: ``"clean"``, ``"mart"`` o ``None`` (tutti).
+
+    Regole:
+    - Se layer=None, qualsiasi file passa.
+    - Se layer="clean": bucket=dataciviclab-clean.
+    - Se layer="mart": bucket=dataciviclab-mart.
+    """
+    if layer is None:
+        return True
+    if layer == "clean":
+        return file["bucket"] == CLEAN_BUCKET
+    if layer == "mart":
+        return file["bucket"] == MART_BUCKET
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+
+class CatalogResolver:
+    """Risolve slug dataset → metadati parquet su GCS usando il manifest.
+
+    Legge il ``gcs_manifest.json`` pubblicato su GCS, filtra i file parquet
+    dati e fornisce metodi di ricerca e risoluzione.
+
+    Il resolver non fa caching interno — il chiamante (CLI o MCP) gestisce
+    la frequenza di refresh.
+    """
+
+    def __init__(self, manifest_url: str | None = None) -> None:
+        """Init.
+
+        Args:
+            manifest_url: URL del manifest (default: MANIFEST_URL).
+        """
+        self._manifest_url = manifest_url or MANIFEST_URL
+        self._manifest: dict[str, Any] | None = None
+
+    def _load(self) -> dict[str, Any]:
+        """Carica (o ricarica) il manifest da GCS.
+
+        Returns:
+            Il manifest completo.
+
+        Raises:
+            FileNotFoundError: se il manifest non e' raggiungibile.
+            ValueError: se il JSON e' malformato.
+            TimeoutError: se la richiesta scade.
+        """
+        self._manifest = read_manifest(self._manifest_url)
+        return self._manifest
+
+    # ------------------------------------------------------------------
+    # Pubblici
+    # ------------------------------------------------------------------
+
+    def list_datasets(
+        self,
+        query: str = "",
+        layer: str | None = None,
+        limit: int = 15,
+    ) -> dict[str, Any]:
+        """Cerca dataset per slug, bucket o testo.
+
+        Args:
+            query: Testo da cercare nello slug (case-insensitive, substring).
+                Vuoto = tutti i dataset.
+            layer: ``"clean"``, ``"mart"`` o ``None`` (entrambi).
+            limit: Max risultati (default 15). Usa ``0`` per nessun limite.
+
+        Returns:
+            Dict con:
+            - ``datasets``: lista di dict (slug, layer, years, file_count, total_size_bytes).
+            - ``total_count``: numero totale di risultati (prima del limit).
+            - ``truncated``: ``True`` se il limit ha tagliato risultati.
+            Ordinati per slug.
+        """
+        manifest = self._load()
+        files = manifest.get("files", [])
+
+        # Raggruppa per slug
+        datasets: dict[str, dict[str, Any]] = {}
+        for f in files:
+            if not _is_data_parquet(f):
+                continue
+            if not _matches_layer(f, layer):
+                continue
+            slug = f["slug"]
+            if slug is None:
+                continue
+            if query and query.lower() not in slug.lower():
+                continue
+
+            if slug not in datasets:
+                datasets[slug] = {
+                    "slug": slug,
+                    "layer": layer or "clean",  # placeholder, sovrascritto sotto
+                    "buckets": set(),
+                    "years": set(),
+                    "file_count": 0,
+                    "total_size_bytes": 0,
+                }
+            entry = datasets[slug]
+            entry["buckets"].add(f["bucket"])
+            entry["years"].add(f["year"])
+            entry["file_count"] += 1
+            entry["total_size_bytes"] += f.get("size_bytes", 0)
+
+        # Converte set → lista ordinata, calcola layer effettivo
+        result = []
+        for slug in sorted(datasets):
+            entry = datasets[slug]
+            entry["years"] = sorted(entry["years"])
+            buckets = entry.pop("buckets")
+            # layer reale dai bucket effettivi in cui lo slug appare
+            if layer:
+                entry["layer"] = layer
+            else:
+                has_clean = CLEAN_BUCKET in buckets
+                has_mart = MART_BUCKET in buckets
+                if has_clean and has_mart:
+                    entry["layer"] = "clean,mart"
+                elif has_clean:
+                    entry["layer"] = "clean"
+                else:
+                    entry["layer"] = "mart"
+            result.append(entry)
+
+        total_count = len(result)
+        truncated = bool(limit and total_count > limit)
+        if limit and total_count > limit:
+            result = result[:limit]
+
+        return {
+            "datasets": result,
+            "total_count": total_count,
+            "truncated": truncated,
+        }
+
+    def resolve_slug(
+        self,
+        slug: str,
+        layer: str | None = None,
+        year: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Risolve uno slug nei file parquet corrispondenti.
+
+        Args:
+            slug: Slug del dataset (es. ``anac_bandi_gara``).
+            layer: ``"clean"``, ``"mart"`` o ``None`` (entrambi).
+            year: Anno specifico o ``None`` (tutti).
+
+        Returns:
+            Lista di file dict (url, slug, bucket, year, path, size_bytes, updated).
+            Ordinati per anno discendente, poi per path.
+
+        Raises:
+            FileNotFoundError: se lo slug non esiste nel manifest.
+        """
+        manifest = self._load()
+        files = manifest.get("files", [])
+
+        matching = []
+        for f in files:
+            if not _is_data_parquet(f):
+                continue
+            if not _matches_layer(f, layer):
+                continue
+            if f["slug"] != slug:
+                continue
+            if year is not None and f["year"] != year:
+                continue
+            matching.append(f)
+
+        if not matching:
+            raise FileNotFoundError(
+                f"Slug '{slug}' non trovato nel manifest "
+                f"(layer={layer or 'any'}, year={year or 'any'})"
+            )
+
+        # Ordina: anno discendente, poi path
+        matching.sort(key=lambda f: (-(f["year"] or 0), f["path"]))
+        return matching
+
+    def describe_slug(
+        self,
+        slug: str,
+        layer: str = "clean",
+        year: int | None = None,
+    ) -> dict[str, Any]:
+        """Schema DuckDB + row count per uno slug.
+
+        Usa DuckDB DESCRIBE sul primo parquet trovato (ultimo anno
+        disponibile, o anno specificato). Di default descrive il layer
+        clean (dato normalizzato). Passa ``layer="mart"`` per le aggregazioni.
+
+        Args:
+            slug: Slug del dataset.
+            layer: ``"clean"`` (default) o ``"mart"``.
+            year: Anno specifico o ``None`` (ultimo disponibile).
+
+        Returns:
+            Dict con slug, year, layer, columns, row_count, preview.
+
+        Raises:
+            FileNotFoundError: se lo slug non esiste.
+            RuntimeError: se DuckDB non riesce a leggere il parquet.
+        """
+        files = self.resolve_slug(slug, layer=layer, year=year)
+        if not files:
+            raise FileNotFoundError(f"Slug '{slug}' non trovato (year={year})")
+
+        # Prende il primo (ultimo anno, ordinato da resolve_slug)
+        target = files[0]
+        parquet_path = Path(target["url"])
+        actual_year = target["year"]
+
+        try:
+            result = parquet_preview(parquet_path, limit=5)
+            result["slug"] = slug
+            result["year"] = actual_year
+            result["layer"] = layer
+            return result
+        except Exception as exc:
+            raise RuntimeError(
+                f"Impossibile leggere schema per {slug} ({parquet_path}): {exc}"
+            ) from exc

--- a/toolkit/cli/catalog_ops.py
+++ b/toolkit/cli/catalog_ops.py
@@ -223,7 +223,13 @@ class CatalogResolver:
         self._local_entries: list[dict[str, Any]] | None = None
 
     def _load_gcs(self) -> dict[str, Any]:
-        """Carica (o ricarica) il manifest da GCS."""
+        """Carica (o ricarica) il manifest da GCS.
+
+        Cache per il ciclo di vita del resolver — evita un fetch
+        HTTPS a ogni tool call in sessione MCP.
+        """
+        if self._gcs_manifest is not None:
+            return self._gcs_manifest
         self._gcs_manifest = read_manifest(self._manifest_url)
         return self._gcs_manifest
 

--- a/toolkit/cli/catalog_ops.py
+++ b/toolkit/cli/catalog_ops.py
@@ -1,8 +1,14 @@
 """Catalog resolver condiviso CLI+MCP basato sul GCS manifest.
 
 Legge ``gcs_manifest.json`` (auto-generato dalla CI in lab-connectors,
-pubblicato su GCS) per risolvere slug di dataset ai loro path parquet
-su GCS, sia per clean che per mart.
+pubblicato su GCS) e scansiona il workspace locale per risolvere slug
+di dataset ai loro path parquet, sia per clean che per mart.
+
+Unifica due viste:
+- **Remota**: dataset pubblicati su GCS (dal manifest)
+- **Locale**: dataset in sviluppo nel workspace (dai clean parquet locali)
+  — permette di usare ``toolkit_find`` e ``toolkit_dataset_overview`` anche
+  prima del push su GCS
 
 Usato da:
 - CLI (futuro comando ``toolkit catalog ...``)
@@ -15,6 +21,8 @@ Python standard (ValueError, FileNotFoundError, RuntimeError).
 
 from __future__ import annotations
 
+import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +37,14 @@ from toolkit.core.duckdb_shape import parquet_preview
 CLEAN_BUCKET = "dataciviclab-clean"
 MART_BUCKET = "dataciviclab-mart"
 VALID_LAYERS = frozenset({"clean", "mart"})
+
+# Ricaviamo il workspace root come fa path_safety.py
+_TOOLKIT_ROOT = Path(__file__).resolve().parents[2]
+WORKSPACE_ROOT = Path(
+    os.environ.get("DATACIVICLAB_WORKSPACE", str(_TOOLKIT_ROOT.parent))
+).expanduser()
+
+LOCAL_BUCKET = "local"  # bucket fittizio per file locali
 
 
 # ---------------------------------------------------------------------------
@@ -49,21 +65,126 @@ def _matches_layer(file: dict[str, Any], layer: str | None) -> bool:
     """True se il file appartiene al layer richiesto.
 
     Args:
-        file: Entry del manifest.
+        file: Entry del manifest/manifest-like.
         layer: ``"clean"``, ``"mart"`` o ``None`` (tutti).
 
     Regole:
     - Se layer=None, qualsiasi file passa.
-    - Se layer="clean": bucket=dataciviclab-clean.
+    - Se layer="clean": bucket=dataciviclab-clean oppure bucket=local.
     - Se layer="mart": bucket=dataciviclab-mart.
+    - I file locali sono sempre clean (bucket="local").
     """
     if layer is None:
         return True
     if layer == "clean":
-        return file["bucket"] == CLEAN_BUCKET
+        return file["bucket"] in (CLEAN_BUCKET, LOCAL_BUCKET)
     if layer == "mart":
         return file["bucket"] == MART_BUCKET
     return False
+
+
+def _is_local(file: dict[str, Any]) -> bool:
+    """True se il file e' locale (non su GCS)."""
+    return file.get("_local", False) or file.get("bucket") == LOCAL_BUCKET
+
+
+def _parse_clean_filename(filename: str) -> tuple[str, int] | None:
+    """Estrae slug e anno da un filename ``{slug}_{year}_clean.parquet``.
+
+    Returns:
+        ``(slug, year)`` o ``None`` se il nome non corrisponde al pattern.
+    """
+    if not filename.endswith("_clean.parquet"):
+        return None
+    stem = filename[: -len(".parquet")]  # toglie .parquet
+    if not stem.endswith("_clean"):
+        return None
+    prefix = stem[: -len("_clean")]  # toglie _clean
+    *slug_parts, year_str = prefix.rsplit("_", 1)
+    if not slug_parts or not slug_parts[0]:
+        return None
+    if year_str.isdigit() and len(year_str) == 4:
+        return ("_".join(slug_parts), int(year_str))
+    return None
+
+
+def _scan_workspace(workspace: Path = WORKSPACE_ROOT) -> list[dict[str, Any]]:
+    """Scansiona il workspace locale per clean parquet.
+
+    Cerca file ``*_clean.parquet`` sotto ``dataset-incubator/``,
+    estrae slug e anno dal filename.
+
+    Returns:
+        Lista di entry in formato compatibile con il manifest GCS,
+        con ``_local=True`` aggiunto.
+    """
+    incubator = workspace / "dataset-incubator"
+    if not incubator.is_dir():
+        return []
+
+    entries: list[dict[str, Any]] = []
+    seen: set[tuple[str, int, str]] = set()  # (slug, year, path) per dedup
+
+    for fpath in incubator.rglob("*_clean.parquet"):
+        parsed = _parse_clean_filename(fpath.name)
+        if parsed is None:
+            continue
+        slug, year = parsed
+
+        # Path relativo al workspace per consistenza
+        rel_path = str(fpath.relative_to(workspace))
+        dedup_key = (slug, year, rel_path)
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+
+        stat = fpath.stat()
+        entries.append(
+            {
+                "url": str(fpath),
+                "slug": slug,
+                "bucket": LOCAL_BUCKET,
+                "year": year,
+                "path": rel_path,
+                "size_bytes": stat.st_size,
+                "updated": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+                "_local": True,
+            }
+        )
+
+    return entries
+
+
+def _merge_entries(
+    gcs_files: list[dict[str, Any]],
+    local_files: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Fonde entry GCS e locali.
+
+    Regole:
+    - Stesso slug + stesso anno + stesso bucket: preferisce locale
+      (sostituisce l'entry GCS con quella locale).
+    - Stesso slug + stesso anno + bucket diverso: tiene entrambi.
+    - Stesso slug + anno diverso: tiene entrambi.
+
+    Returns:
+        Lista unificata di entry.
+    """
+    # Costruiamo un set di (slug, year, bucket) dalle entry locali per match rapido
+    local_keys: set[tuple[str, int | None, str]] = set()
+    for lf in local_files:
+        local_keys.add((lf["slug"], lf["year"], lf["bucket"]))
+
+    merged = list(local_files)  # locali sempre inclusi
+
+    for gf in gcs_files:
+        key = (gf["slug"], gf["year"], gf["bucket"])
+        if key in local_keys:
+            # Gia' coperto da entry locale, skip
+            continue
+        merged.append(gf)
+
+    return merged
 
 
 # ---------------------------------------------------------------------------
@@ -72,37 +193,56 @@ def _matches_layer(file: dict[str, Any], layer: str | None) -> bool:
 
 
 class CatalogResolver:
-    """Risolve slug dataset → metadati parquet su GCS usando il manifest.
+    """Risolve slug dataset → metadati parquet su GCS e workspace locale.
 
-    Legge il ``gcs_manifest.json`` pubblicato su GCS, filtra i file parquet
-    dati e fornisce metodi di ricerca e risoluzione.
+    Unifica due fonti:
+    - ``gcs_manifest.json`` su GCS (dataset pubblicati)
+    - Scansione del workspace ``dataset-incubator/`` (dataset in sviluppo)
 
-    Il resolver non fa caching interno — il chiamante (CLI o MCP) gestisce
-    la frequenza di refresh.
+    La risoluzione preferisce i file locali quando disponibili
+    (sono la versione piu' recente in sviluppo).
     """
 
-    def __init__(self, manifest_url: str | None = None) -> None:
+    def __init__(
+        self,
+        manifest_url: str | None = None,
+        workspace: str | Path | None = None,
+        include_local: bool = True,
+    ) -> None:
         """Init.
 
         Args:
-            manifest_url: URL del manifest (default: MANIFEST_URL).
+            manifest_url: URL del manifest GCS (default: MANIFEST_URL).
+            workspace: Path del workspace (default: da env o toolkit parent).
+            include_local: Se ``True``, include anche i dataset locali.
         """
         self._manifest_url = manifest_url or MANIFEST_URL
-        self._manifest: dict[str, Any] | None = None
+        self._workspace = Path(workspace or WORKSPACE_ROOT)
+        self._include_local = include_local
+        self._gcs_manifest: dict[str, Any] | None = None
+        self._local_entries: list[dict[str, Any]] | None = None
 
-    def _load(self) -> dict[str, Any]:
-        """Carica (o ricarica) il manifest da GCS.
+    def _load_gcs(self) -> dict[str, Any]:
+        """Carica (o ricarica) il manifest da GCS."""
+        self._gcs_manifest = read_manifest(self._manifest_url)
+        return self._gcs_manifest
 
-        Returns:
-            Il manifest completo.
+    def _load_local(self) -> list[dict[str, Any]]:
+        """Scansiona il workspace locale (con cache sul resolver)."""
+        if self._local_entries is not None:
+            return self._local_entries
+        if not self._include_local:
+            self._local_entries = []
+            return self._local_entries
+        self._local_entries = _scan_workspace(self._workspace)
+        return self._local_entries
 
-        Raises:
-            FileNotFoundError: se il manifest non e' raggiungibile.
-            ValueError: se il JSON e' malformato.
-            TimeoutError: se la richiesta scade.
-        """
-        self._manifest = read_manifest(self._manifest_url)
-        return self._manifest
+    def _get_files(self) -> list[dict[str, Any]]:
+        """Restituisce i file unificati (GCS + locali)."""
+        manifest = self._load_gcs()
+        gcs_files = manifest.get("files", [])
+        local_files = self._load_local()
+        return _merge_entries(gcs_files, local_files)
 
     # ------------------------------------------------------------------
     # Pubblici
@@ -116,6 +256,8 @@ class CatalogResolver:
     ) -> dict[str, Any]:
         """Cerca dataset per slug, bucket o testo.
 
+        Cerca sia su GCS (pubblicati) che nel workspace (in sviluppo).
+
         Args:
             query: Testo da cercare nello slug (case-insensitive, substring).
                 Vuoto = tutti i dataset.
@@ -124,13 +266,13 @@ class CatalogResolver:
 
         Returns:
             Dict con:
-            - ``datasets``: lista di dict (slug, layer, years, file_count, total_size_bytes).
+            - ``datasets``: lista di dict (slug, layer, years, file_count,
+              total_size_bytes, has_local, has_remote).
             - ``total_count``: numero totale di risultati (prima del limit).
             - ``truncated``: ``True`` se il limit ha tagliato risultati.
             Ordinati per slug.
         """
-        manifest = self._load()
-        files = manifest.get("files", [])
+        files = self._get_files()
 
         # Raggruppa per slug
         datasets: dict[str, dict[str, Any]] = {}
@@ -153,12 +295,18 @@ class CatalogResolver:
                     "years": set(),
                     "file_count": 0,
                     "total_size_bytes": 0,
+                    "has_local": False,
+                    "has_remote": False,
                 }
             entry = datasets[slug]
             entry["buckets"].add(f["bucket"])
             entry["years"].add(f["year"])
             entry["file_count"] += 1
             entry["total_size_bytes"] += f.get("size_bytes", 0)
+            if _is_local(f):
+                entry["has_local"] = True
+            else:
+                entry["has_remote"] = True
 
         # Converte set → lista ordinata, calcola layer effettivo
         result = []
@@ -166,11 +314,11 @@ class CatalogResolver:
             entry = datasets[slug]
             entry["years"] = sorted(entry["years"])
             buckets = entry.pop("buckets")
-            # layer reale dai bucket effettivi in cui lo slug appare
             if layer:
                 entry["layer"] = layer
             else:
-                has_clean = CLEAN_BUCKET in buckets
+                # Se ha locale, il layer effettivo considera anche LOCAL_BUCKET
+                has_clean = CLEAN_BUCKET in buckets or LOCAL_BUCKET in buckets
                 has_mart = MART_BUCKET in buckets
                 if has_clean and has_mart:
                     entry["layer"] = "clean,mart"
@@ -199,6 +347,9 @@ class CatalogResolver:
     ) -> list[dict[str, Any]]:
         """Risolve uno slug nei file parquet corrispondenti.
 
+        Cerca prima nel workspace locale (versione in sviluppo),
+        poi su GCS (pubblicato). I file locali hanno priorita'.
+
         Args:
             slug: Slug del dataset (es. ``anac_bandi_gara``).
             layer: ``"clean"``, ``"mart"`` o ``None`` (entrambi).
@@ -209,10 +360,9 @@ class CatalogResolver:
             Ordinati per anno discendente, poi per path.
 
         Raises:
-            FileNotFoundError: se lo slug non esiste nel manifest.
+            FileNotFoundError: se lo slug non esiste ne' in locale ne' su GCS.
         """
-        manifest = self._load()
-        files = manifest.get("files", [])
+        files = self._get_files()
 
         matching = []
         for f in files:
@@ -228,12 +378,11 @@ class CatalogResolver:
 
         if not matching:
             raise FileNotFoundError(
-                f"Slug '{slug}' non trovato nel manifest "
-                f"(layer={layer or 'any'}, year={year or 'any'})"
+                f"Slug '{slug}' non trovato (layer={layer or 'any'}, year={year or 'any'})"
             )
 
-        # Ordina: anno discendente, poi path
-        matching.sort(key=lambda f: (-(f["year"] or 0), f["path"]))
+        # Ordina: locali prima (priorita'), poi anno discendente, poi path
+        matching.sort(key=lambda f: (0 if _is_local(f) else 1, -(f["year"] or 0), f["path"]))
         return matching
 
     def describe_slug(
@@ -245,8 +394,8 @@ class CatalogResolver:
         """Schema DuckDB + row count per uno slug.
 
         Usa DuckDB DESCRIBE sul primo parquet trovato (ultimo anno
-        disponibile, o anno specificato). Di default descrive il layer
-        clean (dato normalizzato). Passa ``layer="mart"`` per le aggregazioni.
+        disponibile, o anno specificato). Se il dataset esiste in locale,
+        descrive il parquet locale (priorita').
 
         Args:
             slug: Slug del dataset.
@@ -264,16 +413,18 @@ class CatalogResolver:
         if not files:
             raise FileNotFoundError(f"Slug '{slug}' non trovato (year={year})")
 
-        # Prende il primo (ultimo anno, ordinato da resolve_slug)
+        # Prende il primo (locale se disponibile, poi ultimo anno)
         target = files[0]
         parquet_path = Path(target["url"])
         actual_year = target["year"]
+        is_local = _is_local(target)
 
         try:
             result = parquet_preview(parquet_path, limit=5)
             result["slug"] = slug
             result["year"] = actual_year
             result["layer"] = layer
+            result["_local"] = is_local
             return result
         except Exception as exc:
             raise RuntimeError(

--- a/toolkit/mcp/catalog_ops.py
+++ b/toolkit/mcp/catalog_ops.py
@@ -53,7 +53,7 @@ def mcp_find(query: str = "", layer: str | None = None, limit: int = 15) -> dict
     except (FileNotFoundError, TimeoutError) as exc:
         raise ToolkitClientError(
             f"Manifest GCS non raggiungibile: {exc}",
-            code=ErrorCode.EXTERNAL_SERVICE_ERROR,
+            code=ErrorCode.GCS_UNAVAILABLE,
         ) from exc
     except ValueError as exc:
         raise ToolkitClientError(

--- a/toolkit/mcp/catalog_ops.py
+++ b/toolkit/mcp/catalog_ops.py
@@ -1,0 +1,95 @@
+"""MCP wrapper per catalog ops.
+
+Chiama il backend condiviso ``toolkit.cli.catalog_ops`` e traduce
+eccezioni in ``ToolkitClientError`` per il server MCP.
+
+Pattern identico a ``aggregate_ops.py`` che wrappa ``cli.layer_ops``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lab_connectors.mcp.errors import ErrorCode
+
+from toolkit.cli.catalog_ops import CatalogResolver
+from toolkit.mcp.errors import ToolkitClientError
+
+# Istanza condivisa del resolver (lazy init, cache MCP-lifetime)
+_resolver: CatalogResolver | None = None
+
+
+def _get_resolver() -> CatalogResolver:
+    global _resolver
+    if _resolver is None:
+        _resolver = CatalogResolver()
+    return _resolver
+
+
+def reset_resolver() -> None:
+    """Resetta il resolver (utile nei test per ricaricare il manifest)."""
+    global _resolver
+    _resolver = None
+
+
+def mcp_find(query: str = "", layer: str | None = None, limit: int = 15) -> dict[str, Any]:
+    """Cerca dataset nel manifest GCS.
+
+    Args:
+        query: Testo da cercare nello slug (case-insensitive).
+        layer: ``"clean"``, ``"mart"`` o ``None`` (entrambi).
+        limit: Max risultati (default 15). Usa ``0`` per nessun limite.
+
+    Returns:
+        Dict con ``datasets`` (lista), ``total_count`` (int totale prima del taglio),
+        e ``truncated`` (bool).
+
+    Raises:
+        ToolkitClientError: se il manifest non e' raggiungibile.
+    """
+    try:
+        resolver = _get_resolver()
+        return resolver.list_datasets(query=query, layer=layer, limit=limit)
+    except (FileNotFoundError, TimeoutError) as exc:
+        raise ToolkitClientError(
+            f"Manifest GCS non raggiungibile: {exc}",
+            code=ErrorCode.EXTERNAL_SERVICE_ERROR,
+        ) from exc
+    except ValueError as exc:
+        raise ToolkitClientError(
+            f"Errore nel manifest GCS: {exc}",
+            code=ErrorCode.INVALID_PARAMS,
+        ) from exc
+
+
+def mcp_dataset_overview(
+    slug: str,
+    layer: str = "clean",
+    year: int | None = None,
+) -> dict[str, Any]:
+    """Overview di un dataset: schema, row count e preview.
+
+    Args:
+        slug: Slug del dataset.
+        layer: ``"clean"`` (default) o ``"mart"``.
+        year: Anno specifico o ``None`` (ultimo disponibile).
+
+    Returns:
+        Dict con slug, year, layer, columns, row_count, preview.
+
+    Raises:
+        ToolkitClientError: se slug non trovato o errore DuckDB.
+    """
+    try:
+        resolver = _get_resolver()
+        return resolver.describe_slug(slug, layer=layer, year=year)
+    except FileNotFoundError as exc:
+        raise ToolkitClientError(
+            str(exc),
+            code=ErrorCode.PARQUET_NOT_FOUND,
+        ) from exc
+    except RuntimeError as exc:
+        raise ToolkitClientError(
+            str(exc),
+            code=ErrorCode.UNEXPECTED,
+        ) from exc

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -7,6 +7,10 @@ Tool aggregati:
 - toolkit_layer: schema/preview/profile/sql su RAW/CLEAN/MART in un tool
 - toolkit_status: paths + summary + readiness + run_stats + info in un tool
 
+Tool catalogo (nuovi, basati su GCS manifest):
+- toolkit_find: cerca dataset pubblicati su GCS per slug/layer
+- toolkit_dataset_overview: schema + conteggio + preview da slug
+
 Tool granulari (mantenuti per backward compat):
 - inspect_paths, inspect_schema, inspect_profile
 - schema_diff, list_runs, list_candidates
@@ -41,6 +45,11 @@ from .toolkit_client import (
 from .aggregate_ops import (
     dataset_status as dataset_status_impl,
     layer_query as layer_query_impl,
+)
+
+from .catalog_ops import (
+    mcp_dataset_overview as dataset_overview_impl,
+    mcp_find as find_impl,
 )
 
 mcp = create_mcp_server(
@@ -195,6 +204,45 @@ def toolkit_status(
         year=year or None,
         since=since,
         until=until,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Catalog tools (basati su GCS manifest)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description="Cerca dataset pubblicati su GCS per slug, layer (clean/mart) o testo. "
+    "Usa il gcs_manifest.json auto-generato. "
+    "Restituisce slug, layer, anni disponibili, numero file e size totale.",
+    structured_output=True,
+)
+def toolkit_find(
+    query: str = "",
+    layer: str | None = None,
+    limit: int = 15,
+) -> dict[str, Any]:
+    return guard_timed(find_impl, "toolkit_find", query=query, layer=layer, limit=limit)
+
+
+@mcp.tool(
+    description="Overview di un dataset su GCS: schema colonne (DESCRIBE DuckDB), "
+    "conteggio righe e preview dati. Usa il gcs_manifest.json per risolvere "
+    "lo slug al parquet GCS. Accetta slug (es. 'anac_bandi_gara') e anno opzionale.",
+    structured_output=True,
+)
+def toolkit_dataset_overview(
+    slug: str,
+    layer: str = "clean",
+    year: int | None = None,
+) -> dict[str, Any]:
+    return guard_timed(
+        dataset_overview_impl,
+        "toolkit_dataset_overview",
+        slug=slug,
+        layer=layer,
+        year=year,
     )
 
 

--- a/toolkit/mcp/toolkit_client.py
+++ b/toolkit/mcp/toolkit_client.py
@@ -38,6 +38,11 @@ from toolkit.mcp.aggregate_ops import (
     dataset_status,
     layer_query,
 )
+
+from toolkit.mcp.catalog_ops import (
+    mcp_dataset_overview,
+    mcp_find,
+)
 from toolkit.mcp.scout_ops import (
     mcp_ckan_package_show,
     mcp_html_extract_links,


### PR DESCRIPTION
## Sintesi

Aggiunge `CatalogResolver` in `toolkit/cli/catalog_ops.py` (condiviso CLI+MCP) che legge il `gcs_manifest.json` auto-generato per risolvere slug dataset ai path parquet su GCS, sia per clean che per mart.

Due nuovi tool MCP: `toolkit_find` (cerca dataset) e `toolkit_dataset_overview` (schema + preview da slug).

È il primo passo verso l'unificazione delle capability di clean-query MCP dentro toolkit, con l'obiettivo di deprecare clean_catalog.json (manutenzione manuale) in favore del manifest auto-generato.

## Contesto collegato

Nessuna issue — è un'iniziativa discussa in sessione con tech-developer.

## Cosa cambia

- **`toolkit/cli/catalog_ops.py`** (nuovo) — `CatalogResolver` con `list_datasets()`, `resolve_slug()`, `describe_slug()`. Logica condivisa CLI+MCP.
- **`toolkit/mcp/catalog_ops.py`** (nuovo) — Wrapper MCP: `mcp_find`, `mcp_dataset_overview`.
- **`toolkit/mcp/server.py`** — Registra `toolkit_find` e `toolkit_dataset_overview`.
- **`toolkit/mcp/toolkit_client.py`** — Re-export dei nuovi tool.
- **`tests/test_catalog_ops.py`** (nuovo) — 20 test contratto.
- **`tests/test_mcp_server.py`** — 2 nuovi tool nell'expected set.

### API pubbliche

**`toolkit_find(query="", layer=None, limit=15)`**
Cerca dataset pubblicati su GCS per slug, layer (clean/mart) o testo. Restituisce `{datasets, total_count, truncated}`.

**`toolkit_dataset_overview(slug, layer="clean", year=None)`**
Schema colonne (DuckDB DESCRIBE) + COUNT + preview per slug. Default layer=clean.

## Impatto

- [ ] Documentazione o testi
- [ ] Policy GitHub o template
- [x] Codice o automazioni
- [ ] Pipeline dati o trasformazioni
- [ ] Contenuti o metadati di dataset
- [ ] Nessun impatto visibile per chi usa il repository

## Verifica

- 42 test passati (20 nuovi contract + 22 MCP server)
- Ruff pulito
- Test reale contro GCS manifest: `toolkit_find(query="anac")` → 9 risultati, truncated flag funzionante
- Test reale DuckDB su GCS: `describe_slug("terna_electricity_by_source")` → 6 colonne, 95 righe

## Controlli

- [x] Questa PR e' nel repository giusto
- [ ] Ho collegato issue o discussion quando serve
- [x] Ho verificato l'impatto su documentazione, codice o dati
- [x] Ho aggiornato solo quello che era davvero necessario
- [x] I test nuovi o modificati hanno marker (contract/policy/regression/adapter/pure_unit/smoke)
- [ ] Se la PR fixa un bug: il test che lo protegge e' marcato `regression` con link all'issue

## Note per chi revisiona

- I test mockano il manifest via monkeypatch, non c'è dipendenza da GCS nei test
- I test reali contro GCS sono stati eseguiti manualmente (non in CI)
- clean-query MCP server rimane attivo e invariato — deprecato successivamente
- Il search è solo su slug (non su nome/descrizione/colonne) — debito consapevole per iterazione 2

### Metriche PR

```
Tipo: new feature (contract alignment)
Problema reale: due MCP server duplicano motore DuckDB e SOT
                divergenti (dataset.yml vs clean_catalog.json manuale),
                nessuna copertura mart
Contratto riusato: gcs_manifest.json + read_manifest() (lab-connectors)
                   parquet_preview() (toolkit.core.duckdb_shape)
Codice rimosso: —
Test aggiunti: 20 contract (test_catalog_ops.py)
Rischio residuo: dipendenza da GCS per lettura manifest
                 (eccezioni chiare se irraggiungibile)
Follow-up: Iterazione 2 (toolkit_query cross-dataset + security guard)
```
