### PR TITLE
feat(registry): modulo condiviso clean_catalog/mart_catalog/signals + reader CLI/MCP + find semantico

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "requests>=2.33.1",
   "typer>=0.12.0",
   "rich>=13.0",
+  "jsonschema>=4.0",
   "lab-connectors[duckdb,mcp] @ git+https://github.com/dataciviclab/lab-connectors.git"
 ]
 
@@ -98,6 +99,7 @@ exclude = ["tests*"]
 
 [tool.setuptools.package-data]
 toolkit = ["sql/*.sql"]
+"toolkit.registry" = ["schemas/*.json"]
 
 [tool.setuptools.dynamic]
 version = { attr = "toolkit.version.__version__" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ exclude = ["tests*"]
 
 [tool.setuptools.package-data]
 toolkit = ["sql/*.sql"]
-"toolkit.registry" = ["schemas/*.json"]
+"toolkit.registry" = ["schemas/*.json", "semantic_types.yaml"]
 
 [tool.setuptools.dynamic]
 version = { attr = "toolkit.version.__version__" }

--- a/tests/test_catalog_ops.py
+++ b/tests/test_catalog_ops.py
@@ -190,6 +190,75 @@ def resolver_with_local(monkeypatch: pytest.MonkeyPatch) -> CatalogResolver:
             },
         },
     )
+    # Catalogo semantico committato: isolato nei test (nessuna semantica)
+    monkeypatch.setattr("toolkit.domain.catalog._scan_committed_catalogs", lambda _workspace: {})
+    return resolver
+
+
+# Catalogo semantico fake: arricchisce entry già presenti nel manifest.
+_FAKE_SEMANTIC: dict[str, dict[str, Any]] = {
+    "anac_bandi_gara": {
+        "slug": "anac_bandi_gara",
+        "name": "Bandi di gara ANAC",
+        "description": "Bandi di gara pubblici",
+        "tags": ["appalti"],
+        "category": "appalti",
+        "period": {"start": 2023, "end": 2024},
+        "columns": [
+            {
+                "name": "cig_code",
+                "type": "VARCHAR",
+                "role": "dimension",
+                "description": "Codice CIG",
+            },
+            {"name": "importo", "type": "DOUBLE", "role": "metric", "description": "Importo gara"},
+        ],
+        "_repo": "dataset-incubator",
+    },
+    "terna_electricity_by_source": {
+        "slug": "terna_electricity_by_source",
+        "name": "Elettricità per fonte",
+        "description": "Produzione elettrica per fonte",
+        "tags": ["energia"],
+        "category": "energia",
+        "period": {"start": 2023, "end": 2024},
+        "columns": [
+            {"name": "fonte", "type": "VARCHAR", "role": "dimension", "description": ""},
+            {"name": "gwh", "type": "DOUBLE", "role": "metric", "description": "GWh prodotti"},
+        ],
+        "_repo": "dataset-incubator",
+    },
+    "popolazione_istat_comunale_2019_2025": {
+        "slug": "popolazione_istat_comunale_2019_2025",
+        "name": "Popolazione comunale",
+        "description": "Popolazione residente per comune",
+        "tags": [],
+        "category": "popolazione",
+        "columns": [{"name": "comune", "type": "VARCHAR", "role": "dimension", "description": ""}],
+        "_repo": "dataset-incubator",
+    },
+}
+
+
+@pytest.fixture
+def resolver_semantic(monkeypatch: pytest.MonkeyPatch) -> CatalogResolver:
+    """Resolver con manifest mockato E catalogo semantico mockato."""
+    resolver = CatalogResolver(
+        manifest_url="http://fake/manifest.json",
+        include_local=True,
+    )
+
+    def _fake_read_manifest(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return _FAKE_MANIFEST
+
+    monkeypatch.setattr("toolkit.domain.catalog.read_manifest", _fake_read_manifest)
+    monkeypatch.setattr("toolkit.domain.catalog._scan_workspace_parquets", lambda _w: [])
+    monkeypatch.setattr(
+        "toolkit.domain.catalog._scan_workspace_configs", lambda _w, stage="all": {}
+    )
+    monkeypatch.setattr(
+        "toolkit.domain.catalog._scan_committed_catalogs", lambda _w: _FAKE_SEMANTIC
+    )
     return resolver
 
 
@@ -544,3 +613,67 @@ class TestEdgeCases:
         res = resolver.list_datasets(limit=3)
         assert res["truncated"] is True
         assert len(res["datasets"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Semantic find (mossa 1: catalogo committato nel resolver)
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticFind:
+    def test_find_by_description(self, resolver_semantic: CatalogResolver) -> None:
+        """Query su description del catalogo committato trova il dataset."""
+        res = resolver_semantic.list_datasets(query="bandi di gara")
+        slugs = {d["slug"] for d in res["datasets"]}
+        assert "anac_bandi_gara" in slugs
+        entry = next(d for d in res["datasets"] if d["slug"] == "anac_bandi_gara")
+        assert entry["description"] == "Bandi di gara pubblici"
+        assert entry["meta_match"] is True
+        assert entry["_repo"] == "dataset-incubator"
+
+    def test_find_by_column(self, resolver_semantic: CatalogResolver) -> None:
+        """Query su nome colonna → matched_columns popolato."""
+        res = resolver_semantic.list_datasets(query="importo")
+        entry = next(d for d in res["datasets"] if d["slug"] == "anac_bandi_gara")
+        assert entry["meta_match"] is not True
+        assert entry["matched_columns"] == [
+            {"name": "importo", "type": "DOUBLE", "role": "metric", "description": "Importo gara"}
+        ]
+
+    def test_find_metric_only(self, resolver_semantic: CatalogResolver) -> None:
+        """metric_only esclude i dataset senza colonne metric."""
+        res = resolver_semantic.list_datasets(metric_only=True)
+        slugs = {d["slug"] for d in res["datasets"]}
+        assert "anac_bandi_gara" in slugs
+        assert "terna_electricity_by_source" in slugs
+        assert "popolazione_istat_comunale_2019_2025" not in slugs
+
+    def test_find_metric_only_respects_query(self, resolver_semantic: CatalogResolver) -> None:
+        """metric_only + query semantica si combinano."""
+        res = resolver_semantic.list_datasets(query="produzione elettrica", metric_only=True)
+        slugs = {d["slug"] for d in res["datasets"]}
+        assert "terna_electricity_by_source" in slugs
+        assert "anac_bandi_gara" not in slugs
+
+    def test_describe_semantic_enrichment(
+        self, resolver_semantic: CatalogResolver, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """describe_slug arricchito: description/tags/period + colonne con role."""
+        fake_preview = {
+            "path": "x",
+            "column_count": 1,
+            "columns": [{"name": "importo", "type": "DOUBLE"}],
+            "row_count": 10,
+            "preview": [],
+            "truncated": False,
+        }
+        monkeypatch.setattr(
+            "toolkit.domain.catalog.parquet_preview", lambda *a, **k: dict(fake_preview)
+        )
+
+        res = resolver_semantic.describe_slug("anac_bandi_gara")
+        assert res["description"] == "Bandi di gara pubblici"
+        assert res["tags"] == ["appalti"]
+        assert res["period"] == {"start": 2023, "end": 2024}
+        assert res["columns"][0]["role"] == "metric"
+        assert res["columns"][0]["description"] == "Importo gara"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -29,6 +29,8 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_preflight",
         "toolkit_find",
         "toolkit_dataset_overview",
+        "toolkit_registry_list",
+        "toolkit_registry_show",
     }
 
 

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -1,0 +1,294 @@
+"""Test del registry builder condiviso (fixture mini-repo, nessuna rete).
+
+Il builder riusa il runtime del toolkit (config model, path resolver,
+run_state, parquet_schema): la fixture crea un mini-repo con dataset.yml
+(root relativo), parquet locali e run records — stesso layout reale.
+
+Marker: contract (artefatti validi contro gli schemi), policy (namespace
+canonico = dataset.name), pure_unit (logica pura).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from toolkit.registry.builders import (
+    build_clean_catalog,
+    build_mart_catalog,
+    build_signals,
+)
+from toolkit.registry.layout import RepoLayout
+from toolkit.registry.paths import PathContract
+from toolkit.registry.runs import run_block
+
+pytest.importorskip("duckdb")
+
+MART_YML = """
+root: "../../out"
+schema_version: 1
+dataset:
+  name: "{name}"
+  source_id: "{source_id}"
+  tags: [test, demo]
+  category: demo
+  years: [2024, 2025]
+  time_coverage:
+    start_year: 2000
+    end_year: 2024
+mart:
+  tables:
+    - name: "mart_trend"
+      sql: "sql/mart_trend.sql"
+  validate:
+    table_rules:
+      mart_trend:
+        required_columns: [year, geo, value]
+        primary_key: [year, geo]
+        min_rows: 10
+"""
+
+SIMPLE_YML = """
+root: "../../out"
+schema_version: 1
+dataset:
+  name: "{name}"
+  source_id: "{source_id}"
+  tags: [test]
+  category: demo
+  years: [2024]
+"""
+
+RUN_RECORD = {
+    "dataset": "my_dataset",
+    "year": 2024,
+    "run_id": "20260101T000000Z_abc123",
+    "status": "SUCCESS",
+    "started_at": "2026-01-01T00:00:00Z",
+    "finished_at": "2026-01-01T00:00:01Z",
+    "duration_seconds": 1.0,
+    "layers": {
+        "raw": {
+            "status": "SUCCESS",
+            "metrics": {"output_rows": None, "output_bytes": 6961784},
+        },
+        "clean": {
+            "status": "SUCCESS",
+            "metrics": {"output_rows": 120, "output_bytes": 9757664},
+        },
+        "mart": {"status": "SUCCESS", "metrics": {"output_rows": 30}},
+    },
+    "validations": {
+        "raw": {"quality_score": 100},
+        "clean": {"quality_score": 95},
+        "mart": {"quality_score": 100},
+    },
+}
+
+
+def _write_parquet(path: Path) -> None:
+    import duckdb
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with duckdb.connect() as con:
+        con.execute("CREATE TABLE t (geo VARCHAR, year INTEGER, value DOUBLE)")
+        con.execute("INSERT INTO t VALUES ('ITC4', 2024, 1.5), ('ITH3', 2024, 2.5)")
+        con.execute(f"COPY t TO '{path}' (FORMAT parquet)")
+
+
+def _write_run_record(runs_root: Path, slug: str, year: int = 2024) -> None:
+    run_dir = runs_root / slug / str(year)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "20260101T000000Z_abc123.json").write_text(json.dumps(RUN_RECORD), encoding="utf-8")
+
+
+def _make_repo(
+    tmp_path: Path, *, with_mart: bool = True, dirname: str = "my-dataset"
+) -> RepoLayout:
+    """Mini-repo: datasets/{dirname}/dataset.yml + parquet locale + run record.
+
+    Il run record copre solo il 2024 mentre il config dichiara anche il 2025:
+    verifica il fallback su ``years_seen`` di run_state.
+    """
+    ds_dir = tmp_path / "datasets" / dirname
+    ds_dir.mkdir(parents=True)
+    name = "my_dataset"
+    yml = MART_YML if with_mart else SIMPLE_YML
+    (ds_dir / "dataset.yml").write_text(yml.format(name=name, source_id="src1"), encoding="utf-8")
+    if with_mart:
+        (ds_dir / "sql").mkdir()
+        (ds_dir / "sql" / "mart_trend.sql").write_text("SELECT 1", encoding="utf-8")
+    else:
+        (ds_dir / "sql").mkdir()
+        (ds_dir / "sql" / "clean.sql").write_text("SELECT 1", encoding="utf-8")
+
+    out = tmp_path / "out"
+    _write_parquet(out / "data" / "clean" / name / "2024" / f"{name}_2024_clean.parquet")
+    _write_parquet(out / "data" / "clean" / name / "2025" / f"{name}_2025_clean.parquet")
+    _write_run_record(out / "data" / "_runs", name)
+
+    return RepoLayout(
+        repo_root=tmp_path,
+        dataset_dirs=("datasets",),
+        source_repo="dataciviclab/test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# clean_catalog
+# ---------------------------------------------------------------------------
+
+
+def test_clean_catalog_contract(tmp_path: Path) -> None:
+    """Il catalogo generato è valido contro lo schema condiviso (contract)."""
+    layout = _make_repo(tmp_path)
+    catalog, errors = build_clean_catalog(layout)
+
+    assert errors == [], f"errori inattesi: {errors}"
+    assert len(catalog["datasets"]) == 1
+    ds = catalog["datasets"][0]
+    assert ds["slug"] == "my_dataset"
+    assert ds["period"] == {"start": 2000, "end": 2024}  # da time_coverage
+    assert [c["name"] for c in ds["columns"]] == ["geo", "year", "value"]
+    assert ds["mart_refs"] == ["my_dataset__mart_trend"]
+    assert ds["run"]["status"] == "SUCCESS"
+    assert ds["run"]["quality_score"] == {"raw": 100, "clean": 95, "mart": 100}
+    assert ds["run"]["output_bytes"] == {"raw": 6961784, "clean": 9757664}
+
+
+def test_clean_catalog_dirname_not_identity(tmp_path: Path) -> None:
+    """La dir con trattini non è identità: la chiave è dataset.name (policy)."""
+    layout = _make_repo(tmp_path, dirname="my-dataset")
+    catalog, _ = build_clean_catalog(layout)
+    assert catalog["datasets"][0]["slug"] == "my_dataset"
+
+
+def test_clean_catalog_missing_parquet_reported(tmp_path: Path) -> None:
+    """Dataset dichiarato senza parquet locale → errore, non catalogo finto."""
+    layout = _make_repo(tmp_path)
+    import shutil
+
+    shutil.rmtree(layout.repo_root / "out" / "data" / "clean")
+    catalog, errors = build_clean_catalog(layout)
+    assert any("nessun parquet clean locale" in e for e in errors)
+    assert catalog["datasets"] == []
+
+
+# ---------------------------------------------------------------------------
+# mart_catalog
+# ---------------------------------------------------------------------------
+
+
+def test_mart_catalog_contract(tmp_path: Path) -> None:
+    """Il mart catalog è valido e usa la convention {dataset}__{mart} (contract)."""
+    layout = _make_repo(tmp_path)
+    catalog, errors = build_mart_catalog(layout)
+
+    assert errors == [], f"errori inattesi: {errors}"
+    assert len(catalog["marts"]) == 1
+    mart = catalog["marts"][0]
+    assert mart["slug"] == "my_dataset__mart_trend"
+    assert mart["dataset"] == "my_dataset"
+    assert mart["primary_key"] == ["year", "geo"]
+    assert mart["required_columns"] == ["year", "geo", "value"]
+    assert mart["min_rows"] == 10
+    assert mart["run"]["status"] == "SUCCESS"
+
+
+# ---------------------------------------------------------------------------
+# pipeline_signals
+# ---------------------------------------------------------------------------
+
+
+def test_signals_contract(tmp_path: Path) -> None:
+    """Segnale ok con mart; campi years/run presenti (contract)."""
+    layout = _make_repo(tmp_path)
+    payload, errors = build_signals(layout)
+
+    assert errors == [], f"errori inattesi: {errors}"
+    assert payload["summary"]["total"] == 1
+    assert payload["summary"]["by_status"] == {"ok": 1, "warn": 0, "error": 0}
+    sig = payload["signals"][0]
+    assert sig["id"] == "my_dataset"
+    assert sig["status"] == "ok"
+    assert sig["years"] == [2024, 2025]
+    assert sig["run"]["run_id"] == "20260101T000000Z_abc123"
+
+
+def test_signals_warn_without_mart(tmp_path: Path) -> None:
+    """Senza mart il segnale è warn, non ok (policy)."""
+    layout = _make_repo(tmp_path, with_mart=False)
+    payload, errors = build_signals(layout)
+    assert errors == []
+    assert payload["signals"][0]["status"] == "warn"
+    assert payload["signals"][0]["action"].startswith("aggiungere mart")
+
+
+# ---------------------------------------------------------------------------
+# path contract (pure_unit)
+# ---------------------------------------------------------------------------
+
+
+def test_path_contract_year_layout() -> None:
+    contract = PathContract()  # default DI
+    assert (
+        contract.clean_parquet_url("irpef_comunale", 2024)
+        == "gs://dataciviclab-clean/irpef_comunale/2024/irpef_comunale_2024_clean.parquet"
+    )
+    assert (
+        contract.mart_parquet_url("irpef_comunale", "mart_trend", year=2024)
+        == "gs://dataciviclab-mart/irpef_comunale/2024/mart_trend.parquet"
+    )
+    loc = contract.clean_location("multi_year", [2023, 2024])
+    assert loc["multi_file"] is True
+    assert "/*/" in loc["path"]
+
+
+def test_path_contract_flat_layout() -> None:
+    contract = PathContract(prefix="eurostat", clean_layout="flat", mart_layout="flat")
+    assert (
+        contract.clean_parquet_url("eurostat_gdp_nuts3", 2026)
+        == "gs://dataciviclab-clean/eurostat/eurostat_gdp_nuts3/eurostat_gdp_nuts3_2026_clean.parquet"
+    )
+    assert (
+        contract.mart_parquet_url("eurostat_gdp_nuts3", "mart_geo_benchmark")
+        == "gs://dataciviclab-mart/eurostat/eurostat_gdp_nuts3/mart_geo_benchmark.parquet"
+    )
+
+
+# ---------------------------------------------------------------------------
+# run block (pure_unit)
+# ---------------------------------------------------------------------------
+
+
+def test_run_block_mapping() -> None:
+    block = run_block(RUN_RECORD)
+    assert block == {
+        "run_id": "20260101T000000Z_abc123",
+        "year": 2024,
+        "status": "SUCCESS",
+        "quality_score": {"raw": 100, "clean": 95, "mart": 100},
+        # raw: output_rows null → omesso; output_bytes preservato
+        "output_rows": {"clean": 120, "mart": 30},
+        "output_bytes": {"raw": 6961784, "clean": 9757664},
+        "started_at": "2026-01-01T00:00:00Z",
+        "finished_at": "2026-01-01T00:00:01Z",
+        "duration_seconds": 1.0,
+    }
+
+
+def test_run_block_none_for_incomplete() -> None:
+    assert run_block(None) is None
+    assert run_block({"year": 2024, "status": "SUCCESS"}) is None  # no run_id
+
+
+def test_registry_builder_imports() -> None:
+    """Export pubblico del package (contract)."""
+    import toolkit.registry as reg
+
+    assert all(
+        hasattr(reg, name)
+        for name in ("build_clean_catalog", "build_mart_catalog", "build_signals", "RepoLayout")
+    )

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -197,6 +197,32 @@ def test_mart_catalog_contract(tmp_path: Path) -> None:
     assert mart["run"]["status"] == "SUCCESS"
 
 
+def test_mart_catalog_year_layout_without_years(tmp_path: Path) -> None:
+    """Layout 'year' + mart senza years → errore di derive, non crash (regression)."""
+    from toolkit.registry.layout import RepoLayout as RL
+
+    ds_dir = tmp_path / "datasets" / "no-years"
+    ds_dir.mkdir(parents=True)
+    no_years_yml = """
+root: "../../out"
+schema_version: 1
+dataset:
+  name: "no_years"
+  years: []
+mart:
+  tables:
+    - name: "mart_trend"
+      sql: "sql/mart_trend.sql"
+"""
+    (ds_dir / "dataset.yml").write_text(no_years_yml, encoding="utf-8")
+    layout = RL(repo_root=tmp_path, dataset_dirs=("datasets",), source_repo="dataciviclab/test")
+
+    catalog, errors = build_mart_catalog(layout, path_contract=PathContract())  # layout year
+
+    assert catalog["marts"] == []
+    assert any("location mart non risolvibile" in e for e in errors)
+
+
 # ---------------------------------------------------------------------------
 # pipeline_signals
 # ---------------------------------------------------------------------------

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -143,6 +143,7 @@ def _make_repo(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.contract
 def test_clean_catalog_contract(tmp_path: Path) -> None:
     """Il catalogo generato è valido contro lo schema condiviso (contract)."""
     layout = _make_repo(tmp_path)
@@ -161,6 +162,7 @@ def test_clean_catalog_contract(tmp_path: Path) -> None:
     assert ds["run"]["output_bytes"] == {"raw": 6961784, "clean": 9757664}
 
 
+@pytest.mark.policy
 def test_clean_catalog_dirname_not_identity(tmp_path: Path) -> None:
     """La dir con trattini non è identità: la chiave è dataset.name (policy)."""
     layout = _make_repo(tmp_path, dirname="my-dataset")
@@ -168,6 +170,7 @@ def test_clean_catalog_dirname_not_identity(tmp_path: Path) -> None:
     assert catalog["datasets"][0]["slug"] == "my_dataset"
 
 
+@pytest.mark.pure_unit
 def test_clean_catalog_missing_parquet_reported(tmp_path: Path) -> None:
     """Dataset dichiarato senza parquet locale → errore, non catalogo finto."""
     layout = _make_repo(tmp_path)
@@ -184,6 +187,7 @@ def test_clean_catalog_missing_parquet_reported(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.contract
 def test_mart_catalog_contract(tmp_path: Path) -> None:
     """Il mart catalog è valido e usa la convention {dataset}__{mart} (contract)."""
     layout = _make_repo(tmp_path)
@@ -200,6 +204,7 @@ def test_mart_catalog_contract(tmp_path: Path) -> None:
     assert mart["run"]["status"] == "SUCCESS"
 
 
+@pytest.mark.pure_unit
 def test_mart_catalog_year_layout_without_years(tmp_path: Path) -> None:
     """Layout 'year' + mart senza years → errore di derive, non crash (regression)."""
     from toolkit.registry.layout import RepoLayout as RL
@@ -231,6 +236,7 @@ mart:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.contract
 def test_signals_contract(tmp_path: Path) -> None:
     """Segnale ok con mart; campi years/run presenti (contract)."""
     layout = _make_repo(tmp_path)
@@ -246,6 +252,7 @@ def test_signals_contract(tmp_path: Path) -> None:
     assert sig["run"]["run_id"] == "20260101T000000Z_abc123"
 
 
+@pytest.mark.policy
 def test_signals_warn_without_mart(tmp_path: Path) -> None:
     """Senza mart il segnale è warn, non ok (policy)."""
     layout = _make_repo(tmp_path, with_mart=False)
@@ -260,6 +267,7 @@ def test_signals_warn_without_mart(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.contract
 def test_path_contract_year_layout() -> None:
     contract = PathContract()  # default DI
     assert (
@@ -275,6 +283,7 @@ def test_path_contract_year_layout() -> None:
     assert "/*/" in loc["path"]
 
 
+@pytest.mark.contract
 def test_path_contract_flat_layout() -> None:
     contract = PathContract(prefix="eurostat", clean_layout="flat", mart_layout="flat")
     assert (
@@ -292,6 +301,7 @@ def test_path_contract_flat_layout() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.pure_unit
 def test_run_block_mapping() -> None:
     block = run_block(RUN_RECORD)
     assert block == {
@@ -308,11 +318,13 @@ def test_run_block_mapping() -> None:
     }
 
 
+@pytest.mark.pure_unit
 def test_run_block_none_for_incomplete() -> None:
     assert run_block(None) is None
     assert run_block({"year": 2024, "status": "SUCCESS"}) is None  # no run_id
 
 
+@pytest.mark.pure_unit
 def test_registry_builder_imports() -> None:
     """Export pubblico del package (contract)."""
     import toolkit.registry as reg
@@ -328,6 +340,7 @@ def test_registry_builder_imports() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.contract
 def test_codelists_contract(tmp_path: Path) -> None:
     """codelists.json espone i valori delle dimensioni dal repo (contract)."""
     from toolkit.registry.builders import build_codelists
@@ -355,6 +368,7 @@ def test_codelists_contract(tmp_path: Path) -> None:
     ]
 
 
+@pytest.mark.pure_unit
 def test_codelists_large_external(tmp_path: Path) -> None:
     """Codelist oltre la soglia → dichiarato in large, non embedded (policy)."""
     from toolkit.registry.builders import build_codelists, MAX_CODELIST_ROWS
@@ -371,6 +385,7 @@ def test_codelists_large_external(tmp_path: Path) -> None:
     assert payload["large"] == ["big"]
 
 
+@pytest.mark.pure_unit
 def test_codelists_empty_without_dir(tmp_path: Path) -> None:
     """Senza dir codelists → payload vuoto, nessun errore (opzionale)."""
     from toolkit.registry.builders import build_codelists

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -355,6 +355,22 @@ def test_codelists_contract(tmp_path: Path) -> None:
     ]
 
 
+def test_codelists_large_external(tmp_path: Path) -> None:
+    """Codelist oltre la soglia → dichiarato in large, non embedded (policy)."""
+    from toolkit.registry.builders import build_codelists, MAX_CODELIST_ROWS
+
+    layout = _make_repo(tmp_path)
+    cl_dir = tmp_path / "codelists"
+    cl_dir.mkdir()
+    rows = "".join(f"code{i},label{i}\n" for i in range(MAX_CODELIST_ROWS + 5))
+    (cl_dir / "big.csv").write_text("code,label_en\n" + rows, encoding="utf-8")
+
+    payload, errors = build_codelists(layout)
+    assert errors == {"derive": [], "validation": []}
+    assert "big" not in payload["codelists"]
+    assert payload["large"] == ["big"]
+
+
 def test_codelists_empty_without_dir(tmp_path: Path) -> None:
     """Senza dir codelists → payload vuoto, nessun errore (opzionale)."""
     from toolkit.registry.builders import build_codelists

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -48,6 +48,8 @@ mart:
         required_columns: [year, geo, value]
         primary_key: [year, geo]
         min_rows: 10
+registry:
+  description: "Test dataset per il registry builder"
 """
 
 SIMPLE_YML = """
@@ -151,6 +153,7 @@ def test_clean_catalog_contract(tmp_path: Path) -> None:
     ds = catalog["datasets"][0]
     assert ds["slug"] == "my_dataset"
     assert ds["period"] == {"start": 2000, "end": 2024}  # da time_coverage
+    assert ds["description"] == "Test dataset per il registry builder"  # da registry.description
     assert [c["name"] for c in ds["columns"]] == ["geo", "year", "value"]
     assert ds["mart_refs"] == ["my_dataset__mart_trend"]
     assert ds["run"]["status"] == "SUCCESS"
@@ -318,3 +321,45 @@ def test_registry_builder_imports() -> None:
         hasattr(reg, name)
         for name in ("build_clean_catalog", "build_mart_catalog", "build_signals", "RepoLayout")
     )
+
+
+# ---------------------------------------------------------------------------
+# codelists
+# ---------------------------------------------------------------------------
+
+
+def test_codelists_contract(tmp_path: Path) -> None:
+    """codelists.json espone i valori delle dimensioni dal repo (contract)."""
+    from toolkit.registry.builders import build_codelists
+
+    layout = _make_repo(tmp_path)
+    cl_dir = tmp_path / "codelists"
+    cl_dir.mkdir()
+    (cl_dir / "units.csv").write_text(
+        "unit,label_en\nEUR_HAB,EUR per inhabitant\nPPS_HAB,PPS per inhabitant\n",
+        encoding="utf-8",
+    )
+    (cl_dir / "geo.csv").write_text(
+        "code,label_en,nuts_level,parent_code\nITC4,Lombardia,3,ITH\n",
+        encoding="utf-8",
+    )
+
+    payload, errors = build_codelists(layout)
+    assert errors == {"derive": [], "validation": []}, f"errori inattesi: {errors}"
+    assert payload["codelists"]["units"] == [
+        {"unit": "EUR_HAB", "label_en": "EUR per inhabitant"},
+        {"unit": "PPS_HAB", "label_en": "PPS per inhabitant"},
+    ]
+    assert payload["codelists"]["geo"] == [
+        {"code": "ITC4", "label_en": "Lombardia", "nuts_level": "3", "parent_code": "ITH"}
+    ]
+
+
+def test_codelists_empty_without_dir(tmp_path: Path) -> None:
+    """Senza dir codelists → payload vuoto, nessun errore (opzionale)."""
+    from toolkit.registry.builders import build_codelists
+
+    layout = _make_repo(tmp_path)
+    payload, errors = build_codelists(layout)
+    assert errors == {"derive": [], "validation": []}
+    assert payload["codelists"] == {}

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -146,7 +146,7 @@ def test_clean_catalog_contract(tmp_path: Path) -> None:
     layout = _make_repo(tmp_path)
     catalog, errors = build_clean_catalog(layout)
 
-    assert errors == [], f"errori inattesi: {errors}"
+    assert errors == {"derive": [], "validation": []}, f"errori inattesi: {errors}"
     assert len(catalog["datasets"]) == 1
     ds = catalog["datasets"][0]
     assert ds["slug"] == "my_dataset"
@@ -172,7 +172,7 @@ def test_clean_catalog_missing_parquet_reported(tmp_path: Path) -> None:
 
     shutil.rmtree(layout.repo_root / "out" / "data" / "clean")
     catalog, errors = build_clean_catalog(layout)
-    assert any("nessun parquet clean locale" in e for e in errors)
+    assert any("nessun parquet clean locale" in e for e in errors["derive"])
     assert catalog["datasets"] == []
 
 
@@ -186,7 +186,7 @@ def test_mart_catalog_contract(tmp_path: Path) -> None:
     layout = _make_repo(tmp_path)
     catalog, errors = build_mart_catalog(layout)
 
-    assert errors == [], f"errori inattesi: {errors}"
+    assert errors == {"derive": [], "validation": []}, f"errori inattesi: {errors}"
     assert len(catalog["marts"]) == 1
     mart = catalog["marts"][0]
     assert mart["slug"] == "my_dataset__mart_trend"
@@ -220,7 +220,7 @@ mart:
     catalog, errors = build_mart_catalog(layout, path_contract=PathContract())  # layout year
 
     assert catalog["marts"] == []
-    assert any("location mart non risolvibile" in e for e in errors)
+    assert any("location mart non risolvibile" in e for e in errors["derive"])
 
 
 # ---------------------------------------------------------------------------
@@ -233,7 +233,7 @@ def test_signals_contract(tmp_path: Path) -> None:
     layout = _make_repo(tmp_path)
     payload, errors = build_signals(layout)
 
-    assert errors == [], f"errori inattesi: {errors}"
+    assert errors == {"derive": [], "validation": []}, f"errori inattesi: {errors}"
     assert payload["summary"]["total"] == 1
     assert payload["summary"]["by_status"] == {"ok": 1, "warn": 0, "error": 0}
     sig = payload["signals"][0]
@@ -247,7 +247,7 @@ def test_signals_warn_without_mart(tmp_path: Path) -> None:
     """Senza mart il segnale è warn, non ok (policy)."""
     layout = _make_repo(tmp_path, with_mart=False)
     payload, errors = build_signals(layout)
-    assert errors == []
+    assert errors == {"derive": [], "validation": []}
     assert payload["signals"][0]["status"] == "warn"
     assert payload["signals"][0]["action"].startswith("aggiungere mart")
 

--- a/tests/test_registry_ops.py
+++ b/tests/test_registry_ops.py
@@ -40,6 +40,7 @@ def mini_workspace(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.mark.contract
 def test_list_registries(mini_workspace: Path) -> None:
     """Lista i repo con artifact, escludendo gli schemi (contract)."""
     data = list_registries(mini_workspace)
@@ -53,6 +54,7 @@ def test_list_registries(mini_workspace: Path) -> None:
     assert cc["entries"] == 1
 
 
+@pytest.mark.contract
 def test_show_registry_full(mini_workspace: Path) -> None:
     """show senza slug ritorna il payload completo (contract)."""
     data = show_registry("eurostat", "clean_catalog", workspace=mini_workspace)
@@ -60,6 +62,7 @@ def test_show_registry_full(mini_workspace: Path) -> None:
     assert len(data["data"]["datasets"]) == 1
 
 
+@pytest.mark.contract
 def test_show_registry_filter_slug(mini_workspace: Path) -> None:
     """show con slug filtra l'entry richiesta (contract)."""
     data = show_registry(
@@ -68,6 +71,7 @@ def test_show_registry_filter_slug(mini_workspace: Path) -> None:
     assert data["entry"]["slug"] == "eurostat_gdp_nuts3"
 
 
+@pytest.mark.contract
 def test_show_registry_not_found(mini_workspace: Path) -> None:
     """Artifact o repo inesistente → FileNotFoundError (contract)."""
     with pytest.raises(FileNotFoundError):
@@ -76,12 +80,14 @@ def test_show_registry_not_found(mini_workspace: Path) -> None:
         show_registry("no-registry-repo", "clean_catalog", workspace=mini_workspace)
 
 
+@pytest.mark.contract
 def test_show_registry_slug_missing(mini_workspace: Path) -> None:
     """Slug inesistente → FileNotFoundError (pure_unit)."""
     with pytest.raises(FileNotFoundError):
         show_registry("eurostat", "pipeline_signals", slug="missing", workspace=mini_workspace)
 
 
+@pytest.mark.pure_unit
 def test_entries_count_pure() -> None:
     """Conteggio entries per tipo artifact (pure_unit)."""
     from toolkit.registry.reader import _entries_count

--- a/tests/test_registry_ops.py
+++ b/tests/test_registry_ops.py
@@ -1,0 +1,93 @@
+"""Test del lettore artifact registry (CLI/MCP: toolkit registry).
+
+Fixture: mini-workspace con due repo, uno con registry/committati.
+
+Marker: contract (lettura cross-repo), pure_unit (conteggio entries).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from toolkit.domain.registry_ops import list_registries, show_registry
+
+
+@pytest.fixture
+def mini_workspace(tmp_path: Path) -> Path:
+    """Workspace con due repo: uno con registry, uno senza."""
+    euro = tmp_path / "eurostat"
+    (euro / "registry").mkdir(parents=True)
+    (euro / "registry" / "clean_catalog.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "datasets": [{"slug": "eurostat_gdp_nuts3", "name": "GDP"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (euro / "registry" / "pipeline_signals.json").write_text(
+        json.dumps({"schema_version": "1", "signals": [{"id": "x"}, {"id": "y"}]}),
+        encoding="utf-8",
+    )
+    # Schema: escluso dalla vista
+    (euro / "registry" / "clean_catalog.schema.json").write_text("{}", encoding="utf-8")
+
+    (tmp_path / "no-registry-repo").mkdir()
+    return tmp_path
+
+
+def test_list_registries(mini_workspace: Path) -> None:
+    """Lista i repo con artifact, escludendo gli schemi (contract)."""
+    data = list_registries(mini_workspace)
+    assert data["total_repos"] == 1
+    repo = data["repos"][0]
+    assert repo["repo"] == "eurostat"
+    names = {a["name"] for a in repo["artifacts"]}
+    assert names == {"clean_catalog", "pipeline_signals"}
+    assert "clean_catalog.schema" not in names
+    cc = next(a for a in repo["artifacts"] if a["name"] == "clean_catalog")
+    assert cc["entries"] == 1
+
+
+def test_show_registry_full(mini_workspace: Path) -> None:
+    """show senza slug ritorna il payload completo (contract)."""
+    data = show_registry("eurostat", "clean_catalog", workspace=mini_workspace)
+    assert data["artifact"] == "clean_catalog"
+    assert len(data["data"]["datasets"]) == 1
+
+
+def test_show_registry_filter_slug(mini_workspace: Path) -> None:
+    """show con slug filtra l'entry richiesta (contract)."""
+    data = show_registry(
+        "eurostat", "clean_catalog", slug="eurostat_gdp_nuts3", workspace=mini_workspace
+    )
+    assert data["entry"]["slug"] == "eurostat_gdp_nuts3"
+
+
+def test_show_registry_not_found(mini_workspace: Path) -> None:
+    """Artifact o repo inesistente → FileNotFoundError (contract)."""
+    with pytest.raises(FileNotFoundError):
+        show_registry("eurostat", "mart_catalog", workspace=mini_workspace)
+    with pytest.raises(FileNotFoundError):
+        show_registry("no-registry-repo", "clean_catalog", workspace=mini_workspace)
+
+
+def test_show_registry_slug_missing(mini_workspace: Path) -> None:
+    """Slug inesistente → FileNotFoundError (pure_unit)."""
+    with pytest.raises(FileNotFoundError):
+        show_registry("eurostat", "pipeline_signals", slug="missing", workspace=mini_workspace)
+
+
+def test_entries_count_pure() -> None:
+    """Conteggio entries per tipo artifact (pure_unit)."""
+    from toolkit.domain.registry_ops import _entries_count
+
+    assert _entries_count("clean_catalog", {"datasets": [1, 2]}) == 2
+    assert _entries_count("mart_catalog", {"marts": [1]}) == 1
+    assert _entries_count("pipeline_signals", {"signals": [1, 2, 3]}) == 3
+    assert _entries_count("codelists", {"codelists": {"geo": [], "units": []}}) == 2
+    assert _entries_count("entity_graph", {}) is None

--- a/tests/test_registry_ops.py
+++ b/tests/test_registry_ops.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from toolkit.domain.registry_ops import list_registries, show_registry
+from toolkit.registry.reader import list_registries, show_registry
 
 
 @pytest.fixture
@@ -84,7 +84,7 @@ def test_show_registry_slug_missing(mini_workspace: Path) -> None:
 
 def test_entries_count_pure() -> None:
     """Conteggio entries per tipo artifact (pure_unit)."""
-    from toolkit.domain.registry_ops import _entries_count
+    from toolkit.registry.reader import _entries_count
 
     assert _entries_count("clean_catalog", {"datasets": [1, 2]}) == 2
     assert _entries_count("mart_catalog", {"marts": [1]}) == 1

--- a/toolkit/cli/app.py
+++ b/toolkit/cli/app.py
@@ -7,6 +7,7 @@ from toolkit.cli.cmd_inspect import register as register_inspect
 from toolkit.cli.cmd_batch import register as register_batch
 from toolkit.cli.cmd_contract import register as register_contract
 from toolkit.cli.cmd_scout import register as register_scout
+from toolkit.cli.cmd_registry import register as register_registry
 from toolkit.version import __version__
 
 app = typer.Typer(no_args_is_help=True, add_completion=False)
@@ -28,6 +29,7 @@ register_inspect(app)
 register_batch(app)
 register_contract(app)
 register_scout(app)
+register_registry(app)
 
 
 def main():

--- a/toolkit/cli/cmd_registry.py
+++ b/toolkit/cli/cmd_registry.py
@@ -27,7 +27,7 @@ def _print_list(data: dict[str, Any]) -> None:
 
 def registry_list(json_output: bool = typer.Option(False, "--json", help="Output JSON")) -> None:
     """Elenca gli artifact registry committati nei repo del workspace."""
-    from toolkit.domain.registry_ops import list_registries
+    from toolkit.registry.reader import list_registries
 
     data = list_registries()
     if json_output:
@@ -43,7 +43,7 @@ def registry_show(
     json_output: bool = typer.Option(False, "--json", help="Output JSON"),
 ) -> None:
     """Mostra un artifact registry di un repo del workspace."""
-    from toolkit.domain.registry_ops import show_registry
+    from toolkit.registry.reader import show_registry
 
     try:
         data = show_registry(repo, artifact, slug=slug)

--- a/toolkit/cli/cmd_registry.py
+++ b/toolkit/cli/cmd_registry.py
@@ -1,0 +1,72 @@
+"""toolkit registry — consulta gli artifact registry committati nel workspace.
+
+Legge i cataloghi generati dal registry builder e committati nei repo
+(``{repo}/registry/*.json``): clean_catalog, mart_catalog, pipeline_signals,
+codelists. Cross-repo, senza riprogettare la discovery.
+
+Speculare al tool MCP toolkit_registry.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import typer
+
+
+def _print_list(data: dict[str, Any]) -> None:
+    repos = data.get("repos", [])
+    typer.echo(f"Registry artifacts nel workspace ({data.get('total_repos', 0)} repo):")
+    for repo_info in repos:
+        typer.echo(f"  {repo_info['repo']}:")
+        for art in repo_info["artifacts"]:
+            entries = f" ({art['entries']} entries)" if art["entries"] is not None else ""
+            typer.echo(f"    {art['name']}.json  [{art['size_bytes'] // 1024} KB]{entries}")
+
+
+def registry_list(json_output: bool = typer.Option(False, "--json", help="Output JSON")) -> None:
+    """Elenca gli artifact registry committati nei repo del workspace."""
+    from toolkit.domain.registry_ops import list_registries
+
+    data = list_registries()
+    if json_output:
+        typer.echo(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+        return
+    _print_list(data)
+
+
+def registry_show(
+    repo: str = typer.Argument(..., help="Repo (es. 'eurostat')"),
+    artifact: str = typer.Argument(..., help="Artifact (es. 'clean_catalog')"),
+    slug: str = typer.Option(None, "--slug", help="Filtra un'entry (dataset/mart/signal/codelist)"),
+    json_output: bool = typer.Option(False, "--json", help="Output JSON"),
+) -> None:
+    """Mostra un artifact registry di un repo del workspace."""
+    from toolkit.domain.registry_ops import show_registry
+
+    try:
+        data = show_registry(repo, artifact, slug=slug)
+    except (FileNotFoundError, ValueError) as exc:
+        typer.echo(f"ERRORE: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    if json_output:
+        typer.echo(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+        return
+
+    entry = data.get("entry")
+    if entry is not None:
+        typer.echo(json.dumps(entry, indent=2, ensure_ascii=False, default=str))
+        return
+    payload = data["data"]
+    typer.echo(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+def register(app: typer.Typer) -> None:
+    registry = typer.Typer(
+        no_args_is_help=True, help="Consulta gli artifact registry del workspace"
+    )
+    registry.command("list")(registry_list)
+    registry.command("show")(registry_show)
+    app.add_typer(registry, name="registry")

--- a/toolkit/domain/catalog.py
+++ b/toolkit/domain/catalog.py
@@ -15,6 +15,7 @@ vanno aggiunte nei wrapper MCP.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -269,6 +270,90 @@ def _merge_gcs_and_local(
 
 
 # ---------------------------------------------------------------------------
+# Catalogo semantico committato (mossa 1: find semantico nel resolver)
+# ---------------------------------------------------------------------------
+
+# Campi semantici arricchiti dal catalogo committato (se presenti).
+SEMANTIC_FIELDS = (
+    "name",
+    "description",
+    "source",
+    "source_id",
+    "tags",
+    "category",
+    "period",
+    "mart_refs",
+)
+
+
+def _scan_committed_catalogs(workspace: Path = WORKSPACE_ROOT) -> dict[str, dict[str, Any]]:
+    """Scansiona i cataloghi committati nei repo del workspace.
+
+    Qualsiasi dir di primo livello con ``registry/clean_catalog.json``
+    (eurostat/, dataset-incubator/, ...). Ritorna ``{slug: entry semantica}``
+    con ``_repo`` (nome dir) aggiunto.
+
+    La semantica (columns con role/semantic_type, description, tags, period)
+    vive nei cataloghi generati dal registry builder e committati nei repo:
+    qui diventa la fonte per il find semantico del resolver.
+    """
+    result: dict[str, dict[str, Any]] = {}
+    if not workspace.is_dir():
+        return result
+    for repo_dir in sorted(p for p in workspace.iterdir() if p.is_dir()):
+        catalog_path = repo_dir / "registry" / "clean_catalog.json"
+        if not catalog_path.is_file():
+            continue
+        try:
+            catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        for ds in catalog.get("datasets", []) or []:
+            slug = ds.get("slug")
+            if slug:
+                entry = dict(ds)
+                entry["_repo"] = repo_dir.name
+                result[slug] = entry
+    return result
+
+
+def _semantic_query_hits(
+    semantic: dict[str, dict[str, Any]], query: str
+) -> dict[str, list[dict[str, Any] | None]]:
+    """Slug che matchano la query sulla semantica (meta o colonne).
+
+    Returns:
+        ``{slug: [None | colonna_matchata, ...]}`` — ``None`` = meta match
+        (name/description/source/tags/category), dict = colonna matchata.
+    """
+    q = query.lower()
+    hits: dict[str, list[dict[str, Any] | None]] = {}
+    for slug, s in semantic.items():
+        matched: list[dict[str, Any] | None] = []
+        meta_parts = " ".join(
+            str(s.get(k) or "") for k in ("name", "description", "source", "tags", "category")
+        )
+        if q in slug.lower() or q in meta_parts.lower():
+            matched.append(None)
+        for col in s.get("columns", []) or []:
+            if (
+                q in str(col.get("name", "")).lower()
+                or q in str(col.get("description", "")).lower()
+            ):
+                matched.append(
+                    {
+                        "name": col.get("name"),
+                        "type": col.get("type"),
+                        "role": col.get("role"),
+                        "description": col.get("description"),
+                    }
+                )
+        if matched:
+            hits[slug] = matched
+    return hits
+
+
+# ---------------------------------------------------------------------------
 # Resolver
 # ---------------------------------------------------------------------------
 
@@ -294,6 +379,27 @@ class CatalogResolver:
         self._gcs_manifest: dict[str, Any] | None = None
         self._local_entries: list[dict[str, Any]] | None = None
         self._workspace_configs: dict[str, dict[str, Any]] | None = None
+        self._semantic: dict[str, dict[str, Any]] | None = None
+
+    def _load_semantic(self) -> dict[str, dict[str, Any]]:
+        """Carica i cataloghi semantici committati nel workspace (lazy)."""
+        if self._semantic is not None:
+            return self._semantic
+        if not self._include_local:
+            self._semantic = {}
+            return self._semantic
+        self._semantic = _scan_committed_catalogs(self._workspace)
+        return self._semantic
+
+    def _merge_semantic(self, entry: dict[str, Any], semantic: dict[str, Any] | None) -> None:
+        """Arricchisce un entry con i campi semantici del catalogo committato."""
+        if not semantic:
+            return
+        for field in SEMANTIC_FIELDS:
+            if semantic.get(field):
+                entry[field] = semantic[field]
+        entry["_repo"] = semantic.get("_repo")
+        entry["_has_semantic"] = True
 
     def _load_gcs(self) -> dict[str, Any]:
         if self._gcs_manifest is not None:
@@ -331,19 +437,26 @@ class CatalogResolver:
         source: str = "all",
         stage: str = "all",
         status_filter: str | None = None,
+        metric_only: bool = False,
     ) -> dict[str, Any]:
         """Cerca dataset per slug, sorgente, layer o testo.
 
         Args:
-            query: Testo nello slug (case-insensitive, substring).
+            query: Testo da cercare — oltre allo slug, matcha la semantica
+                dei cataloghi committati (name, description, tags, category,
+                colonne) se presente nel workspace.
             layer: ``"clean"``, ``"mart"`` o ``None`` (entrambi).
             limit: Max risultati (default 15). Usa ``0`` per nessun limite.
             source: ``"gcs"``, ``"workspace"`` o ``"all"`` (default).
             stage: Filtro workspace: ``"candidates"``, ``"support"``, ``"all"`` (default).
             status_filter: Filtro run status: ``"SUCCESS"``, ``"FAILED"``, ecc.
+            metric_only: Se True, solo dataset con almeno una colonna role=metric
+                (richiede la semantica del catalogo committato).
 
         Returns:
             Dict con ``datasets`` (lista), ``total_count``, ``truncated``.
+            Le entry con semantica includono ``description``, ``tags``,
+            ``category``, ``period``, ``matched_columns`` e ``meta_match``.
         """
         # Input validation
         if source not in VALID_SOURCES:
@@ -358,6 +471,19 @@ class CatalogResolver:
         # Build agg map: slug → entry
         datasets: dict[str, dict[str, Any]] = {}
 
+        # Semantic layer: hit di query sulla semantica + slug con metriche
+        semantic = self._load_semantic()
+        sem_hits: dict[str, list[dict[str, Any] | None]] = (
+            _semantic_query_hits(semantic, query) if query else {}
+        )
+        metric_slugs: set[str] = set()
+        if metric_only:
+            metric_slugs = {
+                slug
+                for slug, s in semantic.items()
+                if any(c.get("role") == "metric" for c in (s.get("columns") or []))
+            }
+
         # --- Source: GCS ---
         if source in ("gcs", "all"):
             manifest = self._load_gcs()
@@ -370,7 +496,9 @@ class CatalogResolver:
                 slug = f["slug"]
                 if slug is None:
                     continue
-                if query and query.lower() not in slug.lower():
+                if query and query.lower() not in slug.lower() and slug not in sem_hits:
+                    continue
+                if metric_only and slug not in metric_slugs:
                     continue
 
                 if slug not in datasets:
@@ -394,7 +522,9 @@ class CatalogResolver:
 
             # Process config entries
             for slug in set(configs) | parquet_only_slugs:
-                if query and query.lower() not in slug.lower():
+                if query and query.lower() not in slug.lower() and slug not in sem_hits:
+                    continue
+                if metric_only and slug not in metric_slugs:
                     continue
                 info = configs.get(slug, {})
 
@@ -426,6 +556,11 @@ class CatalogResolver:
         for slug in sorted(datasets):
             entry = datasets[slug]
             entry["years"] = sorted(entry["years"])
+            self._merge_semantic(entry, semantic.get(slug))
+            hits = sem_hits.get(slug)
+            if hits is not None:
+                entry["matched_columns"] = [h for h in hits if h]
+                entry["meta_match"] = any(h is None for h in hits)
             self._finalize_layer(entry, layer)
             result.append(entry)
 
@@ -593,6 +728,24 @@ class CatalogResolver:
             result["year"] = actual_year
             result["layer"] = layer
             result["_local"] = is_local
+            # Arricchimento semantico dal catalogo committato (se presente):
+            # description/tags/period + role/semantic_type/description colonne.
+            sem = self._load_semantic().get(slug)
+            if sem:
+                for field in ("description", "tags", "category", "period", "source"):
+                    if sem.get(field):
+                        result[field] = sem[field]
+                sem_cols = {c.get("name"): c for c in (sem.get("columns") or [])}
+                for col in result.get("columns", []) or []:
+                    sc = sem_cols.get(col.get("name"))
+                    if sc:
+                        if sc.get("role"):
+                            col["role"] = sc["role"]
+                        if sc.get("semantic_type"):
+                            col["semantic_type"] = sc["semantic_type"]
+                        if sc.get("description"):
+                            col["description"] = sc["description"]
+                result["_repo"] = sem.get("_repo")
             return result
         except Exception as exc:
             raise RuntimeError(

--- a/toolkit/domain/readiness.py
+++ b/toolkit/domain/readiness.py
@@ -55,6 +55,16 @@ def run_state(config_path: str, year: int | None = None) -> dict[str, Any]:
         else []
     )
 
+    # Ultimo run record assoluto: attraverso TUTTI gli anni con run records
+    # (non solo il target year). Usato dai consumer aggregati (registry builder).
+    latest_run_record_abs: dict[str, Any] | None = None
+    if years_seen:
+        abs_year = int(max(years_seen))
+        abs_run_dir = get_run_dir(Path(cfg.root), cfg.dataset, abs_year)
+        abs_files = sorted(abs_run_dir.glob("*.json")) if abs_run_dir.exists() else []
+        if abs_files:
+            latest_run_record_abs = read_json_or_none(abs_files[-1])
+
     return {
         "dataset": paths.get("dataset"),
         "config_path": str(config_path),
@@ -65,6 +75,7 @@ def run_state(config_path: str, year: int | None = None) -> dict[str, Any]:
         "years_seen": years_seen,
         "latest_run": latest_run,
         "latest_run_record": latest_payload,
+        "latest_run_record_abs": latest_run_record_abs,
     }
 
 

--- a/toolkit/domain/registry_ops.py
+++ b/toolkit/domain/registry_ops.py
@@ -1,0 +1,138 @@
+"""Lettura degli artifact registry committati nei repo del workspace.
+
+Il registry builder (``toolkit.registry.builders``) genera e i repo committano
+i cataloghi in ``{repo}/registry/*.json`` (clean_catalog, mart_catalog,
+pipeline_signals, codelists, ...). Questo modulo li espone all'agente (CLI e
+MCP) senza riprogettare la discovery: lettura diretta dei file committati,
+cross-repo.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from toolkit.core.paths import WORKSPACE_ROOT
+
+# Nomi file esclusi dalla vista (schemi e helper, non artifact dati).
+EXCLUDED = (
+    ".schema.json",
+    "README",
+)
+
+
+def _entries_count(name: str, payload: dict[str, Any]) -> int | None:
+    """Conteggio entries per tipo artifact (None se struttura sconosciuta)."""
+    if name == "clean_catalog":
+        return len(payload.get("datasets") or [])
+    if name == "mart_catalog":
+        return len(payload.get("marts") or [])
+    if name == "pipeline_signals":
+        return len(payload.get("signals") or [])
+    if name == "codelists":
+        return len(payload.get("codelists") or {})
+    return None
+
+
+def _scan_repo(repo_dir: Path) -> list[dict[str, Any]]:
+    artifacts: list[dict[str, Any]] = []
+    registry_dir = repo_dir / "registry"
+    if not registry_dir.is_dir():
+        return artifacts
+    for path in sorted(registry_dir.glob("*.json")):
+        if path.name.endswith(EXCLUDED[0]) or path.name.startswith(EXCLUDED[1]):
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            payload = {}
+        artifacts.append(
+            {
+                "name": path.stem,
+                "size_bytes": path.stat().st_size,
+                "entries": _entries_count(path.stem, payload),
+            }
+        )
+    return artifacts
+
+
+def list_registries(workspace: Path = WORKSPACE_ROOT) -> dict[str, Any]:
+    """Elenca gli artifact registry committati nei repo del workspace.
+
+    Returns:
+        Dict con ``repos`` (lista) e ``total_repos``. Ogni repo:
+        ``{repo, artifacts: [{name, size_bytes, entries}]}``.
+    """
+    repos: list[dict[str, Any]] = []
+    if not workspace.is_dir():
+        return {"repos": repos, "total_repos": 0}
+
+    for repo_dir in sorted(p for p in workspace.iterdir() if p.is_dir()):
+        artifacts = _scan_repo(repo_dir)
+        if artifacts:
+            repos.append({"repo": repo_dir.name, "artifacts": artifacts})
+
+    return {"repos": repos, "total_repos": len(repos)}
+
+
+def show_registry(
+    repo: str,
+    artifact: str,
+    slug: str | None = None,
+    workspace: Path = WORKSPACE_ROOT,
+) -> dict[str, Any]:
+    """Legge un artifact committato di un repo del workspace.
+
+    Args:
+        repo: Nome dir del repo (es. ``eurostat``).
+        artifact: Nome artifact senza estensione (es. ``clean_catalog``).
+        slug: Se fornito, filtra l'entry (dataset slug per clean/mart,
+            id per signals, codelist name per codelists).
+
+    Raises:
+        FileNotFoundError: se il file non esiste nel workspace.
+    """
+    path = workspace / repo / "registry" / f"{artifact}.json"
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Artifact '{artifact}' non trovato in {workspace}/{repo}/registry/ "
+            f"(usa 'toolkit registry list' per gli artifact disponibili)"
+        )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    if slug:
+        filtered = _filter_entry(artifact, payload, slug)
+        return {"repo": repo, "artifact": artifact, "slug": slug, "entry": filtered["entry"]}
+    return {"repo": repo, "artifact": artifact, "data": payload}
+
+
+def _filter_entry(name: str, payload: dict[str, Any], slug: str) -> dict[str, Any]:
+    """Filtra l'entry richiesta dall'artifact (errore se non trovata)."""
+    if name == "clean_catalog":
+        entries = payload.get("datasets") or []
+        hit = next((d for d in entries if d.get("slug") == slug), None)
+        if hit is None:
+            raise FileNotFoundError(f"Dataset '{slug}' non presente in clean_catalog")
+        return {"slug": slug, "entry": hit}
+    if name == "mart_catalog":
+        entries = payload.get("marts") or []
+        hit = next((m for m in entries if m.get("slug") == slug), None)
+        if hit is None:
+            raise FileNotFoundError(f"Mart '{slug}' non presente in mart_catalog")
+        return {"slug": slug, "entry": hit}
+    if name == "pipeline_signals":
+        entries = payload.get("signals") or []
+        hit = next((s for s in entries if s.get("id") == slug), None)
+        if hit is None:
+            raise FileNotFoundError(f"Signal '{slug}' non presente in pipeline_signals")
+        return {"slug": slug, "entry": hit}
+    if name == "codelists":
+        entries = payload.get("codelists") or {}
+        if slug not in entries:
+            raise FileNotFoundError(f"Codelist '{slug}' non presente in codelists")
+        return {"slug": slug, "entry": entries[slug]}
+    raise FileNotFoundError(
+        f"Filtro per slug non supportato per l'artifact '{name}' "
+        "(supportati: clean_catalog, mart_catalog, pipeline_signals, codelists)"
+    )

--- a/toolkit/mcp/catalog_ops.py
+++ b/toolkit/mcp/catalog_ops.py
@@ -79,11 +79,6 @@ def mcp_find(
             f"Errori parametri: {exc}",
             code=ErrorCode.INVALID_PARAMS,
         ) from exc
-    except ValueError as exc:
-        raise ToolkitClientError(
-            f"Errore parametri: {exc}",
-            code=ErrorCode.INVALID_PARAMS,
-        ) from exc
 
 
 def mcp_dataset_overview(

--- a/toolkit/mcp/catalog_ops.py
+++ b/toolkit/mcp/catalog_ops.py
@@ -36,17 +36,21 @@ def mcp_find(
     source: str = "all",
     stage: str = "all",
     status_filter: str | None = None,
+    metric_only: bool = False,
 ) -> dict[str, Any]:
     """Cerca dataset nel manifest GCS e/o workspace locale.
 
     Args:
-        query: Testo da cercare nello slug (case-insensitive).
+        query: Testo da cercare — oltre allo slug, matcha la semantica dei
+            cataloghi committati (description, tags, category, colonne).
         layer: ``"clean"``, ``"mart"`` o ``None`` (entrambi).
         limit: Max risultati (default 15). Usa ``0`` per nessun limite.
         source: ``"gcs"`` (pubblicati), ``"workspace"`` (in sviluppo),
                 ``"all"`` (default, unione).
         stage: Filtro workspace: ``"candidates"``, ``"support"``, ``"all"``.
         status_filter: Filtro run status (es. ``"SUCCESS"``).
+        metric_only: Se True, solo dataset con colonne role=metric (dal
+            catalogo committato).
 
     Returns:
         Dict con ``datasets``, ``total_count``, ``truncated``.
@@ -63,11 +67,17 @@ def mcp_find(
             source=source,
             stage=stage,
             status_filter=status_filter,
+            metric_only=metric_only,
         )
     except (FileNotFoundError, TimeoutError) as exc:
         raise ToolkitClientError(
             f"Manifest GCS non raggiungibile: {exc}",
             code=ErrorCode.GCS_UNAVAILABLE,
+        ) from exc
+    except ValueError as exc:
+        raise ToolkitClientError(
+            f"Errori parametri: {exc}",
+            code=ErrorCode.INVALID_PARAMS,
         ) from exc
     except ValueError as exc:
         raise ToolkitClientError(

--- a/toolkit/mcp/registry_ops.py
+++ b/toolkit/mcp/registry_ops.py
@@ -10,8 +10,8 @@ from typing import Any
 
 from lab_connectors.mcp.errors import ErrorCode
 
-from toolkit.domain.registry_ops import list_registries as _list_registries
-from toolkit.domain.registry_ops import show_registry as _show_registry
+from toolkit.registry.reader import list_registries as _list_registries
+from toolkit.registry.reader import show_registry as _show_registry
 from toolkit.mcp.errors import ToolkitClientError
 
 

--- a/toolkit/mcp/registry_ops.py
+++ b/toolkit/mcp/registry_ops.py
@@ -1,0 +1,37 @@
+"""Wrapper MCP per la lettura degli artifact registry committati.
+
+Speculare al comando CLI ``toolkit registry`` (backend condiviso in
+``toolkit.domain.registry_ops``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lab_connectors.mcp.errors import ErrorCode
+
+from toolkit.domain.registry_ops import list_registries as _list_registries
+from toolkit.domain.registry_ops import show_registry as _show_registry
+from toolkit.mcp.errors import ToolkitClientError
+
+
+def mcp_registry_list() -> dict[str, Any]:
+    """Elenca gli artifact registry committati nei repo del workspace."""
+    try:
+        return _list_registries()
+    except Exception as exc:
+        raise ToolkitClientError(f"Errore lettura registry: {exc}", code=ErrorCode.UNEXPECTED)
+
+
+def mcp_registry_show(
+    repo: str,
+    artifact: str,
+    slug: str | None = None,
+) -> dict[str, Any]:
+    """Legge un artifact registry di un repo del workspace."""
+    try:
+        return _show_registry(repo, artifact, slug=slug)
+    except FileNotFoundError as exc:
+        raise ToolkitClientError(str(exc), code=ErrorCode.PARQUET_NOT_FOUND) from exc
+    except Exception as exc:
+        raise ToolkitClientError(f"Errore lettura registry: {exc}", code=ErrorCode.UNEXPECTED)

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -189,11 +189,15 @@ def toolkit_status(
 
 @mcp.tool(
     description="Cerca dataset per slug, source, layer (clean/mart) o testo. "
+    "La query matcha anche la semantica dei cataloghi committati del workspace "
+    "(description, tags, category, nomi colonne) — vedi matched_columns/meta_match. "
     "source='gcs' = pubblicati (da gcs_manifest.json), "
     "source='workspace' = in sviluppo (da dataset.yml + parquet locali), "
     "source='all' (default) = unione. "
-    "Filtri aggiuntivi: stage (candidates/support), status_filter (SUCCESS/FAILED/DRY_RUN). "
-    "Restituisce slug, layer, anni, file count, size, run_status, flag source.",
+    "Filtri aggiuntivi: stage (candidates/support), status_filter (SUCCESS/FAILED/DRY_RUN), "
+    "metric_only (solo dataset con colonne metric dal catalogo). "
+    "Restituisce slug, layer, anni, file count, size, run_status, flag source + "
+    "semantica quando il catalogo committato è presente.",
     structured_output=True,
 )
 def toolkit_find(

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -45,6 +45,11 @@ from .catalog_ops import (
     mcp_find as find_impl,
 )
 
+from .registry_ops import (
+    mcp_registry_list as registry_list_impl,
+    mcp_registry_show as registry_show_impl,
+)
+
 
 mcp = create_mcp_server(
     name="toolkit",
@@ -338,6 +343,35 @@ def toolkit_sparql_query(
     return guard_timed(
         sparql_query_impl, "toolkit_sparql_query", endpoint, query, timeout, max_rows
     )
+
+
+@mcp.tool(
+    description=(
+        "Elenca gli artifact registry committati nei repo del workspace "
+        "(clean_catalog, mart_catalog, pipeline_signals, codelists, ...). "
+        "Ogni repo con registry/ viene elencato con i suoi artifact, "
+        "dimensione e conteggio entries. Usa toolkit_registry_show per il contenuto."
+    ),
+    structured_output=True,
+)
+def toolkit_registry_list() -> dict[str, Any]:
+    return guard_timed(registry_list_impl, "toolkit_registry_list")
+
+
+@mcp.tool(
+    description=(
+        "Mostra un artifact registry committato di un repo del workspace "
+        "(es. repo='eurostat', artifact='clean_catalog'). "
+        "Con slug filtra un'entry: dataset slug (clean_catalog), mart slug "
+        "in formato {dataset}__{mart} (mart_catalog), id (pipeline_signals), "
+        "codelist name (codelists). "
+        "Il catalogo semantico contiene columns (role, semantic_type), "
+        "description, period, location, mart_refs e il blocco run."
+    ),
+    structured_output=True,
+)
+def toolkit_registry_show(repo: str, artifact: str, slug: str | None = None) -> dict[str, Any]:
+    return guard_timed(registry_show_impl, "toolkit_registry_show", repo, artifact, slug)
 
 
 if __name__ == "__main__":

--- a/toolkit/registry/__init__.py
+++ b/toolkit/registry/__init__.py
@@ -1,0 +1,31 @@
+"""Registry builder condiviso DataCivicLab.
+
+Genera gli artifact registry del Lab — clean_catalog, pipeline_signals,
+mart_catalog — riusando il runtime del toolkit (config model, path resolver,
+run_state, parquet_schema) con layout e path contract parametrizzati, così ogni
+repo (dataset-incubator, eurostat, dcl-bologna, ...) riusa la stessa logica.
+
+Chiave canonica: ``dataset.name`` (underscore) — le directory del repo sono
+solo contenitori per trovare il dataset.yml, mai identità del dataset.
+"""
+
+from toolkit.registry.layout import DatasetManifest, RepoLayout, iter_manifests, load_manifest
+from toolkit.registry.paths import PathContract
+from toolkit.registry.builders import (
+    build_clean_catalog,
+    build_mart_catalog,
+    build_registry,
+    build_signals,
+)
+
+__all__ = [
+    "DatasetManifest",
+    "PathContract",
+    "RepoLayout",
+    "build_clean_catalog",
+    "build_mart_catalog",
+    "build_registry",
+    "build_signals",
+    "iter_manifests",
+    "load_manifest",
+]

--- a/toolkit/registry/__init__.py
+++ b/toolkit/registry/__init__.py
@@ -13,6 +13,7 @@ from toolkit.registry.layout import DatasetManifest, RepoLayout, iter_manifests,
 from toolkit.registry.paths import PathContract
 from toolkit.registry.builders import (
     build_clean_catalog,
+    build_codelists,
     build_mart_catalog,
     build_registry,
     build_signals,
@@ -23,6 +24,7 @@ __all__ = [
     "PathContract",
     "RepoLayout",
     "build_clean_catalog",
+    "build_codelists",
     "build_mart_catalog",
     "build_registry",
     "build_signals",

--- a/toolkit/registry/__init__.py
+++ b/toolkit/registry/__init__.py
@@ -1,9 +1,11 @@
-"""Registry builder condiviso DataCivicLab.
+"""Registry builder + lettore condiviso DataCivicLab.
 
-Genera gli artifact registry del Lab — clean_catalog, pipeline_signals,
-mart_catalog — riusando il runtime del toolkit (config model, path resolver,
-run_state, parquet_schema) con layout e path contract parametrizzati, così ogni
-repo (dataset-incubator, eurostat, dcl-bologna, ...) riusa la stessa logica.
+Capacità unica del Lab per gli artifact registry:
+- ``builders``: genera clean_catalog, mart_catalog, pipeline_signals, codelists
+  (riusando il runtime del toolkit: config model, path resolver, run_state,
+  parquet_schema) con layout e path contract parametrizzati.
+- ``reader``: consulta gli artifact committati nei repo del workspace
+  (CLI ``toolkit registry`` e MCP ``toolkit_registry_*``).
 
 Chiave canonica: ``dataset.name`` (underscore) — le directory del repo sono
 solo contenitori per trovare il dataset.yml, mai identità del dataset.
@@ -11,6 +13,7 @@ solo contenitori per trovare il dataset.yml, mai identità del dataset.
 
 from toolkit.registry.layout import DatasetManifest, RepoLayout, iter_manifests, load_manifest
 from toolkit.registry.paths import PathContract
+from toolkit.registry.reader import list_registries, show_registry
 from toolkit.registry.builders import (
     build_clean_catalog,
     build_codelists,
@@ -29,5 +32,7 @@ __all__ = [
     "build_registry",
     "build_signals",
     "iter_manifests",
+    "list_registries",
     "load_manifest",
+    "show_registry",
 ]

--- a/toolkit/registry/builders.py
+++ b/toolkit/registry/builders.py
@@ -1,0 +1,407 @@
+"""Builder degli artifact registry condivisi.
+
+Tre proiezioni dello stesso stato (dataset.yml + run records + parquet locali):
+
+- ``build_clean_catalog`` — inventario queryabile dei clean parquet.
+- ``build_mart_catalog``  — inventario delle tabelle mart (slug {dataset}__{mart}).
+- ``build_signals``      — health check operativo (repo-signals standard ACB).
+
+Tutta la lettura del runtime è delegata al toolkit (config model, path resolver,
+run_state, parquet_schema) — qui solo proiezione e arricchimento di catalogo.
+
+Derive-mode:
+- ``local`` (default): schemi e anni dai parquet locali e dai run records.
+  Nessuna lettura GCS.
+- ``check-gcs``: come local, più verifica di presenza dei parquet pubblici
+  (object_exists) per segnalare gli URL non risolti.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from toolkit.registry.layout import DatasetManifest, RepoLayout, iter_manifests
+from toolkit.registry.paths import PathContract
+from toolkit.registry.runs import latest_run_record, run_block
+from toolkit.registry.schema_reader import (
+    clean_parquet_path,
+    latest_clean_columns,
+    load_semantic_types,
+)
+from toolkit.registry.validation import validate_artifact
+
+
+def _section_of(manifest: DatasetManifest, layout: RepoLayout) -> str:
+    """Nome della sezione del layout che contiene il manifest (es. 'compose')."""
+    try:
+        return str(manifest.yml_path.relative_to(layout.repo_root).parts[0])
+    except ValueError:
+        return ""
+
+
+def _mart_ok(manifest: DatasetManifest) -> bool:
+    """True se il dataset dichiara mart (tables) o ha sql mart presenti."""
+    if manifest.mart_tables:
+        return True
+    sql_dir = manifest.base_dir / "sql"
+    if sql_dir.is_dir():
+        return any(p.name.startswith("mart") and p.suffix == ".sql" for p in sql_dir.iterdir())
+    return False
+
+
+# ---------------------------------------------------------------------------
+# clean_catalog
+# ---------------------------------------------------------------------------
+
+
+def build_clean_catalog(
+    layout: RepoLayout,
+    existing: dict[str, Any] | None = None,
+    derive_mode: str = "local",
+    check_gcs: bool = False,
+    slug: str | None = None,
+    semantic_types_path: Path | None = None,
+    path_contract: PathContract | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Costruisce il clean_catalog per il layout del repo.
+
+    Args:
+        layout: Struttura del repo (dataset_dirs, source_repo).
+        existing: Catalogo precedente (metadata editoriali preservati:
+            name/description/source/stage umani, role/semantic_type colonne).
+        derive_mode: ``"local"`` (default) o ``"check-gcs"``.
+        check_gcs: alias per derive_mode="check-gcs" (compat coi vecchi flag).
+        slug: Limita a un singolo slug (per test e debug).
+        semantic_types_path: Path a semantic_types.yaml (opzionale).
+        path_contract: Contratto GCS (default: layout DI, year).
+
+    Returns:
+        Tuple (catalog, errors). Gli errori NON bloccano il catalogo: le
+        entry non derivabili sono escluse e segnalate.
+    """
+    if derive_mode == "check-gcs" or check_gcs:
+        derive_mode = "check-gcs"
+    contract = path_contract or PathContract()
+    alias_map = load_semantic_types(semantic_types_path)
+
+    editorial: dict[str, dict[str, Any]] = {}
+    if existing:
+        for ds in existing.get("datasets", []) or []:
+            editorial[ds.get("slug", "")] = ds
+
+    datasets: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for manifest in iter_manifests(layout):
+        if slug and manifest.slug != slug:
+            continue
+
+        columns, latest_year = latest_clean_columns(manifest, alias_map)
+        if columns is None:
+            # Nessun parquet locale: possibile solo se l'entry è editoriale
+            # (preservata) — altrimenti errore e skip.
+            if manifest.slug in editorial:
+                datasets.append(editorial[manifest.slug])
+                continue
+            errors.append(
+                f"{manifest.slug}: nessun parquet clean locale "
+                f"per anni {manifest.years} (runnare la pipeline per generarlo)"
+            )
+            continue
+        if latest_year is None:
+            errors.append(f"{manifest.slug}: schema letto ma anno non risolvibile")
+            continue
+
+        years_present = sorted(y for y in manifest.years if clean_parquet_path(manifest.cfg, y))
+        years_eff = years_present or [latest_year]
+
+        entry: dict[str, Any] = {
+            "slug": manifest.slug,
+            "name": manifest.slug.replace("_", " ").title(),
+            "description": "",
+            "source": "",
+            "source_id": manifest.source_id,
+            "period": manifest.period or {"start": years_eff[0], "end": years_eff[-1]},
+            "years": years_eff,
+            "tags": list(manifest.tags),
+            "category": manifest.category,
+            "columns": columns,
+            "location": contract.clean_location(manifest.slug, years_eff),
+            "stage": "incubating",
+            "registry_source": "derive_auto",
+        }
+
+        # Merge editoriale: i campi umani sovrascrivono; role/semantic_type
+        # delle colonne preservati se presenti.
+        old = editorial.get(manifest.slug)
+        if old:
+            for field in ("name", "description", "source", "source_id", "stage", "period"):
+                if old.get(field):
+                    entry[field] = old[field]
+            old_cols = {c.get("name"): c for c in old.get("columns", [])}
+            for col in entry["columns"]:
+                oc = old_cols.get(col["name"])
+                if oc:
+                    if oc.get("description"):
+                        col["description"] = oc["description"]
+                    if oc.get("role"):
+                        col["role"] = oc["role"]
+                    if oc.get("semantic_type"):
+                        col["semantic_type"] = oc["semantic_type"]
+
+        # Link ai mart (convention {dataset}__{mart})
+        if manifest.mart_tables:
+            entry["mart_refs"] = [
+                f"{manifest.slug}__{t.get('name')}" for t in manifest.mart_tables if t.get("name")
+            ]
+
+        # Blocco run (ultimo run record del toolkit)
+        run_rec = latest_run_record(str(manifest.yml_path))
+        if run_block(run_rec):
+            entry["run"] = run_block(run_rec)
+
+        datasets.append(entry)
+
+    # Preserva entry editoriali senza parquet locale né derive (es. adottati)
+    derived_slugs = {d["slug"] for d in datasets}
+    for ds_slug, ds in editorial.items():
+        if ds_slug not in derived_slugs:
+            datasets.append(ds)
+
+    catalog: dict[str, Any] = {
+        "schema_version": 1,
+        "name": "Lab Clean Registry",
+        "description": "Catalogo canonico dei clean parquet pubblici del Lab.",
+        "source_repo": layout.source_repo,
+        "updated_at": str(datetime.now(UTC).date()),
+        "datasets": sorted(datasets, key=lambda d: d["slug"]),
+    }
+
+    if derive_mode == "check-gcs":
+        errors.extend(_check_gcs_locations(catalog, contract))
+
+    errors.extend(validate_artifact(catalog, "clean_catalog.schema.json"))
+    return catalog, errors
+
+
+def _check_gcs_locations(catalog: dict[str, Any], contract: PathContract) -> list[str]:
+    """Verifica che le location gs:// risolvano ad almeno un parquet pubblico."""
+    from lab_connectors.gcs import object_exists
+    from lab_connectors.gcs.paths import parse_gs_url
+
+    errors: list[str] = []
+    for ds in catalog.get("datasets", []):
+        loc = ds.get("location") or {}
+        path = loc.get("path", "")
+        if not path.startswith("gs://"):
+            continue
+        bucket, key = parse_gs_url(path)
+        if "*" in key:
+            prefix = key.split("*")[0].rstrip("/") + "/"
+            if not object_exists(bucket, prefix + "pipeline_run.json"):
+                errors.append(f"{ds['slug']}: nessun pipeline_run.json pubblicato in {prefix}")
+        elif not object_exists(bucket, key):
+            errors.append(f"{ds['slug']}: parquet non trovato su GCS ({path})")
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# mart_catalog
+# ---------------------------------------------------------------------------
+
+
+def build_mart_catalog(
+    layout: RepoLayout,
+    path_contract: PathContract | None = None,
+    slug: str | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Costruisce il mart_catalog per il layout del repo.
+
+    Sorgenti: sezione ``mart:`` del dataset.yml (tables, validate.table_rules)
+    + run records (blocco run). Nessuna lettura parquet in v1 (columns
+    opzionale, non popolato).
+    """
+    contract = path_contract or PathContract()
+    marts: list[dict[str, Any]] = []
+    errors: list[str] = []
+    runs_cache: dict[str, dict[str, Any]] = {}
+
+    for manifest in iter_manifests(layout):
+        if slug and manifest.slug != slug:
+            continue
+        run_rec = latest_run_record(str(manifest.yml_path))
+        if manifest.slug not in runs_cache:
+            runs_cache[manifest.slug] = run_block(run_rec) or {}
+        for table in manifest.mart_tables:
+            name = table.get("name")
+            if not name:
+                continue
+            rule = manifest.mart_rules.get(name, {})
+            entry: dict[str, Any] = {
+                "slug": f"{manifest.slug}__{name}",
+                "dataset": manifest.slug,
+                "table": name,
+                "description": f"{manifest.slug} — mart {name}",
+            }
+            if rule.get("primary_key"):
+                entry["primary_key"] = list(rule["primary_key"])
+            if rule.get("required_columns"):
+                entry["required_columns"] = list(rule["required_columns"])
+            if rule.get("min_rows") is not None:
+                entry["min_rows"] = rule["min_rows"]
+            if runs_cache[manifest.slug]:
+                entry["run"] = runs_cache[manifest.slug]
+            try:
+                entry["location"] = contract.mart_location(
+                    manifest.slug, name, year=max(manifest.years, default=None)
+                )
+            except ValueError:
+                entry["location"] = contract.mart_location(manifest.slug, name)
+            marts.append(entry)
+
+    catalog: dict[str, Any] = {
+        "schema_version": 1,
+        "name": "Lab Mart Registry",
+        "description": "Tabelle analitiche (mart) pubblicate dal Lab.",
+        "source_repo": layout.source_repo,
+        "updated_at": str(datetime.now(UTC).date()),
+        "marts": sorted(marts, key=lambda m: m["slug"]),
+    }
+    errors.extend(validate_artifact(catalog, "mart_catalog.schema.json"))
+    return catalog, errors
+
+
+# ---------------------------------------------------------------------------
+# pipeline_signals
+# ---------------------------------------------------------------------------
+
+
+def build_signals(
+    layout: RepoLayout,
+    topic: str = "pipeline_state",
+) -> tuple[dict[str, Any], list[str]]:
+    """Costruisce pipeline_signals per ACB (repo-signals standard).
+
+    Semantica status: ok = struttura coerente + mart presente; warn = nessun
+    mart; error = struttura rotta (clean.sql mancante per dataset non-compose).
+    NOTA: status=ok NON significa pubblicato (vedi clean_catalog.stage).
+    """
+    signals: list[dict[str, Any]] = []
+    errors: list[str] = []
+    compose_ids: set[str] = set()
+
+    for manifest in iter_manifests(layout):
+        mart_ok = _mart_ok(manifest)
+        is_compose = manifest.is_mart_only
+
+        failures: list[str] = []
+        if not is_compose and not manifest.has_clean_sql:
+            failures.append("missing sql/clean.sql")
+
+        if failures:
+            status = "error"
+            action = "correggere la struttura del dataset"
+        elif not mart_ok:
+            status = "warn"
+            action = "aggiungere mart SQL per completare il dataset"
+        else:
+            status = "ok"
+            action = ""
+
+        years_label = _years_label(manifest.years)
+        mart_label = "mart: si" if mart_ok else "mart: no"
+        detail = f"{years_label} — {mart_label}"
+        if failures:
+            detail += " — " + "; ".join(failures)
+
+        signal: dict[str, Any] = {
+            "id": manifest.slug,
+            "source_id": manifest.source_id,
+            "status": status,
+            "label": manifest.slug,
+            "detail": detail,
+            "action": action,
+        }
+        if manifest.years:
+            signal["years"] = list(manifest.years)
+        run_rec = latest_run_record(str(manifest.yml_path))
+        if run_block(run_rec):
+            signal["run"] = run_block(run_rec)
+        signals.append(signal)
+
+        # Prefisso "compose:" per i manifest in sezione compose del layout
+        if _section_of(manifest, layout) == "compose":
+            compose_ids.add(manifest.slug)
+
+    for sig in signals:
+        if sig["id"] in compose_ids:
+            sig["id"] = f"compose:{sig['id']}"
+
+    by_status = {"ok": 0, "warn": 0, "error": 0}
+    for s in signals:
+        by_status[s["status"]] = by_status.get(s["status"], 0) + 1
+
+    payload: dict[str, Any] = {
+        "schema_version": "1",
+        "generated_at": datetime.now(UTC).date().isoformat(),
+        "repo": layout.source_repo.split("/")[-1] or "unknown",
+        "topic": topic,
+        "summary": {"total": len(signals), "by_status": by_status},
+        "signals": signals,
+    }
+    errors.extend(validate_artifact(payload, "pipeline_signals.schema.json"))
+    return payload, errors
+
+
+def _years_label(years: Iterable[int]) -> str:
+    years = sorted(years)
+    if not years:
+        return "anni: ?"
+    if len(years) == 1:
+        return f"anno {years[0]}"
+    return f"anni {years[0]}-{years[-1]}"
+
+
+# ---------------------------------------------------------------------------
+# Convenience: unico entry point
+# ---------------------------------------------------------------------------
+
+
+def build_registry(
+    layout: RepoLayout,
+    *,
+    derive_mode: str = "local",
+    path_contract: PathContract | None = None,
+    existing_catalog: dict[str, Any] | None = None,
+    semantic_types_path: Path | None = None,
+    slug: str | None = None,
+) -> dict[str, Any]:
+    """Genera i tre artifact per un repo in una sola chiamata.
+
+    Returns:
+        Dict ``{"clean_catalog": {...}, "mart_catalog": {...},
+        "pipeline_signals": {...}, "errors": {...}}``.
+    """
+    catalog, cc_errors = build_clean_catalog(
+        layout,
+        existing=existing_catalog,
+        derive_mode=derive_mode,
+        semantic_types_path=semantic_types_path,
+        path_contract=path_contract,
+        slug=slug,
+    )
+    marts, mc_errors = build_mart_catalog(layout, path_contract=path_contract, slug=slug)
+    signals, ps_errors = build_signals(layout)
+    return {
+        "clean_catalog": catalog,
+        "mart_catalog": marts,
+        "pipeline_signals": signals,
+        "errors": {
+            "clean_catalog": cc_errors,
+            "mart_catalog": mc_errors,
+            "pipeline_signals": ps_errors,
+        },
+    }

--- a/toolkit/registry/builders.py
+++ b/toolkit/registry/builders.py
@@ -123,7 +123,7 @@ def build_clean_catalog(
         entry: dict[str, Any] = {
             "slug": manifest.slug,
             "name": manifest.slug.replace("_", " ").title(),
-            "description": "",
+            "description": manifest.description,
             "source": "",
             "source_id": manifest.source_id,
             "period": manifest.period or {"start": years_eff[0], "end": years_eff[-1]},
@@ -369,6 +369,75 @@ def _years_label(years: Iterable[int]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# codelists (valori delle dimensioni)
+# ---------------------------------------------------------------------------
+
+
+def _read_codelist_csv(path: Path) -> list[dict[str, Any]]:
+    """Legge un codelist CSV (header, prima riga) in lista di dict.
+
+    Preserva tutte le colonne (es. geo.csv: code, label_en, nuts_level,
+    parent_code). Righe vuote ignorate.
+    """
+    import csv
+
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8", newline="") as fh:
+        for row in csv.DictReader(fh):
+            if not row or not any((v or "").strip() for v in row.values()):
+                continue
+            cleaned = {k.strip(): (v or "").strip() for k, v in row.items()}
+            rows.append(cleaned)
+    return rows
+
+
+def build_codelists(
+    layout: RepoLayout,
+    codelists_dir: Path | None = None,
+) -> tuple[dict[str, Any], dict[str, list[str]]]:
+    """Costruisce codelists.json: i valori delle dimensioni del repo.
+
+    Legge ``{repo_root}/codelists/*.csv`` (convenzione eurostat: geo.csv,
+    units.csv, freq.csv, ...) e li espone come mappa ``nome → [righe]``.
+    Permette all'agente MCP di risolvere i codici (es. unit='EUR_HAB',
+    geo='ITC4' con parent_code) prima di scrivere le query.
+
+    Returns:
+        Tuple (payload, errors) con errors = {"derive": [], "validation": [...]}.
+        Se la dir codelists non esiste, ritorna un payload vuoto senza errori
+        (codelists è opzionale).
+    """
+    codelists_dir = codelists_dir or (layout.repo_root / "codelists")
+    codelists: dict[str, Any] = {}
+    errors: list[str] = []
+
+    if not codelists_dir.is_dir():
+        return (
+            {"schema_version": 1, "source_repo": layout.source_repo, "codelists": {}},
+            {"derive": [], "validation": []},
+        )
+
+    for csv_path in sorted(codelists_dir.glob("*.csv")):
+        name = csv_path.stem
+        try:
+            rows = _read_codelist_csv(csv_path)
+        except Exception as exc:
+            errors.append(f"codelist {name}: {exc}")
+            continue
+        if rows:
+            codelists[name] = rows
+
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "source_repo": layout.source_repo,
+        "updated_at": str(datetime.now(UTC).date()),
+        "codelists": codelists,
+    }
+    errors.extend(validate_artifact(payload, "codelists.schema.json"))
+    return payload, {"derive": [], "validation": errors}
+
+
+# ---------------------------------------------------------------------------
 # Convenience: unico entry point
 # ---------------------------------------------------------------------------
 
@@ -399,13 +468,16 @@ def build_registry(
     )
     marts, mc_errors = build_mart_catalog(layout, path_contract=path_contract, slug=slug)
     signals, ps_errors = build_signals(layout)
+    codelists, cl_errors = build_codelists(layout)
     return {
         "clean_catalog": catalog,
         "mart_catalog": marts,
         "pipeline_signals": signals,
+        "codelists": codelists,
         "errors": {
             "clean_catalog": cc_errors,
             "mart_catalog": mc_errors,
             "pipeline_signals": ps_errors,
+            "codelists": cl_errors,
         },
     }

--- a/toolkit/registry/builders.py
+++ b/toolkit/registry/builders.py
@@ -254,12 +254,14 @@ def build_mart_catalog(
                 entry["min_rows"] = rule["min_rows"]
             if runs_cache[manifest.slug]:
                 entry["run"] = runs_cache[manifest.slug]
-            try:
-                entry["location"] = contract.mart_location(
-                    manifest.slug, name, year=max(manifest.years, default=None)
+            year = max(manifest.years, default=None)
+            if contract.mart_layout == "year" and year is None:
+                errors.append(
+                    f"{manifest.slug}__{name}: location mart non risolvibile "
+                    "(layout 'year' senza years dichiarati)"
                 )
-            except ValueError:
-                entry["location"] = contract.mart_location(manifest.slug, name)
+                continue
+            entry["location"] = contract.mart_location(manifest.slug, name, year=year)
             marts.append(entry)
 
     catalog: dict[str, Any] = {

--- a/toolkit/registry/builders.py
+++ b/toolkit/registry/builders.py
@@ -391,6 +391,11 @@ def _read_codelist_csv(path: Path) -> list[dict[str, Any]]:
     return rows
 
 
+# Soglia righe per embedding nel JSON: oltre, il codelist è dichiarato in
+# ``large`` (il MCP lo legge dal CSV del repo, come faceva eurostat-mcp).
+MAX_CODELIST_ROWS = 1000
+
+
 def build_codelists(
     layout: RepoLayout,
     codelists_dir: Path | None = None,
@@ -398,8 +403,11 @@ def build_codelists(
     """Costruisce codelists.json: i valori delle dimensioni del repo.
 
     Legge ``{repo_root}/codelists/*.csv`` (convenzione eurostat: geo.csv,
-    units.csv, freq.csv, ...) e li espone come mappa ``nome → [righe]``.
-    Permette all'agente MCP di risolvere i codici (es. unit='EUR_HAB',
+    units.csv, freq.csv, ...). I codelist piccoli (<= MAX_CODELIST_ROWS righe)
+    sono embedded come mappa ``nome → [righe]``; i grandi (es. geo, c_resid)
+    sono elencati in ``large`` — il consumatore li legge dal CSV del repo
+    (pattern del vecchio eurostat-mcp: embedded per i piccoli, file per i
+    grandi). Permette all'agente MCP di risolvere i codici (es. unit='EUR_HAB',
     geo='ITC4' con parent_code) prima di scrivere le query.
 
     Returns:
@@ -409,6 +417,7 @@ def build_codelists(
     """
     codelists_dir = codelists_dir or (layout.repo_root / "codelists")
     codelists: dict[str, Any] = {}
+    large: list[str] = []
     errors: list[str] = []
 
     if not codelists_dir.is_dir():
@@ -424,7 +433,11 @@ def build_codelists(
         except Exception as exc:
             errors.append(f"codelist {name}: {exc}")
             continue
-        if rows:
+        if not rows:
+            continue
+        if len(rows) > MAX_CODELIST_ROWS:
+            large.append(name)
+        else:
             codelists[name] = rows
 
     payload: dict[str, Any] = {
@@ -433,6 +446,8 @@ def build_codelists(
         "updated_at": str(datetime.now(UTC).date()),
         "codelists": codelists,
     }
+    if large:
+        payload["large"] = sorted(large)
     errors.extend(validate_artifact(payload, "codelists.schema.json"))
     return payload, {"derive": [], "validation": errors}
 

--- a/toolkit/registry/builders.py
+++ b/toolkit/registry/builders.py
@@ -65,7 +65,7 @@ def build_clean_catalog(
     slug: str | None = None,
     semantic_types_path: Path | None = None,
     path_contract: PathContract | None = None,
-) -> tuple[dict[str, Any], list[str]]:
+) -> tuple[dict[str, Any], dict[str, list[str]]]:
     """Costruisce il clean_catalog per il layout del repo.
 
     Args:
@@ -79,8 +79,10 @@ def build_clean_catalog(
         path_contract: Contratto GCS (default: layout DI, year).
 
     Returns:
-        Tuple (catalog, errors). Gli errori NON bloccano il catalogo: le
-        entry non derivabili sono escluse e segnalate.
+        Tuple (catalog, errors) con errors = {"derive": [...], "validation": [...]}.
+        Gli errori derive NON bloccano il catalogo: le entry non derivabili
+        sono escluse e segnalate. Gli errori validation indicano un artifact
+        non conforme allo schema.
     """
     if derive_mode == "check-gcs" or check_gcs:
         derive_mode = "check-gcs"
@@ -93,7 +95,7 @@ def build_clean_catalog(
             editorial[ds.get("slug", "")] = ds
 
     datasets: list[dict[str, Any]] = []
-    errors: list[str] = []
+    derive_errors: list[str] = []
 
     for manifest in iter_manifests(layout):
         if slug and manifest.slug != slug:
@@ -106,13 +108,13 @@ def build_clean_catalog(
             if manifest.slug in editorial:
                 datasets.append(editorial[manifest.slug])
                 continue
-            errors.append(
+            derive_errors.append(
                 f"{manifest.slug}: nessun parquet clean locale "
                 f"per anni {manifest.years} (runnare la pipeline per generarlo)"
             )
             continue
         if latest_year is None:
-            errors.append(f"{manifest.slug}: schema letto ma anno non risolvibile")
+            derive_errors.append(f"{manifest.slug}: schema letto ma anno non risolvibile")
             continue
 
         years_present = sorted(y for y in manifest.years if clean_parquet_path(manifest.cfg, y))
@@ -181,10 +183,10 @@ def build_clean_catalog(
     }
 
     if derive_mode == "check-gcs":
-        errors.extend(_check_gcs_locations(catalog, contract))
+        derive_errors.extend(_check_gcs_locations(catalog, contract))
 
-    errors.extend(validate_artifact(catalog, "clean_catalog.schema.json"))
-    return catalog, errors
+    validation_errors = validate_artifact(catalog, "clean_catalog.schema.json")
+    return catalog, {"derive": derive_errors, "validation": validation_errors}
 
 
 def _check_gcs_locations(catalog: dict[str, Any], contract: PathContract) -> list[str]:
@@ -217,7 +219,7 @@ def build_mart_catalog(
     layout: RepoLayout,
     path_contract: PathContract | None = None,
     slug: str | None = None,
-) -> tuple[dict[str, Any], list[str]]:
+) -> tuple[dict[str, Any], dict[str, list[str]]]:
     """Costruisce il mart_catalog per il layout del repo.
 
     Sorgenti: sezione ``mart:`` del dataset.yml (tables, validate.table_rules)
@@ -226,7 +228,7 @@ def build_mart_catalog(
     """
     contract = path_contract or PathContract()
     marts: list[dict[str, Any]] = []
-    errors: list[str] = []
+    derive_errors: list[str] = []
     runs_cache: dict[str, dict[str, Any]] = {}
 
     for manifest in iter_manifests(layout):
@@ -256,7 +258,7 @@ def build_mart_catalog(
                 entry["run"] = runs_cache[manifest.slug]
             year = max(manifest.years, default=None)
             if contract.mart_layout == "year" and year is None:
-                errors.append(
+                derive_errors.append(
                     f"{manifest.slug}__{name}: location mart non risolvibile "
                     "(layout 'year' senza years dichiarati)"
                 )
@@ -272,8 +274,8 @@ def build_mart_catalog(
         "updated_at": str(datetime.now(UTC).date()),
         "marts": sorted(marts, key=lambda m: m["slug"]),
     }
-    errors.extend(validate_artifact(catalog, "mart_catalog.schema.json"))
-    return catalog, errors
+    validation_errors = validate_artifact(catalog, "mart_catalog.schema.json")
+    return catalog, {"derive": derive_errors, "validation": validation_errors}
 
 
 # ---------------------------------------------------------------------------
@@ -284,7 +286,7 @@ def build_mart_catalog(
 def build_signals(
     layout: RepoLayout,
     topic: str = "pipeline_state",
-) -> tuple[dict[str, Any], list[str]]:
+) -> tuple[dict[str, Any], dict[str, list[str]]]:
     """Costruisce pipeline_signals per ACB (repo-signals standard).
 
     Semantica status: ok = struttura coerente + mart presente; warn = nessun
@@ -292,7 +294,6 @@ def build_signals(
     NOTA: status=ok NON significa pubblicato (vedi clean_catalog.stage).
     """
     signals: list[dict[str, Any]] = []
-    errors: list[str] = []
     compose_ids: set[str] = set()
 
     for manifest in iter_manifests(layout):
@@ -354,8 +355,8 @@ def build_signals(
         "summary": {"total": len(signals), "by_status": by_status},
         "signals": signals,
     }
-    errors.extend(validate_artifact(payload, "pipeline_signals.schema.json"))
-    return payload, errors
+    validation_errors = validate_artifact(payload, "pipeline_signals.schema.json")
+    return payload, {"derive": [], "validation": validation_errors}
 
 
 def _years_label(years: Iterable[int]) -> str:
@@ -385,7 +386,8 @@ def build_registry(
 
     Returns:
         Dict ``{"clean_catalog": {...}, "mart_catalog": {...},
-        "pipeline_signals": {...}, "errors": {...}}``.
+        "pipeline_signals": {...}, "errors": {...}}`` con errors per artifact:
+        ``{"derive": [...], "validation": [...]}``.
     """
     catalog, cc_errors = build_clean_catalog(
         layout,

--- a/toolkit/registry/layout.py
+++ b/toolkit/registry/layout.py
@@ -71,6 +71,7 @@ class DatasetManifest:
     source_id: str = ""
     tags: tuple[str, ...] = ()
     category: str = ""
+    description: str = ""
     time_coverage: dict[str, Any] = field(default_factory=dict)
     mart_tables: tuple[dict[str, Any], ...] = field(default_factory=tuple)
     mart_rules: dict[str, dict[str, Any]] = field(default_factory=dict)
@@ -102,6 +103,19 @@ def load_manifest(yml_path: Path) -> DatasetManifest | None:
     except Exception:
         extra = {}
 
+    # Description: campi custom non esposti dal config model — lettura mirata
+    # del yaml (dataset.description, registry.description/theme).
+    description = ""
+    try:
+        import yaml as _yaml
+
+        raw = _yaml.safe_load(yml_path.read_text(encoding="utf-8")) or {}
+        ds = raw.get("dataset") or {}
+        reg = raw.get("registry") or {}
+        description = ds.get("description") or reg.get("description") or reg.get("theme") or ""
+    except Exception:
+        description = ""
+
     tables = tuple({"name": t.name, "sql": t.sql} for t in cfg.mart.tables if t.name)
     rules: dict[str, dict[str, Any]] = {}
     validate = cfg.mart.validate
@@ -125,6 +139,7 @@ def load_manifest(yml_path: Path) -> DatasetManifest | None:
         source_id=cfg.source_id or "",
         tags=tuple(cfg.tags or []),
         category=cfg.category or "",
+        description=description,
         time_coverage=extra.get("time_coverage") or {},
         mart_tables=tables,
         mart_rules=rules,

--- a/toolkit/registry/layout.py
+++ b/toolkit/registry/layout.py
@@ -1,0 +1,141 @@
+"""Layout repo e lettura dataset.yml.
+
+La lettura del dataset.yml è delegata al config model del toolkit
+(``toolkit.core.config.load_config`` + ``load_dataset_manifest``): qui solo
+navigazione del filesystem (dove stanno i dataset.yml) e normalizzazione dei
+campi che servono agli artifact registry.
+
+Chiave canonica di un dataset: ``dataset.name`` (underscore). La directory che
+contiene il dataset.yml è solo un contenitore (es. ``datasets/eurostat-gdp-nuts3``)
+e non è MAI usata come identità — path locali, run records e GCS usano il name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+
+from toolkit.core.config import load_config
+from toolkit.core.dataset_loader import load_dataset_manifest
+
+DEFAULT_DATASET_DIRS: tuple[str, ...] = ("datasets",)
+
+
+@dataclass(frozen=True)
+class RepoLayout:
+    """Struttura dichiarativa di un repo con dataset.yml.
+
+    Args:
+        repo_root: Root del repo.
+        dataset_dirs: Dir (relative a repo_root) che contengono i dataset.yml
+            (es. ``("datasets",)`` per eurostat; ``("candidates", "compose",
+            "support_datasets")`` per dataset-incubator).
+        source_repo: Identità del repo per gli artifact
+            (es. ``dataciviclab/eurostat``).
+    """
+
+    repo_root: Path
+    dataset_dirs: tuple[str, ...] = DEFAULT_DATASET_DIRS
+    source_repo: str = ""
+
+    def iter_dataset_ymls(self) -> Iterator[Path]:
+        """Itera i dataset.yml presenti nelle dir configurate.
+
+        Un solo livello di profondità (es. ``datasets/{entry}/dataset.yml``).
+        Le entry senza dataset.yml sono ignorate.
+        """
+        for section in self.dataset_dirs:
+            section_dir = self.repo_root / section
+            if not section_dir.is_dir():
+                continue
+            for entry_dir in sorted(section_dir.iterdir()):
+                yml = entry_dir / "dataset.yml"
+                if yml.is_file():
+                    yield yml
+
+
+@dataclass(frozen=True)
+class DatasetManifest:
+    """Vista normalizzata di un dataset.yml (config model del toolkit).
+
+    ``cfg`` è il ``PipelineConfig`` completo: serve ai reader (path resolver,
+    run_state) che lavorano sul contratto del toolkit.
+    """
+
+    slug: str
+    yml_path: Path
+    base_dir: Path
+    cfg: Any = None
+    years: tuple[int, ...] = ()
+    source_id: str = ""
+    tags: tuple[str, ...] = ()
+    category: str = ""
+    time_coverage: dict[str, Any] = field(default_factory=dict)
+    mart_tables: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    mart_rules: dict[str, dict[str, Any]] = field(default_factory=dict)
+    is_mart_only: bool = False
+    has_clean_sql: bool = False
+
+    @property
+    def period(self) -> dict[str, int] | None:
+        tc = self.time_coverage
+        if tc and "start_year" in tc and "end_year" in tc:
+            return {"start": int(tc["start_year"]), "end": int(tc["end_year"])}
+        return None
+
+
+def load_manifest(yml_path: Path) -> DatasetManifest | None:
+    """Carica un dataset.yml via il config model del toolkit.
+
+    Ritorna None se il config non è leggibile o non ha ``dataset.name``.
+    """
+    try:
+        cfg = load_config(str(yml_path), strict_config=False)
+    except Exception:
+        return None
+    if not cfg.dataset:
+        return None
+
+    try:
+        extra = load_dataset_manifest(str(yml_path)) or {}
+    except Exception:
+        extra = {}
+
+    tables = tuple({"name": t.name, "sql": t.sql} for t in cfg.mart.tables if t.name)
+    rules: dict[str, dict[str, Any]] = {}
+    validate = cfg.mart.validate
+    if validate is not None and validate.table_rules:
+        for name, rule in validate.table_rules.items():
+            entry: dict[str, Any] = {}
+            if rule.required_columns:
+                entry["required_columns"] = list(rule.required_columns)
+            if rule.primary_key:
+                entry["primary_key"] = list(rule.primary_key)
+            if rule.min_rows is not None:
+                entry["min_rows"] = rule.min_rows
+            rules[name] = entry
+
+    return DatasetManifest(
+        slug=cfg.dataset,
+        yml_path=yml_path,
+        base_dir=yml_path.parent,
+        cfg=cfg,
+        years=tuple(sorted(cfg.years)),
+        source_id=cfg.source_id or "",
+        tags=tuple(cfg.tags or []),
+        category=cfg.category or "",
+        time_coverage=extra.get("time_coverage") or {},
+        mart_tables=tables,
+        mart_rules=rules,
+        is_mart_only=cfg.is_mart_only,
+        has_clean_sql=bool(cfg.clean.sql),
+    )
+
+
+def iter_manifests(layout: RepoLayout) -> Iterator[DatasetManifest]:
+    """Itera i manifest validi del layout (con ``dataset.name``)."""
+    for yml in layout.iter_dataset_ymls():
+        manifest = load_manifest(yml)
+        if manifest is not None:
+            yield manifest

--- a/toolkit/registry/paths.py
+++ b/toolkit/registry/paths.py
@@ -1,0 +1,81 @@
+"""Path contract GCS per gli artifact registry.
+
+Estende il contratto di ``lab_connectors.gcs.paths`` (bucket names) con due
+layout per layer:
+
+- ``year``: ``{prefix}/{slug}/{year}/{file}`` — layout dataset-incubator.
+- ``flat``: ``{prefix}/{slug}/{file}`` — layout no-year, es. eurostat.
+
+``prefix`` è l'organizzazione nel bucket (es. ``eurostat``); vuoto per i
+dataset a root bucket (layout DI). La chiave canonica è sempre lo slug
+(``dataset.name``, underscore).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from lab_connectors.gcs.paths import MART_BUCKET, CLEAN_BUCKET
+
+
+@dataclass(frozen=True)
+class PathContract:
+    """Contratto di posizionamento GCS per un repo.
+
+    Args:
+        prefix: Organizzazione nel bucket (es. ``"eurostat"``). Vuoto = root.
+        clean_layout: ``"year"`` (default) o ``"flat"`` per il layer clean.
+        mart_layout: ``"year"`` (default) o ``"flat"`` per il layer mart.
+    """
+
+    prefix: str = ""
+    clean_layout: str = "year"
+    mart_layout: str = "year"
+
+    def _prefixed(self, bucket: str) -> str:
+        return f"gs://{bucket}/{self.prefix}" if self.prefix else f"gs://{bucket}"
+
+    # ── Clean ──────────────────────────────────────────────────────────────
+
+    def clean_parquet_url(self, slug: str, year: int) -> str:
+        """URL gs:// del parquet clean per slug+anno."""
+        base = self._prefixed(CLEAN_BUCKET)
+        if self.clean_layout == "flat":
+            return f"{base}/{slug}/{slug}_{year}_clean.parquet"
+        return f"{base}/{slug}/{year}/{slug}_{year}_clean.parquet"
+
+    def clean_location(self, slug: str, years: list[int]) -> dict[str, Any]:
+        """Location per il clean_catalog (pattern con wildcard se multi-file)."""
+        if self.clean_layout == "flat":
+            return {
+                "type": "gcs",
+                "path": f"{self._prefixed(CLEAN_BUCKET)}/{slug}/",
+                "multi_file": False,
+            }
+        multi = len(years) > 1
+        path = (
+            f"{self._prefixed(CLEAN_BUCKET)}/{slug}/*/{slug}_*_clean.parquet"
+            if multi
+            else self.clean_parquet_url(slug, years[0])
+        )
+        return {"type": "gcs", "path": path, "multi_file": multi}
+
+    # ── Mart ───────────────────────────────────────────────────────────────
+
+    def mart_parquet_url(self, dataset: str, table: str, year: int | None = None) -> str:
+        """URL gs:// del parquet mart per dataset+tabella."""
+        base = self._prefixed(MART_BUCKET)
+        if self.mart_layout == "flat":
+            return f"{base}/{dataset}/{table}.parquet"
+        if year is None:
+            raise ValueError("mart_layout='year' richiede year per l'URL mart")
+        return f"{base}/{dataset}/{year}/{table}.parquet"
+
+    def mart_location(self, dataset: str, table: str, year: int | None = None) -> dict[str, Any]:
+        """Location per il mart_catalog."""
+        return {
+            "type": "gcs",
+            "path": self.mart_parquet_url(dataset, table, year=year),
+            "multi_file": False,
+        }

--- a/toolkit/registry/reader.py
+++ b/toolkit/registry/reader.py
@@ -1,10 +1,13 @@
-"""Lettura degli artifact registry committati nei repo del workspace.
+"""Lettore degli artifact registry committati nei repo del workspace.
 
 Il registry builder (``toolkit.registry.builders``) genera e i repo committano
 i cataloghi in ``{repo}/registry/*.json`` (clean_catalog, mart_catalog,
 pipeline_signals, codelists, ...). Questo modulo li espone all'agente (CLI e
 MCP) senza riprogettare la discovery: lettura diretta dei file committati,
 cross-repo.
+
+Fa parte di ``toolkit.registry`` (home unica della capacità registry:
+builder + schemi + lettore). CLI e MCP sono wrapper sottili sopra.
 """
 
 from __future__ import annotations

--- a/toolkit/registry/runs.py
+++ b/toolkit/registry/runs.py
@@ -1,0 +1,94 @@
+"""Blocco ``run`` degli artifact registry.
+
+L'ultimo run record del toolkit è letto da ``toolkit.domain.readiness.run_state``
+(che risolve i path dal config e legge i JSON dei run records) — qui solo la
+proiezione verso ``run.schema.json``: run_id, year, status, quality_score,
+output_rows, output_bytes per layer.
+
+Nessuna lettura file propria: il parsing dei run records è del toolkit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from toolkit.domain.readiness import run_state
+
+LAYERS = ("raw", "clean", "mart")
+
+
+def latest_run_record(yml_path: str) -> dict[str, Any] | None:
+    """Ultimo run record del toolkit per il config.
+
+    Usa ``run_state`` (lettura run records del toolkit). Il target è il max
+    dei config years; se quell'anno non ha run, fallback sull'anno più
+    recente tra gli anni con run records (``years_seen``).
+    """
+    try:
+        state = run_state(yml_path)
+    except Exception:
+        return None
+    record = state.get("latest_run_record")
+    if record:
+        return record
+    years_seen = state.get("years_seen") or []
+    if not years_seen:
+        return None
+    try:
+        state = run_state(yml_path, year=int(max(years_seen)))
+    except Exception:
+        return None
+    return state.get("latest_run_record")
+
+
+def run_block(run_record: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Proietta un run record del toolkit nel blocco ``run`` degli artifact.
+
+    Ritorna None se il record non ha gli identificativi minimi.
+    """
+    if not run_record:
+        return None
+    run_id = run_record.get("run_id")
+    year = run_record.get("year")
+    status = run_record.get("status")
+    if not run_id or year is None or not status:
+        return None
+
+    layers = run_record.get("layers") or {}
+    validations = run_record.get("validations") or {}
+
+    quality_score: dict[str, Any] = {}
+    for layer_name in LAYERS:
+        qs = (validations.get(layer_name) or {}).get("quality_score")
+        if qs is not None:
+            quality_score[layer_name] = qs
+
+    output_rows: dict[str, Any] = {}
+    output_bytes: dict[str, Any] = {}
+    for layer_name in LAYERS:
+        metrics = (layers.get(layer_name) or {}).get("metrics", {})
+        rows = metrics.get("output_rows")
+        if rows is not None:
+            output_rows[layer_name] = rows
+        bytes_ = metrics.get("output_bytes")
+        if bytes_ is not None:
+            output_bytes[layer_name] = bytes_
+
+    block: dict[str, Any] = {
+        "run_id": run_id,
+        "year": year,
+        "status": status,
+    }
+    if quality_score:
+        block["quality_score"] = quality_score
+    if output_rows:
+        block["output_rows"] = output_rows
+    if output_bytes:
+        block["output_bytes"] = output_bytes
+    if run_record.get("started_at"):
+        block["started_at"] = run_record["started_at"]
+    if run_record.get("finished_at"):
+        block["finished_at"] = run_record["finished_at"]
+    if run_record.get("duration_seconds") is not None:
+        block["duration_seconds"] = run_record["duration_seconds"]
+    return block

--- a/toolkit/registry/runs.py
+++ b/toolkit/registry/runs.py
@@ -18,27 +18,17 @@ LAYERS = ("raw", "clean", "mart")
 
 
 def latest_run_record(yml_path: str) -> dict[str, Any] | None:
-    """Ultimo run record del toolkit per il config.
+    """Ultimo run record del toolkit per il config (attraverso gli anni).
 
-    Usa ``run_state`` (lettura run records del toolkit). Il target è il max
-    dei config years; se quell'anno non ha run, fallback sull'anno più
-    recente tra gli anni con run records (``years_seen``).
+    Usa ``run_state`` (lettura run records del toolkit) e il campo
+    ``latest_run_record_abs`` (ultimo run su tutti gli anni, esposto dal
+    toolkit in ``toolkit.domain.readiness.run_state``).
     """
     try:
         state = run_state(yml_path)
     except Exception:
         return None
-    record = state.get("latest_run_record")
-    if record:
-        return record
-    years_seen = state.get("years_seen") or []
-    if not years_seen:
-        return None
-    try:
-        state = run_state(yml_path, year=int(max(years_seen)))
-    except Exception:
-        return None
-    return state.get("latest_run_record")
+    return state.get("latest_run_record_abs")
 
 
 def run_block(run_record: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/toolkit/registry/schema_reader.py
+++ b/toolkit/registry/schema_reader.py
@@ -18,6 +18,9 @@ from toolkit.domain.path_resolver import payload_for_year
 
 from toolkit.registry.layout import DatasetManifest
 
+# Vocabolario condiviso dei tipi semantici (contratto Lab, package-data).
+DEFAULT_SEMANTIC_TYPES = Path(__file__).resolve().parent / "semantic_types.yaml"
+
 # Mappa tipi DuckDB → tipo catalogo (preserva BIGINT vs INTEGER)
 DUCKDB_TO_CATALOG: dict[str, str] = {
     "integer": "INTEGER",
@@ -49,13 +52,16 @@ DUCKDB_TO_CATALOG: dict[str, str] = {
 _DIMENSION_TYPES = {"VARCHAR", "DATE", "BOOLEAN"}
 
 
-def load_semantic_types(path: Path | None) -> dict[str, str]:
-    """Carica alias_map da un semantic_types.yaml (alias.lower → semantic_type).
+def load_semantic_types(path: Path | None = None) -> dict[str, str]:
+    """Carica alias_map dal vocabolario semantic_types (alias.lower → semantic_type).
 
-    Nessun partial/substring match — solo match esatto. Il file è opzionale:
-    senza, le colonne non ricevono semantic_type.
+    Nessun partial/substring match — solo match esatto.
+    Default: il vocabolario condiviso del toolkit (package-data); un path
+    esplicito fa da override (es. vocabolario esteso di un repo).
     """
-    if path is None or not path.is_file():
+    if path is None:
+        path = DEFAULT_SEMANTIC_TYPES
+    if not path.is_file():
         return {}
     import yaml
 

--- a/toolkit/registry/schema_reader.py
+++ b/toolkit/registry/schema_reader.py
@@ -1,0 +1,142 @@
+"""Schema colonne per gli artifact registry.
+
+Lo schema dei parquet clean è letto da ``toolkit.core.duckdb_shape.parquet_schema``
+(il reader runtime del toolkit); qui solo l'arricchimento di catalogo:
+mappatura tipo DuckDB→catalogo, role (dimension/metric) e semantic_type.
+
+La mappatura tipi replica quella di ``dataset-incubator/scripts/build_clean_catalog.py``:
+il parquet locale è lo stesso file che verrà pushato su GCS.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from toolkit.core.duckdb_shape import parquet_schema
+from toolkit.domain.path_resolver import payload_for_year
+
+from toolkit.registry.layout import DatasetManifest
+
+# Mappa tipi DuckDB → tipo catalogo (preserva BIGINT vs INTEGER)
+DUCKDB_TO_CATALOG: dict[str, str] = {
+    "integer": "INTEGER",
+    "int32": "INTEGER",
+    "int": "INTEGER",
+    "bigint": "BIGINT",
+    "int64": "BIGINT",
+    "smallint": "INTEGER",
+    "tinyint": "INTEGER",
+    "hugeint": "BIGINT",
+    "float": "DOUBLE",
+    "real": "DOUBLE",
+    "double": "DOUBLE",
+    "decimal": "DOUBLE",
+    "numeric": "DOUBLE",
+    "varchar": "VARCHAR",
+    "text": "VARCHAR",
+    "char": "VARCHAR",
+    "date": "DATE",
+    "timestamp": "TIMESTAMP",
+    "timestamp_s": "TIMESTAMP",
+    "timestamp_ms": "TIMESTAMP",
+    "timestamp_ns": "TIMESTAMP",
+    "time": "TIME",
+    "boolean": "BOOLEAN",
+    "bool": "BOOLEAN",
+}
+
+_DIMENSION_TYPES = {"VARCHAR", "DATE", "BOOLEAN"}
+
+
+def load_semantic_types(path: Path | None) -> dict[str, str]:
+    """Carica alias_map da un semantic_types.yaml (alias.lower → semantic_type).
+
+    Nessun partial/substring match — solo match esatto. Il file è opzionale:
+    senza, le colonne non ricevono semantic_type.
+    """
+    if path is None or not path.is_file():
+        return {}
+    import yaml
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    alias_map: dict[str, str] = {}
+    for stype, info in (data.get("types") or {}).items():
+        for alias in info.get("aliases", []) if isinstance(info, dict) else []:
+            alias_lower = str(alias).lower()
+            if alias_lower not in alias_map:
+                alias_map[alias_lower] = stype
+    return alias_map
+
+
+def _assign_semantic_type(col_name: str, alias_map: dict[str, str]) -> str | None:
+    return alias_map.get(col_name.lower())
+
+
+def clean_parquet_path(cfg: Any, year: int) -> Path | None:
+    """Path del parquet clean locale per anno (path resolver del toolkit).
+
+    Returns:
+        Path se il file esiste, altrimenti None.
+    """
+    try:
+        payload = payload_for_year(cfg, year)
+        output = (payload.get("paths") or {}).get("clean", {}).get("output")
+    except Exception:
+        return None
+    if not output:
+        return None
+    path = Path(output)
+    return path if path.is_file() else None
+
+
+def parquet_columns(
+    parquet_path: Path | None,
+    alias_map: dict[str, str] | None = None,
+) -> list[dict[str, Any]] | None:
+    """Schema del parquet (via reader runtime) → colonne del catalogo."""
+    if parquet_path is None:
+        return None
+    alias_map = alias_map or {}
+    try:
+        rows = parquet_schema(parquet_path)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    columns: list[dict[str, Any]] = []
+    for row in rows:
+        col_name = str(row.get("name", ""))
+        raw_type = str(row.get("type", "")).lower()
+        bq_type = DUCKDB_TO_CATALOG.get(raw_type, "VARCHAR")
+        role = "dimension" if bq_type in _DIMENSION_TYPES else "metric"
+        col_entry: dict[str, Any] = {
+            "name": col_name,
+            "type": bq_type,
+            "role": role,
+            "description": "",
+        }
+        semantic_type = _assign_semantic_type(col_name, alias_map)
+        if semantic_type:
+            col_entry["semantic_type"] = semantic_type
+        columns.append(col_entry)
+    return columns
+
+
+def latest_clean_columns(
+    manifest: DatasetManifest,
+    alias_map: dict[str, str] | None = None,
+) -> tuple[list[dict[str, Any]] | None, int | None]:
+    """Schema del parquet clean più recente presente in locale.
+
+    Returns:
+        Tuple (columns, latest_year) — (None, None) se nessun parquet locale.
+    """
+    if not manifest.years:
+        return None, None
+    for year in sorted(manifest.years, reverse=True):
+        parquet = clean_parquet_path(manifest.cfg, year)
+        if parquet is not None:
+            return parquet_columns(parquet, alias_map), year
+    return None, None

--- a/toolkit/registry/schemas/README.md
+++ b/toolkit/registry/schemas/README.md
@@ -1,0 +1,43 @@
+# Registry schemas — contratto condiviso Lab
+
+Schemi canonici degli artifact registry generati dal builder condiviso
+(`lab_connectors.registry`, Fase 1). Ogni repo (dataset-incubator, eurostat,
+dcl-bologna, ...) genera i propri JSON con questi contratti e li committa.
+
+## Il modello a 3 viste
+
+Stesso stato (dataset.yml + run records + parquet locali + `--check-gcs`),
+tre proiezioni:
+
+| Artifact | Risponde a | Contenuto | Consumatori |
+|---|---|---|---|
+| `clean_catalog.json` | "cosa esiste e com'è fatto" (clean) | slug, columns (role/semantic_type), period, location, stage | clean-query, data-explorer, resolver |
+| `mart_catalog.json` | "cosa esiste a livello analitico" (mart) | tabelle, PK, required_columns, min_rows, location, run | clean-query, data-explorer |
+| `pipeline_signals.json` | "come è andato e cosa manca" (operativo) | status ok/warn/error, years, run, detail, action | ACB (bootstrap/triage) |
+
+Regole di coerenza:
+
+- **Namespace id**: slug pulito (clean) → `{dataset}__{mart}` (mart, pattern
+  validato) → eventuale prefisso `compose:` (signals). 1 clean → N mart.
+- **Due dimensioni ortogonali**: `stage` (pubblicazione, nei cataloghi) vs
+  `status` (salute strutturale, nei signals). `status=ok` NON significa
+  pubblicato.
+- **`period` vs `years`**: `period` = copertura dati (da `time_coverage`);
+  `years` = anni di run (da `years` del dataset.yml).
+- **Blocco `run`**: vedi `run.schema.json` — inclusa inline in ogni schema
+  (`$defs.run`) perché i validatori standalone non risolvono `$ref` esterni.
+
+## Versionamento
+
+- `clean_catalog.schema.json`: v1 identico a dataset-incubator + aggiunte
+  opzionali (`years`, `mart_refs`, `run`) — backward compatible.
+- `pipeline_signals.schema.json`: v1 identico a dataset-incubator + aggiunte
+  opzionali (`years`, `run`) — backward compatible. `latest_run` (sample run
+  GHA) resta distinto da `run` (run record toolkit).
+- `mart_catalog.schema.json`: v1 nuovo. `columns` opzionale in v1.
+- `run.schema.json`: blocco condiviso, fonte canonica.
+
+## Migrazione
+
+- dataset-incubator mantiene copie locali in `registry/` fino alla Fase 2
+  (CLI wrapper che generano con gli schemi condivisi, output identico).

--- a/toolkit/registry/schemas/README.md
+++ b/toolkit/registry/schemas/README.md
@@ -4,16 +4,19 @@ Schemi canonici degli artifact registry generati dal builder condiviso
 (`lab_connectors.registry`, Fase 1). Ogni repo (dataset-incubator, eurostat,
 dcl-bologna, ...) genera i propri JSON con questi contratti e li committa.
 
-## Il modello a 3 viste
+## Il modello a 4 viste
 
 Stesso stato (dataset.yml + run records + parquet locali + `--check-gcs`),
-tre proiezioni:
+quattro proiezioni:
 
 | Artifact | Risponde a | Contenuto | Consumatori |
 |---|---|---|---|
 | `clean_catalog.json` | "cosa esiste e com'è fatto" (clean) | slug, columns (role/semantic_type), period, location, stage | clean-query, data-explorer, resolver |
 | `mart_catalog.json` | "cosa esiste a livello analitico" (mart) | tabelle, PK, required_columns, min_rows, location, run | clean-query, data-explorer |
 | `pipeline_signals.json` | "come è andato e cosa manca" (operativo) | status ok/warn/error, years, run, detail, action | ACB (bootstrap/triage) |
+| `codelists.json` | "quali valori hanno le dimensioni" | mappa nome-codelist → righe (code, label_en, ...) | agenti MCP (risoluzione codici) |
+
+Il codelists è opzionale: assente se il repo non ha una dir `codelists/`.
 
 Regole di coerenza:
 
@@ -35,6 +38,7 @@ Regole di coerenza:
   opzionali (`years`, `run`) — backward compatible. `latest_run` (sample run
   GHA) resta distinto da `run` (run record toolkit).
 - `mart_catalog.schema.json`: v1 nuovo. `columns` opzionale in v1.
+- `codelists.schema.json`: v1 nuovo (mappa nome-codelist → righe CSV).
 - `run.schema.json`: blocco condiviso, fonte canonica.
 
 ## Migrazione

--- a/toolkit/registry/schemas/clean_catalog.schema.json
+++ b/toolkit/registry/schemas/clean_catalog.schema.json
@@ -1,0 +1,257 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dataciviclab.org/schemas/clean_catalog.schema.json",
+  "title": "DataCivicLab Clean Catalog",
+  "description": "Inventario queryabile dei clean parquet pubblici del Lab: cosa esiste, come e' fatto (colonne, tipi, semantic_type), dove sta (location) e in che fase di pubblicazione (stage). Contratto condiviso in lab-connectors: identico allo schema v1 di dataset-incubator, con aggiunte opzionali (years, mart_refs, run) — backward compatible, schema_version resta 1.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "name",
+    "updated_at",
+    "datasets"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date"
+    },
+    "source_repo": {
+      "type": "string",
+      "description": "Repo GitHub che genera/possiede il catalogo (es. dataciviclab/dataset-incubator)."
+    },
+    "datasets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/dataset"
+      }
+    }
+  },
+  "$defs": {
+    "dataset": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name",
+        "description",
+        "period",
+        "columns",
+        "location"
+      ],
+      "properties": {
+        "slug": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]+$"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "source_id": {
+          "type": "string",
+          "description": "source_id corrispondente in source-observatory/sources_registry.yaml"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tag semantici per categorizzazione e raggruppamento batch"
+        },
+        "category": {
+          "type": "string",
+          "description": "Categoria principale del dataset (es. sanità, energia, finanza)"
+        },
+        "stage": {
+          "type": "string",
+          "enum": [
+            "incubating",
+            "published",
+            "deprecated"
+          ],
+          "description": "incubating = parquet su GCS ma non in DE; published = ha pagina su data-explorer; deprecated = non piu' mantenuto"
+        },
+        "registry_source": {
+          "type": "string",
+          "description": "Origine dell'entry: derive_auto (dal builder) o editorial (mantenuta a mano)."
+        },
+        "period": {
+          "type": "object",
+          "required": [
+            "start",
+            "end"
+          ],
+          "properties": {
+            "start": {
+              "type": "integer"
+            },
+            "end": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Copertura temporale dei dati (da time_coverage del dataset.yml)."
+        },
+        "years": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "description": "Anni eseguiti dal run (da years del dataset.yml). Opzionale, distinto da period."
+        },
+        "mart_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Slug mart appartenenti al dataset, convention {dataset}__{mart} (vedi mart_catalog.schema.json). Opzionale."
+        },
+        "run": {
+          "$ref": "#/$defs/run",
+          "description": "Ultimo run record del toolkit (fonte canonica: run.schema.json). Opzionale — per la diagnostica dettagliata vedi pipeline_signals.json."
+        },
+        "columns": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/column"
+          }
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        }
+      },
+      "additionalProperties": true
+    },
+    "column": {
+      "type": "object",
+      "required": [
+        "name",
+        "type",
+        "role",
+        "description"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "dimension",
+            "metric"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "semantic_type": {
+          "type": "string",
+          "description": "Tipo semantico della colonna (es. municipality_code, fiscal_code, ...)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "location": {
+      "type": "object",
+      "required": [
+        "type",
+        "path"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "gcs",
+            "local"
+          ]
+        },
+        "path": {
+          "type": "string"
+        },
+        "multi_file": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "run": {
+      "type": "object",
+      "required": [
+        "run_id",
+        "year",
+        "status"
+      ],
+      "properties": {
+        "run_id": {
+          "type": "string"
+        },
+        "year": {
+          "type": "integer"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "SUCCESS",
+            "FAILED",
+            "PENDING",
+            "SKIPPED"
+          ]
+        },
+        "quality_score": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "output_rows": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          }
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "finished_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "duration_seconds": {
+          "type": "number"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "output_bytes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "Byte prodotti per layer (es. {\"raw\": 6961784}). Presente anche quando output_rows e' null (es. layer raw)."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Blocco run condiviso — inline copy da run.schema.json (canonica)."
+    }
+  }
+}

--- a/toolkit/registry/schemas/codelists.schema.json
+++ b/toolkit/registry/schemas/codelists.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dataciviclab.org/schemas/codelists.schema.json",
+  "title": "DataCivicLab Codelists",
+  "description": "Valori delle dimensioni per repo (es. eurostat/codelists/*.csv): mappa nome-codelist → righe con le colonne del CSV (code, label_en, ...). Permette all'agente MCP di risolvere i codici (unit='EUR_HAB', geo='ITC4' con parent_code) prima di scrivere le query. Opzionale: assente se il repo non ha codelists.",
+  "type": "object",
+  "required": ["schema_version", "source_repo", "codelists"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "source_repo": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date"
+    },
+    "codelists": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Riga del CSV: code + label_en + eventuali colonne extra (es. geo: nuts_level, parent_code)."
+        }
+      }
+    }
+  }
+}

--- a/toolkit/registry/schemas/codelists.schema.json
+++ b/toolkit/registry/schemas/codelists.schema.json
@@ -17,6 +17,11 @@
       "type": "string",
       "format": "date"
     },
+    "large": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Codelist troppo grandi per l'embedding: il consumatore li legge dal CSV del repo ({repo}/codelists/{name}.csv)."
+    },
     "codelists": {
       "type": "object",
       "additionalProperties": {

--- a/toolkit/registry/schemas/mart_catalog.schema.json
+++ b/toolkit/registry/schemas/mart_catalog.schema.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dataciviclab.org/schemas/mart_catalog.schema.json",
+  "title": "DataCivicLab Mart Catalog",
+  "description": "Inventario queryabile dei mart del Lab: tabelle analitiche per dataset (benchmark/sintesi/trend), schema dichiarato (primary_key, required_columns, min_rows), location e ultimo run. Complemento di clean_catalog.schema.json per il layer MART. Slug convention: {dataset}__{mart}. Il blocco run segue run.schema.json (canonica, inline copy qui).",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "name",
+    "updated_at",
+    "marts"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date"
+    },
+    "source_repo": {
+      "type": "string",
+      "description": "Repo GitHub che genera/possiede il catalogo (es. dataciviclab/eurostat)."
+    },
+    "marts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/mart"
+      }
+    }
+  },
+  "$defs": {
+    "mart": {
+      "type": "object",
+      "required": [
+        "slug",
+        "dataset",
+        "table",
+        "location"
+      ],
+      "properties": {
+        "slug": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]+__[a-z0-9_]+$",
+          "description": "Slug canonico del mart: {dataset}__{mart_name} (es. eurostat_gdp_nuts3__mart_geo_benchmark)."
+        },
+        "dataset": {
+          "type": "string",
+          "description": "Slug del dataset clean parent (vedi clean_catalog.schema.json)."
+        },
+        "table": {
+          "type": "string",
+          "description": "Nome della tabella mart (es. mart_geo_benchmark)."
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        },
+        "primary_key": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Chiave primaria dichiarata (dal dataset.yml mart.validate.table_rules)."
+        },
+        "required_columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Colonne richieste dichiarate (dal dataset.yml)."
+        },
+        "min_rows": {
+          "type": "integer",
+          "description": "Soglia minima di righe dichiarata (dal dataset.yml)."
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/column"
+          },
+          "description": "Schema colonne reale (dal parquet locale in derive_mode=local). Opzionale in v1."
+        },
+        "run": {
+          "$ref": "#/$defs/run",
+          "description": "Ultimo run record del toolkit per il layer mart. Opzionale."
+        }
+      },
+      "additionalProperties": true
+    },
+    "column": {
+      "type": "object",
+      "required": [
+        "name",
+        "type",
+        "role",
+        "description"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "dimension",
+            "metric"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "semantic_type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "location": {
+      "type": "object",
+      "required": [
+        "type",
+        "path"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "gcs",
+            "local"
+          ]
+        },
+        "path": {
+          "type": "string"
+        },
+        "multi_file": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "run": {
+      "type": "object",
+      "required": [
+        "run_id",
+        "year",
+        "status"
+      ],
+      "properties": {
+        "run_id": {
+          "type": "string"
+        },
+        "year": {
+          "type": "integer"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "SUCCESS",
+            "FAILED",
+            "PENDING",
+            "SKIPPED"
+          ]
+        },
+        "quality_score": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "output_rows": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          }
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "finished_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "duration_seconds": {
+          "type": "number"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "output_bytes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "Byte prodotti per layer (es. {\"raw\": 6961784}). Presente anche quando output_rows e' null (es. layer raw)."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Blocco run condiviso — inline copy da run.schema.json (canonica)."
+    }
+  }
+}

--- a/toolkit/registry/schemas/pipeline_signals.schema.json
+++ b/toolkit/registry/schemas/pipeline_signals.schema.json
@@ -1,0 +1,360 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dataciviclab.org/schemas/pipeline_signals.schema.json",
+  "title": "PipelineSignals",
+  "description": "Health check operativo per ACB: stato dei dataset di un repo (ok/warn/error), anni, ultimo run. Segue lo standard repo-signals (agent-context-builder/schemas/repo-signals.md). Contratto condiviso in lab-connectors: identico allo schema v1 di dataset-incubator, con aggiunte opzionali (years, run) — backward compatible, schema_version resta \"1\". NOTA: status=ok NON significa pubblicato — significa struttura coerente + mart presente. Dimensione ortogonale a stage (clean_catalog).",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "generated_at",
+    "repo",
+    "topic",
+    "signals"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": [
+        "1"
+      ],
+      "description": "Versione dello schema (stringa)."
+    },
+    "generated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Data di generazione in formato YYYY-MM-DD."
+    },
+    "repo": {
+      "type": "string",
+      "description": "Nome del repo GitHub (es. 'dataset-incubator', 'eurostat')."
+    },
+    "topic": {
+      "type": "string",
+      "description": "Dominio del segnale (es. 'pipeline_state' — riusato da tutti i repo toolkit-based)."
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "total",
+        "by_status"
+      ],
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "by_status": {
+          "type": "object",
+          "required": [
+            "ok",
+            "warn",
+            "error"
+          ],
+          "properties": {
+            "ok": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "warn": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "error": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "description": "Conteggi aggregati per stato."
+    },
+    "signals": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Signal"
+      },
+      "description": "Lista dei segnali, uno per dataset."
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Signal": {
+      "type": "object",
+      "required": [
+        "id",
+        "status",
+        "label",
+        "detail",
+        "action"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identificativo unico del dataset (slug). Per compose: prefisso 'compose:'."
+        },
+        "source_id": {
+          "type": "string",
+          "description": "Identificativo della fonte dati (opzionale, puo' essere stringa vuota)."
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "ok",
+            "warn",
+            "error"
+          ],
+          "description": "Stato del dataset: ok=valido, warn=anomalia, error=bloccante."
+        },
+        "label": {
+          "type": "string",
+          "description": "Etichetta leggibile del dataset."
+        },
+        "detail": {
+          "type": "string",
+          "description": "Descrizione estesa (anni, fonte, layer)."
+        },
+        "action": {
+          "type": "string",
+          "description": "Azione suggerita. Stringa vuota se nessuna."
+        },
+        "years": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "description": "Anni dichiarati nel dataset.yml (opzionale)."
+        },
+        "run": {
+          "$ref": "#/definitions/Run",
+          "description": "Ultimo run record del toolkit (data/_runs/). Diverso da latest_run (sample run GHA). Opzionale."
+        },
+        "latest_run": {
+          "$ref": "#/definitions/LatestRun",
+          "description": "Risultato del sample run GitHub Actions (opzionale, presente solo se eseguito)."
+        }
+      },
+      "additionalProperties": true
+    },
+    "Run": {
+      "type": "object",
+      "required": [
+        "run_id",
+        "year",
+        "status"
+      ],
+      "properties": {
+        "run_id": {
+          "type": "string"
+        },
+        "year": {
+          "type": "integer"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "SUCCESS",
+            "FAILED",
+            "PENDING",
+            "SKIPPED"
+          ]
+        },
+        "quality_score": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "output_rows": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          }
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "finished_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "duration_seconds": {
+          "type": "number"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "output_bytes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "Byte prodotti per layer (es. {\"raw\": 6961784}). Presente anche quando output_rows e' null (es. layer raw)."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Blocco run condiviso — inline copy da run.schema.json (canonica)."
+    },
+    "LatestRun": {
+      "type": "object",
+      "required": [
+        "status",
+        "run_id",
+        "run_url",
+        "checked_at"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "passed",
+            "failed"
+          ],
+          "description": "Esito del sample run."
+        },
+        "run_id": {
+          "type": "string",
+          "description": "ID del workflow run GitHub Actions."
+        },
+        "run_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL del workflow run GitHub Actions."
+        },
+        "checked_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}",
+          "description": "Data del check in formato YYYY-MM-DD."
+        },
+        "year": {
+          "type": "integer",
+          "description": "Anno singolo testato (alternativo a years per single-year)."
+        },
+        "years": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "description": "Anni testati (alternativo a year per multi-year)."
+        },
+        "config_path": {
+          "type": "string",
+          "description": "Path del dataset.yml testato (singolo config)."
+        },
+        "config_exists": {
+          "type": "boolean",
+          "description": "False se il dataset.yml non esiste piu' nel branch target."
+        },
+        "configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConfigEntry"
+          },
+          "description": "Lista dei config testati (post-merge con multi-anno)."
+        },
+        "duration_seconds": {
+          "type": "number",
+          "description": "Durata totale del run in secondi."
+        },
+        "row_counts": {
+          "type": "object",
+          "properties": {
+            "raw": {
+              "type": "integer",
+              "description": "Righe lette in RAW."
+            },
+            "clean": {
+              "type": "integer",
+              "description": "Righe prodotte in CLEAN."
+            },
+            "mart": {
+              "type": "integer",
+              "description": "Righe totali nelle tabelle MART."
+            }
+          },
+          "additionalProperties": false,
+          "description": "Conteggio righe per layer."
+        },
+        "quality_scores": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Quality score PA per fonte (nome_fonte → punteggio)."
+        },
+        "readiness": {
+          "type": "string",
+          "enum": [
+            "ready",
+            "needs-review",
+            "incomplete"
+          ],
+          "description": "Punteggio di prontezza del dataset."
+        },
+        "readiness_checks": {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "integer"
+            },
+            "ok": {
+              "type": "integer"
+            },
+            "fail": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Esito dei readiness check."
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "year"
+          ]
+        },
+        {
+          "required": [
+            "years"
+          ]
+        }
+      ]
+    },
+    "ConfigEntry": {
+      "type": "object",
+      "required": [
+        "status",
+        "year",
+        "config_path"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "passed",
+            "failed"
+          ],
+          "description": "Esito del run per questo config."
+        },
+        "year": {
+          "type": "integer",
+          "description": "Anno testato."
+        },
+        "config_path": {
+          "type": "string",
+          "description": "Path del dataset.yml."
+        },
+        "config_exists": {
+          "type": "boolean",
+          "description": "False se il dataset.yml non esiste piu'."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/toolkit/registry/schemas/run.schema.json
+++ b/toolkit/registry/schemas/run.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dataciviclab.org/schemas/run.schema.json",
+  "title": "DataCivicLab Run Block",
+  "description": "Blocco run condiviso: ultimo run record del toolkit (data/_runs/{dataset}/{year}/*.json) per un dataset o una tabella mart. Fonte canonica per il campo 'run' in clean_catalog.schema.json, pipeline_signals.schema.json e mart_catalog.schema.json. Ogni schema che lo usa lo include come $defs.run inline (validatori standalone).",
+  "type": "object",
+  "required": ["run_id", "year", "status"],
+  "properties": {
+    "run_id": {
+      "type": "string",
+      "description": "ID del run record del toolkit (es. 20260807T095224Z_85695b3a)."
+    },
+    "year": {
+      "type": "integer",
+      "description": "Anno eseguito dal run."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["SUCCESS", "FAILED", "PENDING", "SKIPPED"],
+      "description": "Stato del run record del toolkit."
+    },
+    "quality_score": {
+      "type": "object",
+      "additionalProperties": { "type": "number" },
+      "description": "Quality score PA per layer (es. {\"clean\": 95, \"mart\": 100})."
+    },
+    "output_rows": {
+      "type": "object",
+      "additionalProperties": { "type": "integer" },
+      "description": "Righe prodotte per layer (es. {\"clean\": 41709, \"mart\": 1512}). raw puo' mancare: il run record del toolkit non la registra sempre."
+    },
+    "output_bytes": {
+      "type": "object",
+      "additionalProperties": { "type": "integer" },
+      "description": "Byte prodotti per layer (es. {\"raw\": 6961784, \"clean\": 9757664}). Presente anche quando output_rows e' null (es. layer raw)."
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "finished_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "duration_seconds": {
+      "type": "number"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Momento di estrazione dell'artifact (per freshness)."
+    }
+  },
+  "additionalProperties": true
+}

--- a/toolkit/registry/semantic_types.yaml
+++ b/toolkit/registry/semantic_types.yaml
@@ -1,0 +1,309 @@
+# semantic_types.yaml — Vocabolario dei tipi semantici riconoscibili
+#
+# Ogni tipo definisce:
+#   description: spiegazione breve
+#   entity: entità del mondo reale rappresentata
+#   aliases: nomi colonna comunemente usati per questo tipo
+#   hub: mappatura verso l'hub di riferimento (opzionale)
+#     hub_slug: slug dell'hub (comuni_master, bdap_anagrafe_enti, ...)
+#     hub_column: colonna nell'hub
+#     normalizers: espressioni SQL per normalizzare la colonna del dataset al formato hub
+#   bridge: se il join è indiretto (opzionale)
+#     via: hub/dataset intermedio
+#     on_column: colonna del bridge su cui avviene il join
+#                (NOTA: non usare "on" — in YAML 1.1 "on:" è parsificato come booleano True)
+#     to: tipo semantico di arrivo
+#   validators: hint per validazione (opzionale)
+
+types:
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # TERRITORIO
+  # ═══════════════════════════════════════════════════════════════════════
+
+  municipality_code:
+    description: "Codice ISTAT del comune a 6 cifre (es. 015002)"
+    entity: Comune
+    aliases: [codice_istat, codice_istat_comune, codice_istat_luogo, codice_comune,
+              cod_comune, pro_com, codice_comune_istat, localizzazione_codice_istat,
+              comune_istat, cod_istat_comune, comune_codice, cod_comune_istat,
+              ente_codice_comune_istat, codice_comune_comune]
+    hub:
+      hub_slug: comuni_master
+      hub_column: codice_istat
+      normalizers:
+        - name: direct
+          expr: "{col}"
+        - name: LPAD(6)
+          expr: "LPAD(CAST({col} AS VARCHAR), 6, '0')"
+        - name: RIGHT(6)
+          expr: "RIGHT({col}, 6)"
+    weight: 20
+
+  cadastral_code:
+    description: "Codice catastale Belfiore (es. A010, C466)"
+    entity: Comune
+    aliases: [codice_catastale, cod_catastale, catastale, codice_belfiore,
+              codice_comune_scuola]
+    hub:
+      hub_slug: comuni_master
+      hub_column: codice_catastale
+      normalizers:
+        - name: direct
+          expr: "{col}"
+        - name: UPPER TRIM
+          expr: "UPPER(TRIM({col}))"
+    weight: 15
+
+  municipality_name:
+    description: "Denominazione testuale del comune"
+    entity: Comune
+    aliases: [comune, denominazione_comune, comune_denominazione, comune_descrizione]
+    hub:
+      hub_slug: comuni_master
+      hub_column: denominazione
+      normalizers:
+        - name: UPPER TRIM
+          expr: "UPPER(TRIM({col}))"
+        - name: "UPPER TRIM + apostrofo→accento"
+          expr: "REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(UPPER(TRIM({col})), \"U'\", chr(217)), \"O'\", chr(210)), \"I'\", chr(204)), \"E'\", chr(200)), \"A'\", chr(192))"
+    weight: 3
+    note: "Join testuale. Fragile per fusioni/omonimie. Preferire municipality_code o cadastral_code."
+
+  province_code:
+    description: "Sigla o codice della provincia"
+    entity: Provincia
+    aliases: [provincia, sigla_provincia, sigla_provincia_pa, sigla_provincia_asl,
+              sigla_provincia_struttura, codice_provincia, sigla_prov, cod_prov]
+    hub:
+      hub_slug: comuni_master
+      hub_column: sigla_provincia
+      normalizers:
+        - name: UPPER TRIM
+          expr: "UPPER(TRIM({col}))"
+    weight: 5
+
+  region_code:
+    description: "Codice o nome della regione"
+    entity: Regione
+    aliases: [regione, codice_regione, cod_regione, cod_reg, regione_codice,
+              istat_regione, regione_istat_cod, regione_beneficiario, amministrazione_regione_sede]
+    hub:
+      hub_slug: comuni_master
+      hub_column: regione
+      normalizers:
+        - name: UPPER TRIM
+          expr: "UPPER(TRIM({col}))"
+    weight: 5
+
+  nuts_code:
+    description: "Codice NUTS Eurostat (es. ITC45)"
+    entity: Provincia (tramite NUTS3)
+    aliases: [geo, nuts, nuts2, nuts3, nuts_code, codice_nuts]
+    hub:
+      hub_slug: comuni_master
+      hub_column: nuts3_2021
+      normalizers:
+        - name: direct
+          expr: "{col}"
+    weight: 8
+    note: "Cross-grano: 1 provincia -> N comuni. Il dato provinciale viene replicato."
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # ANAGRAFICA ENTI
+  # ═══════════════════════════════════════════════════════════════════════
+
+  fiscal_code:
+    description: "Codice fiscale o partita IVA di ente/impresa"
+    entity: Ente (o Impresa)
+    aliases: [codice_fiscale, codice_fiscale_ente, cf, cf_amministrazione_appaltante,
+              cf_soggetto_attuatore, cf_subappaltante, amministrazione_codice_fiscale,
+              partita_iva, p_iva, piva, codi_fiscale, codice_fiscale_beneficiario]
+    hub:
+      hub_slug: comuni_master
+      hub_column: codice_fiscale
+      normalizers:
+        - name: direct
+          expr: "{col}"
+        - name: REPLACE brackets
+          expr: "REPLACE(REPLACE({col}, '[', ''), ']', '')"
+    weight: 15
+    note: "Match solo per enti pubblici. CF di imprese (ANAC, RNA) non matchano (0%)."
+
+  ipa_code:
+    description: "Codice IndicePA dell'ente (es. c_a010)"
+    entity: Ente
+    aliases: [codice_ipa, ipa, cod_ipa]
+    hub:
+      hub_slug: comuni_master
+      hub_column: codice_ipa
+      normalizers:
+        - name: direct
+          expr: "{col}"
+        - name: LOWER
+          expr: "LOWER({col})"
+    weight: 15
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # DOMINIO APPALTI
+  # ═══════════════════════════════════════════════════════════════════════
+
+  cig_code:
+    description: "Codice CIG (Codice Identificativo Gara) ANAC"
+    entity: Gara
+    aliases: [cig, codice_cig, cig_accordo_quadro, CIG_PROG_ESTERNA, CIG_COLLEGAMENTO]
+    bridge:
+      via: anac_bandi_gara
+      on_column: cig
+      to: municipality_code
+    weight: 25
+
+  cup_code:
+    description: "Codice CUP (Codice Unico Progetto)"
+    entity: Progetto
+    aliases: [cup, codice_cup]
+    bridge:
+      via: anac_cup
+      on_column: cup
+      to: municipality_code
+    weight: 20
+
+  ausa_code:
+    description: "Codice AUSA (Anagrafe Unica Stazioni Appaltanti)"
+    entity: Stazione Appaltante
+    aliases: [codice_ausa, ausa]
+    bridge:
+      via: bdap_anagrafe_enti
+      on_column: codice_ente_ipa
+      to: fiscal_code
+    weight: 15
+
+  cpv_code:
+    description: "Codice CPV (vocabolario appalti)"
+    entity: Categoria merceologica
+    aliases: [cod_cpv, codice_cpv, cpv, cod_cpv_principale]
+    weight: 10
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # DOMINIO SCUOLA
+  # ═══════════════════════════════════════════════════════════════════════
+
+  school_code:
+    description: "Codice meccanografico scuola MIM"
+    entity: Scuola
+    aliases: [codice_scuola, codicescuola, codice_meccanografico, cod_scuola]
+    weight: 15
+    note: "Può risalire al comune via mim_anagrafica_scuole_statali"
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # CHIAVI ENTE (bridge BDAP)
+  # ═══════════════════════════════════════════════════════════════════════
+
+  siope_code:
+    description: "Codice ente SIOPE (9 caratteri)"
+    entity: Ente
+    aliases: [codice_ente]
+    bridge:
+      via: bdap_anagrafe_enti
+      on_column: codice_ente_siope
+      to: municipality_code
+    weight: 15
+
+  miur_code:
+    description: "Codice ente MIUR"
+    entity: Ente
+    aliases: [codice_ente_miur, codice_ente_miur]
+    bridge:
+      via: bdap_anagrafe_enti
+      on_column: codice_ente_miur
+      to: municipality_code
+    weight: 15
+
+  ssn_code:
+    description: "Codice ente SSN (Sanità)"
+    entity: Ente sanitario
+    aliases: [codice_ente_ssn]
+    bridge:
+      via: bdap_anagrafe_enti
+      on_column: codice_ente_ssn
+      to: municipality_code
+    weight: 15
+
+  sogei_code:
+    description: "Codice Sogei ente FSC (13 caratteri)"
+    entity: Ente
+    aliases: [username]
+    bridge:
+      via: opencivitas_fsc_enti_rso
+      on_column: username
+      to: municipality_name
+    weight: 10
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # CLASSIFICAZIONI
+  # ═══════════════════════════════════════════════════════════════════════
+
+  ateco_code:
+    description: "Codice ATECO attività economica"
+    entity: Attività economica
+    aliases: [ateco, codice_ateco, sezione_ateco, ateco_code]
+    weight: 8
+
+  country_code:
+    description: "Codice nazione / paese"
+    entity: Nazione
+    aliases: [nazione, stato, paese, country, codice_nazione]
+    weight: 3
+
+  year:
+    description: "Anno di riferimento"
+    entity: Tempo
+    aliases: [anno, year, anno_di_imposta, anno_riferimento, esercizio_finanziario]
+    weight: 1
+
+  month:
+    description: "Mese di riferimento"
+    entity: Tempo
+    aliases: [mese, month, periodo]
+    weight: 1
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # PERSONE (sistema parlamentare e non solo)
+  # ═══════════════════════════════════════════════════════════════════════
+
+  person_id:
+    description: "ID numerico della persona fisica (es. 302103 da ocd/persona.rdf/p302103 — Camera/Senato/Governo)"
+    entity: Persona
+    aliases: [persona_id, person_id, id_persona, codice_persona]
+    weight: 15
+    note: "Chiave standard del sistema parlamentare (deputati, senatori, membri governo). Ponte tra rami via URI persona."
+
+  senator_id:
+    description: "ID numerico del senatore (es. 3923 da dati.senato.it/senatore/3923 — id locale Senato)"
+    entity: Persona
+    aliases: [senatore_id]
+    weight: 15
+    note: "ID locale Senato — NON coincide con persona_id Camera (numerazioni diverse). Ponte tra rami via nominativo o senato_firmatari.deputato_url."
+
+  ddl_id:
+    description: "Identificativo numerico del disegno di legge (osr:idDdl — numerazione interna Senato, condivisa tra senato_ddl e senato_firmatari)"
+    entity: Atto legislativo
+    aliases: [ddl_id, id_ddl]
+    weight: 15
+    note: "NON è l'id dell'URI /ddl/N (numerazione diversa) — usare osr:idDdl per il join tra senato_ddl e senato_firmatari."
+
+  gruppo_parlamentare:
+    description: "URI del gruppo parlamentare (es. ocd/gruppoParlamentare.rdf/gr1612 — Camera)"
+    entity: Gruppo parlamentare
+    aliases: [gruppo, gruppo_parlamentare]
+    weight: 15
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # GIUSTIZIA
+  # ═══════════════════════════════════════════════════════════════════════
+
+  ricorso_number:
+    description: "Numero del ricorso giudiziario"
+    entity: Procedimento
+    aliases: [numero_ricorso, NUMERO_RICORSO, NUMERO_PROVVEDIMENTO, n_ricorso]
+    weight: 20

--- a/toolkit/registry/validation.py
+++ b/toolkit/registry/validation.py
@@ -1,0 +1,48 @@
+"""Validazione degli artifact registry contro gli schemi condivisi.
+
+Gli schemi vivono in ``toolkit/registry/schemas/*.schema.json`` (package-data,
+vedi pyproject). Validatori standalone (jsonschema) — nessun ``$ref`` esterno:
+le definizioni condivise (es. blocco ``run``) sono inline in ogni schema, con
+``run.schema.json`` come fonte canonica.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMAS_DIR = Path(__file__).resolve().parent / "schemas"
+
+
+def load_schema(schema_name: str) -> dict[str, Any]:
+    """Carica uno schema condiviso per nome file (es. ``clean_catalog.schema.json``)."""
+    path = SCHEMAS_DIR / schema_name
+    if not path.is_file():
+        raise FileNotFoundError(f"Schema non trovato in {SCHEMAS_DIR}: {schema_name}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_artifact(instance: dict[str, Any], schema_name: str) -> list[str]:
+    """Valida un artifact contro lo schema condiviso.
+
+    Returns:
+        Lista di errori (stringhe leggibili). Vuota se conforme.
+    """
+    import jsonschema
+
+    schema = load_schema(schema_name)
+    try:
+        if schema.get("$schema", "").endswith("/draft-07/schema#"):
+            validator_cls = jsonschema.Draft7Validator
+        else:
+            validator_cls = jsonschema.Draft202012Validator
+        validator = validator_cls(schema)
+    except Exception as exc:
+        return [f"schema invalido {schema_name}: {exc}"]
+
+    errors = []
+    for err in sorted(validator.iter_errors(instance), key=lambda e: list(e.path)):
+        where = "/".join(str(p) for p in err.path) or "<root>"
+        errors.append(f"{where}: {err.message}")
+    return errors


### PR DESCRIPTION
## Sintesi

Porta su main `toolkit.registry`: il motore condiviso per produrre ed esporre i catalog/indici dei dataset (clean_catalog, mart_catalog, pipeline_signals) a partire da dataset.yml + run records + parquet. È la **Fase 1** del percorso per assorbire nel toolkit i catalog oggi generati da script paralleli nei singoli repo (dataset-incubator, eurostat, dcl-bologna) e deprecare gli MCP per-repo.

Branch riallineato via **rebase su main attuale** (include #450 profilo ESTAT e #451 support-ensure) — nessun conflitto.

## Contesto collegato

Obiettivo (civic-director): un unico motore registry invocato da DI/eurostat/bologna, con i consumatori (MCP, explorer, agent-context-builder) che leggono gli stessi artifact. Questo PR è la base; seguono la migrazione dei repo ai wrapper (pattern già usato da eurostat) e la deprecazione dei MCP per-repo (clean-query DI, eurostat-mcp).

## Cosa cambia

- [x] Nuova funzionalità del motore (modulo `toolkit.registry`)
- [x] CLI — nuovi comandi `toolkit registry list/show` (reader cross-repo)
- [x] MCP tool — `registry_list`/`registry_show` (`toolkit/mcp/registry_ops.py`)
- [x] Resolver — find semantico dai cataloghi committati (description/tags/colonne, metric_only, matched_columns)
- [ ] Bug fix
- [ ] Modifica contratto pubblico esistente (nessuna rottura — tutto additivo)
- [ ] Dipendenze o CI

## Dettagli

**Modulo `toolkit/registry/`** (riallineato dal branch esperimento, 8 commit rebasati su main):
- `builders.py` — `build_registry` / `build_clean_catalog` / `build_mart_catalog` / `build_signals`: tre proiezioni dello stesso stato (dataset.yml + run records + parquet locali); derive-mode `local` (solo workspace) e `check-gcs` (verifica parquet pubblici)
- `layout.py` / `paths.py` — `RepoLayout` + `PathContract` (sezioni candidates/support/compose, layout flat/year per GCS)
- `runs.py` / `schema_reader.py` — run records e schema parquet (colonne + tipi), semantic types
- `schemas/` — schemi JSON standard: `clean_catalog`, `mart_catalog`, `pipeline_signals`, `codelists`, `run`
- `semantic_types.yaml` — mappa alias→semantic_type condivisa (oggi duplicata in dataset-incubator)
- `reader.py` + `validation.py` — lettura/validazione degli artifact committati

**CLI + MCP**:
- `toolkit registry list` — elenca gli artifact registry dei repo del workspace (verificato: trova clean_catalog 114 entries + pipeline_signals di dataset-incubator)
- `toolkit registry show <repo> <artifact>` — mostra un artifact
- MCP `registry_list`/`registry_show` esposti dal server toolkit

**Resolver** (`toolkit/domain/catalog.py` esteso): `mcp_find` ora cerca anche per description/tags/colonne dai cataloghi committati (prima solo slug) — il base per clean-query/explorer.

## Impatto su contratti pubblici

- [ ] Struttura `dataset.yml` — nessun cambio
- [ ] Path output — nessun cambio
- [ ] Schema parquet — nessun cambio
- [x] CLI — *nuovi* comandi `registry list/show` (additivo)
- [x] API pubblica del toolkit — *nuovo* modulo `toolkit.registry`, *nuovi* `mcp_registry_list/show`, `CatalogResolver` esteso (additivo, nessuna firma rimossa)

> Downstream: nessuna rottura. Gli artifact prodotti (schemi) sono gli stessi già usati da dataset-incubator (clean_catalog/pipeline_signals) e eurostat (wrapper già su questo builder). La migrazione dei repo è una PR separata per repo.

## Verifica

```bash
python -m pytest tests/ -q               # 1301 passed, 22 deselected
python scripts/quality/check_tests.py    # strict_failures: 0, exit 0 (marker audit)
ruff check .                              # All checks passed!
mypy toolkit/                             # Success: no issues found in 129 source files
```

- [x] `pytest` passa (1301: regressione sdmx/support/others + `test_registry_builder` 381 righe, `test_registry_ops`, `test_catalog_ops`)
- [x] **Marker audit verde**: i 15 test di `test_registry_builder.py` e i 6 di `test_registry_ops.py` ora hanno marker individuali (`contract` catalog contract/path/run block, `policy` dirname-not-identity/warn senza mart, `pure_unit` mapping puri) — `check_tests.py` strict_failures 0 (fix `40c67e2`)
- [x] `ruff check .` passa
- [x] `mypy toolkit/` passa — Success completo (129 file)
- [x] Verifica live: `toolkit registry list` → clean_catalog (114 entries) + pipeline_signals di dataset-incubator

## Checklist PR

- [x] Perimetro stretto: una PR = modulo registry (Fase 1)
- [x] Test inclusi e **marcati** (marker audit verde)
- [ ] Issue collegata — assente (richiesta diretta; vedi Contesto)
- [x] Nessun modulo pubblico rimosso

## Note per chi revisiona

- Il branch è stato **rebasato su main attuale** (precedentemente era 8 commit indietro e avrebbe "rimosso" #450/#451): il diff è `main..HEAD` pulito, solo additivo sul registry.
- `toolkit registry show eurostat clean_catalog` fallisce oggi perché il repo eurostat non committa gli artifact (li genera al run col wrapper) — comportamento atteso, il reader trova ciò che è committato.
- Fasi successive (fuori perimetro): migrazione DI ai wrapper `build_registry` (rimozione script paralleli + semantic_types locale), deprecazione `tools/clean_query_mcp` e `eurostat-mcp` a favore del toolkit MCP (find/overview/query con fallback locale→GCS già su main).