### PR TITLE
feat: parametro table per selezionare tabella mart in toolkit_layer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ pip install -e ../lab-connectors
 ```bash
 pytest -m core                    # contratto pubblico e workflow canonico
 pytest -m "core or advanced"      # tutto tranne compat legacy
-pytest                            # tutto (~55 test file)
+pytest                            # tutto (~85+ test file)
 ruff check .
 mypy toolkit/
 ```

--- a/README.md
+++ b/README.md
@@ -98,13 +98,14 @@ Il toolkit risolve i path relativi, esegue SQL su DuckDB e produce output in `ro
 
 ## Integrazione AI (MCP)
 
-Il toolkit espone un server MCP per agenti AI e IDE:
+Il toolkit espone **18 tool** MPC per agenti AI e IDE:
 
 | Categoria | Tool |
 |---|---|
-| **Stato completo** | `toolkit_status` |
-| **Ispezione** | `toolkit_inspect_paths`, `toolkit_inspect_schema`, `toolkit_inspect_profile`, `toolkit_list_runs` |
-| **Scout** | `toolkit_probe_url`, `toolkit_ckan_package_show`, `toolkit_sparql_query` |
+| **Catalogo** | `toolkit_find`, `toolkit_dataset_overview` |
+| **Pipeline (aggregati)** | `toolkit_layer`, `toolkit_status` |
+| **Pipeline (ispezione)** | `toolkit_inspect_paths`, `toolkit_inspect_schema`, `toolkit_inspect_profile`, `toolkit_list_runs`, `toolkit_schema_diff`, `toolkit_csv_preview`, `toolkit_list_candidates` [DEPRECATO], `toolkit_preflight` |
+| **Scout** | `toolkit_probe_url`, `toolkit_probe_url_routed`, `toolkit_ckan_package_show`, `toolkit_html_extract_links`, `toolkit_sparql_query`, `toolkit_preview_url` |
 
 Config IDE (`.mcp.json`):
 ```json
@@ -135,7 +136,7 @@ pytest -m core                    # contratto pubblico
 ruff check .                      # lint
 ```
 
-**Test**: 55 file, marker `core` (deve sempre passare), `advanced`, `compat`.
+**Test**: 85+ file, marker `core` (deve sempre passare), `advanced`, `compat`.
 **CI**: `.github/workflows/ci.yml` — Python 3.10–3.12, ruff, coverage ≥70%.
 
 ## Struttura del repo
@@ -149,7 +150,7 @@ toolkit/
     plugins/          # plugin sorgente
     mcp/              # server MCP
     profile/          # profiling RAW
-  tests/              # pytest (55 file)
+  tests/              # pytest (85+ file)
   docs/               # documentazione tecnica
   project-example/    # esempio funzionante
 ```

--- a/toolkit/cli/catalog_ops.py
+++ b/toolkit/cli/catalog_ops.py
@@ -505,8 +505,16 @@ class CatalogResolver:
         slug: str,
         layer: str | None = None,
         year: int | None = None,
+        table: str | None = None,
     ) -> list[dict[str, Any]]:
         """Risolve uno slug nei file parquet corrispondenti.
+
+        Args:
+            slug: Slug del dataset.
+            layer: ``"clean"``, ``"mart"`` o ``None`` (entrambi).
+            year: Anno specifico o ``None`` (tutti).
+            table: Nome tabella mart (solo layer=mart).
+                Es. ``"mart_top_sa"`` — match sul filename senza estensione.
 
         Cerca prima nel workspace locale, poi su GCS.
         """
@@ -525,14 +533,19 @@ class CatalogResolver:
                 continue
             if year is not None and f["year"] is not None and f["year"] != year:
                 continue
-            # year=None nel manifest = file con serie storica completa
-            # mantienilo (il filtro anno va nell'SQL, non nel path)
+            if table is not None:
+                # Match sul filename senza estensione
+                fname = f["path"].rsplit("/", 1)[-1]  # ultimo segmento
+                fstem = fname.rsplit(".", 1)[0] if "." in fname else fname
+                if fstem != table:
+                    continue
             matching.append(f)
 
         if not matching:
-            raise FileNotFoundError(
-                f"Slug '{slug}' non trovato (layer={layer or 'any'}, year={year or 'any'})"
-            )
+            parts = [f"layer={layer or 'any'}", f"year={year or 'any'}"]
+            if table:
+                parts.append(f"table={table}")
+            raise FileNotFoundError(f"Slug '{slug}' non trovato ({', '.join(parts)})")
 
         matching.sort(key=lambda f: (0 if _is_local(f) else 1, -(f["year"] or 9999), f["path"]))
         return matching

--- a/toolkit/cli/layer_ops.py
+++ b/toolkit/cli/layer_ops.py
@@ -404,8 +404,9 @@ def layer_sql(
         config_path: Path a dataset.yml (pipeline mode).
             Mutuamente esclusivo con ``datasets``.
         datasets: Lista slug (catalog mode).
-        table: Nome tabella mart (es ``"mart_top_sa"``).
             Mutuamente esclusivo con ``config_path``.
+        table: Nome tabella mart (es ``"mart_top_sa"``).
+            Solo per catalog mode, layer=mart.
         layer: ``"raw"``, ``"clean"`` (default) o ``"mart"``.
         year: Anno filtro.
         limit: Max righe.

--- a/toolkit/cli/layer_ops.py
+++ b/toolkit/cli/layer_ops.py
@@ -351,14 +351,22 @@ def raw_preview(config_path: str, year: int | None = None, limit: int = 20) -> d
 # ---------------------------------------------------------------------------
 
 
-def _resolve_datasets(datasets: list[str], layer: str, year: int | None) -> dict[str, str]:
+def _resolve_datasets(
+    datasets: list[str],
+    layer: str,
+    year: int | None,
+    table: str | None = None,
+) -> dict[str, str]:
     """Risolve lista slug → dict {slug: parquet_url} via CatalogResolver.
 
     Converte URL ``s3://`` in ``https://storage.googleapis.com/``
     per evitare dipendenza dall'estensione httpfs di DuckDB.
 
-    TODO: centralizzare la conversione in lab_connectors.gcs.paths
-    (``s3_to_https_url``) quando possibile.
+    Args:
+        datasets: Lista slug.
+        layer: ``"clean"`` o ``"mart"``.
+        year: Anno filtro.
+        table: Nome tabella mart (es. ``"mart_top_sa"``). Match sul filename.
 
     Returns:
         Dict slug → url HTTPS del parquet.
@@ -370,7 +378,7 @@ def _resolve_datasets(datasets: list[str], layer: str, year: int | None) -> dict
     resolver = CatalogResolver()
     resolved: dict[str, str] = {}
     for slug in datasets:
-        files = resolver.resolve_slug(slug, layer=layer, year=year)
+        files = resolver.resolve_slug(slug, layer=layer, year=year, table=table)
         if not files:
             raise FileNotFoundError(f"Slug '{slug}' non trovato (layer={layer})")
         url = files[0]["url"]
@@ -388,6 +396,7 @@ def layer_sql(
     limit: int = 20,
     sql: str | None = None,
     mart_index: int = 0,
+    table: str | None = None,
 ) -> dict[str, Any]:
     """Esegue SQL arbitrario su uno o piu' dataset.
 
@@ -395,6 +404,7 @@ def layer_sql(
         config_path: Path a dataset.yml (pipeline mode).
             Mutuamente esclusivo con ``datasets``.
         datasets: Lista slug (catalog mode).
+        table: Nome tabella mart (es ``"mart_top_sa"``).
             Mutuamente esclusivo con ``config_path``.
         layer: ``"raw"``, ``"clean"`` (default) o ``"mart"``.
         year: Anno filtro.
@@ -421,7 +431,7 @@ def layer_sql(
 
     # ---- Catalog mode: risolvi slug → URL parquet ----
     if datasets:
-        resolved = _resolve_datasets(datasets, layer=layer, year=year)
+        resolved = _resolve_datasets(datasets, layer=layer, year=year, table=table)
         # Scope validation: solo i CTE dichiarati
         allowed = set(resolved.keys())
         validated_sql = _validate_sql_scope(sql, allowed)
@@ -542,6 +552,7 @@ def layer_query(
     limit: int = 20,
     sql: str | None = None,
     mart_index: int = 0,
+    table: str | None = None,
 ) -> dict[str, Any]:
     """Query unificata su layer RAW/CLEAN/MART.
 
@@ -593,6 +604,7 @@ def layer_query(
             year=year,
             limit=limit,
             sql=sql,
+            table=table,
         )
 
     if safe_mode == "profile" and safe_layer != "raw":

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -1,47 +1,52 @@
 # Toolkit MCP
 
-Server MCP locale, read-only, per ispezionare rapidamente path risolti, schemi e stato run del `toolkit`.
+Server MCP locale, read-only, per ispezionare la pipeline e il catalogo
+dataset del DataCivicLab.
 
-## Tool esposti
+## Tool esposti (18)
 
-### Tool aggregati (raccomandati)
+### Catalogo (slug-based — GCS + workspace)
 
-- `toolkit_layer(config_path, layer="clean", mode="schema", year=0, limit=20, sql=None, mart_index=0)` — query unificata RAW/CLEAN/MART. Mode: `schema` (colonne+tipi), `preview` (anteprima righe), `profile` (diagnostica raw), `sql` (SQL arbitrario su vista `data`)
-- `toolkit_status(config_path, year=0)` — stato completo dataset: paths + summary + readiness + run_stats + info in una chiamata
+- `toolkit_find(query="", source="all", layer=None, limit=15, stage="all", status_filter=None)` —
+  cerca dataset per slug, source, layer. `source="gcs"` = pubblicati,
+  `source="workspace"` = in sviluppo (con run status), `source="all"` (default) = unione.
+  Restituisce `{datasets, total_count, truncated}`.
+- `toolkit_dataset_overview(slug, layer="clean", year=None, source="all")` —
+  schema colonne (DuckDB DESCRIBE) + row count + preview per slug.
+  `source="gcs"` | `"workspace"` | `"all"` (default).
+
+### Tool aggregati (raccomandati per pipeline)
+
+- `toolkit_layer(config_path=None, datasets=None, layer="clean", mode="schema", year=0, limit=20, sql=None, mart_index=0, table=None)` —
+  query unificata RAW/CLEAN/MART. Due modalita':
+  - `config_path` (pipeline): dataset locale da dataset.yml
+  - `datasets` (catalogo): lista slug, risolti via GCS manifest + workspace
+  - `mode`: `schema`, `preview`, `profile` (solo raw), `sql` (SQL su vista `data`)
+  - `layer=raw` con `mode=sql`: legge CSV via DuckDB `read_csv_auto`
+  - `layer=mart` e `table` (es. `"mart_top_sa"`): seleziona tabella mart specifica
+- `toolkit_status(config_path, year=0)` —
+  stato completo dataset: paths + summary + readiness + run_stats + info
 
 ### Tool granulari (ispezione pipeline)
 
-- `toolkit_inspect_paths(config_path, year=0)` — path contract + run metadata (run_file_count, years_seen, latest_run)
+- `toolkit_inspect_paths(config_path, year=0)` — path contract + run metadata
 - `toolkit_inspect_schema(config_path, layer="clean", year=0)`
-- `toolkit_inspect_profile(config_path, year=0)` — profilo raw (encoding, delim, colonne, missingness)
+- `toolkit_inspect_profile(config_path, year=0)` — profilo raw (encoding, delim, colonne)
 - `toolkit_list_runs(config_path, year=0, since=None, until=None, status=None, limit=20, cross_year=False)`
-- `toolkit_list_candidates(stage="all", status_filter=None)` — elenca dataset disponibili in workspace
-- `toolkit_schema_diff(config_path)` — confronto segnali schema raw cross-year (encoding, colonne, ecc.)
+- `toolkit_list_candidates(stage="all", status_filter=None)` — **DEPRECATO**: usa `toolkit_find(source="workspace")`
+- `toolkit_schema_diff(config_path)` — confronto segnali schema raw cross-year
 - `toolkit_csv_preview(csv_path, limit=20)` — schema + preview CSV via profiler pipeline
+- `toolkit_preflight(config_path, years=None)` — pre-flight check: valida config, verifica fonti, quality score PA
 
 ### Scout fonti
 
-- `toolkit_probe_url(url, timeout=15)` — probe HTTP leggero (HEAD + Range): reachability, status code, content-type
-- `toolkit_probe_url_routed(url, timeout=15)` — probe arricchito con routing automatico (rileva CKAN, SDMX, HTML, file diretto)
-- `toolkit_ckan_package_show(endpoint, package_id, timeout=30)` — fetch dataset CKAN via API `package_show`
-- `toolkit_html_extract_links(url, timeout=20)` — estrae link a file dati (CSV, JSON, XLSX, ZIP, XML) da pagina HTML
-- `toolkit_sparql_query(endpoint, query, timeout=60, max_rows=500)` — esegue query SPARQL SELECT su endpoint pubblico
-
-## Boundary
-
-Questo MCP resta nel repo `toolkit` perche' espone solo introspezione tecnica del contract del motore e servizi di base per scouting fonti:
-
-- path contract risolto
-- schema `raw`, `clean`, `mart`
-- stato minimo dei run
-- readiness check per review candidate
-- probe URL, inferenza topic, fetch CKAN/SPARQL/HTML
-
-Non espone:
-
-- `support_resolve`
-- `list_candidates`
-- logica di workspace state o catalogo
+- `toolkit_probe_url(url, timeout=15)` — probe HTTP leggero (HEAD + Range)
+- `toolkit_probe_url_routed(url, timeout=15)` — probe con routing automatico (CKAN, SDMX, HTML, file diretto)
+- `toolkit_ckan_package_show(endpoint, package_id, timeout=30)` — fetch dataset CKAN
+- `toolkit_html_extract_links(url, timeout=20)` — estrae link dati da HTML
+- `toolkit_sparql_query(endpoint, query, timeout=60, max_rows=500)` — SPARQL SELECT
+- `toolkit_preview_url(url, known_encoding=None, known_delim=None, known_decimal=None, known_skip=None)` —
+  preview remoto CSV/TSV (HEAD + Range + sniff + DuckDB)
 
 ## Config workspace
 
@@ -49,21 +54,20 @@ Esempio `.mcp.json`:
 
 ```json
 "toolkit": {
-  "command": "C:\\path\\to\\toolkit\\.venv\\Scripts\\python.exe",
-  "args": [
-    "-m",
-    "toolkit.mcp.server"
-  ]
+  "command": "/path/to/python",
+  "args": ["-m", "toolkit.mcp.server"]
 }
 ```
 
-Sostituire il path del `command` con il Python reale del clone locale che usera' il server.
+Sostituire il path del `command` con il Python reale del clone locale.
 
 ## Note tecniche
 
-- `toolkit_inspect_paths` usa `toolkit inspect paths --json`; arricchito con run_file_count e years_seen dalla CLI
-- `toolkit_inspect_schema`
-  - `raw`: usa `toolkit inspect config --diff --json`
-  - `clean` / `mart`: legge schema reale dei parquet risolti via `inspect paths`
-- `toolkit_schema_diff` confronta segnali schema raw (encoding, delim, colonne) tra tutti gli anni configurati per il dataset; riutilizza la stessa logica di `toolkit inspect config --diff` ma esposto come tool MCP
-- `toolkit_csv_preview` legge un CSV usando la stessa pipeline di `profile_raw` (`sniff_source_file` + `profile_with_read_cfg`); restituisce schema + prime N righe + mapping_suggestions — utile per ispezionare file raw senza runnare la pipeline
+- I tool catalogo usano `gcs_manifest.json` (auto-generato dalla CI,
+  pubblicato su GCS) come fonte di verità per i dataset pubblicati
+- `toolkit_find` unifica GCS + workspace locale (clean parquet + dataset.yml)
+- `list_candidates` è deprecato: l'unificazione è in `toolkit_find(source="workspace")`
+- `toolkit_layer(mode=sql, datasets=[...])` usa DuckDB con CTE multipli
+  e scope validation (blocca DDL, read_parquet, tabelle non consentite)
+- `toolkit_csv_preview` riusa la stessa pipeline di `profile_raw`
+- `toolkit_inspect_paths` usa `toolkit inspect paths --json` internamente

--- a/toolkit/mcp/aggregate_ops.py
+++ b/toolkit/mcp/aggregate_ops.py
@@ -50,6 +50,7 @@ def layer_query(
     limit: int = 20,
     sql: str | None = None,
     mart_index: int = 0,
+    table: str | None = None,
 ) -> dict[str, Any]:
     """Query unificata su layer RAW/CLEAN/MART.
 
@@ -68,6 +69,7 @@ def layer_query(
         limit: Max righe.
         sql: Query SQL per mode=sql.
         mart_index: Indice tabella mart (solo pipeline mode).
+        table: Nome tabella mart (es ``"mart_top_sa"``).
 
     Raises:
         ToolkitClientError: se parametri invalidi o file non trovato.
@@ -93,6 +95,7 @@ def layer_query(
             limit=limit,
             sql=sql,
             mart_index=mart_index,
+            table=table,
         )
     except ValueError as exc:
         raise ToolkitClientError(str(exc), code=ErrorCode.INVALID_PARAMS) from exc

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -201,7 +201,8 @@ def toolkit_csv_preview(csv_path: str, limit: int = 20) -> dict[str, Any]:
 @mcp.tool(
     description="Query unificata su RAW/CLEAN/MART: schema, preview, profilo o SQL. "
     "Due modalita': config_path (pipeline locale) o datasets (catalogo GCS/workspace). "
-    "mode=sql funziona anche su layer=raw (legge CSV via DuckDB). "
+    "mode=sql funziona su tutti i layer (raw->CSV, clean/mart->parquet). "
+    "Per layer=mart, table specifica la tabella (es. 'mart_top_sa'). "
     "Catalog mode (datasets) supporta solo mode='sql'. "
     "Esempi: mode=sql, datasets=['anac_bandi_gara', 'popolazione_istat']",
     structured_output=True,
@@ -215,6 +216,7 @@ def toolkit_layer(
     limit: int = 20,
     sql: str | None = None,
     mart_index: int = 0,
+    table: str | None = None,
 ) -> dict[str, Any]:
     return guard_timed(
         layer_query_impl,
@@ -227,6 +229,7 @@ def toolkit_layer(
         limit=limit,
         sql=sql,
         mart_index=mart_index,
+        table=table,
     )
 
 


### PR DESCRIPTION
## Sintesi

Aggiunge parametro `table` a `toolkit_layer` per selezionare una specifica tabella mart quando uno slug ne ha più di una (es. `conto-annuale` ha 83 tabelle mart).

## Contesto collegato

Continuazione del lavoro di unificazione iniziato con #419-#422. Il layer mart su GCS è supportato ma senza modo di scegliere quale tabella usare.

## Cosa cambia

- `CatalogResolver.resolve_slug(slug, layer='mart', table='mart_top_sa')` — filtra per filename senza estensione
- `toolkit_layer(datasets=[...], layer='mart', table='mart_top_sa')` — passa il filtro al resolver
- Se `table` non specificato, prende la prima tabella (backward compat)

## Impatto

- [ ] Documentazione o testi
- [ ] Policy GitHub o template
- [x] Codice o automazioni
- [ ] Pipeline dati o trasformazioni
- [ ] Contenuti o metadati di dataset
- [ ] Nessun impatto visibile per chi usa il repository

## Verifica

- Test reale: `anac_appalti_master` / `mart_top_sa` restituisce i top SA per importo
- 67/67 test passanti
- mypy pulito sui file modificati

## Controlli

- [x] Questa PR e' nel repository giusto
- [ ] Ho collegato issue o discussion quando serve
- [x] Ho verificato l'impatto su documentazione, codice o dati
- [x] Ho aggiornato solo quello che era davvero necessario
- [x] I test nuovi o modificati hanno marker (contract/policy/regression/adapter/pure_unit/smoke)
- [ ] Se la PR fixa un bug: il test che lo protegge e' marcato `regression` con link all'issue

## Note per chi revisiona

- `table` matcha sul filename senza estensione (es. `"mart_top_sa"` matcha `mart_top_sa.parquet`)
- Disponibile solo in catalog mode (`datasets=...`)
- Pipeline mode ha già `mart_index` per selezionare output locale
