### PR TITLE
feat: contratto pipeline strutturato per agenti AI (MCP + CLI + auto-generato da macros.sql)

### DIFF
--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -148,6 +148,30 @@ def test_contracts_json_serializable() -> None:
     assert len(parsed["clean"]["macros"]) >= 8
 
 
+def test_contracts_source_types_cover_plugins() -> None:
+    """Ogni plugin in toolkit/plugins/ ha una voce in source_types.
+
+    Test di manutenzione: se si aggiunge un plugin, il contratto raw
+    deve essere aggiornato con il nuovo tipo fonte.
+    """
+    from pathlib import Path
+
+    from toolkit.contracts.pipeline import CONTRACTS
+
+    plugins_dir = Path(__file__).parent.parent / "toolkit" / "plugins"
+    plugin_files = sorted(
+        p.stem for p in plugins_dir.glob("*.py") if p.stem not in ("__init__", "_http_utils")
+    )
+
+    contract_types = {s["type"] for s in CONTRACTS["raw"]["source_types"]}
+
+    missing = set(plugin_files) - contract_types
+    assert not missing, (
+        f"Plugin(s) senza corrispondente in source_types: {missing}. "
+        "Aggiungili a toolkit/contracts/pipeline.py _SOURCE_TYPES."
+    )
+
+
 def test_contract_cli_output() -> None:
     """CLI toolkit contract produce output senza errori."""
     from typer.testing import CliRunner
@@ -160,6 +184,11 @@ def test_contract_cli_output() -> None:
     assert "raw_input" in result.output
     assert "clean_input" in result.output
     assert "normalize_italian_number" in result.output
+
+    result_raw = runner.invoke(app, ["contract", "--layer", "raw"])
+    assert result_raw.exit_code == 0
+    assert "http_file" in result_raw.output
+    assert "LAYER RAW" in result_raw.output
 
     result_clean = runner.invoke(app, ["contract", "--layer", "clean"])
     assert result_clean.exit_code == 0

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,0 +1,177 @@
+"""Test: contratto di pipeline (toolkit/contracts/pipeline.py).
+
+Protegge la struttura pubblica del contratto: chiavi stabili,
+valori attesi, regole di policy (es. warning normalize_italian_number).
+
+Le macro sono AUTO-GENERATE da macros.sql — il test
+"macros_auto_generated" verifica che la generazione funzioni (i test
+sulla macro_reader stessa sono in test_macro_reader.py).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.contract
+
+
+def test_contracts_structure() -> None:
+    """CONTRACTS ha struttura stabile con tutte le sezioni obbligatorie."""
+    from toolkit.contracts.pipeline import CONTRACTS
+
+    assert isinstance(CONTRACTS, dict)
+    assert CONTRACTS["version"] == "1"
+
+    for key in ("pipeline", "raw", "clean", "mart", "cli", "config", "constants", "tldr"):
+        assert key in CONTRACTS, f"Chiave '{key}' mancante in CONTRACTS"
+
+    assert isinstance(CONTRACTS["tldr"], str)
+    assert "http_file" in CONTRACTS["tldr"] or "raw" in CONTRACTS["tldr"]
+    assert "raw_input" in CONTRACTS["tldr"]
+    assert "clean_input" in CONTRACTS["tldr"]
+    assert "toolkit contract" in CONTRACTS["tldr"]
+
+    # CLI commands list
+    assert isinstance(CONTRACTS["cli"], list)
+    assert len(CONTRACTS["cli"]) >= 3
+    assert any("run all" in c["command"] for c in CONTRACTS["cli"])
+
+    # Config quick reference
+    assert "required_top_level_fields" in CONTRACTS["config"]
+    assert "minimal_example" in CONTRACTS["config"]
+
+
+def test_contracts_view_names_from_constants() -> None:
+    """I view name nel contratto corrispondono alle costanti core."""
+    from toolkit.contracts.pipeline import CONTRACTS
+    from toolkit.core.constants import RAW_INPUT_VIEW, CLEAN_INPUT_VIEW, YEAR_PLACEHOLDER
+
+    assert CONTRACTS["clean"]["sql_source"]["view"] == RAW_INPUT_VIEW
+    assert CONTRACTS["mart"]["sql_source"]["view"] == CLEAN_INPUT_VIEW
+    assert CONTRACTS["clean"]["year_placeholder"]["syntax"] == YEAR_PLACEHOLDER
+    assert CONTRACTS["constants"]["RAW_INPUT_VIEW"] == RAW_INPUT_VIEW
+    assert CONTRACTS["constants"]["CLEAN_INPUT_VIEW"] == CLEAN_INPUT_VIEW
+
+
+def test_contracts_normalize_italian_warning_policy() -> None:
+    """La macro normalize_italian_number ha un warning quando decimal=','.
+
+    Questa e' una regola di policy non ovvia — va protetta da test.
+    L'annotazione @contract warning: in macros.sql la produce.
+    """
+    from toolkit.contracts.pipeline import CONTRACTS
+
+    macros = CONTRACTS["clean"]["macros"]
+    italian_macro = [m for m in macros if m["name"] == "normalize_italian_number"]
+    assert len(italian_macro) == 1
+    macro = italian_macro[0]
+
+    assert "warning" in macro, (
+        "normalize_italian_number deve avere un warning che spiega "
+        "di non usarla quando read.decimal=',' e' configurato"
+    )
+    assert "read.decimal" in macro["warning"], (
+        "Il warning deve menzionare read.decimal per essere trovabile"
+    )
+    assert "CAST" in macro["warning"] or "DOUBLE" in macro["warning"], (
+        "Il warning deve suggerire CAST(x AS DOUBLE) come alternativa"
+    )
+
+
+def test_contracts_required_columns_documented() -> None:
+    """La regola required_columns (nomi output, non raw) e' documentata."""
+    from toolkit.contracts.pipeline import CONTRACTS
+
+    val = CONTRACTS["clean"]["validation"]["required_columns"]
+    assert "scope" in val
+    assert "output" in val["scope"].lower() or "alias" in val["scope"].lower(), (
+        "required_columns.scope deve specificare che usa i nomi OUTPUT del clean"
+    )
+
+
+def test_contracts_macros_auto_generated() -> None:
+    """Le macro nel contratto sono auto-generate da macros.sql.
+
+    Il test verifica che:
+    - ogni macro in macros.sql compaia nel contratto
+    - ogni macro nel contratto abbia chiavi obbligatorie
+    - il parser abbia prodotto risultati coerenti
+    """
+    from toolkit.contracts.pipeline import CONTRACTS
+    from toolkit.core.macro_reader import macro_names
+
+    contract_names = {m["name"] for m in CONTRACTS["clean"]["macros"]}
+    sql_names = macro_names()
+
+    # Ogni macro SQL deve essere nel contratto
+    missing = sql_names - contract_names
+    assert not missing, (
+        f"Macro(e) in macros.sql ma non nel contratto: {missing}. "
+        "Hai dimenticato un header '-- -- nome ---' in macros.sql?"
+    )
+    # Ogni macro contrattuale deve esistere in SQL (warning se extra)
+    extra = contract_names - sql_names
+    if extra:
+        import warnings
+
+        warnings.warn(
+            f"Macro(e) nel contratto ma non in macros.sql: {extra}. "
+            "Potrebbero essere state rimosse da macros.sql."
+        )
+
+    # Ogni macro deve avere le chiavi obbligatorie
+    for macro in CONTRACTS["clean"]["macros"]:
+        for key in ("name", "signature", "params", "returns", "description", "example"):
+            assert key in macro, f"Macro '{macro.get('name', '?')}' manca chiave '{key}'"
+
+
+def test_contracts_macros_return_types_known() -> None:
+    """Tutte le macro hanno un returns type esplicito (non default VARCHAR)."""
+    from toolkit.contracts.pipeline import CONTRACTS
+
+    for macro in CONTRACTS["clean"]["macros"]:
+        assert macro["returns"] != "VARCHAR" or macro["name"] == "normalize_string", (
+            f"Macro '{macro['name']}' manca '@contract returns:' in macros.sql "
+            f"(ha '{macro['returns']}' di default)"
+        )
+
+
+def test_contracts_json_serializable() -> None:
+    """CONTRACTS deve essere serializzabile in JSON per MCP/CLI --json."""
+    from toolkit.contracts.pipeline import CONTRACTS
+
+    dumped = json.dumps(CONTRACTS, ensure_ascii=False, default=str)
+    parsed = json.loads(dumped)
+    assert parsed["version"] == "1"
+    assert len(parsed["clean"]["macros"]) >= 8
+
+
+def test_contract_cli_output() -> None:
+    """CLI toolkit contract produce output senza errori."""
+    from typer.testing import CliRunner
+    from toolkit.cli.app import app
+
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["contract"])
+    assert result.exit_code == 0, f"CLI contract fallito: {result.output}"
+    assert "raw_input" in result.output
+    assert "clean_input" in result.output
+    assert "normalize_italian_number" in result.output
+
+    result_clean = runner.invoke(app, ["contract", "--layer", "clean"])
+    assert result_clean.exit_code == 0
+    assert "raw_input" in result_clean.output
+
+    result_mart = runner.invoke(app, ["contract", "--layer", "mart"])
+    assert result_mart.exit_code == 0
+    assert "clean_input" in result_mart.output
+
+    result_json = runner.invoke(app, ["contract", "--json"])
+    assert result_json.exit_code == 0
+    parsed = json.loads(result_json.output)
+    assert parsed["version"] == "1"
+    assert "clean" in parsed
+    assert "mart" in parsed

--- a/tests/test_macro_reader.py
+++ b/tests/test_macro_reader.py
@@ -109,8 +109,8 @@ def test_macro_names_matches() -> None:
 
 
 def test_read_macros_file_not_found(tmp_path: Path) -> None:
-    """File mancante -> FileNotFoundError."""
+    """File mancante -> lista vuota (non blocca il contratto all'import)."""
     from toolkit.core.macro_reader import read_macros
 
-    with pytest.raises(FileNotFoundError):
-        read_macros(tmp_path / "nonexistent.sql")
+    result = read_macros(tmp_path / "nonexistent.sql")
+    assert result == []

--- a/tests/test_macro_reader.py
+++ b/tests/test_macro_reader.py
@@ -1,0 +1,116 @@
+"""Test: parser macro SQL (toolkit/core/macro_reader.py).
+
+Verifica che il parser estragga correttamente nome, parametri, descrizione,
+e annotazioni @contract da macros.sql.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.contract
+
+
+def test_read_macros_returns_all() -> None:
+    """read_macros restituisce tutte le 8 macro standard."""
+    from toolkit.core.macro_reader import read_macros
+
+    macros = read_macros()
+    names = {m["name"] for m in macros}
+    expected = {
+        "normalize_italian_number",
+        "normalize_italian_integer",
+        "normalize_string",
+        "cast_int",
+        "cast_bigint",
+        "cast_double",
+        "decode_flag",
+        "remove_dot_thousands",
+    }
+    assert names == expected, (
+        f"Macro lette: {names - expected} in piu', {expected - names} mancanti"
+    )
+
+
+def test_read_macros_normalize_italian_contract() -> None:
+    """normalize_italian_number ha warning e returns da annotazione."""
+    from toolkit.core.macro_reader import read_macros
+
+    macros = read_macros()
+    m = next(x for x in macros if x["name"] == "normalize_italian_number")
+
+    assert m["returns"] == "DOUBLE"
+    assert "warning" in m
+    assert "read.decimal" in m["warning"]
+    assert "see" in m
+    assert "remove_dot_thousands" in m["see"]
+
+
+def test_read_macros_signature_and_params() -> None:
+    """Firma e parametri sono estratti correttamente."""
+    from toolkit.core.macro_reader import read_macros
+
+    macros = read_macros()
+    by_name = {m["name"]: m for m in macros}
+
+    # Senza parametri
+    # (tutte le macro attuali hanno almeno un parametro)
+
+    # Con un parametro
+    assert by_name["cast_int"]["params"] == ["val"]
+    assert by_name["cast_int"]["signature"] == "cast_int(val)"
+
+    # Con due parametri
+    assert by_name["decode_flag"]["params"] == ["val", "yes_value"]
+    assert by_name["decode_flag"]["signature"] == "decode_flag(val, yes_value)"
+
+
+def test_read_macros_description_non_empty() -> None:
+    """Ogni macro ha una descrizione leggibile."""
+    from toolkit.core.macro_reader import read_macros
+
+    for m in read_macros():
+        assert len(m["description"]) > 10, f"Macro '{m['name']}' ha descrizione troppo corta"
+
+
+def test_read_macros_example_present() -> None:
+    """Ogni macro ha un example (da @contract o generato)."""
+    from toolkit.core.macro_reader import read_macros
+
+    for m in read_macros():
+        assert m["example"], f"Macro '{m['name']}' non ha example"
+
+
+def test_read_macros_return_types() -> None:
+    """Tutte le macro hanno returns type esplicito (non default VARCHAR).
+
+    normalize_string e' l'unica eccezione: restituisce VARCHAR per natura.
+    """
+    from toolkit.core.macro_reader import read_macros
+
+    for m in read_macros():
+        # VARCHAR e' il default del parser - deve essere esplicito solo per normalize_string
+        if m["name"] == "normalize_string":
+            assert m["returns"] == "VARCHAR"
+        else:
+            assert m["returns"] != "VARCHAR", (
+                f"Macro '{m['name']}' manca @contract returns: in macros.sql "
+                f"(ha '{m['returns']}' di default)"
+            )
+
+
+def test_macro_names_matches() -> None:
+    """macro_names e read_macros sono coerenti."""
+    from toolkit.core.macro_reader import read_macros, macro_names
+
+    assert macro_names() == {m["name"] for m in read_macros()}
+
+
+def test_read_macros_file_not_found(tmp_path: Path) -> None:
+    """File mancante -> FileNotFoundError."""
+    from toolkit.core.macro_reader import read_macros
+
+    with pytest.raises(FileNotFoundError):
+        read_macros(tmp_path / "nonexistent.sql")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -20,6 +20,7 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_schema_diff",
         "toolkit_layer",
         "toolkit_status",
+        "toolkit_contract",
         "toolkit_probe_url",
         "toolkit_ckan_package_show",
         "toolkit_html_extract_links",
@@ -29,6 +30,36 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_find",
         "toolkit_dataset_overview",
     }
+
+
+def test_toolkit_contract_structure() -> None:
+    """toolkit_contract returns stable structure with all required keys."""
+    result = mcp_server.toolkit_contract(layer="all")
+    assert "version" in result
+    assert "pipeline" in result
+    assert "clean" in result
+    assert "mart" in result
+    assert "constants" in result
+    assert "tldr" in result
+
+    # Clean contract has macros with warning rules
+    clean = result["clean"]
+    assert clean["sql_source"]["view"] == "raw_input"
+    assert len(clean["macros"]) >= 8
+    italian_macro = [m for m in clean["macros"] if m["name"] == "normalize_italian_number"]
+    assert len(italian_macro) == 1
+    assert "warning" in italian_macro[0]
+
+    # Layer-specific queries
+    clean_only = mcp_server.toolkit_contract(layer="clean")
+    assert clean_only["layer"] == "clean"
+    assert "sql_source" in clean_only
+    assert clean_only["sql_source"]["view"] == "raw_input"
+
+    mart_only = mcp_server.toolkit_contract(layer="mart")
+    assert mart_only["layer"] == "mart"
+    assert "sql_source" in mart_only
+    assert mart_only["sql_source"]["view"] == "clean_input"
 
 
 def test_tool_returns_payload_on_success(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -51,6 +51,12 @@ def test_toolkit_contract_structure() -> None:
     assert "warning" in italian_macro[0]
 
     # Layer-specific queries
+    # Layer-specific queries
+    raw_only = mcp_server.toolkit_contract(layer="raw")
+    assert raw_only["layer"] == "raw"
+    assert "source_types" in raw_only
+    assert any(s["type"] == "http_file" for s in raw_only["source_types"])
+
     clean_only = mcp_server.toolkit_contract(layer="clean")
     assert clean_only["layer"] == "clean"
     assert "sql_source" in clean_only

--- a/toolkit/clean/_helpers.py
+++ b/toolkit/clean/_helpers.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from lab_connectors.duckdb import safe_connect
 
+from toolkit.core.constants import RAW_INPUT_VIEW
 from toolkit.core.duckdb_read import read_raw_to_relation
 from toolkit.core.layer_profile import profile_relation
 
@@ -27,4 +28,4 @@ def _profile_raw_input(
 ) -> dict[str, Any]:
     with safe_connect() as con:
         read_raw_to_relation(con, input_files, read_cfg, read_mode, logger)
-        return profile_relation(con, "raw_input")
+        return profile_relation(con, RAW_INPUT_VIEW)

--- a/toolkit/clean/sql_execute.py
+++ b/toolkit/clean/sql_execute.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from lab_connectors.duckdb import safe_connect
 
+from toolkit.core.constants import CLEAN_OUT_TABLE
 from toolkit.core.duckdb_read import read_raw_to_relation
 from toolkit.core.input_file import RawInputFile
 from toolkit.core.layer_profile import profile_relation
@@ -79,10 +80,10 @@ def _run_sql(
             # Strip trailing semicolons: clean.sql spesso termina con ;
             stripped = sql_query.rstrip().rstrip(";").rstrip()
             sql_query = f"SELECT * FROM ({stripped}) AS _smoke_sample LIMIT {int(sample_rows)}"
-        con.execute(f"CREATE TABLE clean_out AS {sql_query}")
-        output_profile = profile_relation(con, "clean_out")
+        con.execute(f"CREATE TABLE {CLEAN_OUT_TABLE} AS {sql_query}")
+        output_profile = profile_relation(con, CLEAN_OUT_TABLE)
         output_path.parent.mkdir(parents=True, exist_ok=True)
         con.execute(
-            f"COPY clean_out TO '{sql_path(output_path)}' (FORMAT PARQUET, COMPRESSION ZSTD);"
+            f"COPY {CLEAN_OUT_TABLE} TO '{sql_path(output_path)}' (FORMAT PARQUET, COMPRESSION ZSTD);"
         )
         return read_info.source, read_info.params_used, output_profile

--- a/toolkit/cli/app.py
+++ b/toolkit/cli/app.py
@@ -6,6 +6,7 @@ from toolkit.cli.cmd_run import register as register_run
 from toolkit.cli.cmd_validate import register as register_validate
 from toolkit.cli.cmd_inspect import register as register_inspect
 from toolkit.cli.cmd_batch import register as register_batch
+from toolkit.cli.cmd_contract import register as register_contract
 from toolkit.cli.cmd_scout import register as register_scout
 from toolkit.version import __version__
 
@@ -27,6 +28,7 @@ register_run(app)
 register_validate(app)
 register_inspect(app)
 register_batch(app)
+register_contract(app)
 register_scout(app)
 
 

--- a/toolkit/cli/cmd_contract.py
+++ b/toolkit/cli/cmd_contract.py
@@ -1,0 +1,145 @@
+"""toolkit contract — interroga i contratti di pipeline.
+
+Leggibile per umani, machine-readable con --json.
+Speculare al tool MCP toolkit_contract.
+"""
+
+from __future__ import annotations
+
+import json
+import typer
+
+
+def contract(
+    layer: str = typer.Option(
+        "all",
+        "--layer",
+        "-l",
+        help="Layer del contratto: 'raw', 'clean', 'mart', o 'all' (default)",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Output JSON strutturato (machine-readable)",
+    ),
+) -> None:
+    """Mostra i contratti di pipeline del toolkit.
+
+    I contratti descrivono view names, macro SQL, regole di validazione
+    e formati numerici che i file clean.sql e mart.sql devono rispettare.
+
+    Chiama questo comando PRIMA di scrivere clean.sql o mart.sql.
+    """
+    from toolkit.contracts.pipeline import CONTRACTS
+
+    # Risolvi layer
+    if layer == "all":
+        data = CONTRACTS
+    elif layer == "raw":
+        data = {"layer": layer, **CONTRACTS["raw"]}
+    elif layer == "clean":
+        data = {"layer": layer, **CONTRACTS["clean"]}
+    elif layer == "mart":
+        data = {"layer": layer, **CONTRACTS["mart"]}
+    else:
+        typer.echo(f"Layer sconosciuto: {layer}. Usa 'raw', 'clean', 'mart' o 'all'.", err=True)
+        raise typer.Exit(code=1)
+
+    if json_output:
+        typer.echo(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+        return
+
+    # ── Output leggibile per umani ───────────────────────────────────────
+    typer.echo("╭─ Toolkit Pipeline Contracts ─────────────────────────────╮")
+    typer.echo("│")
+    typer.echo(f"│  Versione: {CONTRACTS['version']}")
+    typer.echo("│")
+
+    if layer in ("all", "raw"):
+        _print_raw(data if layer == "raw" else CONTRACTS["raw"])
+
+    if layer == "all":
+        typer.echo("│")
+
+    if layer in ("all", "clean"):
+        _print_clean(data if layer == "clean" else CONTRACTS["clean"])
+
+    if layer == "all":
+        typer.echo("│")
+
+    if layer in ("all", "mart"):
+        _print_mart(data if layer == "mart" else CONTRACTS["mart"])
+
+    if layer == "all":
+        typer.echo("│")
+        typer.echo("│  ── CLI ─────────────────────────────────────────────────")
+        for cmd in CONTRACTS["cli"]:
+            typer.echo(f"│    {cmd['command']}")
+            typer.echo(f"│      {cmd['description']}")
+        typer.echo("│")
+        typer.echo("│  ── dataset.yml ──────────────────────────────────────────")
+        typer.echo(
+            f"│  Campi richiesti: {', '.join(CONTRACTS['config']['required_top_level_fields'][:3])}"
+        )
+        typer.echo(
+            f"│  + {len(CONTRACTS['config']['common_optional_fields'])} campi opzionali comuni"
+        )
+        typer.echo("│")
+        typer.echo(f"│  🔗 Docs: {CONTRACTS['pipeline']['config_docs']}")
+        typer.echo(f"│  📖 Macro: {CONTRACTS['pipeline']['macros_docs']}")
+        typer.echo(f"│  📐 Conventions: {CONTRACTS['pipeline']['conventions_docs']}")
+        typer.echo("│")
+        typer.echo(f"│  💡 {CONTRACTS['tldr']}")
+        typer.echo("│")
+        typer.echo("╰────────────────────────────────────────────────────────╯")
+
+
+def _print_raw(raw: dict) -> None:
+    typer.echo("│  ── LAYER RAW ────────────────────────────────────────────")
+    typer.echo("│  Tipi fonte disponibili:")
+    for src in raw["source_types"]:
+        typer.echo(f"│    {src['type']:25s} {src['description'][:70]}")
+    typer.echo("│")
+    typer.echo("│  Extractor:")
+    for ext in raw["extractors"]:
+        typer.echo(f"│    {ext['type']:25s} {ext['description']}")
+    typer.echo("│")
+    v = raw.get("validation", {})
+    if v.get("profile", {}).get("known_issue"):
+        typer.echo(f"│  ⚠ Profilo: {v['profile']['known_issue']}")
+    typer.echo("│")
+    typer.echo(f"│  Output: {raw.get('output', {}).get('path', '-')}")
+
+
+def _print_clean(clean: dict) -> None:
+    typer.echo("│  ── LAYER CLEAN ──────────────────────────────────────────")
+    typer.echo(f"│  View SQL:      {clean['sql_source']['view']}")
+    typer.echo(f"│  Year token:    {clean['year_placeholder']['syntax']}")
+    typer.echo(f"│  required_columns: {clean['validation']['required_columns']['scope']}")
+    typer.echo("│")
+    typer.echo("│  Macro disponibili:")
+    for m in clean["macros"]:
+        warning = ""
+        if "warning" in m:
+            warning = " ⚠"
+        example = m.get("example", "")
+        typer.echo(f"│    {m['name']:35s} {m['returns']:10s}  {m['description'][:60]}{warning}")
+        typer.echo(f"│    {'':35s} {'':10s}  es: {example[:60]}")
+    if clean.get("read_params", {}).get("decimal"):
+        d = clean["read_params"]["decimal"]
+        typer.echo("│")
+        typer.echo(f"│  ⚠ decimal=',': {d['consequence']}")
+        typer.echo(f"│    → {d['recommended_usage']}")
+
+
+def _print_mart(mart: dict) -> None:
+    typer.echo("│  ── LAYER MART ───────────────────────────────────────────")
+    typer.echo(f"│  View SQL:      {mart['sql_source']['view']}")
+    typer.echo(f"│  Multi-year:    {mart.get('multi_year', {}).get('description', '-')[:70]}")
+    typer.echo(
+        f"│  table_rules:   {mart.get('validation', {}).get('table_rules', {}).get('scope', '-')}"
+    )
+
+
+def register(app: typer.Typer) -> None:
+    app.command("contract")(contract)

--- a/toolkit/cli/cmd_contract.py
+++ b/toolkit/cli/cmd_contract.py
@@ -7,6 +7,8 @@ Speculare al tool MCP toolkit_contract.
 from __future__ import annotations
 
 import json
+from typing import Any
+
 import typer
 
 
@@ -33,6 +35,7 @@ def contract(
     from toolkit.contracts.pipeline import CONTRACTS
 
     # Risolvi layer
+    data: dict[str, Any]
     if layer == "all":
         data = CONTRACTS
     elif layer == "raw":
@@ -94,7 +97,7 @@ def contract(
         typer.echo("╰────────────────────────────────────────────────────────╯")
 
 
-def _print_raw(raw: dict) -> None:
+def _print_raw(raw: dict[str, Any]) -> None:
     typer.echo("│  ── LAYER RAW ────────────────────────────────────────────")
     typer.echo("│  Tipi fonte disponibili:")
     for src in raw["source_types"]:
@@ -111,7 +114,7 @@ def _print_raw(raw: dict) -> None:
     typer.echo(f"│  Output: {raw.get('output', {}).get('path', '-')}")
 
 
-def _print_clean(clean: dict) -> None:
+def _print_clean(clean: dict[str, Any]) -> None:
     typer.echo("│  ── LAYER CLEAN ──────────────────────────────────────────")
     typer.echo(f"│  View SQL:      {clean['sql_source']['view']}")
     typer.echo(f"│  Year token:    {clean['year_placeholder']['syntax']}")
@@ -132,7 +135,7 @@ def _print_clean(clean: dict) -> None:
         typer.echo(f"│    → {d['recommended_usage']}")
 
 
-def _print_mart(mart: dict) -> None:
+def _print_mart(mart: dict[str, Any]) -> None:
     typer.echo("│  ── LAYER MART ───────────────────────────────────────────")
     typer.echo(f"│  View SQL:      {mart['sql_source']['view']}")
     typer.echo(f"│  Multi-year:    {mart.get('multi_year', {}).get('description', '-')[:70]}")

--- a/toolkit/cli/sql_dry_run.py
+++ b/toolkit/cli/sql_dry_run.py
@@ -6,6 +6,7 @@ from typing import Any
 import duckdb
 from lab_connectors.duckdb import safe_connect
 
+from toolkit.core.constants import RAW_INPUT_VIEW, CLEAN_INPUT_VIEW
 from toolkit.clean.run import load_clean_sql
 from toolkit.clean.sql_execute import _load_standard_macros
 from toolkit.core.config import ensure_dict
@@ -59,7 +60,7 @@ def _create_placeholder_raw_input_with_columns(
         projection = ", ".join(f"NULL::VARCHAR AS {_quoted_identifier(name)}" for name in columns)
     else:
         projection = "NULL::VARCHAR AS __dry_run_placeholder"
-    con.execute(f"CREATE OR REPLACE VIEW raw_input AS SELECT {projection} LIMIT 0")
+    con.execute(f"CREATE OR REPLACE VIEW {RAW_INPUT_VIEW} AS SELECT {projection} LIMIT 0")
 
 
 def _extract_missing_binder_column(exc: Exception) -> str | None:
@@ -146,7 +147,9 @@ def _validate_mart_sql(
     clean_cfg_ = ensure_dict(cfg.clean)
     mart_cfg_ = ensure_dict(cfg.mart)
     if clean_cfg_.get("sql"):
-        con.execute("CREATE OR REPLACE VIEW clean_input AS SELECT * FROM __dry_run_clean_preview")
+        con.execute(
+            f"CREATE OR REPLACE VIEW {CLEAN_INPUT_VIEW} AS SELECT * FROM __dry_run_clean_preview"
+        )
 
     tables = mart_cfg_.get("tables") or []
     # In dry-run: require_exists=False per non bloccare candidate senza support

--- a/toolkit/contracts/__init__.py
+++ b/toolkit/contracts/__init__.py
@@ -50,7 +50,12 @@ __all__ = [
     # Costanti file
     "CLEAN_PARQUET_SUFFIX",
     "METADATA_JSON",
+    # Pipeline contracts (AI agent interface)
+    "CONTRACTS",
 ]
+
+
+from toolkit.contracts.pipeline import CONTRACTS  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Costanti — pattern di file canonici

--- a/toolkit/contracts/pipeline.py
+++ b/toolkit/contracts/pipeline.py
@@ -11,6 +11,8 @@ Queste descrivono comportamenti del runtime che non sono auto-estraibili.
 
 from __future__ import annotations
 
+from typing import Any
+
 from toolkit.core.constants import (
     CLEAN_INPUT_VIEW,
     RAW_INPUT_DF_VIEW,
@@ -24,7 +26,7 @@ from toolkit.core.macro_reader import read_macros
 
 # ── Tipi fonte RAW disponibili ────────────────────────────────────────────
 # Corrispondono ai file in toolkit/plugins/.
-_SOURCE_TYPES: list[dict[str, object]] = [
+_SOURCE_TYPES: list[dict[str, Any]] = [
     {
         "type": "http_file",
         "description": "Scarica un file da URL HTTP/HTTPS. Il tipo piu' comune.",
@@ -81,7 +83,7 @@ _SOURCE_TYPES: list[dict[str, object]] = [
 ]
 
 # ── Tipi extractor RAW ───────────────────────────────────────────────────
-_EXTRACTOR_TYPES: list[dict[str, object]] = [
+_EXTRACTOR_TYPES: list[dict[str, Any]] = [
     {
         "type": "identity",
         "description": "Nessuna estrazione: il file e' gia' nel formato giusto.",
@@ -102,7 +104,7 @@ _EXTRACTOR_TYPES: list[dict[str, object]] = [
 
 
 # ── Contratto layer RAW ──────────────────────────────────────────────────
-_RAW_CONTRACT: dict[str, object] = {
+_RAW_CONTRACT: dict[str, Any] = {
     "source_types": _SOURCE_TYPES,
     "extractors": _EXTRACTOR_TYPES,
     "validation": {
@@ -120,10 +122,10 @@ _RAW_CONTRACT: dict[str, object] = {
 # ── Macros: AUTO-GENERATE da macros.sql ───────────────────────────────────
 # Ogni macro in macros.sql con un header "-- ── nome ──" e annotazioni
 # @contract viene parsificata e inclusa qui. Nessuna manutenzione manuale.
-_MACROS: list[dict[str, object]] = read_macros()
+_MACROS: list[dict[str, Any]] = read_macros()
 
 # ── Contratto layer CLEAN ────────────────────────────────────────────────
-_CLEAN_CONTRACT: dict[str, object] = {
+_CLEAN_CONTRACT: dict[str, Any] = {
     "sql_source": {
         "view": RAW_INPUT_VIEW,
         "how_to_use": (
@@ -176,7 +178,7 @@ _CLEAN_CONTRACT: dict[str, object] = {
 }
 
 # ── Contratto layer MART ─────────────────────────────────────────────────
-_MART_CONTRACT: dict[str, object] = {
+_MART_CONTRACT: dict[str, Any] = {
     "sql_source": {
         "view": CLEAN_INPUT_VIEW,
         "how_to_use": (
@@ -204,7 +206,7 @@ _MART_CONTRACT: dict[str, object] = {
 }
 
 # ── Contratto generale pipeline ──────────────────────────────────────────
-_PIPELINE_CONTRACT: dict[str, object] = {
+_PIPELINE_CONTRACT: dict[str, Any] = {
     "layers": [
         {
             "name": "RAW",
@@ -283,7 +285,7 @@ _CLI_COMMANDS: list[dict[str, str]] = [
 ]
 
 # ── Struttura dataset.yml (quick reference) ─────────────────────────────
-_CONFIG_QUICKREF: dict[str, object] = {
+_CONFIG_QUICKREF: dict[str, Any] = {
     "required_top_level_fields": [
         "dataset.name (nome del dataset)",
         "dataset.years (lista anni, es: [2024])",
@@ -323,7 +325,7 @@ mart:
 
 # ── Contratto completo ───────────────────────────────────────────────────
 # Struttura stabile: nuove chiavi sono additive e backward-compatibili.
-CONTRACTS: dict[str, object] = {
+CONTRACTS: dict[str, Any] = {
     "version": "1",
     "pipeline": _PIPELINE_CONTRACT,
     "raw": _RAW_CONTRACT,

--- a/toolkit/contracts/pipeline.py
+++ b/toolkit/contracts/pipeline.py
@@ -1,0 +1,351 @@
+"""Contratti di pipeline del toolkit — struttura leggibile da agenti AI.
+
+Il contratto delle **macro SQL** è AUTO-GENERATO da ``toolkit/sql/macros.sql``
+tramite ``toolkit.core.macro_reader.read_macros()``. Le annotazioni
+``@contract`` nei commenti di macros.sql arricchiscono ogni macro con
+metadati machine-readable (returns, warning, example, see...).
+
+Sezioni curate manualmente: validation rules, read_params, pipeline layers.
+Queste descrivono comportamenti del runtime che non sono auto-estraibili.
+"""
+
+from __future__ import annotations
+
+from toolkit.core.constants import (
+    CLEAN_INPUT_VIEW,
+    RAW_INPUT_DF_VIEW,
+    RAW_INPUT_SOURCE_VIEW,
+    RAW_INPUT_VIEW,
+    SOURCE_INPUT_VIEW,
+    YEAR_PLACEHOLDER,
+)
+from toolkit.core.macro_reader import read_macros
+
+
+# ── Tipi fonte RAW disponibili ────────────────────────────────────────────
+# Corrispondono ai file in toolkit/plugins/.
+_SOURCE_TYPES: list[dict[str, object]] = [
+    {
+        "type": "http_file",
+        "description": "Scarica un file da URL HTTP/HTTPS. Il tipo piu' comune.",
+        "args": {
+            "url": "URL del file (puo' contenere {year})",
+            "filename": "nome locale (puo' contenere {year})",
+        },
+    },
+    {
+        "type": "http_post_file",
+        "description": "Come http_file ma con POST (per API che richiedono body).",
+        "args": {
+            "url": "URL dell'endpoint",
+            "filename": "nome locale",
+            "data": "body della POST (opzionale)",
+        },
+    },
+    {
+        "type": "local_file",
+        "description": "File gia' presente su disco. Usato per test e smoke.",
+        "args": {
+            "path": "path al file o directory",
+            "filename": "pattern glob (opzionale)",
+        },
+    },
+    {
+        "type": "ckan",
+        "description": "Scarica risorse da un portale CKAN via API.",
+        "args": {
+            "portal_url": "URL del portale CKAN (es. https://dati.gov.it)",
+            "package_id": "ID del dataset CKAN",
+            "resource_id": "ID specifico della risorsa (opzionale)",
+            "filename": "nome locale (opzionale)",
+        },
+    },
+    {
+        "type": "sdmx",
+        "description": "Scarica dati da API SDMX 2.1 (es. ISTAT, Eurostat).",
+        "args": {
+            "endpoint": "URL dell'endpoint SDMX",
+            "resource": "ID del dataflow/risorsa",
+            "filename": "nome locale (opzionale)",
+        },
+    },
+    {
+        "type": "sparql",
+        "description": "Esegue query SPARQL SELECT su endpoint pubblico.",
+        "args": {
+            "endpoint": "URL dello SPARQL endpoint",
+            "query": "Query SPARQL SELECT",
+            "filename": "nome locale (opzionale)",
+        },
+    },
+]
+
+# ── Tipi extractor RAW ───────────────────────────────────────────────────
+_EXTRACTOR_TYPES: list[dict[str, object]] = [
+    {
+        "type": "identity",
+        "description": "Nessuna estrazione: il file e' gia' nel formato giusto.",
+    },
+    {
+        "type": "unzip_all",
+        "description": "Estrae tutti i file da uno ZIP.",
+    },
+    {
+        "type": "unzip_first",
+        "description": "Estrae solo il primo file da uno ZIP.",
+    },
+    {
+        "type": "unzip_first_csv",
+        "description": "Estrae il primo file CSV da uno ZIP.",
+    },
+]
+
+
+# ── Contratto layer RAW ──────────────────────────────────────────────────
+_RAW_CONTRACT: dict[str, object] = {
+    "source_types": _SOURCE_TYPES,
+    "extractors": _EXTRACTOR_TYPES,
+    "validation": {
+        "profile": {
+            "description": "Il profilo raw (raw_profile.json) rileva automaticamente encoding, delim, decimal, skip e colonne del CSV.",
+            "known_issue": "La profilazione potrebbe suggerire decimal='.' anche se il CSV usa ','. Va sovrascritto in clean.read.decimal.",
+        },
+    },
+    "output": {
+        "path": "data/raw/<dataset>/<anno>/<filename>",
+        "profile": "data/raw/<dataset>/<anno>/_profile/raw_profile.json",
+    },
+}
+
+# ── Macros: AUTO-GENERATE da macros.sql ───────────────────────────────────
+# Ogni macro in macros.sql con un header "-- ── nome ──" e annotazioni
+# @contract viene parsificata e inclusa qui. Nessuna manutenzione manuale.
+_MACROS: list[dict[str, object]] = read_macros()
+
+# ── Contratto layer CLEAN ────────────────────────────────────────────────
+_CLEAN_CONTRACT: dict[str, object] = {
+    "sql_source": {
+        "view": RAW_INPUT_VIEW,
+        "how_to_use": (
+            f"clean.sql deve fare SELECT ... FROM {RAW_INPUT_VIEW}. "
+            f"Il toolkit crea {RAW_INPUT_VIEW} come view DuckDB leggendo "
+            f"i file raw (CSV/parquet/Excel) con i parametri configurati "
+            f"in clean.read."
+        ),
+        "also_available": [
+            f"{RAW_INPUT_SOURCE_VIEW} (view intermedia con colonne raw)",
+            f"{RAW_INPUT_DF_VIEW} (DataFrame pandas intermedio, reader normalizzato/Excel)",
+        ],
+    },
+    "year_placeholder": {
+        "syntax": YEAR_PLACEHOLDER,
+        "description": (
+            "Il toolkit sostituisce {year} con l'anno del run prima di "
+            "eseguire clean.sql. Esempio: CAST({year} AS INTEGER) AS anno."
+        ),
+    },
+    "macros": _MACROS,
+    "validation": {
+        "required_columns": {
+            "scope": "nomi colonna OUTPUT del clean.sql (dopo AS alias)",
+            "note": (
+                "clean.required_columns in dataset.yml verifica i nomi "
+                "delle colonne come appaiono nel risultato di clean.sql, "
+                "non i nomi raw del CSV. "
+                "Esempio: se raw ha ANNO e clean fa CAST(ANNO AS INTEGER) AS anno, "
+                "usa required_columns: [anno]."
+            ),
+        },
+        "transition": {
+            "description": (
+                "Il monitor di transizione confronta colonne raw vs clean. "
+                "Avvisa se colonne raw spariscono dal clean senza commento "
+                "-- DROP: <motivo>."
+            ),
+        },
+    },
+    "read_params": {
+        "decimal": {
+            "description": "Se read.decimal=',' in dataset.yml, DuckDB usa la virgola come separatore decimale nel CSV.",
+            "consequence": "I numeri in formato italiano sono già parsati correttamente. NON serve normalize_italian_number.",
+            "recommended_usage": "CAST(colonna AS DOUBLE) — il cast diretto preserva il valore già convertito da DuckDB.",
+        },
+    },
+    "example_file": "project-example/sql/clean.sql",
+    "dataset_dir": "datasets/",
+}
+
+# ── Contratto layer MART ─────────────────────────────────────────────────
+_MART_CONTRACT: dict[str, object] = {
+    "sql_source": {
+        "view": CLEAN_INPUT_VIEW,
+        "how_to_use": (
+            f"mart.sql deve fare SELECT ... FROM {CLEAN_INPUT_VIEW}. "
+            f"Il runner MART crea {CLEAN_INPUT_VIEW} come view DuckDB "
+            f"sul parquet clean dell'anno corrente."
+        ),
+    },
+    "multi_year": {
+        "description": (
+            "Per tabelle che aggregano più anni, specifica years in "
+            "dataset.yml mart.tables[].years. Il toolkit unisce i parquet "
+            f"degli anni indicati e li espone come view {CLEAN_INPUT_VIEW}."
+        ),
+    },
+    "validation": {
+        "table_rules": {
+            "scope": "primary_key, not_null, ranges, min_rows vanno dentro mart.validate.table_rules.<nome_tabella>",
+        },
+        "required_tables": {
+            "scope": "mart.required_tables verifica che le tabelle dichiarate siano state prodotte.",
+        },
+    },
+    "example_file": "project-example/sql/mart/mart_regione_anno.sql",
+}
+
+# ── Contratto generale pipeline ──────────────────────────────────────────
+_PIPELINE_CONTRACT: dict[str, object] = {
+    "layers": [
+        {
+            "name": "RAW",
+            "description": "Download file originale dalla fonte. Profilo: encoding, delim, decimal, colonne.",
+            "output": "CSV/parquet in data/raw/<dataset>/<anno>/",
+            "validation": "raw_validation.json",
+        },
+        {
+            "name": "CLEAN",
+            "description": "Trasformazione SQL (clean.sql) su raw_input. Output parquet normalizzato.",
+            "output": "Parquet in data/clean/<dataset>/<anno>/",
+            "validation": "_validate/clean_validation.json",
+            "view": RAW_INPUT_VIEW,
+        },
+        {
+            "name": "MART",
+            "description": "Aggregazione SQL (mart.sql) su clean_input. Output parquet per data-explorer/notebook.",
+            "output": "Parquet in data/mart/<dataset>/<anno>/",
+            "validation": "_validate/mart_validation.json",
+            "view": CLEAN_INPUT_VIEW,
+        },
+    ],
+    "config_file": "dataset.yml",
+    "config_docs": "docs/config-schema.md",
+    "conventions_docs": "docs/conventions.md",
+    "macros_docs": "docs/standard-macros.md",
+}
+
+# ── Comandi CLI disponibili ──────────────────────────────────────────────
+_CLI_COMMANDS: list[dict[str, str]] = [
+    {
+        "command": "toolkit run raw --config dataset.yml",
+        "description": "Scarica i file raw dalla fonte e produce il profilo.",
+        "when": "Prima esecuzione o quando cambi fonte.",
+    },
+    {
+        "command": "toolkit run init --config dataset.yml",
+        "description": "Bootstrap: run raw + scaffold clean.sql se assente.",
+        "when": "Primo avvio di un nuovo dataset.",
+    },
+    {
+        "command": "toolkit run clean --config dataset.yml",
+        "description": "Applica clean.sql ai dati raw e produce parquet CLEAN.",
+        "when": "Dopo aver scritto/modificato clean.sql.",
+    },
+    {
+        "command": "toolkit run mart --config dataset.yml",
+        "description": "Genera tabelle MART dai dati clean.",
+        "when": "Dopo clean, per produrre dataset pubblici.",
+    },
+    {
+        "command": "toolkit run all --config dataset.yml",
+        "description": "Pipeline completa: raw -> clean -> mart in un comando.",
+        "when": "Esecuzione standard dopo aver configurato tutto.",
+    },
+    {
+        "command": "toolkit run preflight --config dataset.yml",
+        "description": "Diagnostica: valida config, verifica fonti, quality score CSV.",
+        "when": "Prima di run all, per scoprire problemi.",
+    },
+    {
+        "command": "toolkit scout <URL>",
+        "description": "Esplora una fonte esterna: probe + routing + infer schema.",
+        "when": "Quando devi capire se una fonte e' utile.",
+    },
+    {
+        "command": "toolkit inspect summary --config dataset.yml",
+        "description": "Stato ultimo run del dataset.",
+        "when": "Per debug o verifica.",
+    },
+    {
+        "command": "toolkit contract --layer <raw|clean|mart|all>",
+        "description": "Mostra i contratti di pipeline (questo comando).",
+        "when": "PRIMA di scrivere SQL o dataset.yml.",
+    },
+]
+
+# ── Struttura dataset.yml (quick reference) ─────────────────────────────
+_CONFIG_QUICKREF: dict[str, object] = {
+    "required_top_level_fields": [
+        "dataset.name (nome del dataset)",
+        "dataset.years (lista anni, es: [2024])",
+        "raw.sources (almeno una fonte)",
+    ],
+    "common_optional_fields": [
+        "clean.sql (path al file SQL di pulizia)",
+        "clean.read.delim (delimitatore CSV, default auto-detect)",
+        "clean.read.encoding (encoding CSV, default utf-8, PA spesso cp1252)",
+        "clean.read.decimal (separatore decimale, default '.'; usa ',' per italiano)",
+        "clean.required_columns (lista colonne OUTPUT attese nel clean)",
+        "mart.tables (lista tabelle MART con nome e path SQL)",
+        "mart.tables[].years (per tabelle multi-anno)",
+        "mart.validate.table_rules (regole per tabella: primary_key, not_null, ranges)",
+        "raw.sources[].type (http_file, ckan, sdmx, sparql, local_file)",
+        "raw.sources[].extractor (identity, unzip_all, unzip_first, unzip_first_csv)",
+        "support (lista dataset di supporto, eseguiti prima del candidate)",
+    ],
+    "minimal_example": """dataset:
+  name: mio_dataset
+  years: [2024]
+raw:
+  sources:
+    - type: http_file
+      args:
+        url: "https://esempio.it/dati.csv"
+        filename: dati_{year}.csv
+clean:
+  sql: sql/clean.sql
+mart:
+  tables:
+    - name: riepilogo
+      sql: sql/mart/riepilogo.sql
+""",
+}
+
+
+# ── Contratto completo ───────────────────────────────────────────────────
+# Struttura stabile: nuove chiavi sono additive e backward-compatibili.
+CONTRACTS: dict[str, object] = {
+    "version": "1",
+    "pipeline": _PIPELINE_CONTRACT,
+    "raw": _RAW_CONTRACT,
+    "clean": _CLEAN_CONTRACT,
+    "mart": _MART_CONTRACT,
+    "cli": _CLI_COMMANDS,
+    "config": _CONFIG_QUICKREF,
+    "constants": {
+        "RAW_INPUT_VIEW": RAW_INPUT_VIEW,
+        "CLEAN_INPUT_VIEW": CLEAN_INPUT_VIEW,
+        "SOURCE_INPUT_VIEW": SOURCE_INPUT_VIEW,
+        "YEAR_PLACEHOLDER": YEAR_PLACEHOLDER,
+    },
+    "tldr": (
+        "PRIMA: toolkit contract --layer raw|clean|mart  |  "
+        "dataset.yml: name + years + raw.sources + clean.sql + mart.tables  |  "
+        "raw: http_file/ckan/sdmx/sparql/local_file  |  "
+        "clean.sql: SELECT ... FROM raw_input  |  {year} per l'anno  |  "
+        "usa le macro (normalize_string, cast_int, ...)  |  "
+        "required_columns = nomi OUTPUT del clean, non raw  |  "
+        "se decimal=',' basta CAST(x AS DOUBLE)  |  "
+        "mart.sql: SELECT ... FROM clean_input  |  "
+        "comandi: toolkit run init / preflight / all / scout / inspect"
+    ),
+}

--- a/toolkit/core/constants.py
+++ b/toolkit/core/constants.py
@@ -1,0 +1,39 @@
+"""Costanti condivise del toolkit — view names, token, contratti di pipeline.
+
+Queste costanti sono il **punto canonico** per i nomi delle view DuckDB
+create dal runtime. Tutti i reader (CSV, parquet, Excel) devono riferirsi
+a queste costanti, non a stringhe hardcoded.
+
+Quando un agente AI chiede "come si chiama la view clean?", la risposta
+deve venire da qui.
+"""
+
+# ── View name: layer CLEAN ────────────────────────────────────────────────
+# Il reader CSV/parquet/Excel crea questa view nella connessione DuckDB.
+# clean.sql deve fare SELECT ... FROM raw_input.
+RAW_INPUT_VIEW = "raw_input"
+
+# View intermedia usata dal reader CSV con colonne esplicite
+# (source_columns). raw_input fa SELECT da raw_input_source.
+RAW_INPUT_SOURCE_VIEW = "raw_input_source"
+
+# Nome intermedio DataFrame registrato in DuckDB prima di rinominare
+# in RAW_INPUT_VIEW. Usato da reader CSV normalizzato e Excel.
+RAW_INPUT_DF_VIEW = "raw_input_df"
+
+# ── View name: layer MART ─────────────────────────────────────────────────
+# Il runner MART crea questa view dal parquet CLEAN dell'anno corrente.
+# mart.sql deve fare SELECT ... FROM clean_input.
+CLEAN_INPUT_VIEW = "clean_input"
+
+# ── View name: multi-year source ──────────────────────────────────────────
+# Usato da multi_year_source.py per unire parquet di più anni.
+SOURCE_INPUT_VIEW = "source_input"
+
+# ── Token ──────────────────────────────────────────────────────────────────
+# Placeholder {year} nei file SQL viene sostituito dal runner con l'anno.
+YEAR_PLACEHOLDER = "{year}"
+
+# ─── Nome tabella output CLEAN ──────────────────────────────────────────────
+# Tabella DuckDB usata per esportare il risultato di clean.sql in parquet.
+CLEAN_OUT_TABLE = "clean_out"

--- a/toolkit/core/duckdb_read.py
+++ b/toolkit/core/duckdb_read.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import duckdb
+from toolkit.core.constants import RAW_INPUT_VIEW, RAW_INPUT_SOURCE_VIEW
 from toolkit.core.input_file import RawInputFile
 from toolkit.core.read_csv_normalized import _execute_normalized_csv_read
 from toolkit.core.read_excel import _execute_excel_read
@@ -193,7 +194,7 @@ def _execute_csv_read(
 
     if source_columns:
         con.execute(
-            f"CREATE OR REPLACE VIEW raw_input_source AS "
+            f"CREATE OR REPLACE VIEW {RAW_INPUT_SOURCE_VIEW} AS "
             f"SELECT *{inject_sql} FROM read_csv([{paths}], {opt_sql});"
         )
         if trim_whitespace:
@@ -217,11 +218,11 @@ def _execute_csv_read(
         if inject_projection:
             full_projection = f"{projection}, {inject_projection}"
         con.execute(
-            f"CREATE OR REPLACE VIEW raw_input AS SELECT {full_projection} FROM raw_input_source;"
+            f"CREATE OR REPLACE VIEW {RAW_INPUT_VIEW} AS SELECT {full_projection} FROM {RAW_INPUT_SOURCE_VIEW};"
         )
     else:
         con.execute(
-            f"CREATE OR REPLACE VIEW raw_input AS SELECT *{inject_sql} FROM read_csv([{paths}], {opt_sql});"
+            f"CREATE OR REPLACE VIEW {RAW_INPUT_VIEW} AS SELECT *{inject_sql} FROM read_csv([{paths}], {opt_sql});"
         )
     params_used["trim_whitespace"] = bool(trim_whitespace)
     if inject_exprs:
@@ -239,11 +240,13 @@ def _execute_parquet_read(
     if not has_inject:
         if len(raw_paths) == 1:
             con.execute(
-                f"CREATE VIEW raw_input AS SELECT * FROM read_parquet('{sql_path(raw_paths[0])}');"
+                f"CREATE VIEW {RAW_INPUT_VIEW} AS SELECT * FROM read_parquet('{sql_path(raw_paths[0])}');"
             )
         else:
             paths_sql = quote_list(raw_paths)
-            con.execute(f"CREATE VIEW raw_input AS SELECT * FROM read_parquet([{paths_sql}]);")
+            con.execute(
+                f"CREATE VIEW {RAW_INPUT_VIEW} AS SELECT * FROM read_parquet([{paths_sql}]);"
+            )
         return ReadInfo(source="parquet", params_used={})
 
     # Build UNION ALL subqueries with inject_column
@@ -272,7 +275,7 @@ def _execute_parquet_read(
             parts.append(f"SELECT * FROM read_parquet('{path_sql}')")
 
     union_sql = " UNION ALL ".join(parts)
-    con.execute(f"CREATE VIEW raw_input AS {union_sql};")
+    con.execute(f"CREATE VIEW {RAW_INPUT_VIEW} AS {union_sql};")
 
     params: dict[str, Any] = {
         "inject_column": {

--- a/toolkit/core/macro_reader.py
+++ b/toolkit/core/macro_reader.py
@@ -1,0 +1,170 @@
+"""Parser strutturato di macros.sql per il contratto pipeline.
+
+Legge il file SQL delle macro standard e restituisce una lista di dict
+con nome, firma, descrizione e annotazioni @contract.
+
+L'annotazione ``@contract`` nei commenti permette di arricchire la macro
+con metadati machine-readable senza inquinare il SQL:
+
+    -- @contract returns: DOUBLE
+    -- @contract warning: NON usare se decimal=',' e' configurato...
+    -- @contract see: altra_macro
+    -- @contract example: nome(param) AS alias
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+_MACROS_SQL_PATH = Path(__file__).parent.parent / "sql" / "macros.sql"
+
+# Regex: commento separatore "── nome_macro ── ..."
+_RE_MACRO_HEADER = re.compile(r"^--\s+──\s+(\w+)\s+─")
+
+# Regex: dichiarazione CREATE OR REPLACE MACRO name(params)
+_RE_MACRO_DECL = re.compile(r"CREATE\s+OR\s+REPLACE\s+MACRO\s+(\w+)\s*\(([^)]*)\)", re.IGNORECASE)
+
+# Regex: annotazione @contract in un commento
+_RE_CONTRACT_ANNOT = re.compile(r"^--\s+@contract\s+(\w+)\s*:\s*(.+)$")
+
+
+def _parse_params(param_str: str) -> list[str]:
+    """Estrae i nomi parametri da una stringa 'val, yes_value'."""
+    if not param_str or not param_str.strip():
+        return []
+    return [p.strip() for p in param_str.split(",") if p.strip()]
+
+
+def _build_example(name: str, params: list[str]) -> str:
+    """Genera un example di default se non esplicitamente fornito."""
+    args = ", ".join(f'"{p}"' if p in ("val", "col", "value") else p for p in params)
+    return f"{name}({args}) AS {name}_result"
+
+
+def read_macros(sql_path: Path | None = None) -> list[dict[str, Any]]:
+    """Parsa macros.sql e restituisce la lista strutturata delle macro.
+
+    Cerca pattern:
+      - blocco di commenti con "-- ── nome ──..." come header
+      - righe "-- <descrizione>" consecutive
+      - righe "-- @contract <chiave>: <valore>" dentro il blocco
+      - "CREATE OR REPLACE MACRO nome(params) AS" subito dopo
+
+    Returns:
+        List[dict] con chiavi: name, signature, params[], returns,
+        description, example, warning (opzionale), see (opzionale).
+    """
+    path = sql_path or _MACROS_SQL_PATH
+    if not path.exists():
+        raise FileNotFoundError(f"Macros SQL file not found: {path}")
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    macros: list[dict[str, Any]] = []
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Cerca header "── nome_macro ──"
+        m = _RE_MACRO_HEADER.match(line)
+        if not m:
+            i += 1
+            continue
+
+        name = m.group(1)
+
+        # Raccogli il blocco commento tra l'header e la dichiarazione SQL
+        description_lines: list[str] = []
+        contract_annots: dict[str, str] = {}
+        last_contract_key: str | None = None
+        j = i + 1
+        while j < len(lines) and lines[j].startswith("--"):
+            # Annotazione @contract
+            cm = _RE_CONTRACT_ANNOT.match(lines[j])
+            if cm:
+                last_contract_key = cm.group(1)
+                contract_annots[last_contract_key] = cm.group(2).strip()
+            elif last_contract_key and lines[j].startswith("--   "):
+                # Continuazione multi-riga di una annotazione @contract
+                # (indentata con 3 spazi dopo "--")
+                continuation = re.sub(r"^--\s{3}", "", lines[j]).strip()
+                if continuation:
+                    contract_annots[last_contract_key] += " " + continuation
+            else:
+                # Descrizione umana: toglie "-- " iniziale
+                desc = re.sub(r"^--\s?", "", lines[j])
+                if desc.strip():
+                    description_lines.append(desc.strip())
+                last_contract_key = None
+            j += 1
+
+        # j ora punta alla riga con CREATE OR REPLACE MACRO
+        if j >= len(lines):
+            i = j
+            continue
+
+        decl_match = _RE_MACRO_DECL.match(lines[j])
+        if not decl_match:
+            # Prova a concatenare con la riga successiva (multi-riga)
+            if j + 1 < len(lines):
+                joined = lines[j] + " " + lines[j + 1]
+                decl_match = _RE_MACRO_DECL.match(joined)
+        if not decl_match:
+            i = j
+            continue
+
+        decl_name = decl_match.group(1)
+        if decl_name != name:
+            # Il nome nel commento non matcha la dichiarazione → skip
+            i = j
+            continue
+
+        params_str = decl_match.group(2)
+        params = _parse_params(params_str)
+        signature = f"{name}({', '.join(params)})" if params else f"{name}()"
+
+        returns = contract_annots.pop("returns", None)
+        warning = contract_annots.pop("warning", None)
+        see = contract_annots.pop("see", None)
+        example = contract_annots.pop("example", None)
+
+        # Descrizione: unisci righe, limita a 120 caratteri per la prima riga
+        description = " ".join(description_lines) if description_lines else ""
+        if len(description) > 120:
+            description = description[:117] + "..."
+
+        # Example di default se non specificato
+        if not example:
+            example = _build_example(name, params)
+
+        macro: dict[str, Any] = {
+            "name": name,
+            "signature": signature,
+            "params": params,
+            "returns": returns or "VARCHAR",  # default DuckDB macro
+            "description": description,
+            "example": example,
+        }
+        if warning:
+            macro["warning"] = warning
+        if see:
+            macro["see"] = see
+
+        macros.append(macro)
+
+        # Salta alla prossima macro
+        if j + 1 < len(lines) and not lines[j + 1].startswith("--"):
+            j += 1  # riga implementazione
+        i = j + 1
+
+    return macros
+
+
+def macro_names(sql_path: Path | None = None) -> set[str]:
+    """Restituisce i nomi delle macro presenti in macros.sql.
+
+    Utility per test — evita di rieseguire la logica di parsing completa.
+    """
+    return {m["name"] for m in read_macros(sql_path)}

--- a/toolkit/core/macro_reader.py
+++ b/toolkit/core/macro_reader.py
@@ -55,10 +55,12 @@ def read_macros(sql_path: Path | None = None) -> list[dict[str, Any]]:
     Returns:
         List[dict] con chiavi: name, signature, params[], returns,
         description, example, warning (opzionale), see (opzionale).
+        Lista vuota se il file SQL non esiste (package installato senza
+        package data — il contratto avra' 0 macro).
     """
     path = sql_path or _MACROS_SQL_PATH
     if not path.exists():
-        raise FileNotFoundError(f"Macros SQL file not found: {path}")
+        return []
 
     lines = path.read_text(encoding="utf-8").splitlines()
     macros: list[dict[str, Any]] = []
@@ -86,10 +88,11 @@ def read_macros(sql_path: Path | None = None) -> list[dict[str, Any]]:
             if cm:
                 last_contract_key = cm.group(1)
                 contract_annots[last_contract_key] = cm.group(2).strip()
-            elif last_contract_key and lines[j].startswith("--   "):
-                # Continuazione multi-riga di una annotazione @contract
-                # (indentata con 3 spazi dopo "--")
-                continuation = re.sub(r"^--\s{3}", "", lines[j]).strip()
+            elif last_contract_key and not _RE_MACRO_HEADER.match(lines[j]):
+                # Continuazione multi-riga di una annotazione @contract.
+                # Qualunque riga di commento dopo @contract (senza nuovo
+                # @contract ne' header macro) e' continuazione.
+                continuation = re.sub(r"^--\s*", "", lines[j]).strip()
                 if continuation:
                     contract_annots[last_contract_key] += " " + continuation
             else:

--- a/toolkit/core/multi_year_source.py
+++ b/toolkit/core/multi_year_source.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from toolkit.core.constants import CLEAN_INPUT_VIEW, SOURCE_INPUT_VIEW
 from toolkit.core.paths import layer_year_dir
 from toolkit.core.sql_utils import sql_path
 
@@ -81,12 +82,12 @@ def bind_multi_year_view(con, files: list[Path], *, source_layer: str = "clean")
         source_expr = f"read_parquet([{paths}])"
 
     # Views universali (sempre disponibili)
-    con.execute(f"CREATE OR REPLACE VIEW source_input AS SELECT * FROM {source_expr}")
-    con.execute("CREATE OR REPLACE VIEW clean_input AS SELECT * FROM source_input")
-    con.execute("CREATE OR REPLACE VIEW clean AS SELECT * FROM source_input")
+    con.execute(f"CREATE OR REPLACE VIEW {SOURCE_INPUT_VIEW} AS SELECT * FROM {source_expr}")
+    con.execute(f"CREATE OR REPLACE VIEW {CLEAN_INPUT_VIEW} AS SELECT * FROM {SOURCE_INPUT_VIEW}")
+    con.execute(f"CREATE OR REPLACE VIEW clean AS SELECT * FROM {SOURCE_INPUT_VIEW}")
 
     # Views specifiche per source_layer (ex cross_year contract)
     if source_layer == "mart":
-        con.execute("CREATE OR REPLACE VIEW mart_input AS SELECT * FROM source_input")
-        con.execute("CREATE OR REPLACE VIEW mart AS SELECT * FROM source_input")
+        con.execute(f"CREATE OR REPLACE VIEW mart_input AS SELECT * FROM {SOURCE_INPUT_VIEW}")
+        con.execute(f"CREATE OR REPLACE VIEW mart AS SELECT * FROM {SOURCE_INPUT_VIEW}")
         con.execute("CREATE OR REPLACE VIEW mart_all_years AS SELECT * FROM source_input")

--- a/toolkit/core/read_csv_normalized.py
+++ b/toolkit/core/read_csv_normalized.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pandas as pd
 
+from toolkit.core.constants import RAW_INPUT_VIEW, RAW_INPUT_DF_VIEW
 from toolkit.core.read_sql_utils import _parse_column_value
 from toolkit.core.io import normalize_encoding
 
@@ -156,8 +157,8 @@ def _execute_normalized_csv_read(
         _load_normalized_csv_frame(input_file, read_cfg, columns) for input_file in input_files
     ]
     combined = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
-    con.register("raw_input_df", combined)
-    con.execute("CREATE OR REPLACE VIEW raw_input AS SELECT * FROM raw_input_df;")
+    con.register(RAW_INPUT_DF_VIEW, combined)
+    con.execute(f"CREATE OR REPLACE VIEW {RAW_INPUT_VIEW} AS SELECT * FROM {RAW_INPUT_DF_VIEW};")
 
     params_used: dict[str, Any] = {
         "columns": dict(columns),

--- a/toolkit/core/read_excel.py
+++ b/toolkit/core/read_excel.py
@@ -7,6 +7,9 @@ from typing import Any
 import pandas as pd
 
 
+from toolkit.core.constants import RAW_INPUT_VIEW, RAW_INPUT_DF_VIEW
+
+
 def _normalize_excel_sheet_name(value: Any) -> str | int:
     """Normalize sheet_name config value to a string or integer for pd.read_excel."""
     if value is None:
@@ -93,8 +96,8 @@ def _execute_excel_read(
             params_used = frame_params
 
     combined = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
-    con.register("raw_input_df", combined)
-    con.execute("CREATE OR REPLACE VIEW raw_input AS SELECT * FROM raw_input_df;")
+    con.register(RAW_INPUT_DF_VIEW, combined)
+    con.execute(f"CREATE OR REPLACE VIEW {RAW_INPUT_VIEW} AS SELECT * FROM {RAW_INPUT_DF_VIEW};")
 
     used = dict(params_used or {})
     if used.get("columns") is None:

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -7,6 +7,7 @@ from typing import Any
 from lab_connectors.duckdb import safe_connect
 
 from toolkit.core.artifacts import should_write
+from toolkit.core.constants import CLEAN_INPUT_VIEW
 from toolkit.core.config import ensure_dict
 from toolkit.core.layer_profile import (
     compare_layer_profiles,
@@ -33,7 +34,7 @@ from toolkit.core.support import flatten_support_template_ctx, resolve_support_p
 from toolkit.core.template import build_runtime_template_ctx, public_template_ctx, render_template
 
 
-_CLEAN_INPUT_TOKEN_RE = re.compile(r"\bclean_input\b", re.IGNORECASE)
+_CLEAN_INPUT_TOKEN_RE = re.compile(rf"\b{CLEAN_INPUT_VIEW}\b", re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------
@@ -231,7 +232,7 @@ def _run_hierarchy_levels(
         level_name = level_cfg.get("level", "unknown")
         table_name = level_cfg.get("table", f"h_{level_name}")
         grain = level_cfg.get("grain", [])
-        source_table = level_cfg.get("source_table") or "clean_input"
+        source_table = level_cfg.get("source_table") or CLEAN_INPUT_VIEW
 
         if not grain:
             logger.warning("hierarchy level '%s' has no grain columns — skipping", level_name)
@@ -363,11 +364,13 @@ def run_mart(
             # clean_input view
             if len(clean_files) == 1:
                 con.execute(
-                    f"CREATE VIEW clean_input AS SELECT * FROM read_parquet('{_sql_path_quote(clean_files[0])}')"
+                    f"CREATE VIEW {CLEAN_INPUT_VIEW} AS SELECT * FROM read_parquet('{_sql_path_quote(clean_files[0])}')"
                 )
             else:
                 paths = ",".join([f"'{_sql_path_quote(p)}'" for p in clean_files])
-                con.execute(f"CREATE VIEW clean_input AS SELECT * FROM read_parquet([{paths}])")
+                con.execute(
+                    f"CREATE VIEW {CLEAN_INPUT_VIEW} AS SELECT * FROM read_parquet([{paths}])"
+                )
 
         tables = mart_cfg.get("tables") or []
         has_hierarchy = bool(mart_cfg.get("hierarchy"))
@@ -418,7 +421,7 @@ def run_mart(
 
             if not clean_sql_configured and _CLEAN_INPUT_TOKEN_RE.search(sql):
                 raise ValueError(
-                    "MART SQL references clean_input but clean.sql is not configured in dataset.yml"
+                    f"MART SQL references {CLEAN_INPUT_VIEW} but clean.sql is not configured in dataset.yml"
                 )
 
             # Save rendered SQL for audit/debug

--- a/toolkit/mcp/README.md
+++ b/toolkit/mcp/README.md
@@ -3,7 +3,7 @@
 Server MCP locale, read-only, per ispezionare la pipeline e il catalogo
 dataset del DataCivicLab.
 
-## Tool esposti (12)
+## Tool esposti (13)
 
 ### Catalogo (slug-based — GCS + workspace)
 
@@ -12,6 +12,10 @@ dataset del DataCivicLab.
 
 ### Pipeline (config-based — dataset.yml locale)
 
+- `toolkit_contract` — **nuovo** contratti pipeline per agenti AI: tipi fonte
+  raw, view names (raw_input/clean_input), macro SQL, regole validazione,
+  formati numerici. Chiamare PRIMA di scrivere dataset.yml/clean.sql/mart.sql
+  con --layer raw|clean|mart|all
 - `toolkit_layer` — query unificata RAW/CLEAN/MART: schema, preview, profile, SQL. Due modalita':
   `config_path` (pipeline locale) o `datasets` (catalogo GCS/workspace)
 - `toolkit_status` — stato completo dataset: paths, summary, readiness, run_stats, info

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -49,8 +49,12 @@ from .catalog_ops import (
 mcp = create_mcp_server(
     name="toolkit",
     instructions=(
-        "Server MCP locale, read-only, per ispezionare path risolti, "
-        "schemi, stato run e preview dati del toolkit. "
+        "Toolkit pipeline server — ispeziona dataset, esegue preview, "
+        "e fornisce contratti per agenti AI.\n\n"
+        "📌 **PRIMA di scrivere clean.sql o mart.sql**: chiama "
+        "toolkit_contract(layer='clean') per view name (raw_input), "
+        "macro disponibili, regole validazione e formati numerici.\n"
+        "Chiama toolkit_contract(layer='mart') per la view mart (clean_input).\n\n"
         "Supporta slug dataset (es. 'terna-electricity-by-source') "
         "al posto del path assoluto a dataset.yml."
     ),
@@ -233,6 +237,29 @@ def toolkit_dataset_overview(
         year=year,
         source=source,
     )
+
+
+# ---------------------------------------------------------------------------
+# Pipeline contracts (AI agent interface)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description="Restituisce i contratti di pipeline del toolkit in formato "
+    "strutturato. Usalo PRIMA di scrivere dataset.yml, clean.sql o mart.sql "
+    "per conoscere tipi fonte raw, view names (raw_input, clean_input), "
+    "macro disponibili, regole di validazione, e formati numerici italiani. "
+    "Parametro layer='raw' | 'clean' | 'mart' | 'all' (default).",
+    structured_output=True,
+)
+def toolkit_contract(layer: str = "all") -> dict[str, object]:
+    from toolkit.contracts.pipeline import CONTRACTS
+
+    if layer == "all":
+        return CONTRACTS
+    if layer in CONTRACTS:
+        return {"layer": layer, **CONTRACTS[layer]}  # type: ignore[misc]
+    return CONTRACTS
 
 
 # ---------------------------------------------------------------------------

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -252,13 +252,13 @@ def toolkit_dataset_overview(
     "Parametro layer='raw' | 'clean' | 'mart' | 'all' (default).",
     structured_output=True,
 )
-def toolkit_contract(layer: str = "all") -> dict[str, object]:
+def toolkit_contract(layer: str = "all") -> dict[str, Any]:
     from toolkit.contracts.pipeline import CONTRACTS
 
     if layer == "all":
         return CONTRACTS
     if layer in CONTRACTS:
-        return {"layer": layer, **CONTRACTS[layer]}  # type: ignore[misc]
+        return {"layer": layer, **CONTRACTS[layer]}
     return CONTRACTS
 
 

--- a/toolkit/sql/macros.sql
+++ b/toolkit/sql/macros.sql
@@ -8,12 +8,21 @@
 -- Uso: SELECT normalize_italian_number("colonna") AS importo FROM raw_input
 --
 -- Tutte le macro sono CREATE OR REPLACE — sicure da eseguire più volte.
+--
+-- 📌 Il contratto macro (toolkit/contracts/) e' AUTO-GENERATO da questo file.
+--    Quando aggiungi una macro, aggiungi un commento "-- @contract <chiave>: <valore>"
+--    per ogni informazione che deve finire nel contratto (returns, warning, example, see...).
+--    I test contract verificano che ogni macro abbia un contratto.
 -- =============================================================================
 
 -- ── normalize_italian_number ───────────────────────────────────────────────
 -- Converte un numero in formato italiano (1.234,56 → 1234.56).
 -- Rimuove punti migliaia, converte virgola decimale in punto.
 -- TRY_CAST restituisce NULL se la conversione fallisce.
+-- @contract returns: DOUBLE
+-- @contract warning: NON usare se read.decimal=',' e' configurato in dataset.yml.
+--   DuckDB ha gia' parsato il numero con la virgola decimale: basta CAST(x AS DOUBLE).
+-- @contract see: remove_dot_thousands per interi con punti migliaia (senza virgola decimale).
 CREATE OR REPLACE MACRO normalize_italian_number(val) AS
    TRY_CAST(REPLACE(REPLACE(val::VARCHAR, '.', ''), ',', '.') AS DOUBLE);
 
@@ -21,6 +30,7 @@ CREATE OR REPLACE MACRO normalize_italian_number(val) AS
 -- Come normalize_italian_number ma restituisce INTEGER.
 -- DuckDB CAST(DOUBLE AS INTEGER) arrotonda (5432.90 → 5433).
 -- "1.234" → 1234, "5.432,10" → 5432, "5.432,90" → 5433.
+-- @contract returns: INTEGER
 CREATE OR REPLACE MACRO normalize_italian_integer(val) AS
    TRY_CAST(REPLACE(REPLACE(val::VARCHAR, '.', ''), ',', '.') AS INTEGER);
 
@@ -29,26 +39,36 @@ CREATE OR REPLACE MACRO normalize_italian_integer(val) AS
 -- decode_flag("ETS", 'X') → TRUE se il valore è 'X', FALSE altrimenti.
 -- Lista di valori ammessi: passare come secondo argomento il valore che
 -- rappresenta TRUE (es. 'X', 'S', '1', 'TRUE').
+-- @contract returns: BOOLEAN
+-- @contract example: decode_flag("ETS", 'X') AS is_ets
 CREATE OR REPLACE MACRO decode_flag(val, yes_value) AS
    CASE WHEN TRIM(val::VARCHAR) = yes_value::VARCHAR THEN TRUE ELSE FALSE END;
 
 -- ── normalize_string ───────────────────────────────────────────────────────
 -- Normalizza una stringa: TRIM + converte stringhe vuote in NULL.
+-- @contract returns: VARCHAR
+-- @contract example: normalize_string("Regione") AS regione
 CREATE OR REPLACE MACRO normalize_string(val) AS
    NULLIF(TRIM(val::VARCHAR), '');
 
 -- ── cast_int ───────────────────────────────────────────────────────────────
 -- TRY_CAST a INTEGER (32-bit). Per numeri grandi usa cast_bigint.
+-- @contract returns: INTEGER
+-- @contract example: cast_int("Eta") AS eta
 CREATE OR REPLACE MACRO cast_int(val) AS
    TRY_CAST(val AS INTEGER);
 
 -- ── cast_bigint ────────────────────────────────────────────────────────────
 -- TRY_CAST a BIGINT (64-bit). Usato dallo scaffold per colonne numeriche.
+-- @contract returns: BIGINT
+-- @contract example: cast_bigint("CODICE_FISCALE") AS codice_fiscale
 CREATE OR REPLACE MACRO cast_bigint(val) AS
    TRY_CAST(val AS BIGINT);
 
 -- ── cast_double ────────────────────────────────────────────────────────────
 -- TRY_CAST a DOUBLE con gestione NULL sicura.
+-- @contract returns: DOUBLE
+-- @contract example: cast_double("IMPORTO") AS importo
 CREATE OR REPLACE MACRO cast_double(val) AS
    TRY_CAST(val AS DOUBLE);
 
@@ -60,5 +80,7 @@ CREATE OR REPLACE MACRO cast_double(val) AS
 --   normalize_italian_number()  — formato italiano (virgola)
 --   cast_double()               — formato internazionale (punto)
 -- "1.234" → 1234.0, "1.234.567" → 1234567.0
+-- @contract returns: DOUBLE
+-- @contract example: remove_dot_thousands("POPOLAZIONE") AS popolazione
 CREATE OR REPLACE MACRO remove_dot_thousands(val) AS
    TRY_CAST(REPLACE(val::VARCHAR, '.', '') AS DOUBLE);


### PR DESCRIPTION
## Sintesi

Aggiunge `toolkit_contract` — un contratto di pipeline machine-readable che un agente AI (via MCP) o un umano (via CLI) interroga **prima** di scrivere dataset.yml, clean.sql o mart.sql, prevenendo errori comuni (view name sbagliato, `normalize_italian_number` su dato già parsato, `required_columns` in maiuscolo, ecc.).

## Contesto collegato

Nato dall'osservazione che in una sessione reale un agente AI ha commesso 4 errori di contratto in 6 minuti, tutti prevenibili con un contratto strutturato interrogabile prima di scrivere codice.

## Cosa cambia

- [x] Nuova funzionalità del motore
- [x] Modifica contratto pubblico (view name in costanti condivise)
- [x] Refactor / performance (7 file runtime ora usano costanti invece di stringhe hardcoded)
- [x] Documentazione (README MCP aggiornato)

## Dettaglio

### Contratto per layer

| Layer | `toolkit contract --layer` | Cosa espone |
|---|---|---|
| **RAW** | `--layer raw` | 6 tipi fonte + 4 extractor + profilo + output path |
| **CLEAN** | `--layer clean` | view `raw_input`, `{year}`, 8 macro auto-generate da `macros.sql` con annotazioni `@contract` (returns, warning, example), regole validazione, gestione `decimal=','` |
| **MART** | `--layer mart` | view `clean_input`, multi-year, table_rules |
| **Full** | (default) | RAW + CLEAN + MART + CLI + config quickref |

### Macro auto-generate

Le macro SQL non sono più un dict statico in `pipeline.py`. Il nuovo `toolkit/core/macro_reader.py` parsifica `macros.sql` e legge le annotazioni `@contract`:

```sql
-- @contract returns: DOUBLE
-- @contract warning: NON usare se read.decimal=',' e' configurato...
-- @contract see: remove_dot_thousands
CREATE OR REPLACE MACRO normalize_italian_number(val) AS ...
```

Nuova macro → aggiungi `-- @contract returns/warning/see/example` nel commento → contratto aggiornato automaticamente. Zero manutenzione manuale.

### Costanti runtime

`toolkit/core/constants.py` centralizza view name canonici (`RAW_INPUT_VIEW`, `CLEAN_INPUT_VIEW`, ...). 7 file runtime (`duckdb_read.py`, `mart/run.py`, `sql_dry_run.py`, ecc.) ora li usano invece di stringhe hardcoded.

### Canali di accesso

- **MCP**: `toolkit_contract(layer='raw'|'clean'|'mart'|'all')` — le istruzioni MCP dicono all'agente di chiamarlo PRIMA di scrivere SQL
- **CLI**: `toolkit contract --layer <layer> [--json]` — output tabellare leggibile o JSON machine-readable

## Impatto su contratti pubblici

- [x] CLI o MCP tool (nuovo comando `toolkit contract` + nuovo tool `toolkit_contract`)
- [ ] API pubblica del toolkit — **no**, `toolkit.contracts.pipeline.CONTRACTS` è nuovo modulo, non rompe backward compat
- [x] Path output — **no**, `constants.py` è additivo, i vecchi path funzionano ancora

## Verifica

```bash
pytest tests/test_contracts.py tests/test_macro_reader.py tests/test_mcp_server.py::test_mcp_server_registers_expected_tools tests/test_mcp_server.py::test_toolkit_contract_structure -v
# 18 passed in ~4s

ruff check toolkit/ tests/
# All checks passed
```

- [x] `pytest -m core` passa
- [x] `ruff check .` passa
- [x] Modificato o aggiunto test con marker appropriato (8 nuovi test `contract` in `test_macro_reader.py`, 7 in `test_contracts.py` + 1 in `test_mcp_server.py`)

## Checklist PR

- [x] Perimetro stretto: un layer logico (contratto pipeline)
- [x] Test inclusi con marker `contract`
- [ ] Issue collegata — **nessuna**, nato da conversazione

## Note per chi revisiona

- Il `macro_reader.py` parsifica `macros.sql` con regex su header `── nome ──` e annotazioni `@contract`. Il test `test_macro_reader.py` protegge la struttura.
- `constants.py` è nuovo ma riusa nomi che esistevano già come stringhe — è un'estrazione, non un cambiamento di contratto.
- I 2 nuovi moduli sotto `toolkit/contracts/` (`__init__.py` + `pipeline.py`) si aggiungono al package esistente senza modificare le funzioni di path contract già presenti.
