### PR TITLE
fix(mcp): wrapper aggregate_ops.layer_query propaga dry_run al backend

### DIFF
--- a/tests/test_query_cross_dataset.py
+++ b/tests/test_query_cross_dataset.py
@@ -238,3 +238,32 @@ class TestDryRun:
         _mock_all(monkeypatch)
         with pytest.raises(ValueError, match="non consentita"):
             layer_query(datasets=["ds_a"], mode="sql", sql="SELECT * FROM unknown_table")
+
+
+class TestMCPWrapperDryRun:
+    """Regressione: il wrapper MCP aggregate_ops.layer_query propaga dry_run.
+
+    La PR #457 ha aggiunto dry_run al backend (domain.layer) e al tool MCP
+    (server.py) ma non al wrapper intermedio (aggregate_ops.layer_query) →
+    TypeError: layer_query() got an unexpected keyword argument 'dry_run'
+    sul percorso reale del tool.
+    """
+
+    def test_wrapper_propagates_dry_run(self, monkeypatch: MonkeyPatch) -> None:
+        """Il wrapper MCP accetta dry_run e lo passa al backend."""
+        from toolkit.mcp.aggregate_ops import layer_query as mcp_layer_query
+
+        received: dict[str, object] = {}
+
+        def fake_backend(**kwargs: object) -> dict[str, object]:
+            received.update(kwargs)
+            return {"valid": True, "plan": "PLAN", "dry_run": True}
+
+        monkeypatch.setattr("toolkit.mcp.aggregate_ops._layer_query_core", fake_backend)
+
+        res = mcp_layer_query(
+            datasets=["ds_a"], layer="clean", mode="sql", sql="SELECT 1", dry_run=True
+        )
+
+        assert res["valid"] is True
+        assert received.get("dry_run") is True

--- a/toolkit/mcp/aggregate_ops.py
+++ b/toolkit/mcp/aggregate_ops.py
@@ -52,6 +52,7 @@ def layer_query(
     sql: str | None = None,
     mart_index: int = 0,
     table: str | None = None,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
     """Query unificata su layer RAW/CLEAN/MART.
 
@@ -71,6 +72,7 @@ def layer_query(
         sql: Query SQL per mode=sql.
         mart_index: Indice tabella mart (solo pipeline mode).
         table: Nome tabella mart (es ``"mart_top_sa"``).
+        dry_run: Se True (mode=sql), valida lo scope SQL e fa EXPLAIN senza eseguire.
 
     Raises:
         ToolkitClientError: se parametri invalidi o file non trovato.
@@ -97,6 +99,7 @@ def layer_query(
             sql=sql,
             mart_index=mart_index,
             table=table,
+            dry_run=dry_run,
         )
     except ValueError as exc:
         raise ToolkitClientError(str(exc), code=ErrorCode.INVALID_PARAMS) from exc


### PR DESCRIPTION
## Tipo

**fix** (hotfix su regressione della #457) — il wrapper MCP `aggregate_ops.layer_query` non propagava `dry_run` al backend.

## Problema reale

La PR #457 ha aggiunto `dry_run` in **due punti** della catena MCP ma non nel terzo:
- ✅ backend `toolkit/domain/layer.py` (`layer_sql` + `layer_query`)
- ✅ tool `toolkit/mcp/server.py` (`toolkit_layer` passa `dry_run=dry_run`)
- ❌ **wrapper intermedio `toolkit/mcp/aggregate_ops.py`** (`layer_query` — che è `layer_query_impl` usato dal tool)

Risultato: `toolkit_layer` con `dry_run=True` crashava sul percorso reale con:
```
TypeError: layer_query() got an unexpected keyword argument 'dry_run'
```
Verificato simulando il codice di main pulito (stash del wrapper).

## Contratto riusato/sostituito

- **Riusato**: `_layer_query_core` (= `domain.layer.layer_query`, già con dry_run dalla #457).
- **Fix**: parametro `dry_run` nella firma del wrapper + propagazione al core.

## Implementazione

| File | Cosa |
|---|---|
| `toolkit/mcp/aggregate_ops.py` | Firma `dry_run: bool = False` + propagazione a `_layer_query_core` (+ docstring) |
| `tests/test_query_cross_dataset.py` | `TestMCPWrapperDryRun.test_wrapper_propagates_dry_run` (regression: il wrapper accetta e propaga dry_run) |

## Verifica

- **Test di regressione**: fallisce senza fix (TypeError), passa con fix ✅
- Percorso end-to-end via wrapper MCP: dry_run valido → `valid: True` + piano; colonna inesistente → `valid: False` + Binder Error
- **1324 test verdi**, ruff pulito

## Rischio residuo

Nessuno — fix minimo (2 righe + docstring) sul punto intermedio mancante.

## Follow-up

- **Riavvio MCP** per caricare il fix.
- Questo conferma che la verifica end-to-end va fatta sul percorso MCP reale (wrapper), non solo sul dominio diretto.