### PR TITLE
feat(config): add optional dataset.tags and dataset.category fields

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -25,6 +25,8 @@ I path relativi sono sempre risolti rispetto alla directory che contiene `datase
 |---|---|---|
 | `dataset.name` | `string` | nessuno |
 | `dataset.years` | `list[int]` | nessuno |
+| `dataset.tags` | `list[string]` | `[]` |
+| `dataset.category` | `string \| null` | `null` |
 
 ## raw
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -110,6 +110,8 @@ def make_config(
         source_id=model.dataset.source_id,
         years=list(model.dataset.years),
         time_coverage=model.dataset.time_coverage,
+        tags=list(model.dataset.tags or []),
+        category=model.dataset.category,
         _model=model,
     )
 

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -585,3 +585,74 @@ def test_mart_required_tables_explicit_subset(tmp_path: Path):
 
     cfg = load_config(yml)
     assert cfg.mart.required_tables == ["table_a"]
+
+
+@pytest.mark.contract
+def test_dataset_tags_default_empty(tmp_path: Path):
+    """dataset.tags defaults to [] when omitted."""
+    yml = tmp_path / "dataset.yml"
+    _yml(yml)
+    cfg = load_config(yml)
+    assert cfg.tags == []
+
+
+@pytest.mark.contract
+def test_dataset_tags_parsed(tmp_path: Path):
+    """dataset.tags è parsato correttamente da YAML lista."""
+    yml = tmp_path / "dataset.yml"
+    _yml_str(
+        yml,
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2024]\n"
+        "  tags: [sanità, farmaceutica, spesa-pubblica]\n"
+        "raw: {}\n"
+        "clean: {}\n"
+        "mart: {}",
+    )
+    cfg = load_config(yml)
+    assert cfg.tags == ["sanità", "farmaceutica", "spesa-pubblica"]
+
+
+@pytest.mark.contract
+def test_dataset_category_default_none(tmp_path: Path):
+    """dataset.category defaults to None when omitted."""
+    yml = tmp_path / "dataset.yml"
+    _yml(yml)
+    cfg = load_config(yml)
+    assert cfg.category is None
+
+
+@pytest.mark.contract
+def test_dataset_category_parsed(tmp_path: Path):
+    """dataset.category è parsato correttamente da YAML."""
+    yml = tmp_path / "dataset.yml"
+    _yml_str(
+        yml,
+        "dataset:\n  name: demo\n  years: [2024]\n  category: sanità\nraw: {}\nclean: {}\nmart: {}",
+    )
+    cfg = load_config(yml)
+    assert cfg.category == "sanità"
+
+
+@pytest.mark.policy
+def test_dataset_tags_and_category_with_source_id(tmp_path: Path):
+    """tags e category convivono con source_id e time_coverage."""
+    yml = tmp_path / "dataset.yml"
+    _yml_str(
+        yml,
+        "dataset:\n"
+        "  name: demo\n"
+        "  years: [2024]\n"
+        "  source_id: test_source\n"
+        "  tags: [tag1, tag2]\n"
+        "  category: test-category\n"
+        "raw: {}\n"
+        "clean: {}\n"
+        "mart: {}",
+    )
+    cfg = load_config(yml)
+    assert cfg.dataset == "demo"
+    assert cfg.source_id == "test_source"
+    assert cfg.tags == ["tag1", "tag2"]
+    assert cfg.category == "test-category"

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -130,6 +130,32 @@ class TestLoadDatasetManifest:
         result = load_dataset_manifest(tmp_path)
         assert result["source_id"] == "istat_sdmx"
 
+    def test_tags_default_empty(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {"dataset": {"name": "test"}})
+        result = load_dataset_manifest(tmp_path)
+        assert result["tags"] == []
+
+    def test_tags_parsed(self, tmp_path: Path) -> None:
+        _write_dataset(
+            tmp_path,
+            {"dataset": {"name": "test", "tags": ["sanità", "farmaceutica"]}},
+        )
+        result = load_dataset_manifest(tmp_path)
+        assert result["tags"] == ["sanità", "farmaceutica"]
+
+    def test_category_default_none(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, {"dataset": {"name": "test"}})
+        result = load_dataset_manifest(tmp_path)
+        assert result["category"] is None
+
+    def test_category_parsed(self, tmp_path: Path) -> None:
+        _write_dataset(
+            tmp_path,
+            {"dataset": {"name": "test", "category": "sanità"}},
+        )
+        result = load_dataset_manifest(tmp_path)
+        assert result["category"] == "sanità"
+
     def test_empty_years_default(self, tmp_path: Path) -> None:
         _write_dataset(tmp_path, {"dataset": {"name": "test"}})
         result = load_dataset_manifest(tmp_path)

--- a/toolkit/core/config.py
+++ b/toolkit/core/config.py
@@ -39,7 +39,10 @@ class ToolkitConfig:
     time_coverage: TimeCoverage | None
 
     # Internal: the typed model (used by typed properties below)
-    _model: ToolkitConfigModel = field(repr=False, compare=False)
+    _model: ToolkitConfigModel
+
+    tags: list[str] = field(default_factory=list)
+    category: str | None = None
 
     # --- Typed accessors ---
 
@@ -116,5 +119,7 @@ def load_config(
         source_id=model.dataset.source_id,
         years=list(model.dataset.years),
         time_coverage=model.dataset.time_coverage,
+        tags=list(model.dataset.tags or []),
+        category=model.dataset.category,
         _model=model,
     )

--- a/toolkit/core/config_models/shared_models.py
+++ b/toolkit/core/config_models/shared_models.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 _SAFE_SQL_IDENTIFIER_RE = r"^[A-Za-z_][A-Za-z0-9_]*$"
@@ -104,6 +104,8 @@ class DatasetBlock(BaseModel):
     years: list[int]
     source_id: str | None = None
     time_coverage: TimeCoverage | None = None
+    tags: list[str] = Field(default_factory=list)
+    category: str | None = None
 
 
 class SupportDatasetConfig(BaseModel):

--- a/toolkit/core/dataset_loader.py
+++ b/toolkit/core/dataset_loader.py
@@ -51,6 +51,8 @@ def load_dataset_manifest(path: str | Path) -> dict[str, Any]:
         "years": ds.get("years") or [],
         "source_id": ds.get("source_id"),
         "time_coverage": ds.get("time_coverage"),
+        "tags": ds.get("tags") or [],
+        "category": ds.get("category"),
     }
 
     # raw.sources

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -399,6 +399,7 @@ def dataset_info(config_path: str) -> dict[str, Any]:
     return {
         "dataset": cfg.dataset if hasattr(cfg, "dataset") else None,
         "config_path": str(config),
+        "source_id": cfg.source_id if hasattr(cfg, "source_id") else None,
         "years": list(cfg.years) if hasattr(cfg, "years") else [],
         "time_coverage": time_cov,
         "source_urls": source_urls,

--- a/toolkit/mcp/schema_ops.py
+++ b/toolkit/mcp/schema_ops.py
@@ -407,6 +407,8 @@ def dataset_info(config_path: str) -> dict[str, Any]:
         "has_mart": has_mart,
         "mart_tables": mart_tables,
         "support_datasets": support_list,
+        "tags": list(cfg.tags) if hasattr(cfg, "tags") else [],
+        "category": cfg.category if hasattr(cfg, "category") else None,
     }
 
 


### PR DESCRIPTION
## Sintesi

Aggiunge `tags` (list[str]) e `category` (str | None) come campi opzionali del blocco `dataset:` in dataset.yml, con propagazione in modello Pydantic, dataclass pubblica, manifest e MCP server. Base per i selettori batch semantici (futuro).

## Contesto collegato

Nessuna issue — richiesta diretta per organizzare batch smart in dataset-incubator.

## Cosa cambia

- [ ] Bug fix
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [x] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [x] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

- [x] Struttura `dataset.yml` (nuovo campo, cambio obbligatorietà)
- [ ] Path output (nuovo layer, cambio percorso artifact)
- [ ] Schema parquet (nuova colonna, rename, cambio tipo)
- [ ] CLI o MCP tool (nuovo comando, cambio parametro)
- [ ] API pubblica del toolkit (firma funzione, classe, eccezione)

> I nuovi campi sono **opzionali** — nessun dataset.yml esistente si rompe.

Downstream aggiornato:
- [ ] `dataset-incubator` — x [x] `docs/`

## Verifica

```bash
pytest toolkit/tests/test_config_loading.py -v --no-header -k "not test_project_example"
pytest toolkit/tests/test_dataset_loader.py -v --no-header
pytest toolkit/tests/test_mcp_toolkit_client.py -v --no-header
ruff check .
```

- [x] `pytest -m core` passa
- [x] `ruff check .` passa
- [ ] `mypy toolkit/` passa (o motiva le eccezioni)
- [x] Modificato o aggiunto test con marker appropriato (`contract` / `policy` / `pure_unit`)

## Checklist PR

- [x] Perimetro stretto: una PR = un layer o un fix mirato
- [ ] Se nuovo plugin: test + docs inclusi
- [ ] Issue collegata o motivazione dell'assenza (richiesta diretta via chat)
- [ ] **Se rimuovo un modulo/funzione pubblica**: N/A

## Note per chi revisiona

I campi sono parsati dal Pydantic `DatasetBlock` e propagati in:
- `ToolkitConfig` (dataclass pubblica) — accesso via `cfg.tags`, `cfg.category`
- `load_dataset_manifest()` — per cataloghi e CI
- `dataset_info()` (MCP server) — esposizione ad agenti AI

Fix minore: `_model` field in `ToolkitConfig` ora ha `default=None` esplicito (era `field()` senza default, che causava errore dataclass quando altri campi con default vengono aggiunti prima).
