### PR TITLE
feat(sdmx): profilo Eurostat (ESTAT) — TSV+unpivot, constraints JSON 2.0, codelist, scout

### DIFF
--- a/tests/test_fetch_sdmx_endpoint.py
+++ b/tests/test_fetch_sdmx_endpoint.py
@@ -1,0 +1,106 @@
+"""Test per _fetch_sdmx — gestione endpoint per agenzie non-ISTAT/ESTAT.
+
+Regressione review PR #450: lo scaffold emette `endpoint` per le agenzie
+non-ESTAT; il fetch deve usarla come base SDMX (root derivato da una URL
+con path dataflow/data), senza toccare i default ISTAT né il profilo ESTAT.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from toolkit.raw._fetch_utils import _fetch_sdmx, _sdmx_root_from_url
+
+pytestmark = pytest.mark.contract
+
+
+class _FakeSdmx:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.fetched: tuple = ()
+
+    def fetch(self, agency, flow, version, filters):
+        self.fetched = (agency, flow, version, filters)
+        return b"payload", "https://fake.test"
+
+
+@pytest.fixture
+def fake_registry(monkeypatch):
+    holder = {}
+    import toolkit.raw._fetch_utils as fu
+
+    def _create(name, **kwargs):
+        src = _FakeSdmx(**kwargs)
+        holder["source"] = src
+        return src
+
+    monkeypatch.setattr(fu.registry, "create", _create)
+    return holder
+
+
+def test_sdmx_root_from_url_dataflow():
+    assert (
+        _sdmx_root_from_url("https://esploradati.istat.it/SDMXWS/rest/dataflow/IT1/22_289")
+        == "https://esploradati.istat.it/SDMXWS/rest"
+    )
+
+
+def test_sdmx_root_from_url_data_path():
+    assert (
+        _sdmx_root_from_url(
+            "https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/NAMA_10R_3GDP?format=TSV"
+        )
+        == "https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1"
+    )
+
+
+def test_fetch_sdmx_endpoint_third_party(fake_registry):
+    """Agenzia terza con endpoint: root derivato usato per data e metadata."""
+    _fetch_sdmx(
+        "sdmx",
+        {},
+        {
+            "agency": "XX",
+            "flow": "FLOW1",
+            "endpoint": "https://sdmx.example.org/rest/dataflow/XX/FLOW1",
+        },
+    )
+    src = fake_registry["source"]
+    assert src.kwargs["data_base_url"] == "https://sdmx.example.org/rest"
+    assert src.kwargs["metadata_base_url"] == "https://sdmx.example.org/rest"
+    assert src.fetched[0] == "XX"
+    assert src.fetched[1] == "FLOW1"
+
+
+def test_fetch_sdmx_endpoint_ignored_for_istat(fake_registry):
+    """ISTAT: endpoint nel config non altera i default del plugin."""
+    _fetch_sdmx(
+        "sdmx",
+        {},
+        {
+            "agency": "IT1",
+            "flow": "22_289",
+            "version": "1.5",
+            "endpoint": "https://esploradati.istat.it/SDMXWS/rest/dataflow/IT1/22_289",
+        },
+    )
+    src = fake_registry["source"]
+    assert "data_base_url" not in src.kwargs
+    assert "metadata_base_url" not in src.kwargs
+    assert src.fetched == ("IT1", "22_289", "1.5", None)
+
+
+def test_fetch_sdmx_endpoint_ignored_for_estat(fake_registry):
+    """ESTAT: endpoint nel config non altera l'auto-risoluzione del profilo."""
+    _fetch_sdmx(
+        "sdmx",
+        {},
+        {
+            "agency": "ESTAT",
+            "flow": "NAMA_10R_3GDP",
+            "endpoint": "https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/NAMA_10R_3GDP",
+        },
+    )
+    src = fake_registry["source"]
+    assert "data_base_url" not in src.kwargs
+    assert src.fetched[0] == "ESTAT"

--- a/tests/test_profile_sniff.py
+++ b/tests/test_profile_sniff.py
@@ -47,13 +47,16 @@ def test_sniff_decimal_csv_dot_values():
 def test_sniff_decimal_csv_dot_no_false_positive():
     """La virgola-delim (anno,valore) non deve contare come decimale.
 
-    Regressione: "2008,88" (due colonne) veniva sniffata come decimale
-    con virgola perché i valori numerici hanno <=3 cifre.
+    Regressione vera: "2008,88" (anno + valore a <=3 cifre separati dal delim
+    CSV) veniva sniffata come decimale con virgola → decimal=',' su CSV col
+    punto → value VARCHAR → mart falliva con avg(VARCHAR).
     """
     sample = (
-        "freq,unit,geo,year,value,flag\nA,EUR_HAB,IT,2000,21900.0,\nA,EUR_HAB,IT,2001,37300.0,\n"
+        "freq,unit,iccs,geo,year,value,flag\n"
+        "A,NR,ICCS0101,AL,2008,88.0,\n"
+        "A,NR,ICCS0101,AL,2009,520.0,\n"
+        "A,NR,ICCS0101,AL,2010,7.0,\n"
     )
-    # valori 5 cifre: anche la logica legacy dava '.'; il fix mantiene '.'
     assert sniff_decimal(sample, delim=",") == "."
 
 

--- a/tests/test_profile_sniff.py
+++ b/tests/test_profile_sniff.py
@@ -28,6 +28,40 @@ def test_sniff_delim_tab():
 def test_sniff_decimal_it_comma():
     sample = "val\n1.234,56\n7.890,12\n"
     assert sniff_decimal(sample) == ","
+    # Con delim noto: coppie adiacenti "1.234" + "56" → virgola decimale
+    assert sniff_decimal(sample, delim=",") == ","
+
+
+@pytest.mark.policy
+def test_sniff_decimal_csv_dot_values():
+    """CSV con delim ',' e valori numerici col punto → '.' (non ',')."""
+    sample = (
+        "freq,unit,iccs,geo,year,value,flag\n"
+        "A,NR,ICCS0101,AL,2008,88.0,\n"
+        "A,NR,ICCS0101,AL,2009,82.0,\n"
+    )
+    assert sniff_decimal(sample, delim=",") == "."
+
+
+@pytest.mark.policy
+def test_sniff_decimal_csv_dot_no_false_positive():
+    """La virgola-delim (anno,valore) non deve contare come decimale.
+
+    Regressione: "2008,88" (due colonne) veniva sniffata come decimale
+    con virgola perché i valori numerici hanno <=3 cifre.
+    """
+    sample = (
+        "freq,unit,geo,year,value,flag\nA,EUR_HAB,IT,2000,21900.0,\nA,EUR_HAB,IT,2001,37300.0,\n"
+    )
+    # valori 5 cifre: anche la logica legacy dava '.'; il fix mantiene '.'
+    assert sniff_decimal(sample, delim=",") == "."
+
+
+@pytest.mark.policy
+def test_sniff_decimal_legacy_backcompat():
+    """Senza delim mantiene il comportamento storico."""
+    assert sniff_decimal("a\n1,5\n2,7\n") == ","
+    assert sniff_decimal("a\n1.5\n2.7\n") == "."
 
 
 @pytest.mark.policy

--- a/tests/test_scaffold_sources.py
+++ b/tests/test_scaffold_sources.py
@@ -1,0 +1,61 @@
+"""Tests per toolkit/scaffold/sources.py — block_sdmx (raw.sources SDMX).
+
+Regressione: il blocco scaffoldato deve esprimere l'endpoint per le agenzie
+non-ESTAT (parità col comportamento storico) e NON emetterlo per ESTAT
+(profilo dedicato che auto-risolve l'endpoint Eurostat).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from toolkit.scaffold.sources import block_sdmx
+
+pytestmark = pytest.mark.pure_unit
+
+
+def _sdmx_info(flow_id: str, agency: str | None = None) -> dict:
+    info = {"flow_id": flow_id, "year_min": 2000, "year_max": 2024}
+    if agency is not None:
+        info["agency"] = agency
+    return info
+
+
+def _has(lines: list[str], needle: str) -> bool:
+    return any(needle in ln for ln in lines)
+
+
+def test_block_sdmx_estat_no_endpoint():
+    """ESTAT: solo flow + agency — l'endpoint è auto-risolto dal profilo."""
+    lines = block_sdmx(
+        _sdmx_info("NAMA_10R_3GDP", agency="ESTAT"),
+        "https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1/data/NAMA_10R_3GDP",
+    )
+    assert _has(lines, 'type: "sdmx"')
+    assert _has(lines, 'flow: "NAMA_10R_3GDP"')
+    assert _has(lines, 'agency: "ESTAT"')
+    assert not _has(lines, "endpoint:")
+
+
+def test_block_sdmx_non_estat_keeps_endpoint():
+    """Agenzie non-ESTAT (es. ISTAT): endpoint dell'URL scoperta dallo scout."""
+    url = "https://esploradati.istat.it/SDMXWS/rest/dataflow/IT1/22_289"
+    lines = block_sdmx(_sdmx_info("22_289", agency="IT1"), url)
+    assert _has(lines, 'flow: "22_289"')
+    assert _has(lines, f'endpoint: "{url}"')
+    assert not _has(lines, "agency:")
+
+
+def test_block_sdmx_no_agency_keeps_endpoint():
+    """Agency non inferita: endpoint comunque presente (comportamento storico)."""
+    url = "https://sdmx.example.org/rest/dataflow/XX/FLOW1"
+    lines = block_sdmx(_sdmx_info("FLOW1"), url)
+    assert _has(lines, f'endpoint: "{url}"')
+
+
+def test_block_sdmx_falls_back_to_http_file():
+    """Senza flow_id: fallback a http_file (comportamento storico)."""
+    url = "https://example.org/some.csv"
+    lines = block_sdmx(None, url)
+    assert _has(lines, 'type: "http_file"')
+    assert _has(lines, f'url: "{url}"')

--- a/tests/test_sdmx_plugin.py
+++ b/tests/test_sdmx_plugin.py
@@ -557,3 +557,190 @@ def test_sdmx_cache_is_per_instance(monkeypatch):
         "https://two.test/rest/data/IT1,22_289,1.5/A.001001.JAN.9.TOTAL.99",
     ]
     assert calls == expected_calls, f"Cache contamination! calls={calls}"
+
+
+# ── Profilo Eurostat (ESTAT) ─────────────────────────────────────────────────
+
+# SDMX-JSON 2.0 di Eurostat: `dimension.{id}.category.{index,label}`, flat.
+ESTAT_CONSTRAINTS_JSON = """
+{
+  "id": ["freq", "unit", "geo", "time"],
+  "size": [1, 7, 1814, 25],
+  "dimension": {
+    "freq": {"label": "Time frequency",
+             "category": {"index": {"A": 0}, "label": {"A": "Annual"}}},
+    "unit": {"label": "Unit of measure",
+             "category": {"index": {"EUR_HAB": 0, "MIO_EUR": 1},
+                          "label": {"EUR_HAB": "Euro per inhabitant", "MIO_EUR": "Million euro"}}},
+    "geo": {"label": "Geopolitical entity (reporting)",
+            "category": {"index": {"EU27_2020": 0, "IT": 1, "ITC4": 2},
+                         "label": {"EU27_2020": "EU (27 countries)", "IT": "Italy", "ITC4": "Nord-Ovest"}}},
+    "time": {"label": "Time",
+             "category": {"index": {"2000": 0, "2001": 1},
+                          "label": {"2000": "2000", "2001": "2001"}}}
+  },
+  "value": {}
+}
+"""
+
+# TSV wide Eurostat: header `dims\TIME_PERIOD`, righe serie, `:` = missing,
+# flag di qualità come lettera finale dopo spazio (es. `1200 d`).
+ESTAT_TSV = (
+    "freq,unit,geo\\TIME_PERIOD\t2000 \t2001 \n"
+    "A,EUR_HAB,IT\t21900 \t23000 \n"
+    "A,MIO_EUR,IT\t: \t1200 d \n"
+)
+
+ESTAT_TSV_MONTHLY = "freq,unit,geo\\TIME_PERIOD\t2024-01\t2024-02\nA,EUR_HAB,IT\t10 \t20 \n"
+
+
+def _estat_fake_get(allowed_urls=None, calls=None):
+    """Factory per mock HttpClient.get che serve constraints JSON 2.0 + TSV."""
+    allowed_urls = allowed_urls or set()
+
+    def _fake_get(self, url, **kwargs):
+        if calls is not None:
+            calls.append(url)
+        params = kwargs.get("params") or {}
+        if url.endswith("/data/NAMA_10R_3GDP/all") and params.get("format") == "JSON":
+            return _ok(_FakeResponse(200, ESTAT_CONSTRAINTS_JSON, url))
+        if url.endswith("/data/NAMA_10R_3GDP/all") and params.get("format") == "TSV":
+            return _ok(_FakeResponse(200, ESTAT_TSV, url))
+        if url.endswith("/data/NAMA_10R_3GDP/A.EUR_HAB") and params.get("format") == "TSV":
+            return _ok(_FakeResponse(200, ESTAT_TSV, url))
+        if url.endswith("/data/NAMA_10R_3GDP/A.EUR_HAB.IT") and params.get("format") == "TSV":
+            return _ok(_FakeResponse(200, ESTAT_TSV, url))
+        if not allowed_urls:
+            raise AssertionError(f"Unexpected URL {url} params={params}")
+        if any(url.endswith(u) for u in allowed_urls):
+            return _ok(_FakeResponse(200, ESTAT_TSV, url))
+        raise AssertionError(f"Unexpected URL {url} params={params}")
+
+    return _fake_get
+
+
+def test_sdmx_estat_fetch_tsv_normalizes(monkeypatch):
+    """ESTAT: TSV wide → CSV long [dims, year, value, flag]; niente version check."""
+    calls = []
+    monkeypatch.setattr(HttpClient, "get", _estat_fake_get(calls=calls))
+
+    # version vuota: il profilo ESTAT NON deve chiamare dataflow né fallire
+    payload, origin = SdmxSource(retries=1).fetch("ESTAT", "NAMA_10R_3GDP", "")
+
+    text = payload.decode("utf-8")
+    assert origin.endswith("/data/NAMA_10R_3GDP/all?format=TSV") or origin.endswith(
+        "/data/NAMA_10R_3GDP/all"
+    )
+    assert "freq,unit,geo,year,value,flag" in text
+    assert "A,EUR_HAB,IT,2000,21900.0," in text
+    assert "A,EUR_HAB,IT,2001,23000.0," in text
+    # missing → value vuota; flag preservato
+    assert "A,MIO_EUR,IT,2000,," in text
+    assert "A,MIO_EUR,IT,2001,1200.0,d" in text
+    # Nessuna chiamata a dataflow (niente version check per ESTAT)
+    assert not any("/dataflow/" in c for c in calls)
+
+
+def test_sdmx_estat_filters_build_key(monkeypatch):
+    """ESTAT: filtri → key parziale nel path dati (ordine dims dal JSON 2.0)."""
+    calls = []
+    monkeypatch.setattr(HttpClient, "get", _estat_fake_get(calls=calls))
+
+    payload, origin = SdmxSource(retries=1).fetch(
+        "ESTAT", "NAMA_10R_3GDP", "", {"freq": "A", "unit": "EUR_HAB"}
+    )
+
+    assert "A,EUR_HAB,IT,2000,21900.0," in payload.decode("utf-8")
+    assert any(c.endswith("/data/NAMA_10R_3GDP/A.EUR_HAB") for c in calls)
+
+
+def test_sdmx_estat_rejects_invalid_filter_value(monkeypatch):
+    """ESTAT: filtro con valore non valido → errore esplicito (constraints 2.0)."""
+    monkeypatch.setattr(HttpClient, "get", _estat_fake_get())
+
+    with pytest.raises(DownloadError, match=r"Invalid value\(s\) for SDMX dimension freq"):
+        SdmxSource(retries=1).fetch("ESTAT", "NAMA_10R_3GDP", "", {"freq": "X"})
+
+
+def test_sdmx_estat_rejects_unknown_filter_dimension(monkeypatch):
+    """ESTAT: dimensione sconosciuta (non nel JSON 2.0) → errore esplicito."""
+    monkeypatch.setattr(HttpClient, "get", _estat_fake_get())
+
+    with pytest.raises(DownloadError, match=r"Unknown SDMX filter dimensions"):
+        SdmxSource(retries=1).fetch("ESTAT", "NAMA_10R_3GDP", "", {"NOT_A_DIM": "X"})
+
+
+def test_sdmx_estat_tsv_monthly(monkeypatch):
+    """ESTAT: TSV mensile (YYYY-MM) → colonne year + month."""
+
+    def _fake_get(self, url, **kwargs):
+        params = kwargs.get("params") or {}
+        if url.endswith("/data/NAMA_10R_3GDP/all") and params.get("format") == "JSON":
+            return _ok(_FakeResponse(200, ESTAT_CONSTRAINTS_JSON, url))
+        if url.endswith("/data/NAMA_10R_3GDP/all") and params.get("format") == "TSV":
+            return _ok(_FakeResponse(200, ESTAT_TSV_MONTHLY, url))
+        raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
+
+    payload, _origin = SdmxSource(retries=1).fetch("ESTAT", "NAMA_10R_3GDP", "")
+
+    text = payload.decode("utf-8")
+    assert "freq,unit,geo,year,month,value,flag" in text
+    assert "A,EUR_HAB,IT,2024,1,10.0," in text
+    assert "A,EUR_HAB,IT,2024,2,20.0," in text
+
+
+ESTAT_CODELIST_JSON = """
+{
+  "version": "1.0",
+  "class": "codelist",
+  "label": "Geopolitical entity (reporting)",
+  "category": {
+    "index": {"IT": 0, "ITC4": 1},
+    "label": {"IT": "Italy", "ITC4": "Nord-Ovest"}
+  },
+  "extension": {
+    "lang": "EN",
+    "id": "GEO",
+    "version": "1.0",
+    "code-annotation": {
+      "IT": [
+        {"type": "IS_STANDARD_CODE", "title": "Y"},
+        {"type": "LEVEL", "title": "0"}
+      ],
+      "ITC4": [
+        {"type": "IS_STANDARD_CODE", "title": "Y"},
+        {"type": "LEVEL", "title": "2"}
+      ]
+    }
+  }
+}
+"""
+
+
+def test_sdmx_estat_fetch_codelist(monkeypatch):
+    """ESTAT: codelist SDMX-JSON 2.0 → {codes, annotations (LEVEL per NUTS)}."""
+
+    def _fake_get(self, url, **kwargs):
+        params = kwargs.get("params") or {}
+        if url.endswith("/codelist/ESTAT/GEO") and params.get("format") == "json":
+            return _ok(_FakeResponse(200, ESTAT_CODELIST_JSON, url))
+        raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr(HttpClient, "get", _fake_get)
+
+    result = SdmxSource(retries=1).fetch_codelist("GEO")
+
+    assert result["id"] == "GEO"
+    assert result["codes"]["IT"] == "Italy"
+    assert result["codes"]["ITC4"] == "Nord-Ovest"
+    assert result["annotations"]["IT"]["LEVEL"] == "0"
+    assert result["annotations"]["ITC4"]["LEVEL"] == "2"
+    assert result["annotations"]["IT"]["IS_STANDARD_CODE"] == "Y"
+
+
+def test_sdmx_fetch_codelist_requires_estat():
+    """fetch_codelist: solo profilo ESTAT (ISTAT non espone JSON 2.0)."""
+    with pytest.raises(DownloadError, match="solo per il profilo Eurostat"):
+        SdmxSource().fetch_codelist("GEO", agency="IT1")

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import re
 import xml.etree.ElementTree as ET
 from typing import Iterable
 
@@ -16,6 +17,26 @@ SDMX_NS = {
     "mes": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message",
     "str": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure",
 }
+
+# ── Eurostat (ESTAT) — profilo agenzia dedicato ───────────────────────────────
+# L'API Eurostat non segue la convenzione SDMX-REST canonica di ISTAT:
+#   - dati: `data/{flow}/{key}?format=TSV` (nessuna versione nel path;
+#     la versione è un numero mobile che cambia a ogni release);
+#   - formato nativo: TSV wide (anni come colonne, flag in coda ai valori) —
+#     Eurostat risponde 406 su `text/csv` e serve SDMX-JSON **2.0** (flat
+#     `dimension.{id}.category.{index,label}`), non il 2.1 di ISTAT;
+#   - le label delle dimensioni NON sono nel TSV: vanno risolte a valle
+#     (clean.sql via codelists), a differenza del profilo ISTAT che le porta
+#     nel payload JSON.
+EUROSTAT_BASE = "https://ec.europa.eu/eurostat/api/dissemination/sdmx/2.1"
+EUROSTAT_AGENCY = "ESTAT"
+EUROSTAT_TIME_DIM = "time"  # dimensione TIME nel JSON 2.0 di Eurostat
+
+# Valore mancante e flag di qualità nel TSV Eurostat (SDMX-TSV): il flag è una
+# lettera finale dopo spazio/virgole (es. `37300 d`, `: ` per missing).
+TSV_MISSING = ":"
+TSV_FLAG_RE = re.compile(r"\s+([a-z])$")
+TSV_MONTHLY_RE = re.compile(r"^\d{4}-\d{2}$")
 
 
 def _safe_text(value: str | None) -> str:
@@ -32,6 +53,88 @@ def _flow_ref(agency: str, flow: str, version: str) -> str:
 
 ISTAT_SDMX_BASE = "https://sdmx.istat.it/SDMXWS/rest"
 ISTAT_ESPLORADATI_BASE = "https://esploradati.istat.it/SDMXWS/rest"
+
+
+def _parse_tsv_value(raw: str) -> tuple[float | None, str | None]:
+    """Parse a Eurostat TSV value cell: number + optional quality flag."""
+    s = raw.strip()
+    if not s or s == TSV_MISSING:
+        return None, None
+    m = TSV_FLAG_RE.search(s)
+    flag = m.group(1) if m else None
+    num = s[: m.start()].strip() if m else s
+    try:
+        return float(num), flag
+    except ValueError:
+        return None, flag
+
+
+def _detect_tsv_dims(raw_header: str) -> list[str]:
+    """Detect dimension names from the first column of the TSV header.
+
+    Header format: ``dim1,dim2,...,dimN\\TIME_PERIOD\\t2020\\t2021...``
+    """
+    first_col = raw_header.strip().split("\t")[0]
+    backslash_pos = first_col.find("\\")
+    dims_raw = first_col[:backslash_pos] if backslash_pos > 0 else first_col
+    return [d.strip() for d in dims_raw.split(",") if d.strip()]
+
+
+def _tsv_to_csv(text: str) -> tuple[list[str], list[dict[str, object]]]:
+    """Unpivot a Eurostat SDMX-TSV payload into long CSV rows.
+
+    Produces ``[dim1..dimN, year, (month), value, flag]`` — lo stesso contratto
+    di ``connectors/tsv_normalize.py`` del repo eurostat. Il TSV è wide: ogni
+    riga è una serie, le colonne successive alla prima sono i periodi.
+    """
+    lines = text.splitlines()
+    if not lines:
+        raise DownloadError("Empty Eurostat TSV payload")
+
+    raw_header = lines[0]
+    dims = _detect_tsv_dims(raw_header)
+
+    parts = raw_header.strip().split("\t")
+    year_cols = [y.strip() for y in parts[1:] if y.strip()]
+    is_monthly = bool(year_cols and TSV_MONTHLY_RE.match(year_cols[0]))
+
+    fieldnames = list(dims) + (
+        ["year", "month", "value", "flag"] if is_monthly else ["year", "value", "flag"]
+    )
+
+    rows: list[dict[str, object]] = []
+    for line in lines[1:]:
+        line = line.strip()
+        if not line:
+            continue
+        cols = line.split("\t")
+        if not cols:
+            continue
+
+        dim_values = [v.strip() for v in cols[0].split(",")]
+        base_row: dict[str, object] = {}
+        for i, d in enumerate(dims):
+            base_row[d] = dim_values[i] if i < len(dim_values) else ""
+
+        for i, period in enumerate(year_cols):
+            if i + 1 >= len(cols):
+                continue
+            value, flag = _parse_tsv_value(cols[i + 1])
+            row = dict(base_row)
+            if is_monthly:
+                ym = period.split("-")
+                row["year"] = ym[0]
+                row["month"] = str(int(ym[1])) if len(ym) > 1 else "1"
+            else:
+                row["year"] = period
+            row["value"] = "" if value is None else value
+            row["flag"] = flag or ""
+            rows.append(row)
+
+    if not rows:
+        raise DownloadError("Eurostat TSV returned no rows")
+
+    return fieldnames, rows
 
 
 class SdmxSource:
@@ -56,6 +159,10 @@ class SdmxSource:
         self.user_agent = user_agent or "dataciviclab-toolkit/0.1"
         self.data_base_url = _normalize_base_url(data_base_url or ISTAT_ESPLORADATI_BASE)
         self.metadata_base_url = _normalize_base_url(metadata_base_url or ISTAT_SDMX_BASE)
+        # Distinguiamo "default ISTAT" da "URL passato dall'utente": il profilo
+        # ESTAT usa automaticamente l'endpoint Eurostat se non esplicitato.
+        self._data_base_url_given = data_base_url is not None
+        self._metadata_base_url_given = metadata_base_url is not None
         self._client = HttpClient(
             timeout=timeout,
             max_retries=retries,
@@ -76,14 +183,108 @@ class SdmxSource:
         return urls
 
     def _metadata_base_urls(self, agency: str) -> list[str]:
+        if self._is_estat(agency) and not self._metadata_base_url_given:
+            return [_normalize_base_url(EUROSTAT_BASE)]
         return self._candidate_base_urls(agency, self.metadata_base_url, ISTAT_ESPLORADATI_BASE)
 
     def _data_base_urls(self, agency: str) -> list[str]:
+        if self._is_estat(agency) and not self._data_base_url_given:
+            return [_normalize_base_url(EUROSTAT_BASE)]
         return self._candidate_base_urls(agency, self.data_base_url, ISTAT_SDMX_BASE)
 
     def _is_retryable_fallback_error(self, exc: DownloadError) -> bool:
         text = str(exc).lower()
         return "endpoint timeout" in text or "endpoint error (http 5" in text
+
+    # ── Profilo Eurostat (ESTAT) ───────────────────────────────────────────
+
+    @staticmethod
+    def _is_estat(agency: str) -> bool:
+        """True se la fonte è l'agenzia Eurostat (convenzioni API dedicate).
+
+        Eurostat serve SDMX-JSON 2.0 (non 2.1), rifiuta `text/csv` (406) e non
+        accetta la versione nel path dati. Il profilo ESTAT dirama fetch e
+        constraints su logica dedicata; ogni altra agenzia mantiene il
+        comportamento esistente (convenzione ISTAT).
+        """
+        return _safe_text(agency).upper() == EUROSTAT_AGENCY
+
+    def _estat_constraints(self, flow: str) -> dict[str, list[str]]:
+        """Valid codes per dimension da SDMX-JSON 2.0 di Eurostat.
+
+        La struttura è piatta: ``dimension.{id}.category.{index,label}`` con
+        l'ordine serializzato della mappa = ordine SDMX delle dimensioni.
+        TIME viene esclusa (nel TSV è l'header delle colonne, non una serie).
+        """
+        cache_key = f"{EUROSTAT_AGENCY}/{flow}"
+        if cache_key in self._constraints_cache:
+            return self._constraints_cache[cache_key]
+        payload, _origin = self._get_json(
+            self._data_base_urls(EUROSTAT_AGENCY),
+            f"data/{flow}/all",
+            params={"format": "JSON", "lastNObservations": "0"},
+        )
+        dimension = payload.get("dimension") or {}
+        result: dict[str, list[str]] = {}
+        for dim_id in dimension:
+            if dim_id == EUROSTAT_TIME_DIM:
+                continue
+            category = (dimension.get(dim_id) or {}).get("category") or {}
+            result[dim_id] = [str(c) for c in (category.get("index") or {})]
+        if not result:
+            raise DownloadError(f"SDMX-Eurostat returned no dimensions for flow={flow}")
+        self._constraints_cache[cache_key] = result
+        return result
+
+    def _estat_fetch_tsv(self, flow: str, key: str) -> tuple[bytes, str]:
+        """Fetch dati Eurostat in formato TSV (wide) e normalizza in CSV long."""
+        path = f"data/{flow}/{key}" if key and key != "all" else f"data/{flow}/all"
+        tsv_text, origin = self._get_text_from_candidates(
+            self._data_base_urls(EUROSTAT_AGENCY),
+            path,
+            accept="text/tab-separated-values",
+            params={"format": "TSV"},
+        )
+        header, rows = _tsv_to_csv(tsv_text)
+        return self._rows_to_csv(header, rows), origin
+
+    def fetch_codelist(self, codelist_id: str, agency: str = EUROSTAT_AGENCY) -> dict[str, object]:
+        """Fetch una codelist SDMX (SDMX-JSON 2.0) e la normalizza.
+
+        Supportato per il profilo Eurostat (ESTAT): restituisce
+        ``{id, codes: {code: label}, annotations: {code: {type: value}},
+        origin}``. Le annotazioni includono ``LEVEL`` (gerarchia NUTS per GEO:
+        0=country, 1/2/3=NUTS1/2/3) e ``IS_STANDARD_CODE``.
+
+        Il repo eurostat la usa per rigenerare ``codelists/*.csv`` al posto di
+        ``scripts/update_codelists.py``; il formato canonico delle colonne
+        resta scelta del chiamante.
+        """
+        if not self._is_estat(agency):
+            raise DownloadError("fetch_codelist è supportato solo per il profilo Eurostat (ESTAT)")
+        payload, origin = self._get_json(
+            self._data_base_urls(agency),
+            f"codelist/{agency}/{codelist_id}",
+            params={"format": "json"},
+        )
+        category = payload.get("category") or {}
+        labels = category.get("label") or {}
+        annotations_raw = (payload.get("extension") or {}).get("code-annotation") or {}
+        annotations: dict[str, dict[str, str]] = {}
+        for code, ann_list in annotations_raw.items():
+            merged: dict[str, str] = {}
+            for ann in ann_list or []:
+                ann_type = str(ann.get("type") or "")
+                if ann_type:
+                    merged[ann_type] = str(ann.get("title") or ann.get("text") or "")
+            if merged:
+                annotations[str(code)] = merged
+        return {
+            "id": codelist_id,
+            "codes": {str(k): str(v) for k, v in labels.items()},
+            "annotations": annotations,
+            "origin": origin,
+        }
 
     def _get_text_from_candidates(
         self,
@@ -196,6 +397,8 @@ class SdmxSource:
         Falls back to empty constraints (all wildcard) when the SDMX endpoint
         does not support JSON for this dataflow.
         """
+        if self._is_estat(agency):
+            return self._estat_constraints(flow)
         cache_key = f"{agency}/{flow}/{version}"
         if cache_key in self._constraints_cache:
             return self._constraints_cache[cache_key]
@@ -333,6 +536,11 @@ class SdmxSource:
 
         if not flow:
             raise DownloadError("SDMX source requires flow")
+
+        # Profilo Eurostat: versione non richiesta (numero mobile, mai nel path)
+        if self._is_estat(agency):
+            return self._fetch_estat(flow, version, filters)
+
         if not version:
             raise DownloadError("SDMX source requires version")
 
@@ -388,3 +596,37 @@ class SdmxSource:
         if not rows:
             raise DownloadError(f"SDMX data returned no rows for {agency}/{flow} and key={key}")
         return self._rows_to_csv(header, rows), origin
+
+    def _fetch_estat(
+        self,
+        flow: str,
+        version: str,
+        filters: dict | None = None,
+    ) -> tuple[bytes, str]:
+        """Fetch Eurostat data via TSV (SDMX-JSON 2.0 non è parsabile dal path
+        ISTAT e `text/csv` risponde 406). La versione è ignorata: Eurostat la
+        serve come numero mobile fuori dal path dati.
+
+        Output: CSV ``[dim1..dimN, year, (month), value, flag]`` — stesso
+        contratto di ``connectors/tsv_normalize.py`` del repo eurostat (le
+        label di dimensione vanno risolte a valle con le codelist).
+        """
+        constraints = self._estat_constraints(flow)
+        key = self._build_key(list(constraints.keys()), filters)
+        for dim, allowed in constraints.items():
+            if not allowed:
+                continue
+            val = filters.get(dim) if filters else None
+            if val is None:
+                continue
+            if isinstance(val, (list, tuple)):
+                invalid = [v for v in val if str(v) not in allowed]
+            else:
+                invalid = [val] if str(val) not in allowed else []
+            if invalid:
+                ellipsis = " ..." if len(allowed) > 10 else ""
+                raise DownloadError(
+                    f"Invalid value(s) for SDMX dimension {dim}: {invalid} — "
+                    f"allowed: {allowed[:10]}{ellipsis}"
+                )
+        return self._estat_fetch_tsv(flow, key)

--- a/toolkit/profile/_sniff_delimiter.py
+++ b/toolkit/profile/_sniff_delimiter.py
@@ -25,10 +25,40 @@ def sniff_delim(sample_text: str) -> Optional[str]:
     return sorted(scores.items(), key=lambda kv: (kv[1][0], kv[1][1], kv[1][2]), reverse=True)[0][0]
 
 
-def sniff_decimal(sample_text: str) -> Optional[str]:
+def sniff_decimal(sample_text: str, delim: Optional[str] = None) -> Optional[str]:
+    if delim is None:
+        # Legacy (senza delim): conteggio regex su tutto il chunk.
+        chunk = sample_text[:200_000]
+        comma_dec = len(re.findall(r"\d+,\d{1,3}\b", chunk))
+        dot_dec = len(re.findall(r"\d+\.\d{1,3}\b", chunk))
+        if comma_dec == 0 and dot_dec == 0:
+            return None
+        return "," if comma_dec >= dot_dec else "."
+
+    # Field-aware: ragiona sui campi separati dal delim del CSV. La virgola che
+    # separa due colonne (es. "2008,88") NON è un separatore decimale — senza
+    # delim produce falsi positivi quando i valori numerici hanno <=3 cifre.
     chunk = sample_text[:200_000]
-    comma_dec = len(re.findall(r"\d+,\d{1,3}\b", chunk))
-    dot_dec = len(re.findall(r"\d+\.\d{1,3}\b", chunk))
+    comma_dec = 0
+    dot_dec = 0
+    for line in chunk.splitlines():
+        fields = [f.strip().strip('"') for f in line.split(delim)]
+        for field in fields:
+            if re.fullmatch(r"\d+,\d{1,2}", field):
+                # "88,5" — virgola decimale semplice (es. delim ';')
+                comma_dec += 1
+            elif re.fullmatch(r"\d+\.\d{1,3}", field):
+                # "88.5" / "21900.0" — punto decimale semplice
+                dot_dec += 1
+            elif re.fullmatch(r"\d+\.\d{3},\d{1,2}", field):
+                # "1.234,56" — numero italiano completo (delim ';': la virgola
+                # decimale resta interna al campo)
+                comma_dec += 1
+        # Coppie adiacenti in formato italiano "1.234" + "56" (mille-separatore
+        # col punto + decimali con virgola) quando il delim è la virgola.
+        for i in range(len(fields) - 1):
+            if re.fullmatch(r"\d+\.\d{3}", fields[i]) and re.fullmatch(r"\d{1,2}", fields[i + 1]):
+                comma_dec += 1
     if comma_dec == 0 and dot_dec == 0:
         return None
     return "," if comma_dec >= dot_dec else "."

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -82,7 +82,9 @@ def sniff_source_file(filepath: Path) -> Dict[str, Any]:
 
     enc, txt = sniff_encoding(filepath)
     delim = sniff_delim(txt)
-    dec = sniff_decimal(txt)
+    # Il delim è noto: sniff_decimal field-aware evita falsi positivi tipo
+    # "2008,88" (anno + valore separati dal delim CSV) come decimale con virgola.
+    dec = sniff_decimal(txt, delim)
     skip = suggest_skip(txt, delim)
     warnings: list[str] = []
 

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -46,6 +46,21 @@ def _format_args(args: dict, year: int) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _sdmx_root_from_url(url: str) -> str:
+    """Deriva il root SDMX da una URL scoperta dallo scout.
+
+    Lo scout espone l'URL col path risorsa (es. ``.../sdmx/2.1/dataflow/IT1/22_289``
+    o ``.../data/NAMA_10R_3GDP``): il plugin SdmxSource costruisce i path
+    partendo dal root (``data/...``, ``dataflow/...``), quindi stripamo il
+    segmento di risorsa.
+    """
+    base = url.split("?")[0].rstrip("/")
+    for marker in ("/dataflow/", "/data/"):
+        if marker in base:
+            return base[: base.index(marker)]
+    return base
+
+
 def _infer_ext(stype: str, formatted_args: dict, origin: str | None = None) -> str:
     if stype in {"sdmx", "sparql"}:
         return ".csv"
@@ -130,9 +145,20 @@ def _fetch_ckan(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, 
 
 @_register_fetch("sdmx")
 def _fetch_sdmx(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, str]:
-    src = registry.create(stype, **(client or {}))
+    agency = str(formatted_args.get("agency") or "IT1")
+    src_client = dict(client or {})
+    # Endpoint esplicito per agenzie non-ISTAT/ESTAT: lo scout scopre l'URL
+    # (spesso col path dataflow/data) → deriviamo il root SDMX e lo usiamo
+    # come base per data e metadata. ISTAT resta sui default (esploradati +
+    # sdmx.istat.it), ESTAT è auto-risolto dal profilo.
+    endpoint = formatted_args.get("endpoint")
+    if endpoint and agency != "IT1" and agency.upper() != "ESTAT":
+        root = _sdmx_root_from_url(str(endpoint))
+        src_client.setdefault("data_base_url", root)
+        src_client.setdefault("metadata_base_url", root)
+    src = registry.create(stype, **src_client)
     return src.fetch(
-        str(formatted_args.get("agency") or "IT1"),
+        agency,
         str(formatted_args["flow"]),
         # La versione è opzionale: il profilo Eurostat (ESTAT) la ignora
         # (numero mobile, mai nel path dati); ISTAT la richiede (errore a valle).

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -134,7 +134,9 @@ def _fetch_sdmx(stype: str, client: dict, formatted_args: dict) -> tuple[bytes, 
     return src.fetch(
         str(formatted_args.get("agency") or "IT1"),
         str(formatted_args["flow"]),
-        str(formatted_args["version"]),
+        # La versione è opzionale: il profilo Eurostat (ESTAT) la ignora
+        # (numero mobile, mai nel path dati); ISTAT la richiede (errore a valle).
+        str(formatted_args.get("version") or ""),
         formatted_args.get("filters"),
     )
 

--- a/toolkit/scaffold/sources.py
+++ b/toolkit/scaffold/sources.py
@@ -125,9 +125,11 @@ def block_links(links: list[str]) -> list[str]:
 def block_sdmx(sdmx_info: dict[str, Any] | None, url: str) -> list[str]:
     """Blocchi raw.sources per endpoint SDMX.
 
-    Per i dataflow Eurostat (agency ESTAT, es. ``/data/NAMA_10R_3GDP``)
-    genera ``agency: ESTAT``: il profilo dedicato nel plugin risolve
-    automaticamente l'endpoint Eurostat e ignora la versione (numero mobile).
+    - ESTAT (Eurostat): ``flow`` + ``agency: ESTAT`` — il profilo dedicato del
+      plugin risolve automaticamente l'endpoint Eurostat e ignora la versione
+      (numero mobile). Nessun ``endpoint`` nel config.
+    - Altre agenzie: ``flow`` + ``endpoint`` (URL scoperta dallo scout): il
+      fetch ``sdmx`` la usa come base (root SDMX derivato) per data e metadata.
     """
     if sdmx_info and sdmx_info.get("flow_id"):
         lines = [
@@ -139,6 +141,8 @@ def block_sdmx(sdmx_info: dict[str, Any] | None, url: str) -> list[str]:
         agency = sdmx_info.get("agency")
         if agency and str(agency).upper() == "ESTAT":
             lines.append('        agency: "ESTAT"')
+        else:
+            lines.append(f'        endpoint: "{url}"')
         lines.append("      primary: true")
         return lines
     return block_http_file(url, "sdmx")

--- a/toolkit/scaffold/sources.py
+++ b/toolkit/scaffold/sources.py
@@ -123,16 +123,24 @@ def block_links(links: list[str]) -> list[str]:
 
 
 def block_sdmx(sdmx_info: dict[str, Any] | None, url: str) -> list[str]:
-    """Blocchi raw.sources per endpoint SDMX."""
+    """Blocchi raw.sources per endpoint SDMX.
+
+    Per i dataflow Eurostat (agency ESTAT, es. ``/data/NAMA_10R_3GDP``)
+    genera ``agency: ESTAT``: il profilo dedicato nel plugin risolve
+    automaticamente l'endpoint Eurostat e ignora la versione (numero mobile).
+    """
     if sdmx_info and sdmx_info.get("flow_id"):
-        return [
+        lines = [
             f'    - name: "sdmx_{sdmx_info["flow_id"]}"',
             '      type: "sdmx"',
             "      args:",
-            f'        endpoint: "{url}"',
             f'        flow: "{sdmx_info["flow_id"]}"',
-            "      primary: true",
         ]
+        agency = sdmx_info.get("agency")
+        if agency and str(agency).upper() == "ESTAT":
+            lines.append('        agency: "ESTAT"')
+        lines.append("      primary: true")
+        return lines
     return block_http_file(url, "sdmx")
 
 

--- a/toolkit/scout/http.py
+++ b/toolkit/scout/http.py
@@ -687,38 +687,66 @@ def fetch_sdmx_years(
 ) -> tuple[int | None, int | None]:
     """Chiama endpoint SDMX per ricavare year_min/year_max da TIME_PERIOD.
 
+    Supporta sia SDMX-ML (ISTAT, parse XML ``generic:ObsKey``) sia SDMX-JSON
+    2.0 (Eurostat, flat ``dimension.time.category.index``): se il parse XML
+    non trova TIME_PERIOD, ritenta con Accept JSON e legge la dimensione time.
+
     Args:
         client: HttpClient opzionale. Se fornito, lo usa invece di crearne uno.
     """
+    import json
+    import xml.etree.ElementTree as ET
+
     try:
         base = base_url.split("?")[0].rstrip("/")
         if "/dataflow/" in base:
             sdmx_root = base[: base.index("/dataflow/")]
+        elif "/data/" in base:
+            # Root API da path dati: es. .../sdmx/2.1/data/NAMA_10R_3GDP
+            sdmx_root = base[: base.index("/data/")]
         elif base.endswith("/dataflow"):
             sdmx_root = base[: -len("/dataflow")]
         else:
             sdmx_root = base
         url = f"{sdmx_root}/data/{flow_id}?lastNObservations=1"
         client = client or _mk_client(timeout=timeout)
-        result = client.get(url, headers={"Accept": "application/xml"})
-        if not result.is_ok or result.response is None:
-            return None, None
-        r = result.response
-        if r.status_code != 200:
-            return None, None
-        import xml.etree.ElementTree as ET
 
-        root = ET.fromstring(r.text)
-        time_values: list[str] = []
-        for val_el in root.findall(".//generic:ObsKey/generic:Value", _SDMX_NS):
-            if val_el.get("id") == "TIME_PERIOD":
-                v = val_el.get("value")
-                if v:
-                    time_values.append(v)
+        # Passo 1: XML (SDMX-ML, convention ISTAT)
+        result = client.get(url, headers={"Accept": "application/xml"})
         years: list[int] = []
-        for tv in time_values:
-            found = _YEAR_RE.findall(tv)
-            years.extend(int(y) for y in found)
+        if result.is_ok and result.response is not None and result.response.status_code == 200:
+            root = ET.fromstring(result.response.text)
+            time_values: list[str] = []
+            for val_el in root.findall(".//generic:ObsKey/generic:Value", _SDMX_NS):
+                if val_el.get("id") == "TIME_PERIOD":
+                    v = val_el.get("value")
+                    if v:
+                        time_values.append(v)
+            for tv in time_values:
+                found = _YEAR_RE.findall(tv)
+                years.extend(int(y) for y in found)
+
+        # Passo 2: fallback JSON 2.0 (Eurostat) — nessun TIME_PERIOD XML.
+        # Eurostat richiede ?format=json esplicito (il default è JSONSTAT,
+        # che richiede lang e risponde 400). Il JSON 2.0 ha la dimensione
+        # time flat in dimension.time.category.index.
+        if not years:
+            result = client.get(
+                url,
+                headers={"Accept": "application/json"},
+                params={"format": "json"},
+            )
+            if result.is_ok and result.response is not None and result.response.status_code == 200:
+                try:
+                    payload = json.loads(result.response.text)
+                except (json.JSONDecodeError, TypeError):
+                    payload = None
+                if payload:
+                    time_dim = (payload.get("dimension") or {}).get("time") or {}
+                    for period in (time_dim.get("category") or {}).get("index") or {}:
+                        found = _YEAR_RE.findall(str(period))
+                        years.extend(int(y) for y in found)
+
         if not years:
             return None, None
         return min(years), max(years)

--- a/toolkit/scout/probe.py
+++ b/toolkit/scout/probe.py
@@ -291,25 +291,43 @@ def _route_html(
 def _route_sdmx(final_url: str, result: dict[str, Any], *, timeout: int) -> dict[str, Any]:
     """Route per URL SDMX."""
     flow_id = None
+    agency = None
     parsed_url = urlparse(final_url)
     path = parsed_url.path
     if "/dataflow/" in path:
         parts = path.split("/dataflow/", 1)[1].split("/")
         if len(parts) >= 2:
             flow_id = parts[1]
+    elif "/data/" in path:
+        # Path dati: /data/{flow} oppure /data/{agency},{flow}[,{version}]
+        data_part = path.split("/data/", 1)[1].split("/")[0]
+        segments = [s for s in data_part.split(",") if s]
+        if len(segments) == 1:
+            flow_id = segments[0]
+        elif len(segments) >= 2:
+            agency, flow_id = segments[0], segments[1]
     elif parsed_url.query:
         from urllib.parse import parse_qs
 
         qs = parse_qs(parsed_url.query)
         flow_id = next(iter(qs.get("flow") or qs.get("id") or []), None)
 
+    # Agenzia implicita per l'API Eurostat (non compare nel path dati)
+    if agency is None and "eurostat" in (parsed_url.netloc + parsed_url.path).lower():
+        agency = "ESTAT"
+
     if flow_id:
         year_min, year_max = fetch_sdmx_years(final_url, flow_id, timeout=timeout)
         result["source_type"] = "sdmx"
-        result["sdmx_info"] = {"flow_id": flow_id, "year_min": year_min, "year_max": year_max}
+        result["sdmx_info"] = {
+            "flow_id": flow_id,
+            "agency": agency,
+            "year_min": year_min,
+            "year_max": year_max,
+        }
     else:
         result["source_type"] = "sdmx"
-        result["sdmx_info"] = {"flow_id": None, "year_min": None, "year_max": None}
+        result["sdmx_info"] = {"flow_id": None, "agency": None, "year_min": None, "year_max": None}
 
     result["ckan_resources"] = None
     result["candidate_links"] = []


### PR DESCRIPTION
## Sintesi

`SdmxSource` ora supporta l'agenzia Eurostat (ESTAT) con convenzioni API dedicate, consentendo al repo `eurostat` di migrare i dataset da `type: script` (tsv_normalize.py) a `type: sdmx` dichiarativo. Incluso un fix al profiler emerso dalla migrazione (`sniff_decimal`) e la risoluzione dei finding della review (endpoint scaffold per agenzie non-ESTAT, mypy motivato).

## Contesto collegato

Nessuna issue — richiesta diretta dal civic-director per integrare il fetch SDMX Eurostat nel toolkit (sostituire gli script ad hoc del repo `dataciviclab/eurostat`). Branch pilota: `dataciviclab/eurostat#feat/toolkit-sdmx-migration`.

## Cosa cambia

- [x] Bug fix
- [x] Nuova funzionalità del motore
- [x] Nuovo plugin sorgente (profilo ESTAT nel plugin `sdmx` esistente)
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet) — vedi sezione sotto
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Dettagli

**Profilo ESTAT in `SdmxSource`** (auto-selezionato da `agency: ESTAT`):
- URL dati `data/{flow}/{key}?format=TSV` — niente versione nel path (Eurostat risponde 404 a `agency,flow,version`, la versione è un numero mobile che cambia a ogni release).
- Constraints da SDMX-JSON 2.0 flat (`dimension.{id}.category`), TIME esclusa — Eurostat non serve il JSON 2.1 di ISTAT.
- Unpivot TSV wide→long con flag di qualità e supporto monthly, stesso contratto di `connectors/tsv_normalize.py` del repo eurostat (`[dims..., year, (month), value, flag]`).
- `version` opzionale: il profilo ESTAT la ignora; ISTAT invariato (richiesta, errore se manca).
- `fetch_codelist()`: codelist SDMX-JSON 2.0 → `{codes, annotations}` con `LEVEL` per la gerarchia NUTS (sostituisce il download di `update_codelists.py`).
- Scout: `probe_url_routed` ricava flow/agency/anni da URL `/data/{flow}` (fallback JSON con `format=json` obbligatorio — il default Eurostat è JSONSTAT che richiede `lang`); scaffold genera `agency: ESTAT`.

**fix(profile) `sniff_decimal` field-aware**: l'euristica conteggiava "2008,88" (anno + valore separati dal delim CSV) come decimale con virgola quando i valori numerici hanno ≤3 cifre → `decimal: ","` su CSV col punto → `value` VARCHAR → mart falliva con `avg(VARCHAR)`. Con delim noto ora ragiona sui campi (fullmatch per campo), coprendo anche il formato italiano "1.234,56".

**Review fix (finding Medium)**: `block_sdmx` riemette `endpoint:` per le agenzie **non-ESTAT** (parità col comportamento storico) — il config scaffoldato per SDMX di terze parti non punta più silenziosamente ai default ISTAT. `_fetch_sdmx` rende l'endpoint **funzionale** per agenzie non-ISTAT/ESTAT (root SDMX derivato stripando il path `dataflow`/`data`, usato per data+metadata); ISTAT e ESTAT restano sui default/invariati. Test: `tests/test_scaffold_sources.py` + `tests/test_fetch_sdmx_endpoint.py`.

## Impatto su contratti pubblici

- [x] Struttura `dataset.yml` — `raw.sources[].args.version` ora **opzionale** per `type: sdmx` (prima obbligatoria); `raw.sources[].args.endpoint` ora **funzionale** per agenzie non-ISTAT/ESTAT (prima campo inerte). I config ISTAT esistenti (con version, senza endpoint) restano validi; nessuna rottura.
- [ ] Path output (nuovo layer, cambio percorso artifact)
- [ ] Schema parquet (nuova colonna, rename, cambio tipo)
- [ ] CLI o MCP tool (nuovo comando, cambio parametro)
- [x] API pubblica del toolkit — `SdmxSource.fetch(version)` accetta `""` per ESTAT; nuovo metodo `SdmxSource.fetch_codelist()`; `sniff_decimal(sample_text, delim=None)` nuovo parametro opzionale (legacy invariata).

> Downstream: nessuna rottura per `dataset-incubator`/ISTAT (suite regressione verde). `eurostat` migra i 5 dataset standard v1 sul proprio branch.

## Verifica

```bash
python -m pytest tests/ -q        # 1261 passed, 22 deselected
ruff check .                       # All checks passed!
mypy toolkit/plugins/sdmx.py toolkit/raw/_fetch_utils.py toolkit/scaffold/sources.py toolkit/scout/http.py toolkit/scout/probe.py toolkit/profile/raw.py toolkit/profile/_sniff_delimiter.py
```

- [x] `pytest` passa (1261, include regressione ISTAT `test_sdmx_plugin.py` 19/19, profiler, scaffold, fetch endpoint)
- [x] `ruff check .` passa
- [x] `mypy` eseguito sui 7 file modificati — **2 errori preesistenti su main** (non introdotti dalla PR): `toolkit/core/read_excel.py:49` (overload pandas, file mai toccato dal diff) e `toolkit/profile/raw.py:307` (return value `dict[Hashable, Any]` in funzione preesistente, riga non toccata). Nessun nuovo errore.
- [x] Test aggiunti con marker `adapter`/`policy`/`pure_unit`/`contract` (fixture ESTAT: TSV, monthly, filtri, codelist; sniff_decimal: csv dot, regressione ≤3 cifre, legacy backcompat; scaffold: endpoint ESTAT/non-ESTAT; fetch endpoint: root derivation, terze/IT1/ESTAT)

Verifica live (non in CI): fetch reale `NAMA_10R_3GDP` con filtro `A.EUR_HAB.IT+ITC4` → 50 righe long-form; constraints reali (geo: 1814); `fetch_codelist('GEO')` → 4292 codici con LEVEL. Run end-to-end su 5 dataset eurostat (gdp/crime/hospital/physicians/poverty) → readiness 8/8, 0.0% righe perse.

## Checklist PR

- [x] Perimetro stretto: una PR = profilo ESTAT + fix profiler correlato + fix review
- [x] Test inclusi
- [ ] Issue collegata — assente (richiesta diretta; vedi Contesto)
- [x] Nessun modulo pubblico rimosso

## Note per chi revisiona

- **Edge case noto**: alcuni flow Eurostat grandi (es. `DEMO_R_MAGEC3`) rispondono **async** (SOAP "queued" con polling ID) invece di sincrono. Non gestito in questa PR — i flow dei dataset pilota (`NAMA_10R_3GDP`, `CRIM_GEN_REG`, `HLTH_RS_*`, `ILC_LI41`) rispondono sincroni. Da valutare in una PR successiva.
- `sniff_decimal` cambia il comportamento di sniffing su **qualsiasi** CSV con valori ≤3 cifre: ora corretto (`.`), prima poteva suggerire `,`. Impatto positivo ma da tenere d'occhio su altri dataset del Lab.
- Il profilo ESTAT produce le colonne raw senza label di dimensione (le risolve il clean.sql via codelists), a differenza del profilo ISTAT che le porta nel JSON.
- `block_sdmx`: per ESTAT nessun `endpoint` nel config (auto-risolto); per altre agenzie `endpoint` emesso e ora funzionale (`_fetch_sdmx` lo usa come base per data+metadata, root derivato).