### PR TITLE
fix(sdmx): ESTAT constraints HTTP 413 -> fallback wildcard for large flows

### DIFF
--- a/tests/test_sdmx_plugin.py
+++ b/tests/test_sdmx_plugin.py
@@ -744,3 +744,31 @@ def test_sdmx_fetch_codelist_requires_estat():
     """fetch_codelist: solo profilo ESTAT (ISTAT non espone JSON 2.0)."""
     with pytest.raises(DownloadError, match="solo per il profilo Eurostat"):
         SdmxSource().fetch_codelist("GEO", agency="IT1")
+
+
+def test_sdmx_estat_large_flow_constraints_413_fallback(monkeypatch):
+    """Flow giganti: JSON constraints HTTP 413 → fallback wildcard, TSV ok.
+
+    DEMO_R_D2JAN (pop per sesso/età, 4M+ obs) fa fallire il JSON constraints
+    con 413 — il source deve ripiegare su key wildcard ('all') e scaricare il
+    TSV, non crashare. Regressione trovata durante la migrazione pop-nuts3.
+    """
+
+    def _fake_get_413_then_tsv(self, url, **kwargs):
+        params = kwargs.get("params") or {}
+        if url.endswith("/data/DEMO_R_D2JAN/all") and params.get("format") == "JSON":
+            return _ok(_FakeResponse(413, "Payload Too Large", url))
+        if url.endswith("/data/DEMO_R_D2JAN/all") and params.get("format") == "TSV":
+            return _ok(_FakeResponse(200, ESTAT_TSV, url))
+        raise AssertionError(f"Unexpected URL {url} params={params}")
+
+    monkeypatch.setattr(HttpClient, "get", _fake_get_413_then_tsv)
+    src = SdmxSource(timeout=30, retries=0)
+
+    # Constraints: fallback a vuoti (no crash)
+    constraints = src._estat_constraints("DEMO_R_D2JAN")
+    assert constraints == {}
+
+    # Fetch: la key diventa 'all' e il TSV viene scaricato
+    data, _origin = src._estat_fetch_tsv("DEMO_R_D2JAN", "all")
+    assert data  # TSV scaricato

--- a/toolkit/plugins/sdmx.py
+++ b/toolkit/plugins/sdmx.py
@@ -219,11 +219,20 @@ class SdmxSource:
         cache_key = f"{EUROSTAT_AGENCY}/{flow}"
         if cache_key in self._constraints_cache:
             return self._constraints_cache[cache_key]
-        payload, _origin = self._get_json(
-            self._data_base_urls(EUROSTAT_AGENCY),
-            f"data/{flow}/all",
-            params={"format": "JSON", "lastNObservations": "0"},
-        )
+        try:
+            payload, _origin = self._get_json(
+                self._data_base_urls(EUROSTAT_AGENCY),
+                f"data/{flow}/all",
+                params={"format": "JSON", "lastNObservations": "0"},
+            )
+        except DownloadError as exc:
+            # Flow troppo grandi (es. DEMO_R_D2JAN, DEMO_R_MAGEC3) non
+            # rispondono al JSON constraints (HTTP 413/404) — fallback a
+            # constraints vuoti = key wildcard (il TSV dati funziona).
+            if "413" in str(exc) or "404" in str(exc):
+                self._constraints_cache[cache_key] = {}
+                return {}
+            raise
         dimension = payload.get("dimension") or {}
         result: dict[str, list[str]] = {}
         for dim_id in dimension:


### PR DESCRIPTION
## Type

- [x] Root fix (removes the cause of a bug)

## Problem

Large Eurostat dataflows (DEMO_R_D2JAN population by sex/age, 4M+ obs)
return HTTP 413 for the JSON constraints request
(`data/{flow}/all?format=JSON&lastNObservations=0`). `_estat_constraints`
crashed with `DownloadError` before any data download — the eurostat
pop-nuts3 migration was blocked.

## Solution

Catch DownloadError with 413/404 in `_estat_constraints` and fall back to
empty constraints (wildcard key `'all'`). The data TSV request works fine —
this implements the fallback already promised in the `preview_constraints`
docstring ("Falls back to empty constraints (all wildcard) when the SDMX
endpoint does not support JSON for this dataflow").

## Test plan

- [x] `pytest tests/test_sdmx_plugin.py -q` — 20 passed (1 new: mocked 413 →
      empty constraints → TSV wildcard fetch)
- [x] `ruff check toolkit/plugins/sdmx.py tests/test_sdmx_plugin.py` passes
- [x] Live: `_estat_constraints('DEMO_R_D2JAN')` returns {} instead of crash

## Downstream impact

- [ ] Parquet schema changed
- [ ] CLI or MCP tool changed
- [x] API behavior — large-flow fetch now succeeds (constraints skipped);
      small flows unchanged

## Closes

No issue. Found during eurostat pop-nuts3 migration (large flow, OOM aside).

## Checklist

- [x] `ruff check .` passes
- [ ] Issue collegata — no (direct request during migration)