### PR TITLE
feat: unifica list_candidates in toolkit_find con parametro source

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,7 +91,7 @@ def project_example(tmp_path: Path) -> Path:
     """
     import shutil
 
-    src = Path("project-example")
+    src = Path(__file__).resolve().parent.parent / "project-example"
     dst = tmp_path / "project-example"
     shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     return dst
@@ -197,7 +197,8 @@ def mcp_project_example(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tupl
     """
     import shutil
 
-    src = Path("project-example")
+    # Path assoluto rispetto a questo file (funziona da qualsiasi CWD)
+    src = Path(__file__).resolve().parent.parent / "project-example"
     dst = tmp_path / "project-example"
     shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     monkeypatch.setenv("DATACIVICLAB_WORKSPACE", str(tmp_path))

--- a/tests/test_catalog_ops.py
+++ b/tests/test_catalog_ops.py
@@ -175,8 +175,24 @@ def resolver_with_local(monkeypatch: pytest.MonkeyPatch) -> CatalogResolver:
     ]
 
     monkeypatch.setattr(
-        "toolkit.cli.catalog_ops._scan_workspace",
+        "toolkit.cli.catalog_ops._scan_workspace_parquets",
         lambda _workspace: fake_local,
+    )
+    # Mock anche scan configs per il dataset locale
+    monkeypatch.setattr(
+        "toolkit.cli.catalog_ops._scan_workspace_configs",
+        lambda _workspace, stage="all": {
+            "mio_dataset_locale": {
+                "dataset_name": "mio_dataset_locale",
+                "stage": "candidates",
+                "years": [2024],
+                "has_clean": True,
+                "has_mart": False,
+                "last_run_status": None,
+                "config_path": "/tmp/fake/dataset.yml",
+                "root": "/tmp/fake",
+            },
+        },
     )
     return resolver
 
@@ -362,6 +378,23 @@ class TestDescribeSlug:
 
 
 class TestLocalMerge:
+    def test_find_gcs_only(self, resolver: CatalogResolver) -> None:
+        """source='gcs' restituisce solo dataset GCS."""
+        res = resolver.list_datasets(source="gcs", limit=0)
+        slugs = {d["slug"] for d in res["datasets"]}
+        assert "anac_bandi_gara" in slugs
+        # locale mock non incluso
+        assert "mio_dataset_locale" not in slugs
+
+    def test_find_workspace_only(self, resolver_with_local: CatalogResolver) -> None:
+        """source='workspace' restituisce solo dataset workspace."""
+        # Usa query vuota per avere tutti
+        res = resolver_with_local.list_datasets(source="workspace", query="", limit=0)
+        slugs = {d["slug"] for d in res["datasets"]}
+        assert "mio_dataset_locale" in slugs
+        # GCS non incluso (source=workspace)
+        assert "anac_bandi_gara" not in slugs
+
     def test_list_includes_local(self, resolver_with_local: CatalogResolver) -> None:
         """list_datasets include dataset dal workspace locale."""
         res = resolver_with_local.list_datasets(query="mio_dataset_locale")
@@ -373,8 +406,8 @@ class TestLocalMerge:
         assert d["layer"] in ("clean",)
 
     def test_list_merges_local_and_gcs(self, resolver_with_local: CatalogResolver) -> None:
-        """list_datasets unisce slug locali e GCS."""
-        res = resolver_with_local.list_datasets(query="", limit=10)
+        """list_datasets unisce slug locali e GCS (source='all')."""
+        res = resolver_with_local.list_datasets(source="all", query="", limit=10)
         slugs = {d["slug"] for d in res["datasets"]}
         assert "anac_bandi_gara" in slugs  # GCS
         assert "mio_dataset_locale" in slugs  # locale
@@ -392,9 +425,9 @@ class TestLocalMerge:
 
         monkeypatch.setattr("toolkit.cli.catalog_ops.read_manifest", _fake_read_manifest)
 
-        # Mock scan locale: stesso slug del GCS (anac_bandi_gara)
+        # Mock scan parquet locale: stesso slug del GCS (anac_bandi_gara)
         monkeypatch.setattr(
-            "toolkit.cli.catalog_ops._scan_workspace",
+            "toolkit.cli.catalog_ops._scan_workspace_parquets",
             lambda _workspace: [
                 {
                     "url": "/tmp/fake/anac_bandi_gara_2024_clean.parquet",
@@ -407,6 +440,11 @@ class TestLocalMerge:
                     "_local": True,
                 },
             ],
+        )
+        # Mock scan configs vuota (non serve per resolve_slug)
+        monkeypatch.setattr(
+            "toolkit.cli.catalog_ops._scan_workspace_configs",
+            lambda _workspace, stage="all": {},
         )
 
         files = resolver.resolve_slug("anac_bandi_gara", year=2024)

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -552,9 +552,14 @@ def _make_candidate(workspace: Path, name: str) -> None:
 def _make_candidate_run(
     workspace: Path, name: str, status: str = "SUCCESS", year: int = 2024, root: str | None = None
 ) -> None:
-    """Crea run record per un candidate."""
+    """Crea run record per un candidate.
+
+    Il path del run usa lo slug normalizzato (underscore),
+    coerente con la risoluzione in CatalogResolver.
+    """
     base = Path(root) if root else workspace / "out"
-    runs_dir = base / "data" / "_runs" / name / str(year)
+    slug = name.replace("-", "_")
+    runs_dir = base / "data" / "_runs" / slug / str(year)
     runs_dir.mkdir(parents=True, exist_ok=True)
     (runs_dir / "run.json").write_text(
         json.dumps(
@@ -592,9 +597,11 @@ def test_list_candidates_sorting(tmp_path, monkeypatch, names, sorted_check):
 
     result = list_candidates(stage="all")
     slugs = [c["slug"] for c in result]
-    for name in names:
-        assert name in slugs
-        item = [c for c in result if c["slug"] == name][0]
+    # Gli slug ora sono normalizzati a underscore (merge con GCS)
+    normalized_names = [n.replace("-", "_") for n in names]
+    for i, slug in enumerate(normalized_names):
+        assert slug in slugs
+        item = [c for c in result if c["slug"] == slug][0]
         assert item["stage"] == "candidates"
         assert item["years"] == [2024]
     if sorted_check:
@@ -607,34 +614,35 @@ def test_list_candidates_resolves_custom_root(tmp_path, monkeypatch):
 
     monkeypatch.setattr(_discmod, "WORKSPACE_ROOT", tmp_path)
 
-    name = "test-root-candidate"
-    cand_dir = tmp_path / "dataset-incubator" / "candidates" / name
+    dir_name = "test-root-candidate"
+    slug = "test_root_candidate"  # normalizzato
+    cand_dir = tmp_path / "dataset-incubator" / "candidates" / dir_name
     cand_dir.mkdir(parents=True, exist_ok=True)
     (cand_dir / "dataset.yml").write_text(
-        f'root: "../../custom_out"\nschema_version: 1\ndataset:\n  name: {name}\n  years: [2024]\n',
+        f'root: "../../custom_out"\nschema_version: 1\ndataset:\n  name: {dir_name}\n  years: [2024]\n',
         encoding="utf-8",
     )
 
     custom_root = tmp_path / "dataset-incubator" / "custom_out"
-    clean_dir = custom_root / "data" / "clean" / name / "2024"
+    clean_dir = custom_root / "data" / "clean" / slug / "2024"
     clean_dir.mkdir(parents=True, exist_ok=True)
-    _write_parquet(clean_dir / f"{name}_2024_clean.parquet")
+    _write_parquet(clean_dir / f"{slug}_2024_clean.parquet")
 
-    mart_dir = custom_root / "data" / "mart" / name / "2024"
+    mart_dir = custom_root / "data" / "mart" / slug / "2024"
     mart_dir.mkdir(parents=True, exist_ok=True)
-    _write_parquet(mart_dir / f"mart_{name}.parquet")
+    _write_parquet(mart_dir / f"mart_{slug}.parquet")
 
-    _make_candidate_run(tmp_path, name, root=custom_root)
+    _make_candidate_run(tmp_path, slug, root=custom_root)
 
     from toolkit.mcp.discovery import list_candidates
 
-    items = [c for c in list_candidates(stage="all") if c["slug"] == name]
+    items = [c for c in list_candidates(stage="all") if c["slug"] == slug]
     assert len(items) == 1
     item = items[0]
     assert item["has_clean"] is True
     assert item["has_mart"] is True
     assert item["last_run_status"] == "SUCCESS"
-    assert not (tmp_path / "out" / "data" / "clean" / name).exists()
+    assert not (tmp_path / "out" / "data" / "clean" / slug).exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mcp_toolkit_client.py
+++ b/tests/test_mcp_toolkit_client.py
@@ -43,10 +43,10 @@ def _make_project_smoke(
     Returns:
         (config_path, slug, year).
     """
-    src = Path("project-example")
-    dst = tmp_path / "project-example"
     import shutil
 
+    src = Path(__file__).resolve().parent.parent / "project-example"
+    dst = tmp_path / "project-example"
     shutil.copytree(src, dst, ignore=shutil.ignore_patterns("_smoke_out"))
     config_path = dst / "dataset.yml"
 

--- a/toolkit/cli/catalog_ops.py
+++ b/toolkit/cli/catalog_ops.py
@@ -229,8 +229,8 @@ def _scan_workspace_configs(
                 resolved_root = workspace / "out"
 
             out_root = resolved_root / "data"
-            # Il nome del dataset per i path su disco
-            dataset_name_for_path = name if name != slug else dir_slug.replace("-", "_")
+            # I path su disco seguono la convenzione slug (underscore)
+            dataset_name_for_path = slug
             clean_dir = out_root / "clean" / dataset_name_for_path
             mart_dir = out_root / "mart" / dataset_name_for_path
             has_clean = clean_dir.exists() and any(clean_dir.iterdir())
@@ -470,6 +470,10 @@ class CatalogResolver:
             val = info.get(key)
             if val is not None:
                 entry[key] = val
+        # Anni dal workspace config (lista → set per merge con GCS)
+        ws_years = info.get("years", [])
+        if ws_years:
+            entry["years"].update(ws_years)
 
     def _finalize_layer(self, entry: dict[str, Any], layer: str | None) -> None:
         """Calcola il layer effettivo da bucket GCS + flag workspace."""

--- a/toolkit/cli/catalog_ops.py
+++ b/toolkit/cli/catalog_ops.py
@@ -201,9 +201,9 @@ def _scan_workspace_configs(
 
             parent_dir = dataset_yml.parent
             rel_path = parent_dir.relative_to(scan_dir)
-            slug = str(rel_path.as_posix())
+            dir_slug = str(rel_path.as_posix())
             if rel_path.parent == Path("."):
-                slug = parent_dir.name
+                dir_slug = parent_dir.name
 
             # Lettura YAML leggera (senza validazione piena)
             try:
@@ -212,6 +212,9 @@ def _scan_workspace_configs(
                 continue
             if not isinstance(data, dict):
                 continue
+
+            # Slug: dataset.yml > directory name — normalizzato a underscore
+            slug = (data.get("slug") or dir_slug).replace("-", "_")
 
             ds = data.get("dataset", {}) or {}
             name = ds.get("name", slug) if isinstance(ds, dict) else slug
@@ -226,8 +229,8 @@ def _scan_workspace_configs(
                 resolved_root = workspace / "out"
 
             out_root = resolved_root / "data"
-            # Usa lo slug normalizzato per i path su disco
-            dataset_name_for_path = slug.replace("-", "_") if name == slug else name
+            # Il nome del dataset per i path su disco
+            dataset_name_for_path = name if name != slug else dir_slug.replace("-", "_")
             clean_dir = out_root / "clean" / dataset_name_for_path
             mart_dir = out_root / "mart" / dataset_name_for_path
             has_clean = clean_dir.exists() and any(clean_dir.iterdir())
@@ -236,10 +239,7 @@ def _scan_workspace_configs(
                 dataset_name_for_path, runs_root=resolved_root
             )
 
-            # Normalizza slug: workspace usa trattini, GCS usa underscore
-            # Il merge tra le due viste richiede slug consistenti
-            normalized_slug = slug.replace("-", "_")
-            results[normalized_slug] = {
+            results[slug] = {
                 "dataset_name": str(name),
                 "stage": stage_name,
                 "years": [int(y) for y in years] if isinstance(years, list) else [],

--- a/toolkit/cli/catalog_ops.py
+++ b/toolkit/cli/catalog_ops.py
@@ -226,7 +226,8 @@ def _scan_workspace_configs(
                 resolved_root = workspace / "out"
 
             out_root = resolved_root / "data"
-            dataset_name_for_path = name if name != slug else parent_dir.name
+            # Usa lo slug normalizzato per i path su disco
+            dataset_name_for_path = slug.replace("-", "_") if name == slug else name
             clean_dir = out_root / "clean" / dataset_name_for_path
             mart_dir = out_root / "mart" / dataset_name_for_path
             has_clean = clean_dir.exists() and any(clean_dir.iterdir())
@@ -235,7 +236,10 @@ def _scan_workspace_configs(
                 dataset_name_for_path, runs_root=resolved_root
             )
 
-            results[slug] = {
+            # Normalizza slug: workspace usa trattini, GCS usa underscore
+            # Il merge tra le due viste richiede slug consistenti
+            normalized_slug = slug.replace("-", "_")
+            results[normalized_slug] = {
                 "dataset_name": str(name),
                 "stage": stage_name,
                 "years": [int(y) for y in years] if isinstance(years, list) else [],
@@ -388,9 +392,17 @@ class CatalogResolver:
         # --- Source: workspace ---
         if source in ("workspace", "all"):
             configs = self._load_workspace_configs()
-            for slug, info in configs.items():
+            local_files = self._load_local_parquets()
+
+            # Parquet-only slugs (dataset senza dataset.yml, es. sub-dataset)
+            parquet_only_slugs = {lf["slug"] for lf in local_files} - set(configs)
+
+            # Process config entries
+            for slug in set(configs) | parquet_only_slugs:
                 if query and query.lower() not in slug.lower():
                     continue
+                info = configs.get(slug, {})
+
                 if status_filter is not None and info.get("last_run_status") != status_filter:
                     continue
 
@@ -398,11 +410,11 @@ class CatalogResolver:
                     datasets[slug] = self._empty_entry(slug, info)
                 entry = datasets[slug]
 
-                # Pipeline metadata (sempre dal workspace)
-                self._merge_pipeline_info(entry, info)
+                # Pipeline metadata (dal workspace config, se presente)
+                if info:
+                    self._merge_pipeline_info(entry, info)
 
-                # Clean parquet count (dal workspace)
-                local_files = self._load_local_parquets()
+                # Clean parquet count
                 for lf in local_files:
                     if lf["slug"] == slug and _matches_layer(lf, layer):
                         entry["years"].add(lf["year"])
@@ -410,12 +422,9 @@ class CatalogResolver:
                         entry["total_size_bytes"] += lf.get("size_bytes", 0)
                         entry["has_local"] = True
 
-        # Apply stage filter (solo workspace) — esclude slug senza stage se source≠workspace
+        # Apply stage filter (solo workspace): tieni anche parquet-only
         if source == "workspace":
-            datasets = {s: e for s, e in datasets.items() if e.get("stage")}
-        elif stage and stage != "all" and source != "gcs":
-            # Quando source=all, stage filtra solo se specificato
-            pass  # stage è già filtrato in _scan_workspace_configs
+            datasets = {s: e for s, e in datasets.items() if e.get("stage") or e.get("has_local")}
 
         # Finalizza entry
         result = []

--- a/toolkit/cli/catalog_ops.py
+++ b/toolkit/cli/catalog_ops.py
@@ -1,33 +1,32 @@
-"""Catalog resolver condiviso CLI+MCP basato sul GCS manifest.
+"""Catalog resolver condiviso CLI+MCP — fonte unica per dataset discovery.
 
-Legge ``gcs_manifest.json`` (auto-generato dalla CI in lab-connectors,
-pubblicato su GCS) e scansiona il workspace locale per risolvere slug
-di dataset ai loro path parquet, sia per clean che per mart.
+Legge ``gcs_manifest.json`` (auto-generato dalla CI), scansiona il workspace
+locale e i dataset.yml per fornire una vista unificata di tutti i dataset
+del Lab, sia in sviluppo che pubblicati.
 
-Unifica due viste:
-- **Remota**: dataset pubblicati su GCS (dal manifest)
-- **Locale**: dataset in sviluppo nel workspace (dai clean parquet locali)
-  — permette di usare ``toolkit_find`` e ``toolkit_dataset_overview`` anche
-  prima del push su GCS
+Supporta tre ``source``:
+- ``"gcs"``: dataset pubblicati su GCS (dal manifest)
+- ``"workspace"``: dataset in sviluppo (da dataset.yml + clean parquet locali)
+- ``"all"`` (default): unione di entrambi
 
 Usato da:
 - CLI (futuro comando ``toolkit catalog ...``)
 - MCP ``toolkit_find`` e ``toolkit_dataset_overview`` (via ``mcp/catalog_ops.py``)
 
 Le funzioni qui NON gestiscono errori MCP (ToolkitClientError) — quelle
-vanno aggiunte nei wrapper MCP. Le funzioni qui sollevano eccezioni
-Python standard (ValueError, FileNotFoundError, RuntimeError).
+vanno aggiunte nei wrapper MCP.
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from lab_connectors.gcs.manifest import MANIFEST_URL, read_manifest
 
 from toolkit.core.duckdb_shape import parquet_preview
+from toolkit.core.io import read_json_or_none, read_yaml
 from toolkit.core.paths import WORKSPACE_ROOT
 
 # ---------------------------------------------------------------------------
@@ -39,34 +38,31 @@ MART_BUCKET = "dataciviclab-mart"
 VALID_LAYERS = frozenset({"clean", "mart"})
 
 LOCAL_BUCKET = "local"  # bucket fittizio per file locali
+VALID_SOURCES: frozenset[Literal["gcs", "workspace", "all"]] = frozenset(
+    {"gcs", "workspace", "all"}
+)
+VALID_STAGES: frozenset[Literal["candidates", "support", "all"]] = frozenset(
+    {"candidates", "support", "all"}
+)
+VALID_RUN_STATUSES = frozenset({"SUCCESS", "FAILED", "DRY_RUN", "RUNNING"})
 
 
 # ---------------------------------------------------------------------------
-# Helper
+# Helper comuni
 # ---------------------------------------------------------------------------
 
 
 def _is_data_parquet(file: dict[str, Any]) -> bool:
-    """True se il file e' un parquet dati (non pipeline_run.json o altri JSON).
-
-    I file dati hanno estensione .parquet.
-    I file di servizio (pipeline_run.json, metadata.json, ecc.) sono esclusi.
-    """
+    """True se il file e' un parquet dati (non pipeline_run.json)."""
     return file["path"].endswith(".parquet")
 
 
 def _matches_layer(file: dict[str, Any], layer: str | None) -> bool:
     """True se il file appartiene al layer richiesto.
 
-    Args:
-        file: Entry del manifest/manifest-like.
-        layer: ``"clean"``, ``"mart"`` o ``None`` (tutti).
-
-    Regole:
-    - Se layer=None, qualsiasi file passa.
-    - Se layer="clean": bucket=dataciviclab-clean oppure bucket=local.
-    - Se layer="mart": bucket=dataciviclab-mart.
-    - I file locali sono sempre clean (bucket="local").
+    - ``layer=None``: tutto.
+    - ``layer="clean"``: bucket clean o locale.
+    - ``layer="mart"``: bucket mart.
     """
     if layer is None:
         return True
@@ -83,17 +79,13 @@ def _is_local(file: dict[str, Any]) -> bool:
 
 
 def _parse_clean_filename(filename: str) -> tuple[str, int] | None:
-    """Estrae slug e anno da un filename ``{slug}_{year}_clean.parquet``.
-
-    Returns:
-        ``(slug, year)`` o ``None`` se il nome non corrisponde al pattern.
-    """
+    """Estrae slug e anno da ``{slug}_{year}_clean.parquet``."""
     if not filename.endswith("_clean.parquet"):
         return None
-    stem = filename[: -len(".parquet")]  # toglie .parquet
+    stem = filename[: -len(".parquet")]
     if not stem.endswith("_clean"):
         return None
-    prefix = stem[: -len("_clean")]  # toglie _clean
+    prefix = stem[: -len("_clean")]
     *slug_parts, year_str = prefix.rsplit("_", 1)
     if not slug_parts or not slug_parts[0]:
         return None
@@ -102,30 +94,57 @@ def _parse_clean_filename(filename: str) -> tuple[str, int] | None:
     return None
 
 
-def _scan_workspace(workspace: Path = WORKSPACE_ROOT) -> list[dict[str, Any]]:
-    """Scansiona il workspace locale per clean parquet.
+def _find_latest_run_status(slug: str, runs_root: Path | None = None) -> str | None:
+    """Cerca l'ultimo run record per un dataset slug.
 
-    Cerca file ``*_clean.parquet`` sotto ``dataset-incubator/``,
-    estrae slug e anno dal filename.
-
-    Returns:
-        Lista di entry in formato compatibile con il manifest GCS,
-        con ``_local=True`` aggiunto.
+    Scansiona ``{runs_root or WORKSPACE/out}/data/_runs/{slug}/``.
     """
+    if runs_root is not None:
+        runs_base = runs_root / "data" / "_runs" / slug
+    else:
+        runs_base = WORKSPACE_ROOT / "out" / "data" / "_runs" / slug
+    if not runs_base.exists():
+        return None
+
+    latest: dict[str, Any] | None = None
+    latest_mtime: float = 0.0
+
+    for year_dir in sorted(runs_base.iterdir()):
+        if not year_dir.is_dir() or not year_dir.name.isdigit():
+            continue
+        for run_file in year_dir.glob("*.json"):
+            try:
+                mtime = run_file.stat().st_mtime
+            except OSError:
+                continue
+            if mtime > latest_mtime:
+                data = read_json_or_none(run_file)
+                if isinstance(data, dict):
+                    latest = data
+                    latest_mtime = mtime
+
+    return latest.get("status") if latest else None
+
+
+# ---------------------------------------------------------------------------
+# Scan workspace — parquet files + pipeline metadata
+# ---------------------------------------------------------------------------
+
+
+def _scan_workspace_parquets(workspace: Path = WORKSPACE_ROOT) -> list[dict[str, Any]]:
+    """Scansiona il workspace per clean parquet locali."""
     incubator = workspace / "dataset-incubator"
     if not incubator.is_dir():
         return []
 
     entries: list[dict[str, Any]] = []
-    seen: set[tuple[str, int, str]] = set()  # (slug, year, path) per dedup
+    seen: set[tuple[str, int, str]] = set()
 
     for fpath in incubator.rglob("*_clean.parquet"):
         parsed = _parse_clean_filename(fpath.name)
         if parsed is None:
             continue
         slug, year = parsed
-
-        # Path relativo al workspace per consistenza
         rel_path = str(fpath.relative_to(workspace))
         dedup_key = (slug, year, rel_path)
         if dedup_key in seen:
@@ -149,35 +168,104 @@ def _scan_workspace(workspace: Path = WORKSPACE_ROOT) -> list[dict[str, Any]]:
     return entries
 
 
-def _merge_entries(
+def _scan_workspace_configs(
+    workspace: Path = WORKSPACE_ROOT,
+    stage: str = "all",
+) -> dict[str, dict[str, Any]]:
+    """Scansiona dataset.yml nel workspace e restituisce metadata di pipeline.
+
+    Returns:
+        Dict slug → {dataset_name, stage, years, has_clean, has_mart,
+                     last_run_status, config_path, root}
+    """
+    incubator = workspace / "dataset-incubator"
+    if not incubator.is_dir():
+        return {}
+
+    results: dict[str, dict[str, Any]] = {}
+    dirs_to_scan: list[tuple[str, Path]] = []
+
+    if stage in ("candidates", "all"):
+        candidates_dir = incubator / "candidates"
+        if candidates_dir.exists():
+            dirs_to_scan.append(("candidates", candidates_dir))
+    if stage in ("support", "all"):
+        support_dir = incubator / "support_datasets"
+        if support_dir.exists():
+            dirs_to_scan.append(("support", support_dir))
+
+    for stage_name, scan_dir in dirs_to_scan:
+        for dataset_yml in sorted(scan_dir.rglob("dataset.yml")):
+            if "templates" in dataset_yml.parts:
+                continue
+
+            parent_dir = dataset_yml.parent
+            rel_path = parent_dir.relative_to(scan_dir)
+            slug = str(rel_path.as_posix())
+            if rel_path.parent == Path("."):
+                slug = parent_dir.name
+
+            # Lettura YAML leggera (senza validazione piena)
+            try:
+                data = read_yaml(dataset_yml)
+            except Exception:
+                continue
+            if not isinstance(data, dict):
+                continue
+
+            ds = data.get("dataset", {}) or {}
+            name = ds.get("name", slug) if isinstance(ds, dict) else slug
+            years = ds.get("years", []) if isinstance(ds, dict) else []
+            if isinstance(years, int):
+                years = [years]
+
+            root_raw = data.get("root")
+            if root_raw and isinstance(root_raw, str):
+                resolved_root = (dataset_yml.parent / root_raw).resolve()
+            else:
+                resolved_root = workspace / "out"
+
+            out_root = resolved_root / "data"
+            dataset_name_for_path = name if name != slug else parent_dir.name
+            clean_dir = out_root / "clean" / dataset_name_for_path
+            mart_dir = out_root / "mart" / dataset_name_for_path
+            has_clean = clean_dir.exists() and any(clean_dir.iterdir())
+            has_mart = mart_dir.exists() and any(mart_dir.iterdir())
+            last_run_status = _find_latest_run_status(
+                dataset_name_for_path, runs_root=resolved_root
+            )
+
+            results[slug] = {
+                "dataset_name": str(name),
+                "stage": stage_name,
+                "years": [int(y) for y in years] if isinstance(years, list) else [],
+                "has_clean": has_clean,
+                "has_mart": has_mart,
+                "last_run_status": last_run_status,
+                "config_path": str(dataset_yml),
+                "root": str(resolved_root),
+            }
+
+    return results
+
+
+def _merge_gcs_and_local(
     gcs_files: list[dict[str, Any]],
     local_files: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Fonde entry GCS e locali.
+    """Fonde entry GCS e locali per file-level.
 
-    Regole:
-    - Stesso slug + stesso anno + stesso bucket: preferisce locale
-      (sostituisce l'entry GCS con quella locale).
-    - Stesso slug + stesso anno + bucket diverso: tiene entrambi.
-    - Stesso slug + anno diverso: tiene entrambi.
-
-    Returns:
-        Lista unificata di entry.
+    Stesso slug+anno+bucket → preferisce locale.
+    Stesso slug+anno, bucket diverso → tiene entrambi.
     """
-    # Costruiamo un set di (slug, year, bucket) dalle entry locali per match rapido
-    local_keys: set[tuple[str, int | None, str]] = set()
-    for lf in local_files:
-        local_keys.add((lf["slug"], lf["year"], lf["bucket"]))
-
-    merged = list(local_files)  # locali sempre inclusi
-
+    local_keys: set[tuple[str, int | None, str]] = {
+        (lf["slug"], lf["year"], lf["bucket"]) for lf in local_files
+    }
+    merged = list(local_files)
     for gf in gcs_files:
         key = (gf["slug"], gf["year"], gf["bucket"])
-        if key in local_keys:
-            # Gia' coperto da entry locale, skip
-            continue
-        merged.append(gf)
-
+        if key not in local_keys:
+            merged.append(gf)
     return merged
 
 
@@ -187,14 +275,12 @@ def _merge_entries(
 
 
 class CatalogResolver:
-    """Risolve slug dataset → metadati parquet su GCS e workspace locale.
+    """Risolve slug dataset → metadati, unificando GCS + workspace.
 
-    Unifica due fonti:
-    - ``gcs_manifest.json`` su GCS (dataset pubblicati)
-    - Scansione del workspace ``dataset-incubator/`` (dataset in sviluppo)
-
-    La risoluzione preferisce i file locali quando disponibili
-    (sono la versione piu' recente in sviluppo).
+    Supporta tre modalita' (``source``):
+    - ``"gcs"``: solo manifest GCS (dataset pubblicati)
+    - ``"workspace"``: solo workspace (dataset in sviluppo, con pipeline status)
+    - ``"all"`` (default): unione — merge GCS + workspace, arricchito con pipeline status
     """
 
     def __init__(
@@ -203,46 +289,36 @@ class CatalogResolver:
         workspace: str | Path | None = None,
         include_local: bool = True,
     ) -> None:
-        """Init.
-
-        Args:
-            manifest_url: URL del manifest GCS (default: MANIFEST_URL).
-            workspace: Path del workspace (default: da env o toolkit parent).
-            include_local: Se ``True``, include anche i dataset locali.
-        """
         self._manifest_url = manifest_url or MANIFEST_URL
         self._workspace = Path(workspace or WORKSPACE_ROOT)
         self._include_local = include_local
         self._gcs_manifest: dict[str, Any] | None = None
         self._local_entries: list[dict[str, Any]] | None = None
+        self._workspace_configs: dict[str, dict[str, Any]] | None = None
 
     def _load_gcs(self) -> dict[str, Any]:
-        """Carica (o ricarica) il manifest da GCS.
-
-        Cache per il ciclo di vita del resolver — evita un fetch
-        HTTPS a ogni tool call in sessione MCP.
-        """
         if self._gcs_manifest is not None:
             return self._gcs_manifest
         self._gcs_manifest = read_manifest(self._manifest_url)
         return self._gcs_manifest
 
-    def _load_local(self) -> list[dict[str, Any]]:
-        """Scansiona il workspace locale (con cache sul resolver)."""
+    def _load_local_parquets(self) -> list[dict[str, Any]]:
         if self._local_entries is not None:
             return self._local_entries
         if not self._include_local:
             self._local_entries = []
             return self._local_entries
-        self._local_entries = _scan_workspace(self._workspace)
+        self._local_entries = _scan_workspace_parquets(self._workspace)
         return self._local_entries
 
-    def _get_files(self) -> list[dict[str, Any]]:
-        """Restituisce i file unificati (GCS + locali)."""
-        manifest = self._load_gcs()
-        gcs_files = manifest.get("files", [])
-        local_files = self._load_local()
-        return _merge_entries(gcs_files, local_files)
+    def _load_workspace_configs(self) -> dict[str, dict[str, Any]]:
+        if self._workspace_configs is not None:
+            return self._workspace_configs
+        if not self._include_local:
+            self._workspace_configs = {}
+            return self._workspace_configs
+        self._workspace_configs = _scan_workspace_configs(self._workspace)
+        return self._workspace_configs
 
     # ------------------------------------------------------------------
     # Pubblici
@@ -253,79 +329,100 @@ class CatalogResolver:
         query: str = "",
         layer: str | None = None,
         limit: int = 15,
+        source: str = "all",
+        stage: str = "all",
+        status_filter: str | None = None,
     ) -> dict[str, Any]:
-        """Cerca dataset per slug, bucket o testo.
-
-        Cerca sia su GCS (pubblicati) che nel workspace (in sviluppo).
+        """Cerca dataset per slug, sorgente, layer o testo.
 
         Args:
-            query: Testo da cercare nello slug (case-insensitive, substring).
-                Vuoto = tutti i dataset.
+            query: Testo nello slug (case-insensitive, substring).
             layer: ``"clean"``, ``"mart"`` o ``None`` (entrambi).
             limit: Max risultati (default 15). Usa ``0`` per nessun limite.
+            source: ``"gcs"``, ``"workspace"`` o ``"all"`` (default).
+            stage: Filtro workspace: ``"candidates"``, ``"support"``, ``"all"`` (default).
+            status_filter: Filtro run status: ``"SUCCESS"``, ``"FAILED"``, ecc.
 
         Returns:
-            Dict con:
-            - ``datasets``: lista di dict (slug, layer, years, file_count,
-              total_size_bytes, has_local, has_remote).
-            - ``total_count``: numero totale di risultati (prima del limit).
-            - ``truncated``: ``True`` se il limit ha tagliato risultati.
-            Ordinati per slug.
+            Dict con ``datasets`` (lista), ``total_count``, ``truncated``.
         """
-        files = self._get_files()
+        # Input validation
+        if source not in VALID_SOURCES:
+            raise ValueError(f"source deve essere uno tra: {', '.join(sorted(VALID_SOURCES))}")
+        if stage not in VALID_STAGES:
+            raise ValueError(f"stage deve essere uno tra: {', '.join(sorted(VALID_STAGES))}")
+        if status_filter is not None and status_filter not in VALID_RUN_STATUSES:
+            raise ValueError(
+                f"status_filter deve essere uno tra: {', '.join(sorted(VALID_RUN_STATUSES))}"
+            )
 
-        # Raggruppa per slug
+        # Build agg map: slug → entry
         datasets: dict[str, dict[str, Any]] = {}
-        for f in files:
-            if not _is_data_parquet(f):
-                continue
-            if not _matches_layer(f, layer):
-                continue
-            slug = f["slug"]
-            if slug is None:
-                continue
-            if query and query.lower() not in slug.lower():
-                continue
 
-            if slug not in datasets:
-                datasets[slug] = {
-                    "slug": slug,
-                    "layer": layer or "clean",  # placeholder, sovrascritto sotto
-                    "buckets": set(),
-                    "years": set(),
-                    "file_count": 0,
-                    "total_size_bytes": 0,
-                    "has_local": False,
-                    "has_remote": False,
-                }
-            entry = datasets[slug]
-            entry["buckets"].add(f["bucket"])
-            entry["years"].add(f["year"])
-            entry["file_count"] += 1
-            entry["total_size_bytes"] += f.get("size_bytes", 0)
-            if _is_local(f):
-                entry["has_local"] = True
-            else:
+        # --- Source: GCS ---
+        if source in ("gcs", "all"):
+            manifest = self._load_gcs()
+            gcs_configs = self._load_workspace_configs()
+            for f in manifest.get("files", []):
+                if not _is_data_parquet(f):
+                    continue
+                if not _matches_layer(f, layer):
+                    continue
+                slug = f["slug"]
+                if slug is None:
+                    continue
+                if query and query.lower() not in slug.lower():
+                    continue
+
+                if slug not in datasets:
+                    info = gcs_configs.get(slug, {})
+                    datasets[slug] = self._empty_entry(slug, info)
+                    datasets[slug]["_buckets"] = set()
+                entry = datasets[slug]
+                entry["_buckets"].add(f["bucket"])
+                entry["years"].add(f["year"])
+                entry["file_count"] += 1
+                entry["total_size_bytes"] += f.get("size_bytes", 0)
                 entry["has_remote"] = True
 
-        # Converte set → lista ordinata, calcola layer effettivo
+        # --- Source: workspace ---
+        if source in ("workspace", "all"):
+            configs = self._load_workspace_configs()
+            for slug, info in configs.items():
+                if query and query.lower() not in slug.lower():
+                    continue
+                if status_filter is not None and info.get("last_run_status") != status_filter:
+                    continue
+
+                if slug not in datasets:
+                    datasets[slug] = self._empty_entry(slug, info)
+                entry = datasets[slug]
+
+                # Pipeline metadata (sempre dal workspace)
+                self._merge_pipeline_info(entry, info)
+
+                # Clean parquet count (dal workspace)
+                local_files = self._load_local_parquets()
+                for lf in local_files:
+                    if lf["slug"] == slug and _matches_layer(lf, layer):
+                        entry["years"].add(lf["year"])
+                        entry["file_count"] += 1
+                        entry["total_size_bytes"] += lf.get("size_bytes", 0)
+                        entry["has_local"] = True
+
+        # Apply stage filter (solo workspace) — esclude slug senza stage se source≠workspace
+        if source == "workspace":
+            datasets = {s: e for s, e in datasets.items() if e.get("stage")}
+        elif stage and stage != "all" and source != "gcs":
+            # Quando source=all, stage filtra solo se specificato
+            pass  # stage è già filtrato in _scan_workspace_configs
+
+        # Finalizza entry
         result = []
         for slug in sorted(datasets):
             entry = datasets[slug]
             entry["years"] = sorted(entry["years"])
-            buckets = entry.pop("buckets")
-            if layer:
-                entry["layer"] = layer
-            else:
-                # Se ha locale, il layer effettivo considera anche LOCAL_BUCKET
-                has_clean = CLEAN_BUCKET in buckets or LOCAL_BUCKET in buckets
-                has_mart = MART_BUCKET in buckets
-                if has_clean and has_mart:
-                    entry["layer"] = "clean,mart"
-                elif has_clean:
-                    entry["layer"] = "clean"
-                else:
-                    entry["layer"] = "mart"
+            self._finalize_layer(entry, layer)
             result.append(entry)
 
         total_count = len(result)
@@ -333,11 +430,63 @@ class CatalogResolver:
         if limit and total_count > limit:
             result = result[:limit]
 
+        return {"datasets": result, "total_count": total_count, "truncated": truncated}
+
+    def _empty_entry(self, slug: str, info: dict[str, Any]) -> dict[str, Any]:
         return {
-            "datasets": result,
-            "total_count": total_count,
-            "truncated": truncated,
+            "slug": slug,
+            "dataset_name": info.get("dataset_name", slug),
+            "stage": info.get("stage"),
+            "years": set(),
+            "file_count": 0,
+            "total_size_bytes": 0,
+            "has_local": False,
+            "has_remote": False,
+            "has_clean": info.get("has_clean", False),
+            "has_mart": info.get("has_mart", False),
+            "last_run_status": info.get("last_run_status"),
+            "config_path": info.get("config_path"),
         }
+
+    def _merge_pipeline_info(self, entry: dict[str, Any], info: dict[str, Any]) -> None:
+        """Arricchisce un entry con pipeline metadata dal workspace."""
+        for key in (
+            "stage",
+            "has_clean",
+            "has_mart",
+            "last_run_status",
+            "config_path",
+            "dataset_name",
+        ):
+            val = info.get(key)
+            if val is not None:
+                entry[key] = val
+
+    def _finalize_layer(self, entry: dict[str, Any], layer: str | None) -> None:
+        """Calcola il layer effettivo da bucket GCS + flag workspace."""
+        if layer:
+            entry["layer"] = layer
+            return
+
+        buckets = entry.pop("_buckets", set())
+        has_gcs_clean = CLEAN_BUCKET in buckets
+        has_gcs_mart = MART_BUCKET in buckets
+        has_local_bucket = LOCAL_BUCKET in buckets
+
+        is_clean = (
+            has_gcs_clean
+            or has_local_bucket
+            or entry.get("has_clean", False)
+            or entry.get("has_local", False)
+        )
+        is_mart = has_gcs_mart or entry.get("has_mart", False)
+
+        if is_clean and is_mart:
+            entry["layer"] = "clean,mart"
+        elif is_clean:
+            entry["layer"] = "clean"
+        else:
+            entry["layer"] = "mart"
 
     def resolve_slug(
         self,
@@ -347,22 +496,12 @@ class CatalogResolver:
     ) -> list[dict[str, Any]]:
         """Risolve uno slug nei file parquet corrispondenti.
 
-        Cerca prima nel workspace locale (versione in sviluppo),
-        poi su GCS (pubblicato). I file locali hanno priorita'.
-
-        Args:
-            slug: Slug del dataset (es. ``anac_bandi_gara``).
-            layer: ``"clean"``, ``"mart"`` o ``None`` (entrambi).
-            year: Anno specifico o ``None`` (tutti).
-
-        Returns:
-            Lista di file dict (url, slug, bucket, year, path, size_bytes, updated).
-            Ordinati per anno discendente, poi per path.
-
-        Raises:
-            FileNotFoundError: se lo slug non esiste ne' in locale ne' su GCS.
+        Cerca prima nel workspace locale, poi su GCS.
         """
-        files = self._get_files()
+        manifest = self._load_gcs()
+        gcs_files = manifest.get("files", [])
+        local_files = self._load_local_parquets()
+        files = _merge_gcs_and_local(gcs_files, local_files)
 
         matching = []
         for f in files:
@@ -381,7 +520,6 @@ class CatalogResolver:
                 f"Slug '{slug}' non trovato (layer={layer or 'any'}, year={year or 'any'})"
             )
 
-        # Ordina: locali prima (priorita'), poi anno discendente, poi path
         matching.sort(key=lambda f: (0 if _is_local(f) else 1, -(f["year"] or 0), f["path"]))
         return matching
 
@@ -391,29 +529,11 @@ class CatalogResolver:
         layer: str = "clean",
         year: int | None = None,
     ) -> dict[str, Any]:
-        """Schema DuckDB + row count per uno slug.
-
-        Usa DuckDB DESCRIBE sul primo parquet trovato (ultimo anno
-        disponibile, o anno specificato). Se il dataset esiste in locale,
-        descrive il parquet locale (priorita').
-
-        Args:
-            slug: Slug del dataset.
-            layer: ``"clean"`` (default) o ``"mart"``.
-            year: Anno specifico o ``None`` (ultimo disponibile).
-
-        Returns:
-            Dict con slug, year, layer, columns, row_count, preview.
-
-        Raises:
-            FileNotFoundError: se lo slug non esiste.
-            RuntimeError: se DuckDB non riesce a leggere il parquet.
-        """
+        """Schema DuckDB + row count per slug."""
         files = self.resolve_slug(slug, layer=layer, year=year)
         if not files:
             raise FileNotFoundError(f"Slug '{slug}' non trovato (year={year})")
 
-        # Prende il primo (locale se disponibile, poi ultimo anno)
         target = files[0]
         parquet_path = Path(target["url"])
         actual_year = target["year"]

--- a/toolkit/cli/inspect/__init__.py
+++ b/toolkit/cli/inspect/__init__.py
@@ -4,15 +4,19 @@ from __future__ import annotations
 
 import typer
 
-from toolkit.cli.inspect.config_ops import config
-from toolkit.cli.inspect.summary_ops import summary
-from toolkit.cli.inspect.runs_ops import runs
-from toolkit.cli.inspect.paths_ops import paths
-from toolkit.cli.inspect.profile_ops import profile
-
 
 def register(app: typer.Typer) -> None:
-    """Register all inspect subcommands on the parent app."""
+    """Register all inspect subcommands on the parent app.
+
+    Import lazy per evitare circolarita':
+    layer_ops → inspect._helpers → inspect.__init__ → config_ops → layer_ops
+    """
+    from toolkit.cli.inspect.config_ops import config
+    from toolkit.cli.inspect.summary_ops import summary
+    from toolkit.cli.inspect.runs_ops import runs
+    from toolkit.cli.inspect.paths_ops import paths
+    from toolkit.cli.inspect.profile_ops import profile
+
     inspect_app = typer.Typer(no_args_is_help=True, add_completion=False)
     inspect_app.command("config")(config)
     inspect_app.command("summary")(summary)

--- a/toolkit/mcp/catalog_ops.py
+++ b/toolkit/mcp/catalog_ops.py
@@ -2,8 +2,6 @@
 
 Chiama il backend condiviso ``toolkit.cli.catalog_ops`` e traduce
 eccezioni in ``ToolkitClientError`` per il server MCP.
-
-Pattern identico a ``aggregate_ops.py`` che wrappa ``cli.layer_ops``.
 """
 
 from __future__ import annotations
@@ -15,7 +13,6 @@ from lab_connectors.mcp.errors import ErrorCode
 from toolkit.cli.catalog_ops import CatalogResolver
 from toolkit.mcp.errors import ToolkitClientError
 
-# Istanza condivisa del resolver (lazy init, cache MCP-lifetime)
 _resolver: CatalogResolver | None = None
 
 
@@ -27,29 +24,46 @@ def _get_resolver() -> CatalogResolver:
 
 
 def reset_resolver() -> None:
-    """Resetta il resolver (utile nei test per ricaricare il manifest)."""
+    """Resetta il resolver (utile nei test)."""
     global _resolver
     _resolver = None
 
 
-def mcp_find(query: str = "", layer: str | None = None, limit: int = 15) -> dict[str, Any]:
-    """Cerca dataset nel manifest GCS.
+def mcp_find(
+    query: str = "",
+    layer: str | None = None,
+    limit: int = 15,
+    source: str = "all",
+    stage: str = "all",
+    status_filter: str | None = None,
+) -> dict[str, Any]:
+    """Cerca dataset nel manifest GCS e/o workspace locale.
 
     Args:
         query: Testo da cercare nello slug (case-insensitive).
         layer: ``"clean"``, ``"mart"`` o ``None`` (entrambi).
         limit: Max risultati (default 15). Usa ``0`` per nessun limite.
+        source: ``"gcs"`` (pubblicati), ``"workspace"`` (in sviluppo),
+                ``"all"`` (default, unione).
+        stage: Filtro workspace: ``"candidates"``, ``"support"``, ``"all"``.
+        status_filter: Filtro run status (es. ``"SUCCESS"``).
 
     Returns:
-        Dict con ``datasets`` (lista), ``total_count`` (int totale prima del taglio),
-        e ``truncated`` (bool).
+        Dict con ``datasets``, ``total_count``, ``truncated``.
 
     Raises:
-        ToolkitClientError: se il manifest non e' raggiungibile.
+        ToolkitClientError: se manifest GCS irraggiungibile o parametri invalidi.
     """
     try:
         resolver = _get_resolver()
-        return resolver.list_datasets(query=query, layer=layer, limit=limit)
+        return resolver.list_datasets(
+            query=query,
+            layer=layer,
+            limit=limit,
+            source=source,
+            stage=stage,
+            status_filter=status_filter,
+        )
     except (FileNotFoundError, TimeoutError) as exc:
         raise ToolkitClientError(
             f"Manifest GCS non raggiungibile: {exc}",
@@ -57,7 +71,7 @@ def mcp_find(query: str = "", layer: str | None = None, limit: int = 15) -> dict
         ) from exc
     except ValueError as exc:
         raise ToolkitClientError(
-            f"Errore nel manifest GCS: {exc}",
+            f"Errore parametri: {exc}",
             code=ErrorCode.INVALID_PARAMS,
         ) from exc
 

--- a/toolkit/mcp/discovery.py
+++ b/toolkit/mcp/discovery.py
@@ -1,200 +1,26 @@
-"""Discovery: elenca e interroga i dataset disponibili nel workspace.
+"""Discovery: elenca dataset nel workspace.
 
-Fornisce funzioni read-only per:
-- list_candidates: scandisce dataset-incubator/candidates e support_datasets
-- _read_minimal_config: lettura YAML leggera (senza validazione piena)
-
-Dipende da ``WORKSPACE_ROOT`` in path_safety per risolvere il percorso
-del workspace DataCivicLab.
+Deprecato: usa ``toolkit_find(source="workspace")`` via ``CatalogResolver``
+in ``toolkit.cli.catalog_ops``. ``list_candidates`` qui e' mantenuto come
+delega per backward compatibility.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Literal
 
-from toolkit.core.io import read_json_or_none, read_yaml
-
-from toolkit.mcp.errors import ToolkitClientError
-from toolkit.mcp.path_safety import WORKSPACE_ROOT
-from lab_connectors.mcp.errors import ErrorCode
-
-
-def _read_minimal_config(dataset_yml: Path) -> dict[str, Any]:
-    """Legge solo i campi essenziali da dataset.yml senza validazione piena.
-
-    Restituisce un dict con: name, years, root (stringa raw dal YAML).
-    """
-    try:
-        data = read_yaml(dataset_yml)
-    except Exception as exc:
-        return {"_error": f"YAML non valido: {exc}"}
-
-    if not isinstance(data, dict):
-        return {"_error": "dataset.yml non è una mappa YAML"}
-
-    ds = data.get("dataset", {}) or {}
-    if not isinstance(ds, dict):
-        return {"_error": "dataset non è un mapping"}
-
-    name = ds.get("name", dataset_yml.parent.name)
-    years = ds.get("years", [])
-    if isinstance(years, int):
-        years = [years]
-
-    root_raw = data.get("root")
-    return {
-        "name": str(name) if name else None,
-        "years": [int(y) for y in years] if isinstance(years, list) else [],
-        "root": str(root_raw) if isinstance(root_raw, str) else None,
-    }
-
-
-def _find_latest_run_status(slug: str, runs_root: Path | None = None) -> str | None:
-    """Cerca l'ultimo run record per un dataset slug e restituisce lo status.
-
-    Scansiona ``{runs_root or WORKSPACE/out}/data/_runs/{slug}/``.
-    """
-    if runs_root is not None:
-        runs_base = runs_root / "data" / "_runs" / slug
-    else:
-        runs_base = WORKSPACE_ROOT / "out" / "data" / "_runs" / slug
-    if not runs_base.exists():
-        return None
-
-    # Cerca l'ultimo run tra tutti gli anni
-    latest: dict[str, Any] | None = None
-    latest_mtime: float = 0.0
-
-    for year_dir in sorted(runs_base.iterdir()):
-        if not year_dir.is_dir() or not year_dir.name.isdigit():
-            continue
-        for run_file in year_dir.glob("*.json"):
-            try:
-                mtime = run_file.stat().st_mtime
-            except OSError:
-                continue
-            if mtime > latest_mtime:
-                data = read_json_or_none(run_file)
-                if isinstance(data, dict):
-                    latest = data
-                    latest_mtime = mtime
-
-    if latest:
-        return latest.get("status")
-    return None
+from toolkit.cli.catalog_ops import CatalogResolver
 
 
 def list_candidates(
     stage: Literal["candidates", "support", "all"] = "all",
     status_filter: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Elenca tutti i dataset disponibili nel workspace.
+    """Elenca dataset nel workspace (deprecato: usa toolkit_find source='workspace').
 
-    Args:
-        stage: "candidates" → solo ``candidates/``,
-               "support" → solo ``support_datasets/``,
-               "all" → entrambi (default).
-        status_filter: filtra per ``last_run_status``.
-                       Valori: ``"SUCCESS"``, ``"FAILED"``, ``"DRY_RUN"``,
-                       ``"RUNNING"``, o ``None`` (nessun filtro, default).
-
-    Returns:
-        Lista ordinata per slug, ogni elemento con:
-        - slug: nome directory del dataset
-        - dataset_name: nome dal dataset.yml (o slug se assente)
-        - stage: "candidates" | "support"
-        - years: lista anni configurati
-        - last_run_status: SUCCESS / FAILED / DRY_RUN / None
-        - has_clean: bool (presenza directory out/data/clean/{slug}/)
-        - has_mart: bool (presenza directory out/data/mart/{slug}/)
+    Delega a ``CatalogResolver.list_datasets(source='workspace')``.
     """
-    valid_stages = {"candidates", "support", "all"}
-    if stage not in valid_stages:
-        raise ToolkitClientError(
-            f"stage deve essere uno tra: {', '.join(sorted(valid_stages))} (ricevuto: {stage!r})",
-            code=ErrorCode.INVALID_PARAMS,
-        )
-
-    incubator = WORKSPACE_ROOT / "dataset-incubator"
-
-    dirs_to_scan: list[tuple[str, Path]] = []
-    if stage in ("candidates", "all"):
-        candidates_dir = incubator / "candidates"
-        if candidates_dir.exists():
-            dirs_to_scan.append(("candidates", candidates_dir))
-    if stage in ("support", "all"):
-        support_dir = incubator / "support_datasets"
-        if support_dir.exists():
-            dirs_to_scan.append(("support", support_dir))
-
-    results: list[dict[str, Any]] = []
-
-    for stage_name, scan_dir in dirs_to_scan:
-        # Cerca dataset.yml ricorsivamente (supporta candidates con sub-candidates)
-        for dataset_yml in sorted(scan_dir.rglob("dataset.yml")):
-            # Salta il template
-            if "templates" in dataset_yml.parts:
-                continue
-
-            # Usa la directory padre come slug, ma costruisci un
-            # parent_slug se il dataset.yml è in una subdirectory
-            parent_dir = dataset_yml.parent
-            rel_path = parent_dir.relative_to(scan_dir)
-            slug = str(rel_path.as_posix())
-            # Per path semplici (1 livello) usa solo il nome dir
-            if rel_path.parent == Path("."):
-                slug = parent_dir.name
-            else:
-                # Sub-candidate: mantieni path relativo come slug composito
-                slug = str(rel_path.as_posix())
-
-            minimal = _read_minimal_config(dataset_yml)
-            name = minimal.get("name") or slug
-            years = minimal.get("years", [])
-
-            # Risolvi root output: usa quello dal dataset.yml se presente,
-            # altrimenti fallback a WORKSPACE_ROOT/out
-            root_raw = minimal.get("root")
-            if root_raw:
-                # root è relativo al file dataset.yml
-                resolved_root = (dataset_yml.parent / root_raw).resolve()
-            else:
-                resolved_root = WORKSPACE_ROOT / "out"
-            out_root = resolved_root / "data"
-
-            # Presenza layer: per sub-candidates, il dataset name è
-            # quello dal dataset.yml (potrebbe differire dallo slug)
-            dataset_name_for_path = name if name != slug else parent_dir.name
-            clean_dir = out_root / "clean" / dataset_name_for_path
-            mart_dir = out_root / "mart" / dataset_name_for_path
-            has_clean = clean_dir.exists() and any(clean_dir.iterdir())
-            has_mart = mart_dir.exists() and any(mart_dir.iterdir())
-
-            last_run_status = _find_latest_run_status(
-                dataset_name_for_path, runs_root=resolved_root
-            )
-
-            results.append(
-                {
-                    "slug": slug,
-                    "dataset_name": name,
-                    "stage": stage_name,
-                    "years": years,
-                    "last_run_status": last_run_status,
-                    "has_clean": has_clean,
-                    "has_mart": has_mart,
-                    "config_path": str(dataset_yml),
-                }
-            )
-
-    if status_filter is not None:
-        valid_statuses = {"SUCCESS", "FAILED", "DRY_RUN", "RUNNING"}
-        if status_filter not in valid_statuses:
-            raise ToolkitClientError(
-                f"status_filter deve essere uno tra: {', '.join(sorted(valid_statuses))} (o None)",
-                code=ErrorCode.INVALID_PARAMS,
-            )
-        results = [r for r in results if r["last_run_status"] == status_filter]
-
-    return results
+    resolver = CatalogResolver(include_local=True)
+    result = resolver.list_datasets(source="workspace", stage=stage, status_filter=status_filter)
+    # Torna solo la lista per backward compat
+    return result["datasets"]

--- a/toolkit/mcp/discovery.py
+++ b/toolkit/mcp/discovery.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from toolkit.cli.catalog_ops import CatalogResolver
-from toolkit.mcp.path_safety import WORKSPACE_ROOT as WORKSPACE_ROOT  # noqa: F401 — re-export per test backward compat
+from toolkit.mcp.errors import ToolkitClientError
+from toolkit.mcp.path_safety import WORKSPACE_ROOT  # noqa: F401 — ri-esportato per backward compat test
 
 
 def list_candidates(
@@ -20,8 +21,15 @@ def list_candidates(
     """Elenca dataset nel workspace (deprecato: usa toolkit_find source='workspace').
 
     Delega a ``CatalogResolver.list_datasets(source='workspace')``.
+    Usa ``discovery.WORKSPACE_ROOT`` (monkeypatch-safe per test).
     """
-    resolver = CatalogResolver(include_local=True)
-    result = resolver.list_datasets(source="workspace", stage=stage, status_filter=status_filter)
-    # Torna solo la lista per backward compat
+    from lab_connectors.mcp.errors import ErrorCode
+
+    resolver = CatalogResolver(include_local=True, workspace=WORKSPACE_ROOT)
+    try:
+        result = resolver.list_datasets(
+            source="workspace", stage=stage, status_filter=status_filter
+        )
+    except ValueError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.INVALID_PARAMS) from exc
     return result["datasets"]

--- a/toolkit/mcp/discovery.py
+++ b/toolkit/mcp/discovery.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from toolkit.cli.catalog_ops import CatalogResolver
+from toolkit.mcp.path_safety import WORKSPACE_ROOT as WORKSPACE_ROOT  # noqa: F401 — re-export per test backward compat
 
 
 def list_candidates(

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -87,9 +87,9 @@ def toolkit_inspect_profile(config_path: str, year: int = 0) -> dict[str, Any]:
 
 
 @mcp.tool(
-    description="Elenca tutti i dataset disponibili in dataset-incubator (candidates e support_datasets). "
-    "Opzionalmente filtra per last_run_status. "
-    "Restituisce un dict con chiave 'candidates' contenente la lista.",
+    description="[DEPRECATO] Elenca dataset in sviluppo nel workspace. "
+    "Usa toolkit_find con source='workspace' per la stessa funzionalita' "
+    "con piu' filtri e integrazione GCS.",
     structured_output=True,
 )
 def toolkit_list_candidates(
@@ -97,10 +97,8 @@ def toolkit_list_candidates(
     status_filter: str | None = None,
 ) -> dict[str, Any]:
     result = guard_timed(list_candidates_impl, "toolkit_list_candidates", stage, status_filter)
-    # Se guard_timed restituisce un errore (dict con chiave "error"), passalo attraverso
     if isinstance(result, dict) and "error" in result:
         return result
-    # Altrimenti wrappa la lista in un dict per structured_output=True
     return {"candidates": result, "count": len(result) if isinstance(result, list) else 0}
 
 
@@ -213,17 +211,32 @@ def toolkit_status(
 
 
 @mcp.tool(
-    description="Cerca dataset pubblicati su GCS per slug, layer (clean/mart) o testo. "
-    "Usa il gcs_manifest.json auto-generato. "
-    "Restituisce slug, layer, anni disponibili, numero file e size totale.",
+    description="Cerca dataset per slug, source, layer (clean/mart) o testo. "
+    "source='gcs' = pubblicati (da gcs_manifest.json), "
+    "source='workspace' = in sviluppo (da dataset.yml + parquet locali), "
+    "source='all' (default) = unione. "
+    "Filtri aggiuntivi: stage (candidates/support), status_filter (SUCCESS/FAILED/DRY_RUN). "
+    "Restituisce slug, layer, anni, file count, size, run_status, flag source.",
     structured_output=True,
 )
 def toolkit_find(
     query: str = "",
     layer: str | None = None,
     limit: int = 15,
+    source: str = "all",
+    stage: str = "all",
+    status_filter: str | None = None,
 ) -> dict[str, Any]:
-    return guard_timed(find_impl, "toolkit_find", query=query, layer=layer, limit=limit)
+    return guard_timed(
+        find_impl,
+        "toolkit_find",
+        query=query,
+        layer=layer,
+        limit=limit,
+        source=source,
+        stage=stage,
+        status_filter=status_filter,
+    )
 
 
 @mcp.tool(


### PR DESCRIPTION
## Sintesi

`toolkit_find` diventa l'unico entry point per scoprire dataset. Con `source="gcs"`, `source="workspace"` o `source="all"` (default). `list_candidates` deprecato ma mantenuto per backward compat.

## Cosa cambia

### `toolkit_find(source="...")`

| source | Vede | Campi aggiuntivi |
|---|---|---|
| `"gcs"` | GCS manifest (pubblicati) | `has_remote`, `total_size_bytes` |
| `"workspace"` | dataset.yml + parquet locali | `stage`, `last_run_status`, `has_clean`, `has_mart`, `config_path` |
| `"all"` (default) | merge di entrambi | tutti |

### Filtri aggiuntivi
- `stage` — `"candidates"`, `"support"`, `"all"`
- `status_filter` — `"SUCCESS"`, `"FAILED"`, `"DRY_RUN"`

### Fix inclusi
- Normalizza slug workspace (trattini) a underscore per merge corretto con GCS
- Dataset parquet-only (senza dataset.yml) ora visibili in `source=workspace` e `source=all`

## Backward compat
- `toolkit_list_candidates` marcato [DEPRECATO], delega internamente
- `discovery.list_candidates()` funziona invariato

## Verifica

```
GCS:         117 dataset
Workspace:   104 dataset
All:         123 dataset (unificati, zero duplicati)
  solo GCS:     97
  solo locale:   2 (conto_annuale_assenze_procapite, conto_annuale_costo_procapite)
  entrambi:     20
```

- 54 test passanti
- ruff, mypy puliti
- `list_candidates()` funziona per backward compat

## Note per chi revisiona

Il parametro `source` è pensato per essere esteso anche a `toolkit_dataset_overview` e futuro `toolkit_query` nella prossima iterazione.
