### PR TITLE
fix(sparql): fallback GET anche su timeout/rete + errore GET 5xx

### DIFF
--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -113,6 +113,50 @@ def test_sparql_fetch_post_403_falls_back_to_get():
         assert mock_cls.return_value.get.called  # il fallback GET è scattato
 
 
+def test_sparql_fetch_get_fallback_5xx_raises():
+    """POST 403 → GET fallback 500 → DownloadError con status del GET.
+
+    Il fallback GET non deve mascherare un errore server del GET stesso.
+    """
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = _http_ok(
+            status=403,
+            text="<!DOCTYPE html><html>Forbidden</html>",
+        )
+        mock_cls.return_value.get.return_value = _http_ok(
+            status=500,
+            text="Internal Server Error",
+        )
+        source = SparqlSource()
+        with pytest.raises(DownloadError, match="GET fallback returned HTTP 500"):
+            source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
+    """POST con errore di rete/timeout (response None) deve cadere sul GET.
+
+    Estensione del fix 403: il docstring prometteva il fallback anche su
+    timeout — il POST con err (connection refused) produce post_status=None
+    e prima del fix andava dritto al raise senza provare il GET.
+    """
+    from lab_connectors.http import HttpResult
+
+    with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+        mock_cls.return_value.post.return_value = HttpResult(
+            response=None, err=TimeoutError("connection refused")
+        )
+        mock_cls.return_value.get.return_value = _http_ok(
+            status=200,
+            text="name,value\nfoo,123\n",
+            headers={"Content-Type": "text/csv"},
+        )
+        source = SparqlSource()
+        payload, origin = source.fetch(
+            "https://dati.senato.it/sparql",
+            "SELECT ?name ?value WHERE { }",
+            accept_format="csv",
+        )
+        assert b"foo" in payload
+        assert mock_cls.return_value.get.called  # il fallback GET è scattato
+
+
 def test_sparql_fetch_network_error():
     """Network error raises DownloadError."""
     with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -50,16 +50,18 @@ class SparqlSource:
         )
         # is_ok è True anche su errori HTTP (response presente, err None) —
         # ma una risposta 4xx/5xx NON è un risultato SPARQL valido.
-        # Fallback GET solo su 4xx (WAF/Virtuoso rifiutano POST): 403 è il
-        # caso tipico. Su 5xx il fallback non deve mascherare l'errore server.
+        # Fallback GET quando il POST non produce dati validi:
+        #   - 4xx (WAF/Virtuoso rifiutano POST, es. 403 Senato)
+        #   - errore di rete/timeout (post_status None)
+        # Su 5xx NON si fa fallback (errore server reale, non va mascherato).
         post_status = (
             result.response.status_code if result.is_ok and result.response is not None else None
         )
         if post_status is not None and post_status < 400:
             return self._parse_response(result.response, is_json)
 
-        # --- Tentativo 2: GET fallback (solo se POST è fallito con 4xx) ---
-        if post_status is not None and 400 <= post_status < 500:
+        # --- Tentativo 2: GET fallback (4xx o errore di rete/timeout) ---
+        if post_status is None or 400 <= post_status < 500:
             url = f"{endpoint}?query={urllib.parse.quote(q)}"
             get_headers = {
                 "Accept": (
@@ -75,6 +77,11 @@ class SparqlSource:
             )
             if get_status is not None and get_status < 400:
                 return self._parse_response(result.response, is_json)
+            if get_status is not None and get_status >= 500:
+                body = (result.response.text or "")[:200] if result.response is not None else ""
+                raise DownloadError(
+                    f"SPARQL GET fallback returned HTTP {get_status} for {endpoint}: {body}"
+                )
 
         if post_status is not None and post_status >= 500:
             body = (result.response.text or "")[:200] if result.response is not None else ""


### PR DESCRIPTION
## Sintesi

Completa il fix SPARQL del POST 403 (#447) con i casi che il docstring prometteva ma il codice non copriva: **timeout/errore di rete** e **GET fallback con 5xx**.

## Contesto collegato

- Estende il fix #447 (merged, v1.47.3)
- Rilevato lavorando su `senato-ddl` (dataset-incubator #781): il POST al Senato può fallire con errore di rete (non solo 403), e in quel caso il GET fallback non scattava

## Cosa cambia

- [x] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

Nessuno — comportamento interno del fetch.

## Dettaglio

**Prima** (gap del #447):
- POST con errore di rete/timeout (`post_status is None`) → `raise DownloadError("POST → unknown")` **senza provare il GET** — nonostante il docstring dicesse "Se POST fallisce (403, timeout), prova GET"
- GET fallback che restituisce 5xx → messaggio generico senza lo status

**Dopo**:
- fallback GET scatta anche quando il POST fallisce con errore di rete/timeout (`post_status is None`)
- GET fallback 5xx → `DownloadError("SPARQL GET fallback returned HTTP {status}")` esplicito
- POST 5xx → errore esplicito (già dal #447, invariato)

## Verifica

```bash
pytest tests/test_sparql_plugin.py  # 26 passed (4 casi: 403→GET, timeout→GET, GET 5xx→err, POST 5xx→err)
mypy toolkit/plugins/sparql.py      # no issues
ruff check .                        # ok
```

Verifica end-to-end sul Senato reale: `SparqlSource.fetch(dati.senato.it, ...)` → POST fallisce → GET fallback → dati CSV restituiti.

## Note

- Il test `test_sparql_fetch_post_timeout_falls_back_to_get` copre il caso timeout
- Il test `test_sparql_fetch_get_fallback_5xx_raises` copre il GET fallback con 500
- I test esistenti (#447) continuano a passare invariati
