### PR TITLE
feat(support): anti-path-drift validation per placeholder {support.X.mart}

### DIFF
--- a/tests/test_run_dry_run.py
+++ b/tests/test_run_dry_run.py
@@ -288,6 +288,61 @@ def test_run_dry_run_fails_when_support_outputs_are_only_partially_present(
     assert "DRY_RUN" in result.output
 
 
+@pytest.mark.policy
+def test_run_dry_run_detects_hardcoded_support_path(
+    tmp_path: Path,
+    runner,
+) -> None:
+    """Anti-pattern: mart SQL uses hardcoded path instead of {support.X.mart} → PATH DRIFT warning."""
+    make_standard_sql(tmp_path)
+    root_dir = tmp_path / "out"
+    support_root = tmp_path / "support_out"
+
+    # Crea output parquet al path che il SQL hardcoded andra' a leggere
+    hardcoded_path = root_dir / "data" / "mart" / "lookup_ds" / "2022" / "lookup_table.parquet"
+    hardcoded_path.parent.mkdir(parents=True, exist_ok=True)
+    duckdb.execute(
+        f"COPY (SELECT 7 AS lookup_value) TO '{hardcoded_path.as_posix()}' (FORMAT PARQUET)"
+    )
+
+    # Crea config support con year 2022
+    support_config = tmp_path / "support_dataset.yml"
+    make_dataset_yml(
+        support_config,
+        root=support_root,
+        name="lookup_ds",
+        years=[2022],
+        clean_sql="sql/clean.sql",
+        mart_tables=[("lookup_table", "sql/lookup.sql")],
+    )
+
+    # ANTI-PATTERN: hardcoded mart path instead of {support.lookup.mart}
+    (tmp_path / "sql" / "mart" / "mart_example.sql").write_text(
+        "select * from read_parquet('{root}/data/mart/lookup_ds/{year}/lookup_table.parquet')",
+        encoding="utf-8",
+    )
+
+    config_path = make_dataset_yml(
+        tmp_path / "dataset.yml",
+        root=root_dir,
+        mart_tables=[("mart_example", "sql/mart/mart_example.sql")],
+        extra=(
+            "support:\n"
+            '  - name: "lookup"\n'
+            f'    config: "{support_config.as_posix()}"\n'
+            "    years: [2022]"
+        ),
+    )
+
+    result = runner.invoke(app, ["run", "all", "--config", str(config_path), "--dry-run"])
+
+    # Dry-run succeeds (does NOT block on drift — only warns)
+    assert result.exit_code == 0, f"exit_code={result.exit_code} output={result.output}"
+    assert "PATH DRIFT" in result.output, f"output={result.output}"
+    assert "lookup_ds" in result.output
+    assert "{support.lookup.mart}" in result.output
+
+
 # ── Logger context ──────────────────────────────────────────────────────────
 
 

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 from toolkit.core.support import (
+    check_support_path_drift,
     flatten_support_template_ctx,
     resolve_support_payloads,
     _support_expected_mart_outputs,
@@ -301,6 +302,82 @@ class TestFlattenSupportTemplateCtx:
         ctx = flatten_support_template_ctx(payloads)
         assert ctx["support.empty_support.outputs"] == []
         assert ctx["support.empty_support.mart"] is None
+
+
+# --- check_support_path_drift ---
+
+
+class TestCheckSupportPathDrift:
+    """Unit tests for anti-path-drift detection."""
+
+    _SAMPLE_PAYLOADS = [
+        {"name": "lookup", "dataset": "comuni_master"},
+        {"name": "glossario", "dataset": "opencivitas_glossario"},
+        {"name": "enti", "dataset": "opencivitas_fsc_enti_rso"},
+    ]
+
+    def test_no_payloads_returns_empty(self):
+        assert check_support_path_drift("select 1", []) == []
+
+    def test_correct_placeholder_no_warning(self):
+        sql = "select * from read_parquet('{support.lookup.mart}')"
+        assert check_support_path_drift(sql, self._SAMPLE_PAYLOADS) == []
+
+    def test_correct_outputs_placeholder_no_warning(self):
+        sql = "select * from read_parquet({support.lookup.outputs}, union_by_name=true)"
+        assert check_support_path_drift(sql, self._SAMPLE_PAYLOADS) == []
+
+    def test_hardcoded_path_detected(self):
+        sql = (
+            "select *\nfrom read_parquet('{root}/data/mart/opencivitas_glossario/{year}/t.parquet')"
+        )
+        warnings = check_support_path_drift(sql, self._SAMPLE_PAYLOADS)
+        assert len(warnings) == 1
+        assert "opencivitas_glossario" in warnings[0]
+        assert "{support.glossario.mart}" in warnings[0]
+
+    def test_multiple_hardcoded_paths(self):
+        sql = (
+            "select * from read_parquet('{root}/data/mart/opencivitas_glossario/2022/t.parquet')\n"
+            "union all\n"
+            "select * from read_parquet('{root}/data/clean/comuni_master/2026/t.parquet')"
+        )
+        warnings = check_support_path_drift(sql, self._SAMPLE_PAYLOADS)
+        assert len(warnings) == 2
+        combined = " ".join(warnings)
+        assert "opencivitas_glossario" in combined
+        assert "comuni_master" in combined
+
+    def test_mixed_correct_and_hardcoded(self):
+        """Uses {support.enti.mart} correctly but has hardcoded path for glossario."""
+        sql = (
+            "with enti as (select * from read_parquet('{support.enti.mart}')),\n"
+            "     metadati as (select * from read_parquet('{root}/data/mart/opencivitas_glossario/2022/t.parquet'))\n"
+            "select * from enti"
+        )
+        warnings = check_support_path_drift(sql, self._SAMPLE_PAYLOADS)
+        assert len(warnings) == 1
+        assert "opencivitas_glossario" in warnings[0]
+        assert "enti" not in warnings[0]
+
+    def test_slug_appears_in_variable_not_path(self):
+        """Slug in a column alias or variable name should not trigger false positive."""
+        sql = "select comuni_master as codice from table"
+        assert check_support_path_drift(sql, self._SAMPLE_PAYLOADS) == []
+
+    def test_slug_appears_in_sql_comment(self):
+        """Slug in a SQL comment should not trigger."""
+        sql = """-- comuni_master join table
+        select * from read_parquet('{support.lookup.mart}')"""
+        assert check_support_path_drift(sql, self._SAMPLE_PAYLOADS) == []
+
+    def test_nonexistent_slug_no_warning(self):
+        """Slug not in any payload entry → no check for it."""
+        sql = "select * from read_parquet('{root}/data/mart/unknown_slug/2024/t.parquet')"
+        assert check_support_path_drift(sql, self._SAMPLE_PAYLOADS) == []
+
+    def test_empty_payloads_does_not_raise_on_any_sql(self):
+        assert check_support_path_drift("garbage {{}} path 'slug' test", []) == []
 
 
 # --- Integration: resolve + flatten ---

--- a/toolkit/cli/sql_dry_run.py
+++ b/toolkit/cli/sql_dry_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any
 
@@ -11,8 +12,14 @@ from toolkit.clean.run import load_clean_sql
 from toolkit.clean.sql_execute import _load_standard_macros
 from toolkit.core.config import ensure_dict
 from toolkit.core.paths import resolve_sql_path as _resolve_mart_sql_path
-from toolkit.core.support import flatten_support_template_ctx, resolve_support_payloads
+from toolkit.core.support import (
+    check_support_path_drift,
+    flatten_support_template_ctx,
+    resolve_support_payloads,
+)
 from toolkit.core.template import build_runtime_template_ctx, render_template
+
+_logger = logging.getLogger("toolkit.cli.sql_dry_run")
 
 _QUOTED_IDENTIFIER_RE = re.compile(r'"([^"]+)"')
 _BINDER_MISSING_COLUMN_RE = re.compile(r'Referenced column "([^"]+)" not found in FROM clause')
@@ -93,12 +100,24 @@ def _build_clean_preview(
 
     # Pre-calcola i path attesi del support per gestire IOError in dry-run
     support_paths: list[str] = []
+    support_payloads_drift: list[dict[str, Any]] = []
     if dry_run and support_cfg:
         try:
             sp_payloads = resolve_support_payloads(support_cfg, require_exists=False, smoke=False)
             support_paths = _all_support_expected_paths(sp_payloads)
+            support_payloads_drift = sp_payloads
         except Exception:
             pass
+
+    # Anti-path-drift: verifica che il SQL non referenzi support dataset
+    # via path hardcoded invece di {support.NAME.mart}
+    if support_payloads_drift:
+        raw_sql_text = clean_sql_path.read_text(encoding="utf-8")
+        drift_warnings = check_support_path_drift(
+            raw_sql_text, support_payloads_drift, sql_label=str(clean_sql_path)
+        )
+        for w in drift_warnings:
+            _logger.warning("PATH DRIFT: %s", w)
 
     # Fallback incrementale: se il clean.sql usa colonne raw non quotate e non
     # dichiarate in clean.read.columns, il binder di DuckDB ci dice il nome
@@ -170,7 +189,16 @@ def _validate_mart_sql(
         name = table.get("name")
         sql_ref = table.get("sql")
         sql_path = _resolve_mart_sql_path(sql_ref, base_dir=cfg.base_dir)
-        sql = _normalize_sql(render_template(sql_path.read_text(encoding="utf-8"), template_ctx))
+        raw_sql_text = sql_path.read_text(encoding="utf-8")
+        # Anti-path-drift: verifica che il SQL non referenzi support dataset
+        # via path hardcoded invece di {support.NAME.mart}
+        if support_payloads:
+            drift_warnings = check_support_path_drift(
+                raw_sql_text, support_payloads, sql_label=f"{sql_path} ({name})"
+            )
+            for w in drift_warnings:
+                _logger.warning("PATH DRIFT: %s", w)
+        sql = _normalize_sql(render_template(raw_sql_text, template_ctx))
         try:
             con.execute(f"EXPLAIN SELECT * FROM ({sql}) AS q LIMIT 0")
         except Exception as exc:

--- a/toolkit/core/support.py
+++ b/toolkit/core/support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -77,6 +78,62 @@ def resolve_support_payloads(
             }
         )
     return resolved
+
+
+def check_support_path_drift(
+    raw_sql: str,
+    support_payloads: list[dict[str, Any]],
+    sql_label: str = "",
+) -> list[str]:
+    """
+    Scans raw SQL (pre-template-render) for hardcoded path references to
+    support datasets that bypass the ``{support.NAME.mart}`` placeholder
+    contract.
+
+    For each declared support entry, verifies that if the support dataset
+    slug appears in a path-like string literal, the corresponding
+    ``{support.NAME.mart}`` or ``{support.NAME.outputs}`` placeholder is
+    also present in the SQL.
+
+    Returns a list of warning messages (empty = no drift detected).
+    """
+    warnings: list[str] = []
+
+    # Build name -> dataset slug map from resolved payloads
+    name_slug_map: dict[str, str] = {}
+    for payload in support_payloads:
+        slug = payload.get("dataset", "")
+        if slug:
+            name_slug_map[payload["name"]] = slug
+
+    if not name_slug_map:
+        return warnings
+
+    # Find which support names are used via placeholder
+    used_via_placeholder: set[str] = set()
+    for match in re.finditer(r"\{support\.([A-Za-z_][A-Za-z0-9_]*)\.(mart|outputs)\}", raw_sql):
+        used_via_placeholder.add(match.group(1))
+
+    for name, slug in name_slug_map.items():
+        if name in used_via_placeholder:
+            continue
+
+        escaped = re.escape(slug)
+        for str_match in re.finditer(
+            r"""['"](?:[^'"]*""" + escaped + r"""[^'"]*)['"]""",
+            raw_sql,
+        ):
+            text = str_match.group(0)
+            # Filtra falsi positivi: deve sembrare un path (slash, backslash, extension)
+            if not any(c in text for c in ("/", "\\", ".")):
+                continue
+            warnings.append(
+                f"Support dataset '{slug}' referenced via hardcoded path "
+                f"instead of {{support.{name}.mart}}: "
+                f"{'' if not sql_label else sql_label + ' > '}{text[:120]}"
+            )
+
+    return warnings
 
 
 def flatten_support_template_ctx(payloads: list[dict[str, Any]]) -> dict[str, Any]:


### PR DESCRIPTION
## Sintesi

Aggiunge validazione statica che rileva quando il SQL referenzia un support dataset via path hardcoded invece di usare il placeholder `{support.NAME.mart}`. 

Due casi reali già identificati in dataset-incubator da migrare successivamente:
- `opencivitas-indicatori` → `{root}/data/mart/opencivitas_glossario/{year}/...` 
- `irpef-comunale` → path su CLEAN invece che MART via support

## Cosa cambia

- [X] Nuova funzionalità del motore

## Impatto su contratti pubblici

Nessuno. Funzione nuova, non blocca, solo warning in dry-run.

## Verifica

```bash
pytest tests/test_support.py tests/test_run_dry_run.py -v
# 52 passed
pytest -q
# 1277 passed
ruff check .
```

- [X] `pytest` passa
- [X] `ruff check .` passa

## Checklist PR

- [X] Perimetro stretto: una PR = un fix mirato
- [X] Test con marker appropriato (`policy`)
