### PR TITLE
fix(sparql): POST 403 → fallback GET (WAF/Virtuoso, caso Senato)

### DIFF
--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -86,6 +86,33 @@ def test_sparql_fetch_http_error():
             source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
 
 
+def test_sparql_fetch_post_403_falls_back_to_get():
+    """POST 403 (WAF/Virtuoso) deve cadere sul fallback GET.
+
+    Regressione: il plugin considerava ok il 403 (is_ok = response presente,
+    err None) e salvava il body HTML come CSV — il fallback GET non scattava.
+    Caso reale: dati.senato.it accetta solo GET (POST → 403).
+    """
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=403,
+            text="<!DOCTYPE html><html>Forbidden</html>",
+        )
+        mock_cls.return_value.get.return_value = _http_ok(
+            status=200,
+            text="name,value\nfoo,123\n",
+            headers={"Content-Type": "text/csv"},
+        )
+        source = SparqlSource()
+        payload, origin = source.fetch(
+            "https://dati.senato.it/sparql",
+            "SELECT ?name ?value WHERE { }",
+            accept_format="csv",
+        )
+        assert b"foo" in payload
+        assert mock_cls.return_value.get.called  # il fallback GET è scattato
+
+
 def test_sparql_fetch_network_error():
     """Network error raises DownloadError."""
     with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -77,9 +77,9 @@ class SparqlSource:
                 return self._parse_response(result.response, is_json)
 
         if post_status is not None and post_status >= 500:
+            body = (result.response.text or "")[:200] if result.response is not None else ""
             raise DownloadError(
-                f"SPARQL endpoint returned HTTP {post_status} for {endpoint}: "
-                f"{(result.response.text or '')[:200]}"
+                f"SPARQL endpoint returned HTTP {post_status} for {endpoint}: {body}"
             )
 
         raise DownloadError(

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -48,20 +48,39 @@ class SparqlSource:
             headers=headers,
             retries=2,
         )
-        if result.is_ok:
+        # is_ok è True anche su errori HTTP (response presente, err None) —
+        # ma una risposta 4xx/5xx NON è un risultato SPARQL valido.
+        # Fallback GET solo su 4xx (WAF/Virtuoso rifiutano POST): 403 è il
+        # caso tipico. Su 5xx il fallback non deve mascherare l'errore server.
+        post_status = (
+            result.response.status_code if result.is_ok and result.response is not None else None
+        )
+        if post_status is not None and post_status < 400:
             return self._parse_response(result.response, is_json)
 
-        # --- Tentativo 2: GET fallback ---
-        url = f"{endpoint}?query={urllib.parse.quote(q)}"
-        get_headers = {
-            "Accept": (
-                "application/sparql-results+xml,"
-                "application/sparql-results+json,application/json,text/csv"
-            ),
-        }
-        result = self._client.get(url, headers=get_headers)
-        if result.is_ok:
-            return self._parse_response(result.response, is_json)
+        # --- Tentativo 2: GET fallback (solo se POST è fallito con 4xx) ---
+        if post_status is not None and 400 <= post_status < 500:
+            url = f"{endpoint}?query={urllib.parse.quote(q)}"
+            get_headers = {
+                "Accept": (
+                    "application/sparql-results+xml,"
+                    "application/sparql-results+json,application/json,text/csv"
+                ),
+            }
+            result = self._client.get(url, headers=get_headers)
+            get_status = (
+                result.response.status_code
+                if result.is_ok and result.response is not None
+                else None
+            )
+            if get_status is not None and get_status < 400:
+                return self._parse_response(result.response, is_json)
+
+        if post_status is not None and post_status >= 500:
+            raise DownloadError(
+                f"SPARQL endpoint returned HTTP {post_status} for {endpoint}: "
+                f"{(result.response.text or '')[:200]}"
+            )
 
         raise DownloadError(
             f"SPARQL request failed for {endpoint}: POST → {result.err or 'unknown'}"


### PR DESCRIPTION
## Sintesi

Fix del plugin SPARQL: il fallback GET non scattava mai su endpoint che rifiutano il POST con 4xx. `is_ok` considerava "ok" qualsiasi risposta HTTP (response presente, err None) → un 403 con body HTML veniva salvato come CSV valido.

Scoperto lavorando su `senato-ddl` (issue dataset-incubator #781): **`dati.senato.it` accetta solo GET** (POST → 403), e il plugin falliva perché il 403 non attivava il fallback documentato ("Se POST fallisce (403, timeout), prova GET").

## Contesto collegato

- Rilevato in: dataset-incubator #781 (senato_ddl)
- Il docstring del plugin già prometteva il fallback su 403 — il codice non lo implementava

## Cosa cambia

- [x] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

- [ ] Struttura `dataset.yml` (nuovo campo, cambio obbligatorietà)
- [ ] Path output (nuovo layer, cambio percorso artifact)
- [ ] Schema parquet (nuova colonna, rename, cambio tipo)
- [ ] CLI o MCP tool (nuovo comando, cambio parametro)
- [ ] API pubblica del toolkit (firma funzione, classe, eccezione)

Nessun contratto pubblico toccato — comportamento interno del fetch.

## Dettaglio

**Prima** (bug):
```python
if result.is_ok:  # True anche su 403 (response presente) → salva HTML come CSV
    return self._parse_response(result.response, is_json)
```

**Dopo** (fix):
- POST ok **solo se status < 400**
- fallback GET **solo su 4xx** (400-499) — il caso WAF/Virtuoso che rifiutano POST
- **5xx** solleva `DownloadError` con codice HTTP esplicito (il fallback non deve mascherare un errore server reale)

## Verifica

```bash
pytest tests/test_sparql_plugin.py tests/test_contracts.py  # 34 passed
ruff check toolkit/plugins/sparql.py tests/test_sparql_plugin.py
```

Test nuovo: `test_sparql_fetch_post_403_falls_back_to_get` — regressione sul caso reale dati.senato.it (POST 403 → GET fallback → CSV valido). Verifica end-to-end: `toolkit run raw -c candidates/senato-ddl/dataset.yml` passa sul Senato reale.

## Note

- Il comportamento precedente su 5xx: `_parse_response` sollevava errore sul body non-SPARQL → ora errore esplicito con codice HTTP (stessa semantica, messaggio più chiaro)
- Il test esistente `test_sparql_fetch_http_error` (500 → DownloadError "HTTP 500") continua a passare
