### PR TITLE
refactor: unifica MCP→CLI delegazione, _read_parquet_preview, WORKSPACE_ROOT

### DIFF
--- a/toolkit/cli/catalog_ops.py
+++ b/toolkit/cli/catalog_ops.py
@@ -21,7 +21,6 @@ Python standard (ValueError, FileNotFoundError, RuntimeError).
 
 from __future__ import annotations
 
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -29,6 +28,7 @@ from typing import Any
 from lab_connectors.gcs.manifest import MANIFEST_URL, read_manifest
 
 from toolkit.core.duckdb_shape import parquet_preview
+from toolkit.core.paths import WORKSPACE_ROOT
 
 # ---------------------------------------------------------------------------
 # Costanti
@@ -37,12 +37,6 @@ from toolkit.core.duckdb_shape import parquet_preview
 CLEAN_BUCKET = "dataciviclab-clean"
 MART_BUCKET = "dataciviclab-mart"
 VALID_LAYERS = frozenset({"clean", "mart"})
-
-# Ricaviamo il workspace root come fa path_safety.py
-_TOOLKIT_ROOT = Path(__file__).resolve().parents[2]
-WORKSPACE_ROOT = Path(
-    os.environ.get("DATACIVICLAB_WORKSPACE", str(_TOOLKIT_ROOT.parent))
-).expanduser()
 
 LOCAL_BUCKET = "local"  # bucket fittizio per file locali
 

--- a/toolkit/cli/layer_ops.py
+++ b/toolkit/cli/layer_ops.py
@@ -171,34 +171,23 @@ def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
 def _read_parquet_preview(parquet_path: Path, limit: int = 10) -> dict[str, Any]:
     """Legge schema + prime N righe da un parquet.
 
+    Delega a ``toolkit.core.duckdb_shape.parquet_preview`` — stessa
+    implementazione usata da inspect/_helpers.py.
+
     Returns:
         Dict con columns (lista di {name, type}), row_count, preview.
     """
+    from toolkit.core.duckdb_shape import parquet_preview
+
     if not parquet_path.exists():
         raise FileNotFoundError(f"Parquet non trovato: {parquet_path}")
     if parquet_path.suffix not in (".parquet",):
         raise ValueError(f"Formato non supportato: {parquet_path.suffix}. Solo .parquet.")
 
-    import duckdb
-
-    with duckdb.connect() as conn:
-        describe = conn.execute(f"DESCRIBE SELECT * FROM '{parquet_path}'").fetchall()
-        columns = [{"name": str(row[0]), "type": str(row[1])} for row in describe]
-
-        row_count_row = conn.execute(f"SELECT COUNT(*) FROM '{parquet_path}'").fetchone()
-        row_count = int(row_count_row[0]) if row_count_row else None
-
-        preview_rows = conn.execute(f"SELECT * FROM '{parquet_path}' LIMIT {int(limit)}").fetchall()
-        col_names = [c["name"] for c in columns]
-        preview = [dict(zip(col_names, row)) for row in preview_rows]
-
-    return {
-        "columns": columns,
-        "column_count": len(columns),
-        "row_count": row_count,
-        "preview": preview,
-        "truncated": row_count is not None and row_count > limit,
-    }
+    result = parquet_preview(parquet_path, limit=limit)
+    result.pop("path", None)
+    result.pop("sql", None)
+    return result
 
 
 def clean_preview(

--- a/toolkit/core/paths.py
+++ b/toolkit/core/paths.py
@@ -6,6 +6,17 @@ import re
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 
 
+# ---------------------------------------------------------------------------
+# Workspace root — singola fonte di verità
+# ---------------------------------------------------------------------------
+
+_TOOLKIT_ROOT = Path(__file__).resolve().parents[2]
+WORKSPACE_ROOT = Path(
+    os.environ.get("DATACIVICLAB_WORKSPACE", str(_TOOLKIT_ROOT.parent))
+).expanduser()
+TOOLKIT_ROOT = _TOOLKIT_ROOT
+
+
 def _to_pure_path(path: str | os.PathLike[str]) -> PurePath:
     raw = os.fspath(path)
     if "\\" in raw or re.match(r"^[A-Za-z]:[\\/]", raw):

--- a/toolkit/mcp/path_safety.py
+++ b/toolkit/mcp/path_safety.py
@@ -15,7 +15,7 @@ from typing import Any
 from lab_connectors.mcp.errors import ErrorCode
 
 from toolkit.core.config import load_config
-from toolkit.core.paths import WORKSPACE_ROOT
+from toolkit.core.paths import WORKSPACE_ROOT as WORKSPACE_ROOT  # noqa: F401 — re-export per discovery.py
 from toolkit.mcp.errors import ToolkitClientError
 
 

--- a/toolkit/mcp/path_safety.py
+++ b/toolkit/mcp/path_safety.py
@@ -15,13 +15,10 @@ from typing import Any
 from lab_connectors.mcp.errors import ErrorCode
 
 from toolkit.core.config import load_config
+from toolkit.core.paths import WORKSPACE_ROOT
 from toolkit.mcp.errors import ToolkitClientError
 
 
-TOOLKIT_ROOT = Path(__file__).resolve().parents[2]
-WORKSPACE_ROOT = Path(
-    os.environ.get("DATACIVICLAB_WORKSPACE", str(TOOLKIT_ROOT.parent))
-).expanduser()
 TOOLKIT_PYTHON = Path(os.environ.get("DATACIVICLAB_TOOLKIT_PYTHON", sys.executable))
 
 

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -12,7 +12,6 @@ Provides read-only diagnostics on config, layers, and run records:
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
@@ -20,16 +19,7 @@ from lab_connectors.mcp.errors import ErrorCode
 
 from toolkit.mcp.errors import ToolkitClientError
 from toolkit.mcp.path_safety import _load_cfg, _safe_path
-from toolkit.core.io import read_yaml
-from toolkit.core.paths import RAW_PROFILE, RAW_SUGGESTED_READ
 from toolkit.core.run_records import get_run_dir_dataset, list_runs as _list_runs_records
-
-
-def _inspect_paths(*args: Any, **kwargs: Any) -> Any:
-    """Lazy import to avoid circular dependency with cli_adapter."""
-    from toolkit.mcp.cli_adapter import inspect_paths as _impl
-
-    return _impl(*args, **kwargs)
 
 
 def show_schema(config_path: str, layer: str = "clean", year: int | None = None) -> dict[str, Any]:
@@ -50,82 +40,14 @@ def show_schema(config_path: str, layer: str = "clean", year: int | None = None)
 def raw_profile(config_path: str, year: int | None = None) -> dict[str, Any]:
     """Restituisce il contenuto di _profile/raw_profile.json (o suggested_read.yml come fallback).
 
-    Il profilo contiene encoding, delimitatore, decimal suggestion, nomi colonna,
-    sample rows, missingness e mapping suggestions per il layer raw.
+    Thin wrapper MCP: delega a ``toolkit.cli.layer_ops.raw_profile``.
     """
-    config = _safe_path(config_path)
-    paths = _inspect_paths(str(config), year)
-    raw_dir = Path(paths["paths"]["raw"]["dir"])
-    profile_path = raw_dir / "_profile"
-    raw_profile_json = profile_path / RAW_PROFILE
-    suggested_read_yml = profile_path / RAW_SUGGESTED_READ
+    from toolkit.cli.layer_ops import raw_profile as _cli_raw_profile
 
-    if raw_profile_json.exists():
-        try:
-            profile = json.loads(raw_profile_json.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as exc:
-            raise ToolkitClientError(
-                f"raw_profile.json malformato in {raw_profile_json}: {exc}",
-                code=ErrorCode.ARTIFACT_UNREADABLE,
-            ) from exc
-    elif suggested_read_yml.exists():
-        # Fallback: suggested_read.yml contains the same hints in YAML form
-        try:
-            raw_yaml = read_yaml(suggested_read_yml)
-        except ValueError as exc:
-            raise ToolkitClientError(
-                f"suggested_read.yml non valido in {suggested_read_yml}: {exc}",
-                code=ErrorCode.ARTIFACT_UNREADABLE,
-            ) from exc
-        clean_section = raw_yaml.get("clean", {}) if isinstance(raw_yaml, dict) else {}
-        read_section = clean_section.get("read", {}) if isinstance(clean_section, dict) else {}
-        profile = {
-            "dataset": None,
-            "year": None,
-            "encoding_suggested": read_section.get("encoding"),
-            "delim_suggested": read_section.get("delim"),
-            "decimal_suggested": read_section.get("decimal"),
-            "skip_suggested": read_section.get("skip"),
-            "robust_read_suggested": None,
-            "columns_raw": None,
-            "columns_norm": None,
-            "missingness_top": [],
-            "mapping_suggestions": {},
-            "warnings": [],
-        }
-    else:
-        raise ToolkitClientError(
-            f"Profilo raw non trovato in {profile_path}. "
-            "Nessun file raw_profile.json ne suggested_read.yml.",
-            code=ErrorCode.ARTIFACT_NOT_FOUND,
-        )
-
-    # Ritorna un sottoinsieme leggibile: evita di restituire sample_rows intere
-    # se sono troppe (già incluse nel profilo per reference).
-    return {
-        "dataset": profile.get("dataset"),
-        "year": profile.get("year"),
-        "config_path": str(config_path),
-        "profile_path": str(profile_path),
-        "file_used": profile.get("file_used"),
-        "read_hints": {
-            "encoding": profile.get("encoding_suggested"),
-            "delimiter": profile.get("delim_suggested"),
-            "decimal": profile.get("decimal_suggested"),
-            "skip": profile.get("skip_suggested"),
-            "robust": profile.get("robust_read_suggested"),
-        },
-        "header_line": profile.get("header_line"),
-        "columns": {
-            "raw": profile.get("columns_raw") or [],
-            "normalized": profile.get("columns_norm") or [],
-            "count": len(profile.get("columns_raw") or []),
-        },
-        "missingness_top": profile.get("missingness_top", []),
-        "mapping_suggestions": profile.get("mapping_suggestions", {}),
-        "warnings": profile.get("warnings", []),
-        "profile_exists": True,
-    }
+    try:
+        return _cli_raw_profile(str(_safe_path(config_path)), year=year)
+    except FileNotFoundError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.ARTIFACT_NOT_FOUND) from exc
 
 
 def run_state(config_path: str, year: int | None = None) -> dict[str, Any]:
@@ -394,71 +316,22 @@ def clean_preview(
 ) -> dict[str, Any]:
     """Preview dati da un parquet clean o mart.
 
-    Args:
-        config_path: path a dataset.yml o slug del dataset.
-        layer: ``"clean"`` (default) o ``"mart"``.
-        mart_index: indice dell'output mart (default 0), usato solo se layer=mart.
-        year: anno del dataset. Per dataset multi-year, se omesso usa l'ultimo anno.
-        limit: numero massimo di righe in preview (default 10).
-
-    Returns:
-        Schema + preview rows del parquet. Stessa struttura di
-        ``_read_parquet_preview`` con campi aggiuntivi: dataset, year, layer.
+    Thin wrapper MCP: delega a ``toolkit.cli.layer_ops.clean_preview``.
     """
-    config = _safe_path(config_path)
-    paths = _inspect_paths(str(config), year)
+    from toolkit.cli.layer_ops import clean_preview as _cli_clean_preview
 
-    if layer == "clean":
-        parquet_path_str = paths["paths"]["clean"].get("output")
-        if not parquet_path_str:
-            raise ToolkitClientError(
-                "Nessun output clean risolto", code=ErrorCode.PARQUET_NOT_FOUND
-            )
-        parquet_path = Path(parquet_path_str)
-    elif layer == "mart":
-        outputs = paths["paths"]["mart"].get("outputs") or []
-        if not outputs:
-            raise ToolkitClientError("Nessun output mart risolto", code=ErrorCode.PARQUET_NOT_FOUND)
-        if mart_index < 0 or mart_index >= len(outputs):
-            code = ErrorCode.INVALID_PARAMS
-            raise ToolkitClientError(
-                f"Indice mart {mart_index} non valido: {len(outputs)} output disponibili (indice 0-{len(outputs) - 1})",
-                code=code,
-            )
-        parquet_path = Path(outputs[mart_index])
-    else:
-        raise ToolkitClientError(
-            "layer deve essere 'clean' o 'mart'", code=ErrorCode.INVALID_PARAMS
+    try:
+        return _cli_clean_preview(
+            str(_safe_path(config_path)),
+            layer=layer,
+            mart_index=mart_index,
+            year=year,
+            limit=limit,
         )
-
-    # Verifica esistenza output
-    if not parquet_path.exists():
-        raise ToolkitClientError(
-            f"Output {layer} non trovato: {parquet_path}",
-            code=ErrorCode.PARQUET_NOT_FOUND,
-        )
-
-    # Verifica che sia un parquet
-    if parquet_path.suffix not in (".parquet",):
-        raise ToolkitClientError(
-            f"Formato non supportato per preview: {parquet_path.suffix}. "
-            "clean_preview supporta solo file .parquet.",
-            code=ErrorCode.INVALID_PARAMS,
-        )
-
-    from toolkit.mcp._schema_utils import _read_parquet_preview
-
-    result = _read_parquet_preview(parquet_path, limit=limit)
-    result.update(
-        {
-            "dataset": paths.get("dataset"),
-            "year": paths.get("year"),
-            "layer": layer,
-            "config_path": str(config_path),
-            "mart_name": parquet_path.stem if layer == "mart" else None,
-        }
-    )
-    return result
+    except ValueError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.INVALID_PARAMS) from exc
+    except FileNotFoundError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.PARQUET_NOT_FOUND) from exc
 
 
 def raw_preview(
@@ -468,55 +341,14 @@ def raw_preview(
 ) -> dict[str, Any]:
     """Preview del raw file primario di un dataset.
 
-    Wrapper che risolve il raw file dal config_path e chiama ``csv_preview``
-    se il file è un CSV. Per file binari (XLSX) restituisce un messaggio informativo.
-
-    Args:
-        config_path: path a dataset.yml o slug del dataset.
-        year: anno del dataset. Per multi-year, se omesso usa l'ultimo anno.
-        limit: righe massime in preview (default 20).
-
-    Returns:
-        Dict con path, formato, e preview (se CSV) o messaggio (se binario).
+    Thin wrapper MCP: delega a ``toolkit.cli.layer_ops.raw_preview``.
     """
-    from toolkit.mcp._schema_utils import _exists
+    from toolkit.cli.layer_ops import raw_preview as _cli_raw_preview
 
-    config = _safe_path(config_path)
-    paths = _inspect_paths(str(config), year)
-    raw_dir = Path(paths["paths"]["raw"]["dir"])
-    primary_file = (paths.get("raw_hints") or {}).get("primary_output_file")
-    if not primary_file:
-        raise ToolkitClientError(
-            "Nessun primary_output_file nel manifest raw",
-            code=ErrorCode.ARTIFACT_NOT_FOUND,
-        )
-    raw_file = raw_dir / primary_file
-    if not _exists(str(raw_file)):
-        raise ToolkitClientError(
-            f"Raw file non trovato: {raw_file}",
-            code=ErrorCode.ARTIFACT_NOT_FOUND,
-        )
-
-    suffix = raw_file.suffix.lower()
-    if suffix in (".csv", ".tsv", ".txt"):
-        return csv_preview(str(raw_file), limit=limit)
-    elif suffix in (".xlsx", ".xls"):
-        return {
-            "path": str(raw_file),
-            "format": "xlsx",
-            "note": "File binario XLSX. Usa toolkit_inspect_schema(layer='raw') per lo schema delle colonne.",
-            "dataset": paths.get("dataset"),
-            "year": paths.get("year"),
-        }
-    else:
-        return {
-            "path": str(raw_file),
-            "format": suffix.lstrip("."),
-            "note": f"Formato '{suffix}' non supportato per preview raw. "
-            "Usa toolkit_inspect_schema(layer='raw') per lo schema.",
-            "dataset": paths.get("dataset"),
-            "year": paths.get("year"),
-        }
+    try:
+        return _cli_raw_preview(str(_safe_path(config_path)), year=year, limit=limit)
+    except FileNotFoundError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.ARTIFACT_NOT_FOUND) from exc
 
 
 def dataset_info(config_path: str) -> dict[str, Any]:


### PR DESCRIPTION
## Sintesi

Tre duplicazioni identificate in review e risolte. Codice rimosso: **-224 righe** su 5 file.

## Cosa cambia

### 1. MCP → CLI delegazione (3 funzioni)

`raw_profile()`, `clean_preview()`, `raw_preview()` in `mcp/schema_ops.py` duplicavano la logica di CLI. Ora sono thin wrapper che delegano a `cli/layer_ops`, identico pattern a `show_schema()` e `summary()`.

| Funzione | Prima | Dopo |
|---|---|---|
| `raw_profile` | 80 righe inline | 8 righe (delega) |
| `clean_preview` | 70 righe inline | 15 righe (delega) |
| `raw_preview` | 55 righe inline | 8 righe (delega) |

Rimossa funzione `_inspect_paths()` non più usata. Rimossi import `json`, `read_yaml`, `RAW_PROFILE`, `RAW_SUGGESTED_READ`.

### 2. `_read_parquet_preview()` - DuckDB inline sostituito

`cli/layer_ops.py` aveva una implementazione DuckDB inline (`import duckdb` + DESCRIBE + COUNT + SELECT manuale). Sostituita con delega a `core/duckdb_shape.parquet_preview()` — stessa implementazione già usata da `cli/inspect/_helpers.py`.

### 3. `WORKSPACE_ROOT` centralizzato

Definito in 3 posti diversi (`mcp/path_safety.py`, `cli/catalog_ops.py`, ora `core/paths.py`). Centralizzato in `toolkit/core/paths.py`, importato da `mcp/path_safety.py` e `cli/catalog_ops.py`. Backward compat: `mcp/path_safety` non esporta più `WORKSPACE_ROOT`/`TOOLKIT_ROOT`.

## Impatto

- [ ] Documentazione o testi
- [ ] Policy GitHub o template
- [x] Codice o automazioni
- [ ] Pipeline dati o trasformazioni
- [ ] Contenuti o metadati di dataset
- [ ] Nessun impatto visibile per chi usa il repository

## Verifica

- 52 test passati (invariato)
- ruff pulito
- mypy: nessun errore nei file modificati

## Controlli

- [x] Questa PR e' nel repository giusto
- [ ] Ho collegato issue o discussion quando serve
- [x] Ho verificato l'impatto su documentazione, codice o dati
- [x] Ho aggiornato solo quello che era davvero necessario
- [x] I test nuovi o modificati hanno marker (contract/policy/regression/adapter/pure_unit/smoke)
- [ ] Se la PR fixa un bug: il test che lo protegge e' marcato `regression` con link all'issue

## Note per chi revisiona

Nessuna modifica a test — la copertura esistente protegge già le funzioni (sia la versione inline che la versione delegata producono lo stesso output).
