### PR TITLE
feat(graph): tool MCP toolkit_graph — grafo entità cross-repo (fusion ADR)

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -31,6 +31,7 @@ def test_mcp_server_registers_expected_tools() -> None:
         "toolkit_dataset_overview",
         "toolkit_registry_list",
         "toolkit_registry_show",
+        "toolkit_graph",
     }
 
 

--- a/tests/test_registry_graph.py
+++ b/tests/test_registry_graph.py
@@ -1,0 +1,178 @@
+"""Test del grafo entità → dataset aggregato cross-repo.
+
+Fixture: mini-workspace con due repo, ognuno con la sezione entities nel
+registry (fusion e legacy).
+
+Marker: contract (output pubblico del tool MCP toolkit_graph).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from toolkit.registry.graph import DOMAIN_KEYWORDS, filter_graph, load_workspace_graph
+
+
+@pytest.fixture
+def graph_workspace(tmp_path: Path) -> Path:
+    """Due repo con entities: DI (legacy entity_graph) + eurostat (fusion)."""
+    # DI legacy: entity_graph.json separato
+    di = tmp_path / "dataset-incubator" / "registry"
+    di.mkdir(parents=True)
+    (di / "entity_graph.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "entities": {
+                    "Comune": {
+                        "entity": "Comune",
+                        "label": "Comune (ISTAT)",
+                        "datasets": [
+                            {
+                                "slug": "irpef_comunale",
+                                "name": "Irpef Comunale",
+                                "column": "codice_istat_comune",
+                                "semantic_type": "municipality_code",
+                            }
+                        ],
+                        "types": {"municipality_code": 1},
+                    },
+                    "Gara": {
+                        "entity": "Gara",
+                        "label": "Gara / Appalto",
+                        "datasets": [
+                            {
+                                "slug": "anac_bandi_gara",
+                                "name": "Bandi ANAC",
+                                "column": "cig",
+                                "semantic_type": "cig_code",
+                            }
+                        ],
+                        "types": {"cig_code": 1},
+                    },
+                },
+                "bridges": [
+                    {
+                        "from": {
+                            "entity": "Gara",
+                            "dataset": "anac_aggiudicatari",
+                            "via": "cig_code",
+                        },
+                        "to": {
+                            "entity": "Comune",
+                            "bridge": "anac_bandi_gara",
+                            "on": "cig",
+                            "semantic_type": "municipality_code",
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # eurostat fusion: registry.json unico con entities (stessa entity "Comune" + nuova)
+    eu = tmp_path / "eurostat" / "registry"
+    eu.mkdir(parents=True)
+    (eu / "registry.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "repo": "eurostat",
+                "datasets": [],
+                "marts": [],
+                "signals": [],
+                "codelists": {},
+                "entities": {
+                    "generated_from": "registry",
+                    "entities": {
+                        "Comune": {
+                            "entity": "Comune",
+                            "label": "Comune (ISTAT)",
+                            "datasets": [
+                                {
+                                    "slug": "eurostat_demo_balance_nuts3",
+                                    "name": "Demo Balance",
+                                    "column": "geo",
+                                    "semantic_type": "nuts_code",
+                                }
+                            ],
+                            "types": {"nuts_code": 1},
+                        }
+                    },
+                    "bridges": [],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    (tmp_path / "no-registry-repo").mkdir()
+    return tmp_path
+
+
+@pytest.mark.contract
+def test_load_workspace_graph_merges_entities(graph_workspace: Path) -> None:
+    """Entity con lo stesso nome si fondono (datasets concatenati, types sommati)."""
+    graph = load_workspace_graph(graph_workspace)
+
+    assert graph["repos"] == ["dataset-incubator", "eurostat"]
+    # Comune fusa: 1 (DI) + 1 (EU)
+    comune = graph["entities"]["Comune"]
+    assert len(comune["datasets"]) == 2
+    assert comune["types"] == {"municipality_code": 1, "nuts_code": 1}
+    # Gara solo in DI
+    assert len(graph["entities"]["Gara"]["datasets"]) == 1
+    # Bridge da DI preservato
+    assert len(graph["bridges"]) == 1
+
+
+@pytest.mark.contract
+def test_filter_by_key(graph_workspace: Path) -> None:
+    """Filtro per tipo semantico su graph aggregato."""
+    graph = load_workspace_graph(graph_workspace)
+    res = filter_graph(graph, by_key="nuts_code")
+
+    assert list(res["entities"].keys()) == ["Comune"]
+    assert res["summary"]["total_datasets"] == 1
+    assert res["entities"]["Comune"]["datasets"][0]["slug"] == "eurostat_demo_balance_nuts3"
+
+
+@pytest.mark.contract
+def test_filter_by_registry(graph_workspace: Path) -> None:
+    """Filtro per entità."""
+    graph = load_workspace_graph(graph_workspace)
+    res = filter_graph(graph, by_registry="Gara")
+
+    assert list(res["entities"].keys()) == ["Gara"]
+    assert res["summary"]["total_datasets"] == 1
+
+
+@pytest.mark.contract
+def test_filter_by_domain(graph_workspace: Path) -> None:
+    """Filtro per dominio logico → solo bridge pertinenti."""
+    graph = load_workspace_graph(graph_workspace)
+    res = filter_graph(graph, by_domain="appalti")
+
+    assert res["domain"] == "appalti"
+    assert res["count"] == 1  # bridge cig_code → Comune
+
+
+@pytest.mark.contract
+def test_filter_by_domain_unknown(graph_workspace: Path) -> None:
+    """Dominio non riconosciuto → error con domini disponibili."""
+    graph = load_workspace_graph(graph_workspace)
+    res = filter_graph(graph, by_domain="xyz")
+
+    assert "error" in res
+    assert "appalti" in res["error"]
+
+
+@pytest.mark.contract
+def test_domain_keywords_cover_clean_query_contract() -> None:
+    """I domini del graph coprono quelli di clean-query (parità di contratto)."""
+    expected = {"appalti", "enti", "territorio", "giustizia", "scuola", "progetti", "economia"}
+    assert set(DOMAIN_KEYWORDS) == expected

--- a/toolkit/mcp/registry_ops.py
+++ b/toolkit/mcp/registry_ops.py
@@ -13,6 +13,7 @@ from lab_connectors.mcp.errors import ErrorCode
 from toolkit.registry.reader import list_registries as _list_registries
 from toolkit.registry.reader import show_registry as _show_registry
 from toolkit.mcp.errors import ToolkitClientError
+from toolkit.registry.graph import filter_graph, load_workspace_graph
 
 
 def mcp_registry_list() -> dict[str, Any]:
@@ -35,3 +36,23 @@ def mcp_registry_show(
         raise ToolkitClientError(str(exc), code=ErrorCode.PARQUET_NOT_FOUND) from exc
     except Exception as exc:
         raise ToolkitClientError(f"Errore lettura registry: {exc}", code=ErrorCode.UNEXPECTED)
+
+
+def mcp_graph(
+    by_key: str = "",
+    by_dataset: str = "",
+    by_registry: str = "",
+    by_domain: str = "",
+) -> dict[str, Any]:
+    """Grafo aggregato cross-repo: entità + bridge da tutti i registry."""
+    try:
+        graph = load_workspace_graph()
+        return filter_graph(
+            graph,
+            by_key=by_key,
+            by_dataset=by_dataset,
+            by_registry=by_registry,
+            by_domain=by_domain,
+        )
+    except Exception as exc:
+        raise ToolkitClientError(f"Errore lettura graph: {exc}", code=ErrorCode.UNEXPECTED)

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -46,6 +46,7 @@ from .catalog_ops import (
 )
 
 from .registry_ops import (
+    mcp_graph as graph_impl,
     mcp_registry_list as registry_list_impl,
     mcp_registry_show as registry_show_impl,
 )
@@ -375,6 +376,34 @@ def toolkit_registry_list() -> dict[str, Any]:
 )
 def toolkit_registry_show(repo: str, artifact: str, slug: str | None = None) -> dict[str, Any]:
     return guard_timed(registry_show_impl, "toolkit_registry_show", repo, artifact, slug)
+
+
+@mcp.tool(
+    description=(
+        "Mostra la mappa delle relazioni tra dataset del Lab (cross-repo). "
+        "Ogni dataset si collega a un'entità del mondo reale (Comune, Provincia, "
+        "Ente, Gara, ...) tramite un tipo semantico (municipality_code, fiscal_code, ...). "
+        "I bridge collegano entità tra loro (es. CIG → Comune via anac_bandi_gara). "
+        "Aggrega i registry di tutti i repo del workspace (fusion ADR). "
+        "Filtri: by_key (tipo semantico), by_dataset (slug), by_registry (entità), "
+        "by_domain (appalti/enti/territorio/giustizia/scuola/progetti/economia)."
+    ),
+    structured_output=True,
+)
+def toolkit_graph(
+    by_key: str = "",
+    by_dataset: str = "",
+    by_registry: str = "",
+    by_domain: str = "",
+) -> dict[str, Any]:
+    return guard_timed(
+        graph_impl,
+        "toolkit_graph",
+        by_key=by_key,
+        by_dataset=by_dataset,
+        by_registry=by_registry,
+        by_domain=by_domain,
+    )
 
 
 if __name__ == "__main__":

--- a/toolkit/registry/graph.py
+++ b/toolkit/registry/graph.py
@@ -1,0 +1,182 @@
+"""Grafo entità → dataset aggregato cross-repo (fusion ADR).
+
+Aggrega gli artifact ``entities`` dei registry committati nel workspace
+(``load_repo_registry``): nodi = entità del mondo reale (Comune, Provincia,
+Gara, ...), archi = dataset che le descrivono, bridge = relazioni tra entità.
+
+Consumato dal tool MCP ``toolkit_graph`` (speculare al ``dataset_graph`` del
+MCP clean-query, ma cross-repo: clean-query leggeva solo entity_graph.json di
+dataset-incubator).
+
+Merge per nome entity: lo stesso concetto (es. ``Comune``) può comparire in
+più repo — le entry ``datasets`` vengono concatenate e i conteggi ``types``
+sommati. I bridge sono concatenati (dedup).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from toolkit.core.paths import WORKSPACE_ROOT
+from toolkit.registry.reader import load_repo_registry
+
+# Domini logici → tipi semantici (per il filtro by_domain del graph).
+# Portato dal MCP clean-query (dataset_graph) per parità di comportamento.
+DOMAIN_KEYWORDS: dict[str, set[str]] = {
+    "appalti": {"cig_code", "ausa_code", "cpv_code"},
+    "enti": {"fiscal_code", "ipa_code", "siope_code", "miur_code", "ssn_code", "sogei_code"},
+    "territorio": {
+        "municipality_code",
+        "cadastral_code",
+        "municipality_name",
+        "province_code",
+        "region_code",
+        "nuts_code",
+    },
+    "giustizia": {"ricorso_number"},
+    "scuola": {"school_code"},
+    "progetti": {"cup_code"},
+    "economia": {"ateco_code"},
+}
+
+
+def _entity_section(payload: dict[str, Any] | None) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Estrae (entities, bridges) dal payload registry (fusion o legacy)."""
+    if not payload:
+        return {}, []
+    section = payload.get("entities") or {}
+    entities = section.get("entities") or {}
+    bridges = section.get("bridges") or []
+    return entities, bridges
+
+
+def load_workspace_graph(workspace: Path = WORKSPACE_ROOT) -> dict[str, Any]:
+    """Grafo aggregato cross-repo: entità fuse per nome + bridge concatenati.
+
+    Returns:
+        ``{"entities": {name: {...}}, "bridges": [...], "repos": [nomi]}`` —
+        ogni entity ha ``datasets`` (da tutti i repo) e ``types`` sommati.
+    """
+    entities: dict[str, dict[str, Any]] = {}
+    bridges: list[dict[str, Any]] = []
+    repos: list[str] = []
+
+    if not workspace.is_dir():
+        return {"entities": {}, "bridges": [], "repos": []}
+
+    for repo_dir in sorted(p for p in workspace.iterdir() if p.is_dir()):
+        payload, _is_legacy = load_repo_registry(repo_dir)
+        repo_entities, repo_bridges = _entity_section(payload)
+        if not repo_entities and not repo_bridges:
+            continue
+        repos.append(repo_dir.name)
+
+        for name, info in repo_entities.items():
+            if name not in entities:
+                entities[name] = {
+                    "entity": name,
+                    "label": info.get("label", name),
+                    "datasets": [],
+                    "types": {},
+                }
+            entities[name]["datasets"].extend(info.get("datasets", []) or [])
+            for stype, count in (info.get("types") or {}).items():
+                entities[name]["types"][stype] = entities[name]["types"].get(stype, 0) + count
+
+        for bridge in repo_bridges:
+            if bridge not in bridges:
+                bridges.append(bridge)
+
+    for info in entities.values():
+        info["datasets"].sort(key=lambda d: d["slug"])
+
+    return {"entities": entities, "bridges": bridges, "repos": repos}
+
+
+def filter_graph(
+    graph: dict[str, Any],
+    by_key: str = "",
+    by_dataset: str = "",
+    by_registry: str = "",
+    by_domain: str = "",
+) -> dict[str, Any]:
+    """Filtra il grafo aggregato per chiave, dataset, entità o dominio.
+
+    Stesso contratto del ``dataset_graph`` di clean-query.
+
+    Returns:
+        Dict con ``entities`` (filtrate), ``bridges``, ``summary`` e ``tip``.
+        Con ``by_domain`` restituisce ``{"domain", "relations", "count"}``.
+    """
+    entities = graph.get("entities", {})
+    bridges = graph.get("bridges", [])
+
+    # ── Filtra per dominio → solo bridge pertinenti ──
+    if by_domain:
+        keywords = DOMAIN_KEYWORDS.get(by_domain.lower(), set())
+        if not keywords:
+            return {
+                "error": f"Dominio '{by_domain}' non riconosciuto. "
+                f"Disponibili: {', '.join(sorted(DOMAIN_KEYWORDS))}"
+            }
+        filtered_bridges = [b for b in bridges if any(kw in str(b).lower() for kw in keywords)]
+        return {
+            "domain": by_domain,
+            "relations": filtered_bridges,
+            "count": len(filtered_bridges),
+        }
+
+    # ── Filtra per entità (by_registry) ──
+    if by_registry:
+        by_reg_lower = by_registry.lower()
+        matched = {
+            name: info
+            for name, info in entities.items()
+            if by_reg_lower in name.lower() or by_reg_lower in info.get("label", "").lower()
+        }
+        if not matched:
+            return {
+                "error": f"Entità '{by_registry}' non trovata. "
+                f"Disponibili: {sorted(entities.keys())}"
+            }
+        entities = matched
+
+    # ── Filtra per chiave (by_key) e/o dataset (by_dataset) ──
+    if by_key or by_dataset:
+        entities_filtered: dict[str, dict[str, Any]] = {}
+        by_key_lower = by_key.lower()
+        by_ds_lower = by_dataset.lower()
+        for entity_name, entity_info in entities.items():
+            ds_filtered = []
+            for ds in entity_info.get("datasets", []):
+                if by_key and by_key_lower not in ds.get("semantic_type", "").lower():
+                    continue
+                if by_dataset and not (
+                    by_ds_lower in ds["slug"].lower() or by_ds_lower in ds.get("name", "").lower()
+                ):
+                    continue
+                ds_filtered.append(ds)
+            if ds_filtered:
+                filtered_info = dict(entity_info)
+                filtered_info["datasets"] = ds_filtered
+                entities_filtered[entity_name] = filtered_info
+        entities = entities_filtered
+
+    total_datasets = sum(len(e["datasets"]) for e in entities.values())
+
+    return {
+        "entities": entities,
+        "bridges": bridges,
+        "summary": {
+            "total_entities": len(entities),
+            "total_relations": len(bridges),
+            "total_datasets": total_datasets,
+        },
+        "tip": (
+            "Usa by_key='municipality_code' per vedere i dataset con codice ISTAT, "
+            "by_dataset='irpef_comunale' per vedere le entità collegate, "
+            "by_registry='Comune' per esplorare un'entità, "
+            "o by_domain='appalti' per i bridge del dominio appalti."
+        ),
+    }


### PR DESCRIPTION
## Tipo

**feature** — nuovo tool MCP `toolkit_graph`: grafo entità → dataset **cross-repo**, speculare al `dataset_graph` del MCP clean-query ma costruito sulla fusion ADR (registry unico).

## Problema reale

Il graph entità esisteva in due copie: `entity_graph.json` legacy di dataset-incubator (19 entities/28 bridges, letto da clean-query) e la sezione `entities` del registry unico per-repo (fusion). Il toolkit esponeva il graph solo come **dump grezzo per-repo** (`toolkit_registry_show(artifact='entities')`) senza aggregazione né filtri navigabili — e clean-query vedeva **solo DI** (19 entità), non eurostat/dcl-bologna.

## Contratto riusato/sostituito

- **Riusato**: `load_repo_registry` (già il reader canonico della fusion) come fonte per l'aggregazione cross-repo.
- **Portato**: `DOMAIN_KEYWORDS` (appalti/enti/territorio/giustizia/scuola/progetti/economia) dal `dataset_graph` di clean-query, per parità di comportamento.
- **Sostituito (a valle)**: il tool diventa il candidato per rimpiazzare `dataset_graph` di clean-query (che legge solo DI legacy).

## Implementazione

| File | Cosa |
|---|---|
| `toolkit/registry/graph.py` (nuovo) | Dominio: `load_workspace_graph()` (merge entity per nome, types sommati, bridge concatenati) + `filter_graph()` (by_key/by_dataset/by_registry/by_domain) + `DOMAIN_KEYWORDS` |
| `toolkit/mcp/registry_ops.py` | Wrapper `mcp_graph` |
| `toolkit/mcp/server.py` | Registrazione tool `toolkit_graph` |
| `tests/test_registry_graph.py` (nuovo) | 6 test contract |
| `tests/test_mcp_server.py` | Tool list aggiornata |

## Verifica

- Graph completo: **19 entities, 28 bridges, 3 repo aggregati** (DI + eurostat + dcl-bologna)
- Merge cross-repo: "Nazione" = 30 datasets (4 DI + 26 eurostat), "Comune" = 61
- `by_key=nuts_code` → 30 datasets eurostat; `by_domain=territorio` → 27 relations; dominio invalido → error con domini disponibili
- **1320 test verdi**, ruff pulito

## Rischio residuo

- Il graph è derivato dai registry **committati** (stato della migrazione): i 2 dataset eurostat non ancora riallineati (bd_hgnace2, pop_nuts3) mancano finché la CI non completa l'allineamento — non è un bug del tool.
- clean-query continua a leggere `entity_graph.json` legacy finché non migra a `toolkit_graph` (pulizia cross-repo pianificata, build_graph.py già rimosso in DI).

## Follow-up obbligatorio

- **Riavviare il server MCP** per esporre `toolkit_graph`.
- Migrazione clean-query → `toolkit_graph` e rimozione `entity_graph.json` (proiezione legacy) quando clean-query non lo consumerà più.