### PR TITLE
fix(raw): _format_args sostituisce {year} anche su path normalizzati Path

### DIFF
--- a/tests/test_raw_run_format_args.py
+++ b/tests/test_raw_run_format_args.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from toolkit.raw._fetch_utils import _format_args
@@ -15,6 +17,22 @@ class TestFormatArgs:
         args = {"url": "https://example.com/data{year}.csv"}
         result = _format_args(args, 2023)
         assert result["url"] == "https://example.com/data2023.csv"
+
+    def test_format_args_path_year_substitution(self) -> None:
+        """local_file path normalized to Path still substitutes {year}.
+
+        Regression: _normalize_paths converts args.path to a PosixPath; the
+        {year} placeholder must be replaced on Path values too.
+        """
+        args = {"path": Path("/repo/_local/seed/dati/{year}/ETA_{year}.CSV")}
+        result = _format_args(args, 2024)
+        assert result["path"] == Path("/repo/_local/seed/dati/2024/ETA_2024.CSV")
+
+    def test_format_args_path_without_year_untouched(self) -> None:
+        """Path without {year} is returned unchanged (same type)."""
+        args = {"path": Path("/repo/anagrafica/_data/CompartoContratto.CSV")}
+        result = _format_args(args, 2024)
+        assert result["path"] == Path("/repo/anagrafica/_data/CompartoContratto.CSV")
 
     def test_format_args_no_url_suffix_by_year(self) -> None:
         """Without url_suffix_by_year, output is unchanged."""

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -10,6 +10,7 @@ import uuid
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from toolkit.core.exceptions import DownloadError
@@ -22,7 +23,7 @@ from toolkit.core.registry import registry
 
 
 def _format_args(args: dict, year: int) -> dict:
-    formatted = {}
+    formatted: dict[str, Any] = {}
     for k, v in (args or {}).items():
         if isinstance(v, Path):
             # _normalize_paths converte i path relativi in PosixPath: il
@@ -43,7 +44,9 @@ def _format_args(args: dict, year: int) -> dict:
         if isinstance(suffix_map, dict):
             suffix = suffix_map.get(year, "")
             if isinstance(suffix, str):
-                formatted["url"] = formatted["url"] + suffix
+                # url può essere Path (local_file): normalizza a str per il suffix
+                base_url = str(formatted["url"])
+                formatted["url"] = base_url + suffix
     # Remove url_suffix_by_year from output — internal config, not for consumers
     formatted.pop("url_suffix_by_year", None)
     return formatted

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -24,7 +24,15 @@ from toolkit.core.registry import registry
 def _format_args(args: dict, year: int) -> dict:
     formatted = {}
     for k, v in (args or {}).items():
-        if isinstance(v, str) and "{year}" in v:
+        if isinstance(v, Path):
+            # _normalize_paths converte i path relativi in PosixPath: il
+            # placeholder {year} va sostituito anche su valori Path (es.
+            # raw.sources[].args.path per local_file).
+            if "{year}" in str(v):
+                formatted[k] = Path(str(v).replace("{year}", str(year)))
+            else:
+                formatted[k] = v
+        elif isinstance(v, str) and "{year}" in v:
             # replace instead of str.format to avoid conflicts with SPARQL {} braces
             formatted[k] = v.replace("{year}", str(year))
         else:


### PR DESCRIPTION
## Tipo

**root fix** — `_format_args` non sostituiva `{year}` sui path normalizzati a `PosixPath`.

## Problema reale

`_normalize_paths` converte `raw.sources[].args.path` (tipo `local_file`) in `PosixPath`. `_format_args` gestiva la sostituzione di `{year}` solo su valori `str` — i path `Path` con placeholder restavano non sostituiti, facendo fallire i seed locali con `{year}` nel percorso.

## Contratto riusato/sostituito

- **Riusato**: la logica `{year}` → `str(year)` già esistente per le stringhe (replace, non `str.format`, per non confliggere con `{}` di SPARQL).
- **Sostituito**: il branch `if isinstance(v, str)` ora gestisce anche `Path`.

## Implementazione

| File | Cosa |
|---|---|
| `toolkit/raw/_fetch_utils.py` | Branch `Path` in `_format_args`: sostituisce `{year}` su `str(v)`, ri-costruisce `Path`; path senza placeholder restituito invariato (stesso tipo) |
| `tests/test_raw_run_format_args.py` | 2 test: path con `{year}` sostituito, path senza `{year}` invariato |

## Verifica

- 11 test verdi (file), 1329+ totali, ruff pulito.
- Comportamento: `Path("/repo/_local/seed/dati/{year}/ETA_{year}.CSV")` → `Path(".../dati/2024/ETA_2024.CSV")`; path senza placeholder → `Path` invariato.

## Rischio residuo

Nessuno — fix mirato a un tipo di valore (`Path`) del branch esistente.

## Follow-up

Nessuno obbligatorio.