### PR TITLE
feat(support): ADR-005 — tipi codelist/file, orchestrazione ensure, placeholder clean/mart.TABLE/path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ La CI di `dataset-incubator` carica su GCS dopo ogni run validato.
 |---|---|
 | `toolkit run` | Esecuzione completa RAW→CLEAN→MART (default) |
 | `toolkit run --batch <file>` | Esegue piú dataset in sequenza |
+| `toolkit run --refresh-support` | Forza la rigenerazione dei support (di default i support con output già presenti vengono riusati) |
 | `toolkit run raw` | Solo layer RAW |
 | `toolkit run clean` | Solo layer CLEAN |
 | `toolkit run mart` | Solo layer MART |

--- a/docs/adr/005-support-ensure.md
+++ b/docs/adr/005-support-ensure.md
@@ -1,0 +1,170 @@
+# ADR-005: Support dataset unificati — tipo, materializzazione e orchestrazione ensure
+
+**Status:** accepted (2026-08)
+
+## Contesto
+
+Il toolkit gestisce già i "support" (dataset di riferimento per i join nei
+clean.sql: anagrafiche, glossari, codelist) con un contratto minimo:
+
+```yaml
+support:
+  - name: comuni
+    config: "../../support_datasets/istat-elenco-comuni/dataset.yml"
+    years: [2026]
+```
+
+Infrastruttura esistente su main: campo `support:` nel config model,
+`core/support.py` (`resolve_support_payloads`, `check_support_path_drift`,
+`flatten_support_template_ctx`), orchestrazione in `cmd_run.run_full` che
+esegue il support **sempre** (run_year step=all per ogni entry/anno),
+placeholder template `{support.NAME.mart}` / `{support.NAME.outputs}`.
+
+Limiti emersi:
+1. **Solo `type: dataset`** — le codelist SDMX (`eurostat/codelists/*.csv`) e i
+   mapping locali (`dcl-bologna/mapping/*.csv`) non sono rappresentabili:
+   non sono dataset runnabili, oggi sono file CSV referenziati nei SQL con
+   path relativi/hardcoded e fragili.
+2. **Nessun skip-if-exists** — a ogni `run full` il support viene rieseguito
+   interamente (RAW+CLEAN+MART) anche se le sue tabelle sono già presenti e
+   stabili (es. anagrafiche che cambiano una volta l'anno).
+3. **Solo layer MART esposto** — `resolve_support_payloads` guarda
+   `mart.tables` e `flatten_support_template_ctx` espone solo la **prima**
+   tabella mart; il caso reale del lab (`inps-rdc-pdc` join su
+   `mart_codici_catastali`, seconda tabella di `istat-elenco-comuni`) non è
+   coperto dal placeholder, e manca l'accesso al layer CLEAN del support.
+
+Alternative considerate:
+- **Mantenere lo status quo** (run incondizionato, path hardcoded nei SQL,
+  anti-drift solo warning): non risolve la fragilità dei path né il costo dei
+  run; le codelist restano fuori contratto.
+- **Support come dataset di prima classe con run sempre**: nessun guadagno
+  sul costo; non rappresenta codelist/file.
+- **Contratto `support` esteso + orchestrazione `ensure`** (scelta).
+
+## Decisione
+
+### 1. Contratto `support:` esteso con `type`
+
+`type` è opzionale, default `dataset` (backward compatible — nessun config
+esistente si rompe):
+
+```yaml
+support:
+  - name: comuni
+    type: dataset              # materializza: run del config (se mancano output)
+    config: "../../support_datasets/istat-elenco-comuni/dataset.yml"
+    years: [2026]
+  - name: geo
+    type: codelist             # materializza: fetch (SDMX) → parquet canonico
+    provider: sdmx
+    agency: ESTAT
+    id: GEO
+  - name: quartieri
+    type: file                 # materializza: exec command (se dichiarato)
+    path: "mapping/colonnine-quartieri.csv"
+    command: "python mapping/colonnine_quartieri.py"   # opzionale
+```
+
+Validazione per tipo:
+- `dataset` → richiede `config` + `years` (come oggi)
+- `codelist` → richiede `provider`/`agency`/`id` (o `endpoint`); il fetch è
+  quello già presente in `SdmxSource.fetch_codelist` (profilo ESTAT, #450)
+- `file` → richiede `path` (relativo al root del candidate, normalizzato);
+  `command` opzionale per la rigenerazione
+
+### 2. Orchestrazione `ensure` (skip-if-exists + materializza-se-manca)
+
+Sostituisce il blocco "Process support datasets" in `cmd_run.run_full`:
+
+```
+per ogni support entry:
+    output_attesi = support_output_paths(entry, year)
+        dataset  → clean parquet + tutte le tabelle mart (per anno)
+        codelist → out/data/support/{name}/{name}.parquet
+        file     → path dichiarato
+    se tutti gli output esistono  e  non --refresh-support  → SKIP (log reuse)
+    se mancano:
+        dataset  → run_year(support_cfg, year, step="all")   # invariato
+        codelist → fetch_codelist + scrittura parquet canonico
+        file     → exec command (se presente), altrimenti errore esplicito
+    (smoke: materializza su {root}/smoke — pattern già esistente)
+```
+
+Proprietà:
+- **Skip per-anno** (un support con anni [2026] già materializzato non viene
+  rieseguito; un anno nuovo scatena il run solo per quell'anno)
+- **Freshness baseline = esistenza** del file atteso; l'aggiornamento
+  forzato è esplicito via `--refresh-support` (le codelist SDMX cambiano
+  raramente — NUTS ~ogni 3 anni; il confronto hash/run-record è evoluzione
+  futura)
+- Un support fallito blocca il candidate (invariato)
+- Dry-run: solo log, nessuna esecuzione
+
+### 3. Output attesi = CLEAN + MART e set placeholder completo
+
+`resolve_support_payloads` considera come output attesi sia il layer CLEAN
+sia tutte le tabelle MART del support (altrimenti un support usato solo in
+clean verrebbe considerato mancante). `flatten_support_template_ctx` espone:
+
+| Placeholder | Risolve a |
+|---|---|
+| `{support.NAME.clean}` | parquet clean del support (per anno) |
+| `{support.NAME.mart}` | prima tabella mart (backward compat) |
+| `{support.NAME.mart.TABLE}` | tabella mart specifica (il caso `mart_codici_catastali`) |
+| `{support.NAME.outputs}` | lista completa (invariato) |
+| `{support.NAME.path}` | file materializzato (codelist/file) |
+
+`check_support_path_drift` esteso ai nuovi placeholder
+(`clean`, `mart.TABLE`, `path`).
+
+### 4. Layer materializzazione codelist
+
+Path canonico dedicato: `out/data/support/{name}/{name}.parquet` (senza anno:
+le codelist non sono serie temporali, sono una fotografia al refresh).
+Le codelist **non** sono dataset (niente raw/clean/mart, niente catalogo):
+un layer separato evita confusione col catalogo clean. La migrazione dei
+`codelists/*.csv` del repo eurostat è responsabilità del repo eurostat
+(placeholder + anti-drift la impongono).
+
+### 5. Ordine dei support
+
+Sequenziale nell'ordine dichiarato (come oggi) + **validazione anti-ciclo**
+(nessun support può riferire se stesso, direttamente o transitivamente).
+L'ordinamento topologico completo è rimandato finché non esiste un caso reale
+di support→support.
+
+## Conseguenze
+
+**Positive:**
+- Codelist e mapping locali entrano nel contratto `dataset.yml` con
+  materializzazione e path canonici → niente più path relativi/hardcoded
+  nei SQL (l'anti-drift li segnala)
+- Risparmio sui run: anagrafiche stabili non vengono rieseguite a ogni
+  `run full`; skip per-anno
+- Accesso al layer CLEAN del support e alle tabelle MART specifiche
+  (risolve il caso reale `mart_codici_catastali`)
+- Riusa l'infrastruttura esistente (`resolve_support_payloads`, template
+  ctx, anti-drift, smoke handling) — nessuna riscrittura
+
+**Negative:**
+- Nuovo campo `type` nel contratto `support:` (default `dataset`, nessuna
+  rottura, ma il contratto dataset.yml cresce)
+- Materializzazione codelist richiede il profilo ESTAT/ISTAT già mergiato
+  (#450) — le codelist SDMX non-ESTAT restano fuori finché non c'è un
+  provider corrispondente
+- `--refresh-support` forza la rigenerazione manualmente: la freshness
+  automatica (hash/run-record) non è coperta
+
+## Implementazione
+
+1. `toolkit/core/config.py` — `type` nel modello support + validazione per
+   tipo + `_normalize_paths`
+2. `toolkit/core/support.py` — output attesi clean+mart, `support_output_paths`,
+   `materialize_support` (per tipo), placeholder set esteso
+3. `toolkit/cli/cmd_run.py` — blocco ensure (skip-if-exists + materialize),
+   flag `--refresh-support`
+4. `toolkit/core/sql_validation.py` — anti-drift esteso
+5. `toolkit/domain/path_resolver.py` — payload support per i nuovi tipi
+6. Test: estensione `test_support.py` + nuovi (skip, codelist, file, placeholder)
+7. Pilota: `inps-rdc-pdc` → `{support.comuni.mart.mart_codici_catastali}`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,3 +8,4 @@ Decisioni architetturali del toolkit, in ordine cronologico.
 | [002](002-three-layers.md) | Tre layer RAW → CLEAN → MART | 2026-02 |
 | [003](003-pydantic-config.md) | Config Pydantic con migrazione graduale | 2026-04 |
 | [004](004-parquet-output.md) | Parquet come formato di output | 2026-02 |
+| [005](005-support-ensure.md) | Support dataset unificati — tipo, materializzazione, orchestrazione ensure | 2026-08 |

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -373,6 +373,61 @@ Note:
 - gli output vengono scritti in `root/data/mart/<dataset>/<name>.parquet` (livello dataset, senza anno)
 - la validazione multi-anno non produce un validation.json separato (la validazione è integrata in MART)
 
+## support
+
+Dataset / codelist / file di riferimento per i join nei SQL di clean e mart.
+Vengono eseguiti (o riusati) **prima** del candidate; il risultato è esposto
+al template SQL come placeholder `{support.NAME.*}` (vedi ADR-005).
+
+| Campo | Tipo | Default |
+|---|---|---|
+| `support[].name` | `str` | — (obbligatorio, univoco) |
+| `support[].type` | `dataset` \| `codelist` \| `file` | `dataset` |
+| `support[].config` | path dataset.yml | — (solo `dataset`) |
+| `support[].years` | `list[int]` | — (solo `dataset`) |
+| `support[].id` | `str` | — (solo `codelist`) |
+| `support[].agency` | `str` | `ESTAT` (solo `codelist`) |
+| `support[].provider` | `str` | `sdmx` (solo `codelist`) |
+| `support[].path` | `str` | — (solo `file`, relativo al root candidate) |
+| `support[].command` | `str` | — (solo `file`, opzionale: rigenera il file) |
+
+```yaml
+support:
+  - name: comuni
+    type: dataset                 # materializza: run del config (skip se clean+mart presenti)
+    config: "../../support_datasets/istat-elenco-comuni/dataset.yml"
+    years: [2026]
+  - name: geo
+    type: codelist                # materializza: fetch_codelist → parquet canonico
+    agency: ESTAT
+    id: GEO
+  - name: quartieri
+    type: file                    # materializza: exec command se il file manca
+    path: "mapping/colonnine-quartieri.csv"
+    command: "python mapping/colonnine_quartieri.py"
+```
+
+**Orchestrazione (ensure):** gli output attesi per tipo sono — `dataset`:
+parquet clean + tutte le tabelle mart (per anno); `codelist`:
+`out/data/support/{name}/{name}.parquet`; `file`: il path dichiarato.
+Se gli output sono già presenti il run li **riusa** (skip-if-exists, per-anno);
+la rigenerazione forzata è `toolkit run --refresh-support`. Un support fallito
+blocca il candidate. L'esecuzione di un `command` file richiede
+`TOOLKIT_ALLOW_SCRIPT_SOURCE=1`.
+
+**Placeholder nel SQL** (il toolkit li risolve prima di eseguire):
+
+| Placeholder | Risolve a |
+|---|---|
+| `{support.NAME.mart}` | prima tabella mart del support (compat) |
+| `{support.NAME.mart.TABLE}` | tabella mart specifica |
+| `{support.NAME.clean}` | parquet clean del support |
+| `{support.NAME.path}` | file materializzato (codelist/file) |
+| `{support.NAME.outputs}` | lista completa degli output |
+
+I SQL devono usare i placeholder e non path hardcoded: `check_support_path_drift`
+segnala il drift come warning in dry-run.
+
 ## validation
 
 Campi supportati:

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -79,6 +79,19 @@ Versioni schema stabili:
 - Ogni validation report include `validation_schema_version`.
 - I metadata CLEAN espongono `read_params_source`, `read_source_used`, `read_params_used`.
 
+## 8. Support dataset (ADR-005)
+- I support (dataset/codelist/file) si dichiarano in `support:` nel dataset.yml e si
+  referenziano nel SQL **solo** con i placeholder `{support.NAME.*}` — mai con path
+  hardcoded (il drift è segnalato come warning in dry-run da `check_support_path_drift`).
+- Placeholder disponibili: `{support.NAME.mart}` (prima tabella), `{support.NAME.mart.TABLE}`,
+  `{support.NAME.clean}`, `{support.NAME.path}` (codelist/file), `{support.NAME.outputs}`.
+- Orchestrazione: i support sono eseguiti prima del candidate e riusati se gli output
+  (clean+mart per dataset; parquet canonico per codelist; path per file) sono già presenti.
+  Rigenerazione forzata: `toolkit run --refresh-support`.
+- Codelist SDMX: parquet canonico in `out/data/support/{name}/{name}.parquet`, fuori dal
+  catalogo clean (le codelist non sono dataset).
+- Riferimento: [ADR-005](adr/005-support-ensure.md), schema in [config-schema.md](config-schema.md).
+
 Rimandi:
 - schema completo: [config-schema.md](config-schema.md)
 - workflow avanzati e legacy boundary: [advanced-workflows.md](advanced-workflows.md)

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -214,6 +214,12 @@ def test_run_mart_supports_support_placeholder(tmp_path: Path) -> None:
     duckdb.execute(
         f"COPY (SELECT 'ok' AS marker) TO '{support_output.as_posix()}' (FORMAT PARQUET)"
     )
+    # ADR-005: output attesi = clean + mart → il fixture crea anche il clean
+    support_clean = (
+        support_root / "data" / "clean" / "lookup_ds" / "2024" / "lookup_ds_2024_clean.parquet"
+    )
+    support_clean.parent.mkdir(parents=True, exist_ok=True)
+    duckdb.execute(f"COPY (SELECT 'ok' AS marker) TO '{support_clean.as_posix()}' (FORMAT PARQUET)")
 
     support_config = tmp_path / "support_dataset.yml"
     support_config.write_text(

--- a/tests/test_run_dry_run.py
+++ b/tests/test_run_dry_run.py
@@ -356,7 +356,7 @@ def test_run_dry_run_detects_hardcoded_support_path(
     assert result.exit_code == 0, f"exit_code={result.exit_code} output={result.output}"
     assert "PATH DRIFT" in result.output, f"output={result.output}"
     assert "lookup_ds" in result.output
-    assert "{support.lookup.mart}" in result.output
+    assert "support.lookup" in result.output
 
 
 # ── Logger context ──────────────────────────────────────────────────────────

--- a/tests/test_run_full_support.py
+++ b/tests/test_run_full_support.py
@@ -97,3 +97,170 @@ support:
         ["run", "--config", str(cand_yml), "--dry-run", "--years", "2022"],
     )
     assert result.exit_code != 0
+
+
+def test_run_full_skips_existing_support(
+    project_example: Path, runner, tmp_path: Path, monkeypatch
+) -> None:
+    """ADR-005: se gli output del support (clean+mart) esistono già, il run
+    lo riusa senza rieseguirlo (skip-if-exists)."""
+    # Support dataset con output già materializzati
+    support_dir = tmp_path / "support_ds"
+    (support_dir / "sql").mkdir(parents=True)
+    (support_dir / "sql" / "clean.sql").write_text(
+        "SELECT 1 AS ok FROM raw_input\n", encoding="utf-8"
+    )
+    (support_dir / "sql" / "mart.sql").write_text("SELECT * FROM clean_input\n", encoding="utf-8")
+    (support_dir / "data").mkdir()
+    (support_dir / "data" / "dummy.csv").write_text("a;b\n1;2\n", encoding="utf-8")
+    (support_dir / "dataset.yml").write_text(
+        """schema_version: 1
+root: out
+dataset:
+  name: support_ds
+  years: [2022]
+raw:
+  sources:
+    - name: csv
+      type: local_file
+      args:
+        path: data/dummy.csv
+        filename: support_ds_2022.csv
+clean:
+  sql: sql/clean.sql
+mart:
+  tables:
+    - name: support_mart
+      sql: sql/mart.sql
+""",
+        encoding="utf-8",
+    )
+    # Output attesi già presenti (ADR-005: clean + mart)
+    clean_dir = support_dir / "out" / "data" / "clean" / "support_ds" / "2022"
+    mart_dir = support_dir / "out" / "data" / "mart" / "support_ds" / "2022"
+    clean_dir.mkdir(parents=True)
+    mart_dir.mkdir(parents=True)
+    (clean_dir / "support_ds_2022_clean.parquet").write_bytes(b"")
+    (mart_dir / "support_mart.parquet").write_bytes(b"")
+
+    cand_yml = project_example / "dataset.yml"
+    cand_yml.write_text(
+        cand_yml.read_text(encoding="utf-8")
+        + f"""
+support:
+  - name: "sup"
+    config: "{support_dir / "dataset.yml"}"
+    years: [2022]
+""",
+        encoding="utf-8",
+    )
+
+    # Spy: run_year non deve essere chiamata per il support (skip)
+    import toolkit.cli.cmd_run as cmd_run_mod
+
+    support_runs: list[int] = []
+    orig_run_year = cmd_run_mod.run_year
+
+    def spy_run_year(cfg, year, **kwargs):
+        if getattr(cfg, "dataset", None) == "support_ds":
+            support_runs.append(year)
+        return orig_run_year(cfg, year, **kwargs)
+
+    monkeypatch.setattr(cmd_run_mod, "run_year", spy_run_year)
+
+    result = runner.invoke(
+        app,
+        ["run", "--config", str(cand_yml), "--years", "2022"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert support_runs == [], f"support rieseguito nonostante output presenti: {support_runs}"
+    assert "reuse support sup" in result.output
+
+
+class _FakeSupportCtx:
+    validations = {
+        "raw": {"passed": True},
+        "clean": {"passed": True},
+        "mart": {"passed": True},
+    }
+
+
+def test_run_full_runs_missing_support(
+    project_example: Path, runner, tmp_path: Path, monkeypatch
+) -> None:
+    """ADR-005: se gli output del support mancano, il run lo esegue (invariato)."""
+    support_dir = tmp_path / "support_ds"
+    (support_dir / "sql").mkdir(parents=True)
+    (support_dir / "sql" / "clean.sql").write_text(
+        "SELECT 1 AS ok FROM raw_input\n", encoding="utf-8"
+    )
+    (support_dir / "sql" / "mart.sql").write_text("SELECT * FROM clean_input\n", encoding="utf-8")
+    (support_dir / "data").mkdir()
+    (support_dir / "data" / "dummy.csv").write_text("a;b\n1;2\n", encoding="utf-8")
+    (support_dir / "dataset.yml").write_text(
+        """schema_version: 1
+root: out
+dataset:
+  name: support_ds
+  years: [2022]
+raw:
+  sources:
+    - name: csv
+      type: local_file
+      args:
+        path: data/dummy.csv
+        filename: support_ds_2022.csv
+clean:
+  sql: sql/clean.sql
+mart:
+  tables:
+    - name: support_mart
+      sql: sql/mart.sql
+""",
+        encoding="utf-8",
+    )
+
+    cand_yml = project_example / "dataset.yml"
+    cand_yml.write_text(
+        cand_yml.read_text(encoding="utf-8")
+        + f"""
+support:
+  - name: "sup"
+    config: "{support_dir / "dataset.yml"}"
+    years: [2022]
+""",
+        encoding="utf-8",
+    )
+
+    import toolkit.cli.cmd_run as cmd_run_mod
+
+    support_runs: list[int] = []
+    orig_run_year = cmd_run_mod.run_year
+
+    def spy_run_year(cfg, year, **kwargs):
+        if getattr(cfg, "dataset", None) == "support_ds":
+            support_runs.append(year)
+            # Simula il run: crea gli output attesi (clean + mart)
+            clean_dir = support_dir / "out" / "data" / "clean" / "support_ds" / str(year)
+            mart_dir = support_dir / "out" / "data" / "mart" / "support_ds" / str(year)
+            clean_dir.mkdir(parents=True, exist_ok=True)
+            mart_dir.mkdir(parents=True, exist_ok=True)
+            (clean_dir / f"support_ds_{year}_clean.parquet").write_bytes(b"")
+            (mart_dir / "support_mart.parquet").write_bytes(b"")
+            return _FakeSupportCtx()
+        return orig_run_year(cfg, year, **kwargs)
+
+    monkeypatch.setattr(cmd_run_mod, "run_year", spy_run_year)
+
+    result = runner.invoke(
+        app,
+        ["run", "--config", str(cand_yml), "--years", "2022"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert support_runs == [2022], (
+        f"support non eseguito nonostante output mancanti: {support_runs}"
+    )

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import os
 import pytest
+
+from toolkit.core.exceptions import DownloadError
 
 from toolkit.core.support import (
     check_support_path_drift,
     flatten_support_template_ctx,
+    materialize_codelist_to,
+    materialize_support,
     resolve_support_payloads,
     _support_expected_mart_outputs,
 )
@@ -66,6 +71,10 @@ def _make_support_dataset(
             mart_dir.mkdir(parents=True, exist_ok=True)
             for table in mart_tables:
                 (mart_dir / f"{table}.parquet").write_bytes(b"")
+            # ADR-005: output attesi = clean + mart → il fixture crea anche il clean
+            clean_dir = ds_dir / "data" / "clean" / name / str(year)
+            clean_dir.mkdir(parents=True, exist_ok=True)
+            (clean_dir / f"{name}_{year}_clean.parquet").write_bytes(b"")
 
     return config_path
 
@@ -185,7 +194,8 @@ class TestResolveSupportPayloadsHappy:
         payload = result[0]
         assert len(payload["years_resolved"]) == 1
         yr = payload["years_resolved"][0]
-        assert len(yr["outputs"]) == 1
+        # ADR-005: output attesi = clean + mart (2 file)
+        assert len(yr["outputs"]) == 2
         assert yr["existing_outputs"] == []
         assert yr["all_outputs_exist"] is False
 
@@ -334,7 +344,7 @@ class TestCheckSupportPathDrift:
         warnings = check_support_path_drift(sql, self._SAMPLE_PAYLOADS)
         assert len(warnings) == 1
         assert "opencivitas_glossario" in warnings[0]
-        assert "{support.glossario.mart}" in warnings[0]
+        assert "support.glossario" in warnings[0]
 
     def test_multiple_hardcoded_paths(self):
         sql = (
@@ -392,10 +402,132 @@ class TestResolveAndFlatten:
 
         assert "support.my_support.outputs" in ctx
         assert "support.my_support.mart" in ctx
-        assert len(ctx["support.my_support.outputs"]) == 1
+        assert len(ctx["support.my_support.outputs"]) == 2  # clean + mart
         assert ctx["support.my_support.mart"].endswith("table_a.parquet")
+        assert ctx["support.my_support.clean"].endswith("support_ds_2024_clean.parquet")
+        assert ctx["support.my_support.mart.table_a"].endswith("table_a.parquet")
 
     def test_no_flatten_on_empty_resolve(self):
         resolved = resolve_support_payloads(None, require_exists=True)
         ctx = flatten_support_template_ctx(resolved)
         assert ctx == {}
+
+
+# ---------------------------------------------------------------------------
+# ADR-005: tipi codelist / file
+# ---------------------------------------------------------------------------
+
+
+class TestCodelistFileSupport:
+    def test_codelist_payload_path(self, tmp_path: Path):
+        root = tmp_path / "cand"
+        root.mkdir()
+        entries = [{"name": "geo", "type": "codelist", "id": "GEO", "agency": "ESTAT"}]
+        payloads = resolve_support_payloads(entries, require_exists=False, root=root)
+        payload = payloads[0]
+        assert payload["type"] == "codelist"
+        assert payload["path"].endswith(os.path.join("data", "support", "geo", "geo.parquet"))
+        assert payload["mart"] is None
+        assert payload["all_outputs_exist"] is False
+
+    def test_codelist_require_exists_missing(self, tmp_path: Path):
+        root = tmp_path / "cand"
+        root.mkdir()
+        entries = [{"name": "geo", "type": "codelist", "id": "GEO"}]
+        with pytest.raises(FileNotFoundError, match="codelist 'geo' non materializzata"):
+            resolve_support_payloads(entries, require_exists=True, root=root)
+
+    def test_codelist_requires_root(self):
+        with pytest.raises(ValueError, match="requires the candidate root"):
+            resolve_support_payloads(
+                [{"name": "geo", "type": "codelist", "id": "GEO"}], require_exists=False
+            )
+
+    def test_codelist_requires_id(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="requires 'id'"):
+            resolve_support_payloads(
+                [{"name": "geo", "type": "codelist"}], require_exists=False, root=tmp_path
+            )
+
+    def test_file_payload_path(self, tmp_path: Path):
+        root = tmp_path
+        entries = [{"name": "quartieri", "type": "file", "path": "mapping/q.csv"}]
+        payloads = resolve_support_payloads(entries, require_exists=False, root=root)
+        assert payloads[0]["type"] == "file"
+        assert payloads[0]["path"] == str(root / "mapping" / "q.csv")
+
+    def test_file_existing_is_skippable(self, tmp_path: Path):
+        (tmp_path / "mapping").mkdir()
+        (tmp_path / "mapping" / "q.csv").write_text("x\n", encoding="utf-8")
+        entries = [{"name": "quartieri", "type": "file", "path": "mapping/q.csv"}]
+        payloads = resolve_support_payloads(entries, require_exists=False, root=tmp_path)
+        assert payloads[0]["all_outputs_exist"] is True
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(ValueError, match=r"support\[\]\.type"):
+            resolve_support_payloads(
+                [{"name": "x", "type": "boh"}], require_exists=False, root=Path(".")
+            )
+
+
+class TestFlattenCodelistFile:
+    def test_ctx_path_placeholder(self, tmp_path: Path):
+        root = tmp_path / "cand"
+        root.mkdir()
+        payloads = resolve_support_payloads(
+            [{"name": "geo", "type": "codelist", "id": "GEO"}],
+            require_exists=False,
+            root=root,
+        )
+        ctx = flatten_support_template_ctx(payloads)
+        assert ctx["support.geo.path"].endswith("geo.parquet")
+        assert ctx["support.geo.outputs"] == [ctx["support.geo.path"]]
+
+
+class TestMaterializeCodelist:
+    def test_writes_parquet(self, tmp_path: Path, monkeypatch):
+        import toolkit.plugins.sdmx as sdmx_mod
+
+        class _FakeSdmx:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def fetch_codelist(self, codelist_id, agency="ESTAT"):
+                return {
+                    "id": codelist_id,
+                    "codes": {"IT": "Italy", "ITC4": "Nord-Ovest"},
+                    "annotations": {"IT": {"LEVEL": "0"}, "ITC4": {"LEVEL": "2"}},
+                    "origin": "https://fake.test",
+                }
+
+        monkeypatch.setattr(sdmx_mod, "SdmxSource", _FakeSdmx)
+
+        entry = {"name": "geo", "type": "codelist", "id": "GEO", "agency": "ESTAT"}
+        target = materialize_codelist_to(entry, tmp_path)
+        assert target.exists()
+
+        import duckdb
+
+        rows = duckdb.sql(
+            f"SELECT code, label_en, LEVEL FROM read_parquet('{target}') ORDER BY code"
+        ).fetchall()
+        assert rows == [("IT", "Italy", "0"), ("ITC4", "Nord-Ovest", "2")]
+
+    def test_unsupported_provider_raises(self, tmp_path: Path):
+        entry = {"name": "geo", "type": "codelist", "id": "GEO", "provider": "boh"}
+        with pytest.raises(DownloadError, match="provider 'boh' non supportato"):
+            materialize_codelist_to(entry, tmp_path)
+
+
+class TestMaterializeFile:
+    def test_missing_without_command_raises(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("TOOLKIT_ALLOW_SCRIPT_SOURCE", "1")
+        entry = {"name": "q", "type": "file", "path": "mapping/q.csv"}
+        with pytest.raises(DownloadError, match="senza 'command'"):
+            materialize_support(entry, root=tmp_path)
+
+    def test_command_requires_env_guard(self, tmp_path: Path, monkeypatch):
+        monkeypatch.delenv("TOOLKIT_ALLOW_SCRIPT_SOURCE", raising=False)
+        entry = {"name": "q", "type": "file", "path": "mapping/q.csv", "command": "true"}
+        with pytest.raises(DownloadError, match="TOOLKIT_ALLOW_SCRIPT_SOURCE"):
+            materialize_support(entry, root=tmp_path)

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -51,7 +51,12 @@ def load_clean_sql(
         from toolkit.core.support import flatten_support_template_ctx, resolve_support_payloads
 
         try:
-            payloads = resolve_support_payloads(support_cfg, require_exists=False, smoke=smoke)
+            payloads = resolve_support_payloads(
+                support_cfg,
+                require_exists=False,
+                smoke=smoke,
+                root=Path(root) if root else None,
+            )
             support_ctx = flatten_support_template_ctx(payloads)
         except Exception:
             # Se il support non è disponibile (non ancora eseguito), il template

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -869,6 +869,7 @@ def _run_pipeline(
     sample_bytes: int | None = None,
     root: str | None = None,
     dry_run: bool = False,
+    refresh_support: bool = False,
 ) -> dict[str, Any]:
     """Esegue pre-flight + support + raw → clean → mart.
 
@@ -945,62 +946,109 @@ def _run_pipeline(
                 sum(1 for s in preflight["sources"] if not s["reachable"]),
             )
 
-    # Process support datasets
+    # Process support datasets (ADR-005: ensure — skip se output presenti, materializza se manca)
     support_entries = cfg.support or []
     if support_entries:
+        from toolkit.core.support import materialize_support, resolve_support_payloads
+
         logger.info(
             "RUN — processing %d support dataset(s) before candidate",
             len(support_entries),
         )
         for entry in support_entries:
-            logger.info("Support: %s — %s", entry.name, entry.config)
+            entry_dict = dump_cfg_section(entry)
+            stype = str(entry_dict.get("type") or "dataset")
 
             if dry_flag:
-                logger.info("  [dry-run] support: %s — years=%s", entry.name, entry.years)
+                logger.info(
+                    "  [dry-run] support: %s — type=%s years=%s",
+                    entry.name,
+                    stype,
+                    getattr(entry, "years", []),
+                )
                 continue
 
             try:
-                if sample_mode:
-                    _sup0, _ = load_cfg_and_logger(str(entry.config))
-                    support_cfg, support_logger = load_cfg_and_logger(
-                        str(entry.config),
-                        root_override=str(_sup0.root / "smoke"),
-                    )
-                else:
-                    support_cfg, support_logger = load_cfg_and_logger(str(entry.config))
+                payloads = resolve_support_payloads(
+                    [entry_dict],
+                    require_exists=False,
+                    smoke=smoke,
+                    root=cfg.root,
+                )
+                payload = payloads[0]
             except Exception as exc:
-                logger.error("Support: cannot load config %s: %s", entry.config, exc)
+                logger.error("Support: cannot resolve %s: %s", entry.name, exc)
                 results["status"] = "failed"
                 break
 
-            for sy in entry.years:
-                logger.info("Support: running %s year=%s", entry.name, sy)
+            if payload["all_outputs_exist"] and not refresh_support:
+                logger.info("  reuse support %s (output presenti)", entry.name)
+                continue
+
+            if stype == "dataset":
                 try:
-                    ctx = run_year(
-                        support_cfg,
-                        sy,
-                        step="all",
-                        logger=support_logger,
-                        sample_rows=sample_rows_final,
-                        sample_bytes=sample_bytes_final,
-                        smoke=smoke,
-                    )
+                    if sample_mode:
+                        _sup0, _ = load_cfg_and_logger(str(entry.config))
+                        support_cfg, support_logger = load_cfg_and_logger(
+                            str(entry.config),
+                            root_override=str(_sup0.root / "smoke"),
+                        )
+                    else:
+                        support_cfg, support_logger = load_cfg_and_logger(str(entry.config))
                 except Exception as exc:
-                    logger.error("Support run failed: %s year=%s — %s", entry.name, sy, exc)
+                    logger.error("Support: cannot load config %s: %s", entry.config, exc)
                     results["status"] = "failed"
                     break
 
-                all_support_passed = all(
-                    ctx.validations.get(layer, {}).get("passed", False)
-                    for layer in ("raw", "clean", "mart")
-                )
-                if not all_support_passed:
-                    logger.error("Support validation failed: %s year=%s", entry.name, sy)
+                for sy in entry.years:
+                    logger.info("Support: running %s year=%s", entry.name, sy)
+                    try:
+                        ctx = run_year(
+                            support_cfg,
+                            sy,
+                            step="all",
+                            logger=support_logger,
+                            sample_rows=sample_rows_final,
+                            sample_bytes=sample_bytes_final,
+                            smoke=smoke,
+                        )
+                    except Exception as exc:
+                        logger.error("Support run failed: %s year=%s — %s", entry.name, sy, exc)
+                        results["status"] = "failed"
+                        break
+
+                    all_support_passed = all(
+                        ctx.validations.get(layer, {}).get("passed", False)
+                        for layer in ("raw", "clean", "mart")
+                    )
+                    if not all_support_passed:
+                        logger.error("Support validation failed: %s year=%s", entry.name, sy)
+                        results["status"] = "failed"
+                        break
+
+                if results["status"] == "failed":
+                    break
+            else:
+                # codelist / file: materializza (fetch / command) — output verificato mancante
+                logger.info("Support: materializing %s (%s)", entry.name, stype)
+                try:
+                    materialize_support(entry_dict, root=cfg.root, smoke=smoke)
+                except Exception as exc:
+                    logger.error("Support materialization failed: %s — %s", entry.name, exc)
                     results["status"] = "failed"
                     break
-
-            if results["status"] == "failed":
-                break
+                try:
+                    payloads = resolve_support_payloads(
+                        [entry_dict], require_exists=False, smoke=smoke, root=cfg.root
+                    )
+                    if not payloads[0]["all_outputs_exist"]:
+                        logger.error("Support materialization produced no output: %s", entry.name)
+                        results["status"] = "failed"
+                        break
+                except Exception as exc:
+                    logger.error("Support: cannot re-resolve %s: %s", entry.name, exc)
+                    results["status"] = "failed"
+                    break
 
     # ── Candidate ────────────────────────────────────────────────────────
     candidate_blocked = results["status"] == "failed" and not dry_flag
@@ -1081,6 +1129,7 @@ def _execute_pipeline(
     root: str | None,
     json_output: bool,
     dry_run: bool,
+    refresh_support: bool = False,
 ) -> None:
     """Wrapper CLI: esegue _run_pipeline e stampa output su stdout."""
     results = _run_pipeline(
@@ -1092,6 +1141,7 @@ def _execute_pipeline(
         sample_bytes=sample_bytes,
         root=root,
         dry_run=dry_run,
+        refresh_support=refresh_support,
     )
 
     if json_output:
@@ -1258,6 +1308,11 @@ def register(app: typer.Typer) -> None:
         ),
         json_output: bool = typer.Option(False, "--json", help="Output JSON report"),
         dry_run: bool = typer.Option(False, "--dry-run", help="Print plan without executing"),
+        refresh_support: bool = typer.Option(
+            False,
+            "--refresh-support",
+            help="Rigenera i support anche se gli output sono già presenti",
+        ),
     ):
         """Esegue la pipeline: singolo dataset o batch (--batch)."""
         if ctx.invoked_subcommand is not None:
@@ -1281,7 +1336,15 @@ def register(app: typer.Typer) -> None:
             raise typer.Exit(code=2)
         try:
             _execute_pipeline(
-                config, years_str, smoke, sample_rows, sample_bytes, root, json_output, dry_run
+                config,
+                years_str,
+                smoke,
+                sample_rows,
+                sample_bytes,
+                root,
+                json_output,
+                dry_run,
+                refresh_support=refresh_support,
             )
         except FileNotFoundError as exc:
             typer.echo(str(exc), err=True)

--- a/toolkit/contracts/pipeline.py
+++ b/toolkit/contracts/pipeline.py
@@ -64,12 +64,15 @@ _SOURCE_TYPES: list[dict[str, Any]] = [
     },
     {
         "type": "sdmx",
-        "description": "Scarica dati da API SDMX 2.1 (es. ISTAT, Eurostat).",
+        "description": "Scarica dati da API SDMX 2.1. Profilo ISTAT (agency IT1, default) e profilo Eurostat (agency ESTAT, TSV wide + JSON 2.0).",
         "args": {
-            "endpoint": "URL dell'endpoint SDMX",
-            "resource": "ID del dataflow/risorsa",
-            "filename": "nome locale (opzionale)",
+            "agency": "Agenzia SDMX: IT1 (ISTAT, default) o ESTAT (Eurostat)",
+            "flow": "ID del dataflow (es. NAMA_10R_3GDP, 22_289)",
+            "version": "Versione dataflow. Obbligatoria per ISTAT; opzionale/ignorata per ESTAT (numero mobile, mai nel path)",
+            "filters": "Filtri per dimensione (es. {freq: A, geo: [IT, ITC4]}). Valori validati contro i constraints dell'API",
+            "endpoint": "URL SDMX scoperta dallo scout. Funzionale per agenzie non-ISTAT/ESTAT (root derivato); ISTAT/ESTAT auto-risolvono",
         },
+        "note": "Output: CSV normalizzato. ISTAT: colonne con _label (JSON 2.1). ESTAT: [dims..., year, (month), value, flag] — le label si risolvono a valle con le codelist.",
     },
     {
         "type": "sparql",
@@ -333,8 +336,33 @@ _CONFIG_QUICKREF: dict[str, Any] = {
         "mart.validate.transition.max_row_drop_pct (soglia % righe perse clean→mart, default none)",
         "raw.sources[].type (http_file, ckan, sdmx, sparql, local_file)",
         "raw.sources[].extractor (identity, unzip_all, unzip_first, unzip_first_csv)",
-        "support (lista dataset di supporto, eseguiti prima del candidate)",
+        "support (lista support eseguiti prima del candidate — vedi sezione support)",
     ],
+    "support": {
+        "description": "Dataset/codelist/file di riferimento per i join nei SQL. Eseguiti (o riusati) PRIMA del candidate; esposti al template come placeholder {support.NAME.*}.",
+        "types": [
+            {
+                "type": "dataset",
+                "fields": "name, config (dataset.yml del support), years",
+                "materialize": "run del config (skip se clean+mart già presenti)",
+                "placeholder": "{support.NAME.mart}, {support.NAME.mart.TABLE}, {support.NAME.clean}, {support.NAME.outputs}",
+            },
+            {
+                "type": "codelist",
+                "fields": "name, id, agency (default ESTAT), provider (default sdmx)",
+                "materialize": "fetch_codelist → parquet in out/data/support/{name}/{name}.parquet (skip se presente)",
+                "placeholder": "{support.NAME.path}",
+            },
+            {
+                "type": "file",
+                "fields": "name, path, command (opzionale, per rigenerare il file)",
+                "materialize": "exec command se il file manca (richiede TOOLKIT_ALLOW_SCRIPT_SOURCE=1)",
+                "placeholder": "{support.NAME.path}",
+            },
+        ],
+        "ensure": "se gli output del support sono già presenti il run li riusa (skip-if-exists, per-anno); rigenerazione forzata con --refresh-support. Output attesi dataset = clean + tutte le tabelle mart.",
+        "anti_drift": "i SQL devono usare i placeholder {support.NAME.*} e non path hardcoded (check_support_path_drift, warning in dry-run).",
+    },
     "minimal_example": """dataset:
   name: mio_dataset
   years: [2024]
@@ -379,6 +407,7 @@ CONTRACTS: dict[str, Any] = {
         "required_columns = nomi OUTPUT del clean, non raw  |  "
         "se decimal=',' basta CAST(x AS DOUBLE)  |  "
         "mart.sql: SELECT ... FROM clean_input  |  "
+        "support: {support.NAME.mart|clean|path} (skip-if-exists, --refresh-support per forzare)  |  "
         "validazione: inline nel run record (_runs/), non piu' file separati  |  "
         "comandi: toolkit run init / preflight / all / scout / inspect"
     ),

--- a/toolkit/core/config.py
+++ b/toolkit/core/config.py
@@ -613,12 +613,20 @@ def _normalize_paths(data: dict, base_dir: Path) -> None:
     support = data.get("support")
     if isinstance(support, list):
         for item in support:
-            if isinstance(item, dict) and "config" in item:
-                val = item["config"]
-                if isinstance(val, str):
-                    p = Path(val)
-                    if not p.is_absolute():
-                        item["config"] = (base_dir / p).resolve()
+            if isinstance(item, dict):
+                if "config" in item:
+                    val = item["config"]
+                    if isinstance(val, str):
+                        p = Path(val)
+                        if not p.is_absolute():
+                            item["config"] = (base_dir / p).resolve()
+                # ADR-005: path del support file normalizzato sul root candidate
+                if "path" in item:
+                    val = item["path"]
+                    if isinstance(val, str):
+                        p = Path(val)
+                        if not p.is_absolute():
+                            item["path"] = str((base_dir / p).resolve())
 
 
 def _normalize_section_paths(section: dict, base_dir: Path) -> None:
@@ -750,6 +758,25 @@ def load_config(
         duplicates = sorted({n for n in support_names if support_names.count(n) > 1})
         if duplicates:
             raise ValueError("support[].name values must be unique: " + ", ".join(duplicates))
+
+        # ADR-005: validazione del tipo e dei campi richiesti per tipo
+        from toolkit.core.support import SUPPORT_TYPES
+
+        for s in support:
+            if not isinstance(s, dict):
+                continue
+            stype = str(s.get("type") or "dataset")
+            if stype not in SUPPORT_TYPES:
+                raise ValueError(
+                    f"support[].type must be one of {SUPPORT_TYPES}, got {stype!r} "
+                    f"for support '{s.get('name')}'"
+                )
+            if stype == "dataset" and "config" not in s:
+                raise ValueError(f"support dataset '{s.get('name')}' requires 'config'")
+            if stype == "codelist" and not s.get("id"):
+                raise ValueError(f"support codelist '{s.get('name')}' requires 'id'")
+            if stype == "file" and not s.get("path"):
+                raise ValueError(f"support file '{s.get('name')}' requires 'path'")
 
     # Convert support entries to dict-like objects with attribute access
     support_objects = [_dict2ns(s) if isinstance(s, dict) else s for s in support]

--- a/toolkit/core/read_excel.py
+++ b/toolkit/core/read_excel.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import pandas as pd
 
@@ -45,7 +45,8 @@ def _load_excel_frame(
     sheet_name = _normalize_excel_sheet_name(read_cfg.get("sheet_name"))
 
     ext = input_file.suffix.lower()
-    engine = "xlrd" if ext == ".xls" else "openpyxl"
+    # Literal richiesto dagli overload pandas (engine non è str generico)
+    engine: Literal["xlrd", "openpyxl"] = "xlrd" if ext == ".xls" else "openpyxl"
     df = pd.read_excel(
         input_file,
         sheet_name=sheet_name,

--- a/toolkit/core/sql_validation.py
+++ b/toolkit/core/sql_validation.py
@@ -100,7 +100,9 @@ def _build_clean_preview(
     support_payloads_drift: list[dict[str, Any]] = []
     if dry_run and support_cfg:
         try:
-            sp_payloads = resolve_support_payloads(support_cfg, require_exists=False, smoke=False)
+            sp_payloads = resolve_support_payloads(
+                support_cfg, require_exists=False, smoke=False, root=cfg.root
+            )
             support_paths = _all_support_expected_paths(sp_payloads)
             support_payloads_drift = sp_payloads
         except Exception:

--- a/toolkit/core/support.py
+++ b/toolkit/core/support.py
@@ -4,7 +4,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from toolkit.core.config import load_config
 from toolkit.core.exceptions import DownloadError
@@ -283,8 +283,8 @@ def _write_codelist_parquet(result: dict[str, object], target: Path) -> None:
     """Serializza {codes, annotations} in parquet: code, label_en + annotation types."""
     import duckdb
 
-    codes: dict[str, str] = result.get("codes") or {}
-    annotations: dict[str, dict[str, str]] = result.get("annotations") or {}
+    codes = cast(dict[str, str], result.get("codes") or {})
+    annotations = cast(dict[str, dict[str, str]], result.get("annotations") or {})
 
     ann_types: list[str] = []
     for ann in annotations.values():

--- a/toolkit/core/support.py
+++ b/toolkit/core/support.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 from pathlib import Path
 from typing import Any
 
 from toolkit.core.config import load_config
+from toolkit.core.exceptions import DownloadError
 from toolkit.core.paths import layer_year_dir
+
+# Tipi di support (ADR-005): dataset (default), codelist, file.
+SUPPORT_TYPES = ("dataset", "codelist", "file")
+
+# Convenzione layer materializzazione codelist: out/data/support/{name}/{name}.parquet
+SUPPORT_LAYER = "support"
 
 
 def _support_expected_mart_outputs(cfg, year: int) -> list[Path]:
@@ -14,70 +23,298 @@ def _support_expected_mart_outputs(cfg, year: int) -> list[Path]:
     return [mart_dir / f"{name}.parquet" for name in table_names]
 
 
+def _support_expected_clean_output(cfg, year: int) -> Path:
+    """Parquet CLEAN del support dataset (ADR-005: output attesi = clean + mart)."""
+    clean_dir = layer_year_dir(cfg.root, "clean", cfg.dataset, year)
+    return clean_dir / f"{cfg.dataset}_{year}_clean.parquet"
+
+
+def _codelist_output_path(root: Path, name: str) -> Path:
+    """Parquet canonico di una codelist materializzata (ADR-005)."""
+    return root / "data" / SUPPORT_LAYER / name / f"{name}.parquet"
+
+
+def _entry_type(entry: dict[str, Any]) -> str:
+    stype = str(entry.get("type") or "dataset")
+    if stype not in SUPPORT_TYPES:
+        raise ValueError(
+            f"support[].type must be one of {SUPPORT_TYPES}, got {stype!r} "
+            f"for support '{entry.get('name')}'"
+        )
+    return stype
+
+
 def resolve_support_payloads(
     support_entries: list[dict[str, Any]] | None,
     *,
     require_exists: bool,
     smoke: bool = False,
+    root: Path | None = None,
 ) -> list[dict[str, Any]]:
+    """Risolve gli output attesi di ogni support entry, per tipo (ADR-005).
+
+    - ``type: dataset``: carica il config del support e risolve clean + tutte
+      le tabelle mart per anno (comportamento storico esteso al clean).
+    - ``type: codelist``: parquet canonico in ``{root}/data/support/{name}/``
+      (richiede ``root`` = root del candidate).
+    - ``type: file``: path dichiarato (relativo normalizzato sul root).
+
+    Con ``require_exists=True`` gli output mancanti sollevano errore esplicito
+    (mart/clean del support non ancora eseguito, o codelist/file non
+    materializzati).
+    """
     resolved: list[dict[str, Any]] = []
     for entry in support_entries or []:
         name = str(entry["name"])
-        config_path = Path(entry["config"])
-        years = [int(year) for year in entry.get("years") or []]
-        # Smoke mode: output del support e' in {root}/smoke/data/... (root override eseguito in run_full)
-        if smoke:
-            _sup0 = load_config(config_path)
-            support_cfg = load_config(config_path, root_override=_sup0.root / "smoke")
-        else:
-            support_cfg = load_config(config_path)
+        stype = _entry_type(entry)
 
-        year_payloads: list[dict[str, Any]] = []
-        all_outputs: list[str] = []
-        for year in years:
-            expected_paths = _support_expected_mart_outputs(support_cfg, year)
-            output_paths = [str(path) for path in expected_paths]
-            existing_paths = [str(path) for path in expected_paths if path.exists()]
-            all_outputs_exist = len(output_paths) > 0 and len(existing_paths) == len(output_paths)
-            if require_exists and not output_paths:
-                raise ValueError(
-                    "Support dataset MART non configurato: "
-                    f"{name} ({config_path}) anno {year}. "
-                    "Il dataset di supporto deve dichiarare almeno una tabella in mart.tables."
-                )
-            if require_exists and not all_outputs_exist:
-                raise FileNotFoundError(
-                    "Support dataset output mancante: "
-                    f"{name} ({config_path}) anno {year}. "
-                    "Esegui prima il MART del support dataset o correggi support[].years."
-                )
-            year_payloads.append(
-                {
-                    "year": year,
-                    "dataset": support_cfg.dataset,
-                    "config_path": str(config_path),
-                    "mart_dir": str(
-                        layer_year_dir(support_cfg.root, "mart", support_cfg.dataset, year)
-                    ),
-                    "outputs": output_paths,
-                    "existing_outputs": existing_paths,
-                    "all_outputs_exist": all_outputs_exist,
-                }
+        if stype == "dataset":
+            resolved.append(_resolve_dataset_entry(entry, name, require_exists, smoke))
+        elif stype == "codelist":
+            resolved.append(_resolve_codelist_entry(entry, name, require_exists, root))
+        else:  # file
+            resolved.append(_resolve_file_entry(entry, name, require_exists, root))
+    return resolved
+
+
+def _resolve_dataset_entry(
+    entry: dict[str, Any], name: str, require_exists: bool, smoke: bool
+) -> dict[str, Any]:
+    if "config" not in entry:
+        raise ValueError(f"support dataset '{name}' requires 'config'")
+    config_path = Path(entry["config"])
+    years = [int(year) for year in entry.get("years") or []]
+    if smoke:
+        _sup0 = load_config(config_path)
+        support_cfg = load_config(config_path, root_override=_sup0.root / "smoke")
+    else:
+        support_cfg = load_config(config_path)
+
+    year_payloads: list[dict[str, Any]] = []
+    all_outputs: list[str] = []
+    for year in years:
+        mart_paths = _support_expected_mart_outputs(support_cfg, year)
+        clean_path = _support_expected_clean_output(support_cfg, year)
+        expected_paths = [clean_path, *mart_paths]
+        output_paths = [str(path) for path in expected_paths]
+        existing_paths = [str(path) for path in expected_paths if path.exists()]
+        all_outputs_exist = len(output_paths) > 0 and len(existing_paths) == len(output_paths)
+        if require_exists and not mart_paths:
+            raise ValueError(
+                "Support dataset MART non configurato: "
+                f"{name} ({config_path}) anno {year}. "
+                "Il dataset di supporto deve dichiarare almeno una tabella in mart.tables."
             )
-            all_outputs.extend(existing_paths if require_exists else output_paths)
-
-        resolved.append(
+        if require_exists and not all_outputs_exist:
+            missing = [p for p in expected_paths if not p.exists()]
+            raise FileNotFoundError(
+                "Support dataset output mancante: "
+                f"{name} ({config_path}) anno {year}: {missing[0]}. "
+                "Esegui prima il run del support dataset o correggi support[].years."
+            )
+        year_payloads.append(
             {
-                "name": name,
-                "config_path": str(config_path),
+                "year": year,
                 "dataset": support_cfg.dataset,
-                "years": years,
-                "years_resolved": year_payloads,
-                "outputs": all_outputs,
-                "mart": all_outputs[0] if all_outputs else None,
+                "config_path": str(config_path),
+                "mart_dir": str(
+                    layer_year_dir(support_cfg.root, "mart", support_cfg.dataset, year)
+                ),
+                "clean": str(clean_path),
+                "outputs": output_paths,
+                "existing_outputs": existing_paths,
+                "all_outputs_exist": all_outputs_exist,
             }
         )
-    return resolved
+        all_outputs.extend(existing_paths if require_exists else output_paths)
+
+    mart_by_table: dict[str, str] = {}
+    for table in support_cfg.mart.tables or []:
+        if not table.name:
+            continue
+        year = years[0] if years else 0
+        mart_dir = layer_year_dir(support_cfg.root, "mart", support_cfg.dataset, year)
+        mart_by_table[table.name] = str(mart_dir / f"{table.name}.parquet")
+
+    return {
+        "name": name,
+        "type": "dataset",
+        "config_path": str(config_path),
+        "dataset": support_cfg.dataset,
+        "years": years,
+        "years_resolved": year_payloads,
+        "outputs": all_outputs,
+        "mart": (str(mart_paths[0]) if mart_paths else None),
+        "mart_by_table": mart_by_table,
+        "clean": (year_payloads[0]["clean"] if year_payloads else None),
+        "path": None,
+        "all_outputs_exist": all(yp["all_outputs_exist"] for yp in year_payloads)
+        if year_payloads
+        else False,
+    }
+
+
+def _resolve_codelist_entry(
+    entry: dict[str, Any], name: str, require_exists: bool, root: Path | None
+) -> dict[str, Any]:
+    if root is None:
+        raise ValueError(f"support codelist '{name}' requires the candidate root")
+    if not entry.get("id"):
+        raise ValueError(f"support codelist '{name}' requires 'id'")
+    target = _codelist_output_path(root, name)
+    all_outputs_exist = target.exists()
+    if require_exists and not all_outputs_exist:
+        raise FileNotFoundError(
+            f"Support codelist '{name}' non materializzata: {target}. "
+            "Esegui il run del candidate (materializza prima) o --refresh-support."
+        )
+    return {
+        "name": name,
+        "type": "codelist",
+        "config_path": None,
+        "dataset": None,
+        "years": [],
+        "years_resolved": [],
+        "outputs": [str(target)],
+        "existing_outputs": [str(target)] if all_outputs_exist else [],
+        "all_outputs_exist": all_outputs_exist,
+        "mart": None,
+        "mart_by_table": {},
+        "clean": None,
+        "path": str(target),
+    }
+
+
+def _resolve_file_entry(
+    entry: dict[str, Any], name: str, require_exists: bool, root: Path | None
+) -> dict[str, Any]:
+    if not entry.get("path"):
+        raise ValueError(f"support file '{name}' requires 'path'")
+    if root is None:
+        raise ValueError(f"support file '{name}' requires the candidate root")
+    raw_path = Path(entry["path"])
+    target = raw_path if raw_path.is_absolute() else Path(root) / raw_path
+    all_outputs_exist = target.exists()
+    if require_exists and not all_outputs_exist:
+        raise FileNotFoundError(
+            f"Support file '{name}' mancante: {target}. "
+            "Esegui il run del candidate (materializza prima) o --refresh-support."
+        )
+    return {
+        "name": name,
+        "type": "file",
+        "config_path": None,
+        "dataset": None,
+        "years": [],
+        "years_resolved": [],
+        "outputs": [str(target)],
+        "existing_outputs": [str(target)] if all_outputs_exist else [],
+        "all_outputs_exist": all_outputs_exist,
+        "mart": None,
+        "mart_by_table": {},
+        "clean": None,
+        "path": str(target),
+    }
+
+
+def materialize_support(
+    entry: dict[str, Any], *, root: Path | None = None, smoke: bool = False
+) -> Path | None:
+    """Materializza un support non-dataset (codelist/file) sul disco.
+
+    `type: dataset` NON è materializzabile qui: il run del support avviene
+    nell'orchestrazione (cmd_run), che ha il config completo.
+
+    Ritorna il path materializzato (o None per il tipo file, che scrive dove
+    dichiarato dal command).
+    """
+    name = str(entry["name"])
+    stype = _entry_type(entry)
+    if stype == "dataset":
+        raise ValueError(f"support dataset '{name}' si materializza via run, non qui")
+    if stype == "codelist":
+        if root is None:
+            raise ValueError(f"support codelist '{name}' requires root (candidate)")
+        return materialize_codelist_to(entry, root, smoke=smoke)
+    _materialize_file(entry, name)
+    return None
+
+
+def _materialize_file(entry: dict[str, Any], name: str) -> None:
+    command = entry.get("command")
+    if not command:
+        raise DownloadError(f"support file '{name}' mancante e senza 'command' per rigenerarlo")
+    if os.environ.get("TOOLKIT_ALLOW_SCRIPT_SOURCE") != "1":
+        raise DownloadError(
+            "support file materialization requires TOOLKIT_ALLOW_SCRIPT_SOURCE=1 "
+            f"(command per '{name}')"
+        )
+    result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=600)
+    if result.returncode != 0:
+        stderr_preview = result.stderr[:500] if result.stderr else "(no stderr)"
+        raise DownloadError(
+            f"Support file command failed (exit {result.returncode}): {stderr_preview}"
+        )
+
+
+def materialize_codelist_to(entry: dict[str, Any], root: Path, *, smoke: bool = False) -> Path:
+    """Fetch codelist (SDMX) e scrive il parquet canonico nel support layer."""
+    from toolkit.plugins.sdmx import SdmxSource
+
+    provider = str(entry.get("provider") or "sdmx")
+    if provider != "sdmx":
+        raise DownloadError(
+            f"support codelist '{entry.get('name')}': provider {provider!r} non supportato"
+        )
+    agency = str(entry.get("agency") or "ESTAT")
+    codelist_id = str(entry["id"])
+    name = str(entry["name"])
+
+    src = SdmxSource(timeout=60, retries=2)
+    result = src.fetch_codelist(codelist_id, agency=agency)
+
+    target = _codelist_output_path(root, name)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    _write_codelist_parquet(result, target)
+    return target
+
+
+def _write_codelist_parquet(result: dict[str, object], target: Path) -> None:
+    """Serializza {codes, annotations} in parquet: code, label_en + annotation types."""
+    import duckdb
+
+    codes: dict[str, str] = result.get("codes") or {}
+    annotations: dict[str, dict[str, str]] = result.get("annotations") or {}
+
+    ann_types: list[str] = []
+    for ann in annotations.values():
+        for key in ann:
+            if key not in ann_types:
+                ann_types.append(key)
+
+    rows: list[tuple[str, str, tuple[str, ...]]] = []
+    for code, label in sorted(codes.items()):
+        ann = annotations.get(code, {})
+        rows.append((code, label, tuple(ann.get(t, "") for t in ann_types)))
+
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False, encoding="utf-8") as fh:
+        import csv
+
+        writer = csv.writer(fh, lineterminator="\n")
+        writer.writerow(["code", "label_en", *ann_types])
+        for code, label, ann_values in rows:
+            writer.writerow([code, label, *ann_values])
+        tmp_csv = fh.name
+
+    try:
+        duckdb.sql(
+            f"COPY (SELECT * FROM read_csv('{tmp_csv}', auto_detect=true, all_varchar=true)) "
+            f"TO '{target}' (FORMAT PARQUET)"
+        )
+    finally:
+        Path(tmp_csv).unlink(missing_ok=True)
 
 
 def check_support_path_drift(
@@ -87,13 +324,12 @@ def check_support_path_drift(
 ) -> list[str]:
     """
     Scans raw SQL (pre-template-render) for hardcoded path references to
-    support datasets that bypass the ``{support.NAME.mart}`` placeholder
-    contract.
+    support datasets that bypass the ``{support.NAME.*}`` placeholder
+    contract (mart, clean, mart.TABLE, path, outputs).
 
     For each declared support entry, verifies that if the support dataset
-    slug appears in a path-like string literal, the corresponding
-    ``{support.NAME.mart}`` or ``{support.NAME.outputs}`` placeholder is
-    also present in the SQL.
+    slug appears in a path-like string literal, a ``{support.NAME.*}``
+    placeholder is also present in the SQL.
 
     Returns a list of warning messages (empty = no drift detected).
     """
@@ -102,7 +338,7 @@ def check_support_path_drift(
     # Build name -> dataset slug map from resolved payloads
     name_slug_map: dict[str, str] = {}
     for payload in support_payloads:
-        slug = payload.get("dataset", "")
+        slug = payload.get("dataset") or payload.get("name")
         if slug:
             name_slug_map[payload["name"]] = slug
 
@@ -111,7 +347,9 @@ def check_support_path_drift(
 
     # Find which support names are used via placeholder
     used_via_placeholder: set[str] = set()
-    for match in re.finditer(r"\{support\.([A-Za-z_][A-Za-z0-9_]*)\.(mart|outputs)\}", raw_sql):
+    for match in re.finditer(
+        r"\{support\.([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_.]*)\}", raw_sql
+    ):
         used_via_placeholder.add(match.group(1))
 
     for name, slug in name_slug_map.items():
@@ -128,8 +366,8 @@ def check_support_path_drift(
             if not any(c in text for c in ("/", "\\", ".")):
                 continue
             warnings.append(
-                f"Support dataset '{slug}' referenced via hardcoded path "
-                f"instead of {{support.{name}.mart}}: "
+                f"Support '{slug}' referenced via hardcoded path "
+                f"instead of a {{support.{name}.*}} placeholder: "
                 f"{'' if not sql_label else sql_label + ' > '}{text[:120]}"
             )
 
@@ -142,4 +380,10 @@ def flatten_support_template_ctx(payloads: list[dict[str, Any]]) -> dict[str, An
         name = payload["name"]
         ctx[f"support.{name}.outputs"] = payload["outputs"]
         ctx[f"support.{name}.mart"] = payload["mart"]
+        if payload.get("clean"):
+            ctx[f"support.{name}.clean"] = payload["clean"]
+        for table, table_path in (payload.get("mart_by_table") or {}).items():
+            ctx[f"support.{name}.mart.{table}"] = table_path
+        if payload.get("path"):
+            ctx[f"support.{name}.path"] = payload["path"]
     return ctx

--- a/toolkit/domain/path_resolver.py
+++ b/toolkit/domain/path_resolver.py
@@ -120,7 +120,9 @@ def payload_for_year(cfg, year: int) -> dict[str, Any]:
             "raw": _raw_output_paths(root, cfg.dataset, year),
             "clean": _clean_paths(root, cfg.dataset, year),
             "mart": _mart_paths(root, cfg.dataset, year, mart_tables),
-            "support": resolve_support_payloads(ensure_dict(cfg.support), require_exists=False),
+            "support": resolve_support_payloads(
+                ensure_dict(cfg.support), require_exists=False, root=Path(root)
+            ),
             "run_dir": str(run_dir),
         },
         "run_file_count": len(run_files),

--- a/toolkit/mart/run.py
+++ b/toolkit/mart/run.py
@@ -120,7 +120,9 @@ def run_mart_multi_year(
     if not multi_year_tables:
         return {"output_rows": 0, "output_bytes": 0, "tables_count": 0, "col_count": None}
 
-    support_payloads = resolve_support_payloads(support_cfg, require_exists=True, smoke=smoke)
+    support_payloads = resolve_support_payloads(
+        support_cfg, require_exists=True, smoke=smoke, root=Path(root_dir)
+    )
     base_ctx = build_runtime_template_ctx(
         dataset=dataset,
         year=dataset_years[0] if dataset_years else 0,
@@ -443,7 +445,9 @@ def run_mart(
                 "(add explicit tables or a hierarchy section)"
             )
 
-        support_payloads = resolve_support_payloads(support_cfg, require_exists=True, smoke=smoke)
+        support_payloads = resolve_support_payloads(
+            support_cfg, require_exists=True, smoke=smoke, root=Path(root_dir)
+        )
         template_ctx = build_runtime_template_ctx(
             dataset=dataset,
             year=year,

--- a/toolkit/profile/raw.py
+++ b/toolkit/profile/raw.py
@@ -11,7 +11,7 @@ import csv
 import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import duckdb
 from lab_connectors.duckdb import safe_connect
@@ -276,7 +276,9 @@ def _sample_profile_rows(
           le colonne (non troncata). Usata dall'inferenza NOT NULL della validazione.
     """
     df = con.execute("SELECT * FROM v LIMIT 50").fetchdf()
-    sample_rows = df.to_dict(orient="records")
+    # pandas-stubs: to_dict(orient='records') restituisce dict[Hashable, Any];
+    # le chiavi sono sempre str (nomi colonna) → cast esplicito.
+    sample_rows = cast(list[dict[str, Any]], df.to_dict(orient="records"))
 
     # Single-pass missingness: one query with all columns in CASE expressions.
     # Avoids O(N) separate queries (N = columns), which was slow for 50+ column files.


### PR DESCRIPTION
## Sintesi

ADR-005: support unificati. Estende il contratto `support:` con i tipi `codelist` e `file` (finora solo `dataset`), introduce l'orchestrazione **ensure** (skip-if-exists: i support con output già presenti non vengono rieseguiti a ogni `run full`) e completa il set dei placeholder template (`clean`, `mart.TABLE`, `path`). Inclusi: `mypy toolkit/` pulito al 100% e contract/docs aggiornati.

## Contesto collegato

ADR-005 in `docs/adr/005-support-ensure.md`. Segue la #450 (profilo SDMX ESTAT): `fetch_codelist` è il motore di materializzazione delle codelist.

## Cosa cambia

- [x] Nuova funzionalità del motore
- [x] Modifica contratto pubblico (dataset.yml — sezione `support:`, vedi sotto)
- [x] Documentazione (ADR + config-schema + conventions + contract)
- [ ] Bug fix
- [ ] Nuovo plugin sorgente
- [ ] Refactor / performance
- [ ] Dipendenze o CI

## Dettagli

**Contratto `support:` esteso** (type default `dataset` → nessuna rottura dei config esistenti):

```yaml
support:
  - name: comuni
    type: dataset              # invariato — materializza: run del config
    config: "../../support_datasets/istat-elenco-comuni/dataset.yml"
    years: [2026]
  - name: geo
    type: codelist             # NUOVO — materializza: fetch_codelist → parquet canonico
    provider: sdmx
    agency: ESTAT
    id: GEO
  - name: quartieri
    type: file                 # NUOVO — materializza: exec command se manca
    path: "mapping/colonnine-quartieri.csv"
    command: "python mapping/colonnine_quartieri.py"   # opzionale
```

**Orchestrazione ensure** (sostituisce il run incondizionato dei support in `cmd_run.run_full`):
- output attesi per tipo: dataset → clean + tutte le tabelle mart (per anno); codelist → `out/data/support/{name}/{name}.parquet`; file → path dichiarato
- se tutti presenti e non `--refresh-support` → **SKIP** (log "reuse support"); se mancano → dataset: run (invariato), codelist: `fetch_codelist` + parquet, file: exec command
- skip per-anno; support fallito blocca il candidate (invariato); smoke/dry-run invariati

**Placeholder set completo** (`flatten_support_template_ctx`):
- `{support.NAME.mart}` prima tabella (compat) + `{support.NAME.mart.TABLE}` per tabella (risolve il caso reale `mart_codici_catastali`)
- `{support.NAME.clean}` parquet clean del support
- `{support.NAME.path}` file materializzato (codelist/file)
- `{support.NAME.outputs}` invariato
- `check_support_path_drift` esteso a tutti i placeholder

**Contract + docs** (commit `926fd45`):
- `toolkit_contract`: source type `sdmx` allineato al contratto reale post-#450 (`agency/flow/version/filters/endpoint`, profilo ISTAT+ESTAT); nuova sezione `config.support` (tipi, materializzazione, placeholder, anti-drift); tldr aggiornato
- `docs/config-schema.md`: sezione `support:` completa (tipi, ensure, `--refresh-support`, placeholder)
- `docs/conventions.md`: sezione 8 "Support dataset (ADR-005)"
- `README.md`: riga `--refresh-support`

## Impatto su contratti pubblici

- [x] Struttura `dataset.yml` — campo `support[].type` (default `dataset`), `support[].path` normalizzato sul root candidate. I config esistenti restano validi.
- [ ] Path output — *nuovo* layer materializzazione codelist `out/data/support/{name}/` (additivo, non tocca i layer esistenti)
- [ ] Schema parquet
- [ ] CLI o MCP tool — *nuovo* flag `--refresh-support` (additivo)
- [x] API pubblica del toolkit — `resolve_support_payloads` parametro `root` opzionale (additivo); nuovi `materialize_support`, `materialize_codelist_to`; `SUPPORT_TYPES`

> Downstream: nessuna rottura per i candidate esistenti (default `dataset` = comportamento storico + skip quando gli output ci sono già). Pilota previsto: `inps-rdc-pdc` → `{support.comuni.mart.mart_codici_catastali}` (dataset-incubator), poi eurostat codelist e dcl-bologna mapping.

## Verifica

```bash
python -m pytest tests/ -q        # 1275 passed, 22 deselected
ruff check .                       # All checks passed!
mypy toolkit/                      # Success: no issues found in 119 source files
```

- [x] `pytest` passa (1275: regressione support storica + 14 nuovi — tipi codelist/file, materializzazione codelist con mock, guard script per file, skip-if-exists e run-if-missing end-to-end con spy su `run_year`, placeholder set)
- [x] `ruff check .` passa
- [x] `mypy toolkit/` passa — **Success completo (119 file)**: fix `2088c86` (cast in `_write_codelist_parquet`) + fix `926fd45` dei 2 errori preesistenti su main (`read_excel.py` engine → `Literal`, `profile/raw.py` cast per `df.to_dict`) + cast `result.get()` — **zero errori residui**
- [x] ADR-005 documentato + contract/docs allineati (sdmx, support, tldr)

## Checklist PR

- [x] Perimetro stretto: una PR = ADR-005 (support ensure + tipi) + mypy pulito + contract/docs
- [x] Test inclusi
- [x] ADR come motivazione dell'assenza di issue
- [x] Nessun modulo pubblico rimosso

## Note per chi revisiona

- **Smoke per codelist**: la materializzazione codelist usa lo stesso path canonico in smoke mode (le codelist sono piccole, il root-override smoke non è applicato). Documentato nell'ADR come limite accettato per ora.
- **Freshness**: skip basato su esistenza del file + `--refresh-support` manuale. Hash/run-record = evoluzione futura (ADR).
- **`--refresh-support`** non è propagato al batch (`--batch`): perimetro stretto, da estendere se serve.
- Il layer `out/data/support/` è nuovo e non entra nel catalogo clean (le codelist non sono dataset).
- Il contract `toolkit_contract` documenta ora anche il source type `sdmx` corretto (prima era obsoleto: `endpoint/resource/filename` → ora `agency/flow/version/filters/endpoint`).