### PR TITLE
fix(resolver): allinea scanner e discovery ai repo migrati (fusion ADR)

### DIFF
--- a/tests/test_catalog_ops.py
+++ b/tests/test_catalog_ops.py
@@ -9,12 +9,17 @@ Protegge:
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
 
 from lab_connectors.gcs.paths import CLEAN_BUCKET, MART_BUCKET
-from toolkit.domain.catalog import CatalogResolver, _parse_clean_filename
+from toolkit.domain.catalog import (
+    CatalogResolver,
+    _parse_clean_filename,
+    _scan_committed_catalogs,
+)
 
 pytestmark = pytest.mark.contract
 
@@ -677,3 +682,145 @@ class TestSemanticFind:
         assert res["period"] == {"start": 2023, "end": 2024}
         assert res["columns"][0]["role"] == "metric"
         assert res["columns"][0]["description"] == "Importo gara"
+
+
+# ---------------------------------------------------------------------------
+# Scan cataloghi semantici committati (fusion ADR)
+# ---------------------------------------------------------------------------
+
+
+class TestScanCommittedCatalogs:
+    """Scan semantico cross-repo: registry.json unico + fallback legacy.
+
+    Regressione fusion ADR: prima leggeva solo ``clean_catalog.json``, quindi
+    i repo migrati a ``registry.json`` (eurostat, dcl-bologna) sparivano dal
+    find semantico. Ora usa ``load_repo_registry`` (stesso reader del resolver
+    GCS).
+    """
+
+    def test_reads_fusion_registry_and_legacy(self, tmp_path: "Any") -> None:
+        """Repo migrato (registry.json) e legacy (clean_catalog.json) indicizzati."""
+        # Repo migrato: registry.json unico con sezione datasets
+        migrato = tmp_path / "eurostat"
+        (migrato / "registry").mkdir(parents=True)
+        (migrato / "registry" / "registry.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "repo": "eurostat",
+                    "datasets": [
+                        {
+                            "slug": "eurostat_crime_nuts3",
+                            "name": "Criminalità NUTS3",
+                            "tags": ["giustizia", "reati"],
+                            "columns": [
+                                {"name": "geo", "role": "dimension", "semantic_type": "nuts_code"}
+                            ],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        # Repo legacy: solo clean_catalog.json
+        legacy = tmp_path / "dataset-incubator"
+        (legacy / "registry").mkdir(parents=True)
+        (legacy / "registry" / "clean_catalog.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "datasets": [
+                        {
+                            "slug": "anac_bandi_gara",
+                            "name": "Bandi ANAC",
+                            "tags": ["appalti"],
+                            "columns": [{"name": "cig", "role": "dimension"}],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        sem = _scan_committed_catalogs(tmp_path)
+
+        assert "eurostat_crime_nuts3" in sem
+        assert sem["eurostat_crime_nuts3"]["_repo"] == "eurostat"
+        assert sem["eurostat_crime_nuts3"]["tags"] == ["giustizia", "reati"]
+
+        assert "anac_bandi_gara" in sem
+        assert sem["anac_bandi_gara"]["_repo"] == "dataset-incubator"
+        assert sem["anac_bandi_gara"]["name"] == "Bandi ANAC"
+
+    def test_skips_repo_without_registry(self, tmp_path: "Any") -> None:
+        """Repo senza registry non produce entry."""
+        (tmp_path / "no-registry").mkdir()
+        sem = _scan_committed_catalogs(tmp_path)
+        assert sem == {}
+
+
+# ---------------------------------------------------------------------------
+# Scan configs workspace — cross-repo (gap fusion: configs DI-centrico)
+# ---------------------------------------------------------------------------
+
+
+class TestScanWorkspaceConfigs:
+    """Scan dataset.yml cross-repo: DI (candidates/compose/support) + migrati.
+
+    Regressione fusion ADR: prima scansionava solo dataset-incubator
+    candidates/support, quindi i repo migrati (eurostat, dcl-bologna) avevano
+    stage=None/has_clean=False pur avendo dataset.yml e parquet locali. Ora
+    usa la mappa canonica REPO_DATASET_DIRS (scalabile ai nuovi repo).
+    """
+
+    def test_reads_migrated_repo_datasets(self, tmp_path: "Any") -> None:
+        """Dataset.yml in datasets/ di un repo migrato viene indicizzato."""
+        migrated = tmp_path / "eurostat"
+        (migrated / "datasets" / "eurostat-crime-nuts3").mkdir(parents=True)
+        (migrated / "datasets" / "eurostat-crime-nuts3" / "dataset.yml").write_text(
+            "root: '../../out'\n"
+            "dataset:\n"
+            "  name: 'eurostat_crime_nuts3'\n"
+            "  source_id: 'eurostat'\n"
+            "  years: [2026]\n",
+            encoding="utf-8",
+        )
+        # Parquet locale finto → has_clean True
+        (migrated / "out" / "data" / "clean" / "eurostat_crime_nuts3").mkdir(parents=True)
+        (migrated / "out" / "data" / "clean" / "eurostat_crime_nuts3" / "x.parquet").touch()
+
+        from toolkit.domain.catalog import _scan_workspace_configs
+
+        configs = _scan_workspace_configs(tmp_path)
+
+        assert "eurostat_crime_nuts3" in configs
+        entry = configs["eurostat_crime_nuts3"]
+        assert entry["stage"] == "datasets"
+        assert entry["has_clean"] is True
+        assert "dataset.yml" in entry["config_path"]
+
+    def test_keeps_di_candidates_compose_and_support(self, tmp_path: "Any") -> None:
+        """DI candidates/compose/support_datasets restano indicizzati."""
+        for section in ("candidates", "compose", "support_datasets"):
+            d = tmp_path / "dataset-incubator" / section
+            d.mkdir(parents=True)
+            (d / "dataset.yml").write_text("dataset:\n  name: 'x'\n", encoding="utf-8")
+        (tmp_path / "dataset-incubator" / "candidates" / "anac-bandi-gara").mkdir(parents=True)
+        (
+            tmp_path / "dataset-incubator" / "candidates" / "anac-bandi-gara" / "dataset.yml"
+        ).write_text("dataset:\n  name: 'anac_bandi_gara'\n", encoding="utf-8")
+        (tmp_path / "dataset-incubator" / "compose" / "anac-appalti-master").mkdir(parents=True)
+        (
+            tmp_path / "dataset-incubator" / "compose" / "anac-appalti-master" / "dataset.yml"
+        ).write_text("dataset:\n  name: 'anac_appalti_master'\n", encoding="utf-8")
+        supp = tmp_path / "dataset-incubator" / "support_datasets" / "anac-collaudo"
+        supp.mkdir(parents=True)
+        (supp / "dataset.yml").write_text("dataset:\n  name: 'anac_collaudo'\n", encoding="utf-8")
+
+        from toolkit.domain.catalog import _scan_workspace_configs
+
+        configs = _scan_workspace_configs(tmp_path)
+
+        assert configs["anac_bandi_gara"]["stage"] == "candidates"
+        assert configs["anac_appalti_master"]["stage"] == "compose"
+        assert configs["anac_collaudo"]["stage"] == "support"

--- a/tests/test_catalog_ops.py
+++ b/tests/test_catalog_ops.py
@@ -288,6 +288,55 @@ class TestListDatasets:
         assert res["total_count"] == 4
         assert res["truncated"] is False
 
+    @pytest.mark.regression
+    def test_merge_gcs_workspace_mixed_years(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Merge source=all con file GCS senza anno + parquet locale non crasha.
+
+        Regressione: i file GCS dai registry hanno year=None (path flat), lo
+        scan workspace int → sorted(set{years}) crashava con TypeError
+        ('<' int vs NoneType). Il None non deve entrare nel set years.
+        """
+        resolver = CatalogResolver(include_local=True)
+        # GCS: file senza anno (dal registry)
+        monkeypatch.setattr(
+            "toolkit.domain.catalog._gcs_files_from_registry",
+            lambda _w: [
+                {
+                    "url": "gs://dataciviclab-clean/mio_dataset/*.parquet",
+                    "slug": "mio_dataset",
+                    "bucket": CLEAN_BUCKET,
+                    "year": None,
+                    "path": "gs://dataciviclab-clean/mio_dataset/*.parquet",
+                    "_gcs": True,
+                }
+            ],
+        )
+        # Workspace: parquet locale con anno
+        monkeypatch.setattr(
+            "toolkit.domain.catalog._scan_workspace_parquets",
+            lambda _w: [
+                {
+                    "url": "/tmp/mio_dataset_2024_clean.parquet",
+                    "slug": "mio_dataset",
+                    "bucket": "local",
+                    "year": 2024,
+                    "path": "mio_dataset/2024/mio_dataset_2024_clean.parquet",
+                    "size_bytes": 100,
+                    "updated": "2026-01-01T00:00:00Z",
+                    "_local": True,
+                }
+            ],
+        )
+        monkeypatch.setattr("toolkit.domain.catalog._scan_workspace_configs", lambda _w, **_: {})
+        monkeypatch.setattr("toolkit.domain.catalog._scan_committed_catalogs", lambda _w: {})
+
+        res = resolver.list_datasets(query="mio_dataset", source="all")
+        assert res["total_count"] == 1
+        entry = res["datasets"][0]
+        assert entry["years"] == [2024]  # solo anni reali, nessun None
+        assert entry["has_remote"] is True
+        assert entry["has_local"] is True
+
     def test_list_by_query(self, resolver: CatalogResolver) -> None:
         """Filtro query per slug (case-insensitive, substring)."""
         res = resolver.list_datasets(query="ANAC")

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -61,3 +61,41 @@ def test_from_root_relative_accepts_forward_slashes_for_windows_like_root():
     rel = "data/raw/demo/2022/file.csv"
 
     assert str(from_root_relative(rel, root)) == r"C:\repo\out\data\raw\demo\2022\file.csv"
+
+
+# ---------------------------------------------------------------------------
+# Config discovery cross-repo (fusion ADR generalizzata)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_resolve_config_path_cross_repo(tmp_path):
+    """Lo slug si risolve nei repo migrati (datasets/) e in DI (candidates/)."""
+    from toolkit.core.discovery import resolve_config_path
+
+    # Repo migrato: layout flat datasets/
+    eu = tmp_path / "eurostat" / "datasets" / "eurostat-crime-nuts3"
+    eu.mkdir(parents=True)
+    (eu / "dataset.yml").write_text("dataset:\n  name: 'eurostat_crime_nuts3'\n", encoding="utf-8")
+
+    # DI: candidates/
+    di = tmp_path / "dataset-incubator" / "candidates" / "anac-bandi-gara"
+    di.mkdir(parents=True)
+    (di / "dataset.yml").write_text("dataset:\n  name: 'anac_bandi_gara'\n", encoding="utf-8")
+
+    assert (
+        resolve_config_path("eurostat-crime-nuts3", workspace=tmp_path)
+        == (eu / "dataset.yml").resolve()
+    )
+    assert (
+        resolve_config_path("anac-bandi-gara", workspace=tmp_path) == (di / "dataset.yml").resolve()
+    )
+
+
+@pytest.mark.contract
+def test_resolve_config_path_not_found(tmp_path):
+    """Slug inesistente → FileNotFoundError con suggerimento."""
+    from toolkit.core.discovery import resolve_config_path
+
+    with pytest.raises(FileNotFoundError, match="Nessun dataset trovato"):
+        resolve_config_path("slug-inesistente", workspace=tmp_path)

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -499,3 +499,30 @@ class TestEntityGraph:
             for b in bridges
         )
         assert graph["schema_version"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Mappa canonica repo → dataset_dirs (fusion ADR generalizzata)
+# ---------------------------------------------------------------------------
+
+
+class TestRepoDatasetDirs:
+    """La mappa REPO_DATASET_DIRS è la fonte unica dei layout per repo."""
+
+    def test_default_flat_for_unknown_repos(self) -> None:
+        """Repo non mappato → default ('datasets',) — scalabile senza codice."""
+        from toolkit.registry.layout import repo_dataset_dirs
+
+        assert repo_dataset_dirs("eurostat") == ("datasets",)
+        assert repo_dataset_dirs("dcl-bologna") == ("datasets",)
+        assert repo_dataset_dirs("nuovo-repo-futuro") == ("datasets",)
+
+    def test_di_custom_dirs(self) -> None:
+        """dataset-incubator dichiara i suoi tre layout."""
+        from toolkit.registry.layout import repo_dataset_dirs
+
+        assert repo_dataset_dirs("dataset-incubator") == (
+            "candidates",
+            "compose",
+            "support_datasets",
+        )

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -509,6 +509,7 @@ class TestEntityGraph:
 class TestRepoDatasetDirs:
     """La mappa REPO_DATASET_DIRS è la fonte unica dei layout per repo."""
 
+    @pytest.mark.contract
     def test_default_flat_for_unknown_repos(self) -> None:
         """Repo non mappato → default ('datasets',) — scalabile senza codice."""
         from toolkit.registry.layout import repo_dataset_dirs
@@ -517,6 +518,7 @@ class TestRepoDatasetDirs:
         assert repo_dataset_dirs("dcl-bologna") == ("datasets",)
         assert repo_dataset_dirs("nuovo-repo-futuro") == ("datasets",)
 
+    @pytest.mark.contract
     def test_di_custom_dirs(self) -> None:
         """dataset-incubator dichiara i suoi tre layout."""
         from toolkit.registry.layout import repo_dataset_dirs

--- a/toolkit/core/discovery.py
+++ b/toolkit/core/discovery.py
@@ -6,7 +6,8 @@ Centralizza la logica oggi dispersa tra:
 
 La funzione ``resolve_config_path()`` implementa 3 stadi:
 1. CWD o path diretto
-2. Slug → candidates/compose/support_datasets
+2. Slug → repo del workspace con la mappa canonica ``REPO_DATASET_DIRS``
+   (dataset-incubator: candidates/compose/support_datasets; altri repo: datasets)
 3. FileNotFoundError con suggerimento
 """
 
@@ -15,8 +16,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from toolkit.core.paths import WORKSPACE_ROOT
-
-_INCUBATOR_DIRS = ("candidates", "compose", "support_datasets")
 
 
 def resolve_config_path(
@@ -28,8 +27,9 @@ def resolve_config_path(
     Args:
         hint: ``None`` → cerca ``dataset.yml`` nel CWD.
               Path o stringa con ``/`` o ``.yml`` → path diretto.
-              Stringa senza ``/`` né ``.yml`` → slug risolto in
-              ``candidates/{slug}/dataset.yml`` (e categorie affini).
+              Stringa senza ``/`` né ``.yml`` → slug risolto nei repo del
+              workspace (dataset-incubator candidates/compose/support_datasets,
+              altri repo datasets/).
         workspace: Workspace root (default: ``WORKSPACE_ROOT``).
 
     Returns:
@@ -71,16 +71,23 @@ def resolve_config_path(
             f"File non trovato: {candidate}\n  Usa -c <slug> per risolvere automaticamente"
         )
 
-    # ── Stage 3: risoluzione slug ─────────────────────────────────────
-    incubator = ws / "dataset-incubator"
-    for subdir in _INCUBATOR_DIRS:
-        for name in ("dataset.yml", "dataset.yaml"):
-            probe = incubator / subdir / hint_str / name
-            if probe.is_file():
-                return probe.resolve()
+    # ── Stage 3: risoluzione slug nei repo del workspace ──────────────
+    from toolkit.registry.layout import repo_dataset_dirs
+
+    searched: list[str] = []
+    for repo_dir in sorted(p for p in ws.iterdir() if p.is_dir()):
+        for section in repo_dataset_dirs(repo_dir.name):
+            section_dir = repo_dir / section
+            if not section_dir.is_dir():
+                continue
+            for name in ("dataset.yml", "dataset.yaml"):
+                probe = section_dir / hint_str / name
+                if probe.is_file():
+                    return probe.resolve()
+            searched.append(str(section_dir / hint_str))
 
     raise FileNotFoundError(
         f"Nessun dataset trovato per '{hint_str}'.\n"
-        f"  Cercato in: {ws}/dataset-incubator/{{candidates,compose,support_datasets}}/<slug>/dataset.yml\n"
+        f"  Cercato in: {', '.join(searched) or ws}\n"
         f"  Verifica che lo slug sia corretto."
     )

--- a/toolkit/domain/catalog.py
+++ b/toolkit/domain/catalog.py
@@ -582,7 +582,8 @@ class CatalogResolver:
                     datasets[slug]["_buckets"] = set()
                 entry = datasets[slug]
                 entry["_buckets"].add(f["bucket"])
-                entry["years"].add(f["year"])
+                if f["year"] is not None:
+                    entry["years"].add(f["year"])
                 entry["file_count"] += 1
                 entry["total_size_bytes"] += f.get("size_bytes", 0)
                 entry["has_remote"] = True

--- a/toolkit/domain/catalog.py
+++ b/toolkit/domain/catalog.py
@@ -1,11 +1,12 @@
 """Catalog resolver — fonte unica per dataset discovery.
 
-Legge ``gcs_manifest.json`` (auto-generato dalla CI), scansiona il workspace
-locale e i dataset.yml per fornire una vista unificata di tutti i dataset
-del Lab, sia in sviluppo che pubblicati.
+Legge i registry committati (``{repo}/registry/registry.json`` unico, fusion
+ADR, con fallback sui file legacy) e scansiona il workspace locale e i
+dataset.yml per fornire una vista unificata di tutti i dataset del Lab, sia
+in sviluppo che pubblicati.
 
 Supporta tre ``source``:
-- ``"gcs"``: dataset pubblicati su GCS (dal manifest)
+- ``"gcs"``: dataset pubblicati su GCS (dai registry committati)
 - ``"workspace"``: dataset in sviluppo (da dataset.yml + clean parquet locali)
 - ``"all"`` (default): unione di entrambi
 
@@ -15,7 +16,6 @@ vanno aggiunte nei wrapper MCP.
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -173,25 +173,36 @@ def _scan_workspace_configs(
 ) -> dict[str, dict[str, Any]]:
     """Scansiona dataset.yml nel workspace e restituisce metadata di pipeline.
 
+    Cross-repo (come ``_scan_workspace_parquets``): usa la mappa canonica
+    ``REPO_DATASET_DIRS`` (toolkit.registry.layout) — dataset-incubator legge
+    ``candidates/compose/support_datasets``, gli altri repo (eurostat,
+    dcl-bologna, ...) ``datasets/``. Nuovi repo con layout flat funzionano
+    senza toccare il codice.
+
     Returns:
         Dict slug → {dataset_name, stage, years, has_clean, has_mart,
                      last_run_status, config_path, root}
     """
-    incubator = workspace / "dataset-incubator"
-    if not incubator.is_dir():
-        return {}
+    from toolkit.registry.layout import repo_dataset_dirs
+
+    # Nome dir DI → stage legacy (contratto pre-fusion).
+    DI_STAGE = {"candidates": "candidates", "compose": "compose", "support_datasets": "support"}
 
     results: dict[str, dict[str, Any]] = {}
     dirs_to_scan: list[tuple[str, Path]] = []
 
-    if stage in ("candidates", "all"):
-        candidates_dir = incubator / "candidates"
-        if candidates_dir.exists():
-            dirs_to_scan.append(("candidates", candidates_dir))
-    if stage in ("support", "all"):
-        support_dir = incubator / "support_datasets"
-        if support_dir.exists():
-            dirs_to_scan.append(("support", support_dir))
+    for repo_dir in sorted(p for p in workspace.iterdir() if p.is_dir()):
+        for section in repo_dataset_dirs(repo_dir.name):
+            section_dir = repo_dir / section
+            if not section_dir.is_dir():
+                continue
+            # Filtro stage: "all" prende tutto; "candidates"/"support" solo DI.
+            if stage == "candidates" and section != "candidates":
+                continue
+            if stage == "support" and section != "support_datasets":
+                continue
+            stage_name = DI_STAGE.get(section, section)
+            dirs_to_scan.append((stage_name, section_dir))
 
     for stage_name, scan_dir in dirs_to_scan:
         for dataset_yml in sorted(scan_dir.rglob("dataset.yml")):
@@ -344,28 +355,27 @@ SEMANTIC_FIELDS = (
 
 
 def _scan_committed_catalogs(workspace: Path = WORKSPACE_ROOT) -> dict[str, dict[str, Any]]:
-    """Scansiona i cataloghi committati nei repo del workspace.
+    """Scansiona i cataloghi semantici committati nei repo del workspace.
 
-    Qualsiasi dir di primo livello con ``registry/clean_catalog.json``
-    (eurostat/, dataset-incubator/, ...). Ritorna ``{slug: entry semantica}``
+    Usa ``load_repo_registry`` (lo stesso reader del resolver GCS): legge il
+    ``registry.json`` unico dei repo migrati (fusion ADR) e il fallback
+    ``clean_catalog.json`` dei repo legacy. Ritorna ``{slug: entry semantica}``
     con ``_repo`` (nome dir) aggiunto.
 
     La semantica (columns con role/semantic_type, description, tags, period)
-    vive nei cataloghi generati dal registry builder e committati nei repo:
+    vive nei registry generati dal registry builder e committati nei repo:
     qui diventa la fonte per il find semantico del resolver.
     """
+    from toolkit.registry.reader import load_repo_registry
+
     result: dict[str, dict[str, Any]] = {}
     if not workspace.is_dir():
         return result
     for repo_dir in sorted(p for p in workspace.iterdir() if p.is_dir()):
-        catalog_path = repo_dir / "registry" / "clean_catalog.json"
-        if not catalog_path.is_file():
+        payload, _is_legacy = load_repo_registry(repo_dir)
+        if payload is None:
             continue
-        try:
-            catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            continue
-        for ds in catalog.get("datasets", []) or []:
+        for ds in payload.get("datasets", []) or []:
             slug = ds.get("slug")
             if slug:
                 entry = dict(ds)

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -348,9 +348,11 @@ def toolkit_sparql_query(
 @mcp.tool(
     description=(
         "Elenca gli artifact registry committati nei repo del workspace "
-        "(clean_catalog, mart_catalog, pipeline_signals, codelists, ...). "
+        "(registry.json unico fusion, o fallback legacy clean_catalog/mart_catalog/...). "
         "Ogni repo con registry/ viene elencato con i suoi artifact, "
-        "dimensione e conteggio entries. Usa toolkit_registry_show per il contenuto."
+        "dimensione e conteggio entries per sezione "
+        "(datasets, marts, signals, codelists, entities). "
+        "Usa toolkit_registry_show per il contenuto."
     ),
     structured_output=True,
 )
@@ -361,10 +363,11 @@ def toolkit_registry_list() -> dict[str, Any]:
 @mcp.tool(
     description=(
         "Mostra un artifact registry committato di un repo del workspace "
-        "(es. repo='eurostat', artifact='clean_catalog'). "
-        "Con slug filtra un'entry: dataset slug (clean_catalog), mart slug "
-        "in formato {dataset}__{mart} (mart_catalog), id (pipeline_signals), "
-        "codelist name (codelists). "
+        "(es. repo='eurostat', artifact='datasets'). Sezioni: datasets, marts, "
+        "signals, codelists, entities (o 'registry' per l'intero payload; "
+        "accetta anche i nomi legacy clean_catalog/mart_catalog/pipeline_signals/...). "
+        "Con slug filtra un'entry: dataset slug (datasets), mart slug in formato "
+        "{dataset}__{mart} (marts), id (signals), codelist name (codelists). "
         "Il catalogo semantico contiene columns (role, semantic_type), "
         "description, period, location, mart_refs e il blocco run."
     ),

--- a/toolkit/registry/layout.py
+++ b/toolkit/registry/layout.py
@@ -21,6 +21,22 @@ from toolkit.core.dataset_loader import load_dataset_manifest
 
 DEFAULT_DATASET_DIRS: tuple[str, ...] = ("datasets",)
 
+# Mappa canonica repo → dataset_dirs (fusion ADR generalizzata).
+# Ogni repo del workspace può dichiarare dove vivono i suoi dataset.yml;
+# i repo non elencati usano il default ``("datasets",)`` (layout flat).
+REPO_DATASET_DIRS: dict[str, tuple[str, ...]] = {
+    "dataset-incubator": ("candidates", "compose", "support_datasets"),
+}
+
+
+def repo_dataset_dirs(repo_name: str) -> tuple[str, ...]:
+    """Dataset dirs di un repo del workspace (default flat se non mappato).
+
+    La mappa ``REPO_DATASET_DIRS`` è la fonte unica: aggiungere un repo con
+    layout custom = una riga qui, senza toccare resolver, discovery o CLI.
+    """
+    return REPO_DATASET_DIRS.get(repo_name, DEFAULT_DATASET_DIRS)
+
 
 @dataclass(frozen=True)
 class RepoLayout:

--- a/toolkit/registry/reader.py
+++ b/toolkit/registry/reader.py
@@ -222,27 +222,31 @@ def show_registry(
 
 
 def _filter_entry(section: str, data: Any, slug: str) -> dict[str, Any]:
-    """Filtra l'entry richiesta dalla sezione (errore se non trovata)."""
+    """Filtra l'entry richiesta dalla sezione (errore se non trovata).
+
+    Ritorna l'entry stessa (senza wrapper ``{slug, entry}``: il livello di
+    wrapping è già fornito da ``show_registry``).
+    """
     if section in ("datasets", "marts"):
         entries = data or []
         hit = next((d for d in entries if d.get("slug") == slug), None)
         if hit is None:
             raise FileNotFoundError(f"'{slug}' non presente in {section}")
-        return {"slug": slug, "entry": hit}
+        return hit
     if section == "signals":
         entries = data or []
         hit = next((s for s in entries if s.get("id") == slug), None)
         if hit is None:
             raise FileNotFoundError(f"Signal '{slug}' non presente in signals")
-        return {"slug": slug, "entry": hit}
+        return hit
     if section == "codelists":
         entries = data or {}
         if slug not in entries:
             raise FileNotFoundError(f"Codelist '{slug}' non presente in codelists")
-        return {"slug": slug, "entry": entries[slug]}
+        return entries[slug]
     if section == "entities":
         entities = (data or {}).get("entities") or {}
         if slug not in entities:
             raise FileNotFoundError(f"Entità '{slug}' non presente in entities")
-        return {"slug": slug, "entry": entities[slug]}
+        return entities[slug]
     raise FileNotFoundError(f"Filtro per slug non supportato per la sezione '{section}'")


### PR DESCRIPTION
## Tipo

**root fix** + **contract alignment** — riallinea resolver e discovery al modello fusion ADR (registry.json unico), eliminando i residui DI-centrico rimasti dopo la fusione.

## Problema reale

Dopo la fusion registry (#453), il resolver e la discovery restavano ancorati a dataset-incubator: la conoscenza "dove stanno i dataset.yml per repo" era duplicata in 3 punti (`discovery.py` con `_INCUBATOR_DIRS`, `catalog.py` con hardcode candidates/support, wrapper per repo con `RepoLayout` manuale) e nessuno dei due leggeva i repo migrati (eurostat, dcl-bologna). Risultato osservato:

- `find "bologna"` → 0 risultati nonostante 11 dataset con tag (semantica dei repo migrati invisibile)
- repo migrati in `source=workspace` → `stage=None, has_clean=False, run=None` pur avendo dataset.yml e parquet locali
- `compose/` di dataset-incubator (12 dataset) mai scansionato dal resolver (solo il builder lo leggeva)
- `resolve_config_path` risolveva lo slug solo in dataset-incubator
- registry show con slug → output con doppio wrap `entry: {slug, entry: hit}`

## Contratto riusato/sostituito

- **Nuovo contratto centrale**: `REPO_DATASET_DIRS` + `repo_dataset_dirs()` in `toolkit/registry/layout.py` (modulo che già definiva `RepoLayout`) — mappa canonica repo → dataset_dirs, default `("datasets",)` per i repo non elencati (**scalabile: nuovo repo flat = zero modifiche**).
- **Riusato**: `load_repo_registry` (già usato dal resolver GCS) per il find semantico; `iter_dataset_ymls`/`RepoLayout` come base per lo scan configs.

## Codice rimosso o duplicazione eliminata

- `_INCUBATOR_DIRS` hardcoded in `discovery.py` → rimosso (usa la mappa)
- hardcode candidates/support + datasets in `_scan_workspace_configs` → sostituito dalla mappa
- filtro `templates` in scan configs → non più necessario (iter a 1 livello)
- doppio wrap `{slug, entry}` in `_filter_entry` → entry diretta

## Test aggiunti

| Test | Marker | Protegge |
|---|---|---|
| `TestScanCommittedCatalogs.test_reads_fusion_registry_and_legacy` | contract | find semantico cross-repo (registry.json + legacy) |
| `TestScanWorkspaceConfigs.test_reads_migrated_repo_datasets` | contract | repo migrato con stage=datasets/has_clean |
| `TestScanWorkspaceConfigs.test_keeps_di_candidates_compose_and_support` | contract | DI candidates/compose/support preservati |
| `TestRepoDatasetDirs.test_default_flat_for_unknown_repos` | contract | default scalabile per repo futuri |
| `TestRepoDatasetDirs.test_di_custom_dirs` | contract | layout custom DI |
| `test_resolve_config_path_cross_repo` / `_not_found` | contract | discovery slug→path cross-repo |

Totale: **1313 test verdi**, ruff pulito.

## Rischio residuo

- `has_clean/has_mart` nel `find source=gcs` per i repo migrati restano `False` (derivano dallo scan configs, non dai bucket GCS) — `layer` è però corretto (`clean,mart`). Fuori scope, segnalato.
- I wrapper per repo (build_registry.py) continuano a dichiarare `RepoLayout` esplicitamente — compatibili, non toccati.

## Follow-up obbligatorio

- **Riavviare il server MCP** per caricare il resolver (cache semantica/configs per istanza).
- Verifica live post-merge: `find bologna` → 11 risultati; `source=workspace` con stage/run popolati per eurostat/dcl-bologna.