### PR TITLE
feat(layer): dry_run su mode=sql — EXPLAIN senza eseguire (contratto clean-query)

### DIFF
--- a/tests/test_query_cross_dataset.py
+++ b/tests/test_query_cross_dataset.py
@@ -173,3 +173,68 @@ class TestRawSql:
         # Verifica primo risultato: Lombardia=130, Lazio=50
         assert result["preview"][0]["tot"] == 130
         assert result["preview"][1]["tot"] == 50
+
+
+class _ExplainConn:
+    """Connessione finta per dry_run: execute("EXPLAIN ...") → fetchone piano."""
+
+    def execute(self, sql: str) -> "_ExplainResult":
+        return _ExplainResult()
+
+    def __enter__(self) -> "_ExplainConn":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
+class _ExplainResult:
+    def fetchone(self) -> tuple[str, str]:
+        return ("physical_plan", "┌──────────┐\n│  PROJECT │\n└──────────┘")
+
+
+def _mock_dry_run(monkeypatch: MonkeyPatch) -> None:
+    """Mocka duckdb.connect con EXPLAIN e _resolve_datasets."""
+    import toolkit.domain.layer as dl
+
+    def fake_resolve(datasets: list[str], *a, **kw) -> dict[str, str]:
+        return {s: f"/tmp/{s}.parquet" for s in datasets}
+
+    monkeypatch.setattr(dl, "_resolve_datasets", fake_resolve)
+    monkeypatch.setattr(duckdb, "connect", lambda *a, **kw: _ExplainConn())
+
+
+class TestDryRun:
+    """dry_run su mode=sql: EXPLAIN senza eseguire (contratto clean-query)."""
+
+    def test_valid_sql_explains(self, monkeypatch: MonkeyPatch) -> None:
+        _mock_dry_run(monkeypatch)
+        r = layer_query(
+            datasets=["ds_a"],
+            layer="clean",
+            mode="sql",
+            sql="SELECT 1",
+            dry_run=True,
+        )
+        assert r["valid"] is True
+        assert "PROJECT" in (r.get("plan") or "")
+        assert r["dry_run"] is True
+
+    def test_invalid_scope_returns_error_payload(self, monkeypatch: MonkeyPatch) -> None:
+        """Scope error nel dry_run → valid:False nel payload (parità clean-query)."""
+        _mock_dry_run(monkeypatch)
+        r = layer_query(
+            datasets=["ds_a"],
+            layer="clean",
+            mode="sql",
+            sql="SELECT * FROM unknown_table",
+            dry_run=True,
+        )
+        assert r["valid"] is False
+        assert "non consentita" in (r.get("error") or "")
+
+    def test_without_dry_run_still_raises(self, monkeypatch: MonkeyPatch) -> None:
+        """Senza dry_run lo scope error continua a sollevare (invariato)."""
+        _mock_all(monkeypatch)
+        with pytest.raises(ValueError, match="non consentita"):
+            layer_query(datasets=["ds_a"], mode="sql", sql="SELECT * FROM unknown_table")

--- a/toolkit/domain/layer.py
+++ b/toolkit/domain/layer.py
@@ -390,6 +390,7 @@ def layer_sql(
     sql: str | None = None,
     mart_index: int = 0,
     table: str | None = None,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
     """Esegue SQL arbitrario su uno o piu' dataset.
 
@@ -406,9 +407,12 @@ def layer_sql(
         sql: Query SQL. I dati sono disponibili come tabella ``data``
             (singolo dataset) o CTE col nome slug (multi dataset).
         mart_index: Indice tabella mart (solo pipeline mode).
+        dry_run: Se True, valida lo scope SQL e fa EXPLAIN senza eseguire
+            (stesso contratto del dry_run di clean-query).
 
     Returns:
-        Risultato della query SQL.
+        Risultato della query SQL, o ``{"valid", "plan"/"error"}`` con
+        ``dry_run=True``.
 
     Raises:
         ValueError: se parametri invalidi o SQL non valido.
@@ -428,7 +432,12 @@ def layer_sql(
         resolved = _resolve_datasets(datasets, layer=layer, year=year, table=table)
         # Scope validation: solo i CTE dichiarati
         allowed = set(resolved.keys())
-        validated_sql = _validate_sql_scope(sql, allowed)
+        try:
+            validated_sql = _validate_sql_scope(sql, allowed)
+        except ValueError as exc:
+            if dry_run:
+                return {"valid": False, "error": str(exc), "dry_run": True}
+            raise
 
         # Costruisci CTE per ogni dataset
         cte_defs = []
@@ -436,6 +445,20 @@ def layer_sql(
             cte_defs.append(f"{slug} AS (SELECT * FROM read_parquet(['{url}']))")
         cte = ", ".join(cte_defs)
         wrapped_sql = f"WITH {cte} {validated_sql}"
+
+        # ── Dry run: EXPLAIN senza eseguire (contratto clean-query) ──
+        if dry_run:
+            try:
+                with safe_connect() as conn:
+                    plan = conn.execute(f"EXPLAIN {wrapped_sql}").fetchone()
+                plan_text = plan[1] if plan and len(plan) > 1 else (plan[0] if plan else None)
+                return {
+                    "valid": True,
+                    "plan": str(plan_text)[:300] if plan_text else None,
+                    "dry_run": True,
+                }
+            except Exception as exc:
+                return {"valid": False, "error": str(exc)[:300], "dry_run": True}
 
         with safe_connect() as conn:
             result = conn.execute(wrapped_sql).fetchall()
@@ -544,6 +567,7 @@ def layer_query(
     sql: str | None = None,
     mart_index: int = 0,
     table: str | None = None,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
     """Query unificata su layer RAW/CLEAN/MART.
 
@@ -556,6 +580,7 @@ def layer_query(
         limit: Max righe in preview/sql.
         sql: Query SQL per mode=sql.
         mart_index: Indice tabella mart (solo pipeline mode).
+        dry_run: Se True e mode=sql, valida lo scope + EXPLAIN senza eseguire.
 
     Raises:
         ValueError: se layer/mode non validi.
@@ -596,6 +621,7 @@ def layer_query(
             limit=limit,
             sql=sql,
             table=table,
+            dry_run=dry_run,
         )
 
     if safe_mode == "profile" and safe_layer != "raw":

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -136,6 +136,9 @@ def toolkit_preview_url(
     "mode=sql funziona su tutti i layer (raw->CSV, clean/mart->parquet). "
     "Per layer=mart, table specifica la tabella (es. 'mart_top_sa'). "
     "Catalog mode (datasets) supporta solo mode='sql'. "
+    "Con dry_run=True (mode=sql) valida lo scope SQL e fa EXPLAIN senza eseguire: "
+    "ritorna {'valid': True, 'plan': ...} o {'valid': False, 'error': ...} "
+    "— utile per provare la query prima di eseguirla. "
     "Esempi: mode=sql, datasets=['anac_bandi_gara', 'popolazione_istat']",
     structured_output=True,
 )
@@ -149,6 +152,7 @@ def toolkit_layer(
     sql: str | None = None,
     mart_index: int = 0,
     table: str | None = None,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
     return guard_timed(
         layer_query_impl,
@@ -162,6 +166,7 @@ def toolkit_layer(
         sql=sql,
         mart_index=mart_index,
         table=table,
+        dry_run=dry_run,
     )
 
 


### PR DESCRIPTION
## Tipo

**feature** — parametro `dry_run` su `toolkit_layer mode=sql`: valida lo scope SQL e fa `EXPLAIN` senza eseguire. Ultimo gap di parità con clean-query per il rimpiazzo pulito.

## Problema reale

Un agente che scrive SQL su dataset grossi (o cross-dataset) non ha modo di validare la query prima di eseguirla: una query sbagliata costa esecuzione lenta, timeout o risultato spazzatura. clean-query ha `query(dry_run=True)` (validazione + EXPLAIN); il toolkit non lo esponeva — era l'ultimo pezzo mancante per rimpiazzare clean-query col toolkit MCP.

## Contratto riusato/sostituito

- **Riusato**: `_validate_sql_scope` già esistente in `toolkit/domain/layer.py` (scope validation, blocco DDL/DML/read_parquet).
- **Aggiunto**: branch EXPLAIN in catalog mode, stesso contratto di clean-query (`valid`/`plan`/`error`).

## Implementazione

| File | Cosa |
|---|---|
| `toolkit/domain/layer.py` | Parametro `dry_run` in `layer_sql` + `layer_query`; branch EXPLAIN; scope error nel payload quando dry_run (parità clean-query), raise invariato senza dry_run |
| `toolkit/mcp/server.py` | Parametro `dry_run` sul tool + doc aggiornata |
| `tests/test_query_cross_dataset.py` | 3 test contract (explain valido, scope error nel payload, senza dry_run invariato) |

## Verifica (8 casi live)

- Query valida → `valid: True` + piano; la stessa query eseguita ritorna dati reali
- Colonna inesistente → `valid: False` + Binder Error
- Tabella fuori scope → `valid: False` + "Riferimento a tabella non consentita"
- Mart con `table`, cross-dataset join → `valid: True` + piano
- Flusso agente completo: dry_run errato → fix → dry_run valido → esecuzione reale ✅
- `dry_run=False` non rompe i mode esistenti
- MCP: `dry_run` nello schema del tool

**1323 test verdi**, ruff pulito.

## Rischio residuo

- Il validatore scope pre-esistente può dare falsi positivi su SQL malformato (es. `SELECT FROM WHERE ...` → "Riferimento a tabella non consentita: 'WHERE'") — comportamento già esistente, il dry_run restituisce comunque `valid: False` correttamente.

## Follow-up

- **Riavvio MCP** per esporre il parametro.
- Con questo, il toolkit MCP copre tutti i flussi di clean-query (find, overview, query con dry_run, graph, registry) — resta la migrazione di clean-query in DI.