### PR TITLE
feat(config): warning tags/category in validate_config + time_coverage in docs

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -27,6 +27,12 @@ I path relativi sono sempre risolti rispetto alla directory che contiene `datase
 | `dataset.years` | `list[int]` | nessuno |
 | `dataset.tags` | `list[string]` | `[]` |
 | `dataset.category` | `string \| null` | `null` |
+| `dataset.time_coverage` | `{start_year: int, end_year: int} \| null` | `null` |
+
+`time_coverage` dichiara l'intervallo temporale del contenuto (non degli anni di
+run). Esposto dal `dataset_loader` (manifest) e dal layer tool per la
+catalogazione; usato dai candidate per serie storiche (es. `ga-sentenze`:
+2023-2026). Opzionale ma raccomandato per serie storiche.
 
 ## raw
 

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -284,6 +284,37 @@ class TestValidateConfig:
         assert result["ok"] is True
         assert any("source_id" in w for w in result["warnings"])
 
+    def test_warns_missing_tags_and_category(self, tmp_path: Path) -> None:
+        _write_dataset(
+            tmp_path,
+            {
+                "dataset": {"name": "test", "years": [2023], "source_id": "openga"},
+                "raw": {"sources": [{"name": "src1"}]},
+            },
+        )
+        result = validate_config(tmp_path)
+        assert result["ok"] is True
+        assert any("tags" in w for w in result["warnings"])
+        assert any("category" in w for w in result["warnings"])
+
+    def test_no_warn_when_tags_category_present(self, tmp_path: Path) -> None:
+        _write_dataset(
+            tmp_path,
+            {
+                "dataset": {
+                    "name": "test",
+                    "years": [2023],
+                    "source_id": "openga",
+                    "tags": ["giustizia"],
+                    "category": "giustizia",
+                },
+                "raw": {"sources": [{"name": "src1"}]},
+            },
+        )
+        result = validate_config(tmp_path)
+        assert result["ok"] is True
+        assert not any("tags" in w or "category" in w for w in result["warnings"])
+
     def test_invalid_yaml(self, tmp_path: Path) -> None:
         (tmp_path / "dataset.yml").write_text("invalid: [")
         result = validate_config(tmp_path)

--- a/toolkit/core/dataset_loader.py
+++ b/toolkit/core/dataset_loader.py
@@ -138,6 +138,15 @@ def validate_config(path: str | Path) -> dict[str, Any]:
     if sources and not manifest.get("source_id"):
         warnings.append("'dataset.source_id' non impostato (utile per catalogazione)")
 
+    if not manifest.get("tags"):
+        warnings.append(
+            "'dataset.tags' non impostato (standard candidate: lista kebab-case descrittiva)"
+        )
+    if not manifest.get("category"):
+        warnings.append(
+            "'dataset.category' non impostato (standard candidate: tema — vedi docs/candidate-standard.md)"
+        )
+
     return {
         "ok": len(errors) == 0,
         "errors": errors,


### PR DESCRIPTION
## Sintesi

`validate_config` segnala `dataset.tags` e `dataset.category` mancanti (accanto al warning `source_id` già esistente). Abilita il gate candidate strict di dataset-incubator: `validate_candidate_structure.py` promuove questi warning a failure per far rispettare lo standard candidate (docs/candidate-standard.md).

Documentato anche `dataset.time_coverage` in `config-schema.md` (campo già in uso nei candidate ma non documentato).

## Contesto collegato

Nessuna issue — emerso dal lavoro di standardizzazione candidate (dataset-incubator, 2026-07-31).

## Cosa cambia

- [ ] Bug fix
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [x] Documentazione

## Impatto su contratti pubblici

Nessuno: warning additivi (non bloccanti), campo documentato già supportato.

- [ ] Struttura `dataset.yml` (nuovo campo, cambio obbligatorietà)
- [ ] Path output (nuovo layer, cambio percorso artifact)
- [ ] Schema parquet (nuova colonna, rename, cambio tipo)
- [ ] CLI o MCP tool (nuovo comando, cambio parametro)
- [ ] API pubblica del toolkit (firma funzione, classe, eccezione)

> Se segnato, hai aggiornato downstream? [x] `dataset-incubator` (gate strict consuma questi warning) — [ ] `docs/`

## Verifica

```bash
python -m pytest tests/test_dataset_loader.py -q
# 40 passed
ruff check toolkit/core/dataset_loader.py
# All checks passed
```

- [x] `pytest -m core` passa
- [x] `ruff check .` passa
- [ ] `mypy toolkit/` passa (o motiva le eccezioni)
- [x] Modificato o aggiunto test con marker appropriato (`pure_unit` ereditato da `pytestmark` di modulo)

## Checklist PR

- [x] Perimetro stretto: una PR = un layer o un fix mirato
- [ ] Se nuovo plugin: test + docs inclusi
- [x] Issue collegata o motivazione dell'assenza
- [ ] **Se rimuovo un modulo/funzione pubblica**: n/a

## Note per chi revisiona

- I warning sono additivi e non bloccanti: `validate_config` resta `ok=True` con warning.
- Il consumer DI (`validate_candidate_structure.py`, branch `feat/candidate-standard`) promuove questi warning a failure via `strict=True` — PR separata in dataset-incubator.
- `time_coverage` è già esposto da `load_dataset_manifest` e usato dal layer tool: la PR documenta il comportamento esistente.
