### PR TITLE
fix(registry): mart multi-anno pubblicati flat (issue #463)

### DIFF
--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -581,3 +581,54 @@ class TestRepoDatasetDirs:
         (repo / "README.md").write_text("x", encoding="utf-8")
 
         assert repo_dataset_dirs(repo) == ()
+
+
+class TestMartMultiYearLocation:
+    """Mart con years esplicite → location flat; per-anno → year.
+
+    Regressione issue #463: il runner scrive i mart multi-anno flat
+    (data/mart/{dataset}/{table}.parquet), ma il builder li pubblicava con
+    path anno inesistente (year=max). Ora tabella con years → flat.
+    """
+
+    @pytest.mark.contract
+    def test_multi_year_mart_flat(self, tmp_path: Path) -> None:
+        """Tabella con years esplicite → path flat (no dir anno)."""
+        from toolkit.registry.builders import build_mart_catalog
+        from toolkit.registry.layout import RepoLayout
+        from toolkit.registry.paths import PathContract
+
+        ds_dir = tmp_path / "datasets" / "my-ds"
+        ds_dir.mkdir(parents=True)
+        (ds_dir / "dataset.yml").write_text(
+            "root: '../../out'\n"
+            "dataset:\n"
+            "  name: 'my_dataset'\n"
+            "  source_id: 'src'\n"
+            "  years: [2024, 2025]\n"
+            "mart:\n"
+            "  tables:\n"
+            "    - name: 'mart_trend'\n"
+            "      sql: 'sql/mart_trend.sql'\n"
+            "      years: [2024, 2025]\n"
+            "    - name: 'mart_sintesi'\n"
+            "      sql: 'sql/mart_sintesi.sql'\n",
+            encoding="utf-8",
+        )
+
+        layout = RepoLayout(
+            repo_root=tmp_path, dataset_dirs=("datasets",), source_repo="dataciviclab/test"
+        )
+        contract = PathContract(prefix="test", clean_layout="year", mart_layout="year")
+        catalog, errors = build_mart_catalog(layout, path_contract=contract)
+
+        assert not errors["derive"], errors["derive"]
+        by_table = {m["table"]: m for m in catalog["marts"]}
+        # multi-anno → flat
+        assert by_table["mart_trend"]["location"]["path"] == (
+            "gs://dataciviclab-mart/test/my_dataset/mart_trend.parquet"
+        )
+        # per-anno → year
+        assert by_table["mart_sintesi"]["location"]["path"] == (
+            "gs://dataciviclab-mart/test/my_dataset/2025/mart_sintesi.parquet"
+        )

--- a/toolkit/registry/builders.py
+++ b/toolkit/registry/builders.py
@@ -256,6 +256,15 @@ def build_mart_catalog(
                 entry["min_rows"] = rule["min_rows"]
             if runs_cache[manifest.slug]:
                 entry["run"] = runs_cache[manifest.slug]
+            # Tabella con years esplicite = multi-anno: il runner la scrive
+            # flat (data/mart/{dataset}/{table}.parquet, no dir anno) → la
+            # location pubblicata deve essere flat. Tabella per-anno → year.
+            table_years = table.get("years")
+            if table_years:
+                # Flat: stessa struttura del runner multi-anno.
+                entry["location"] = contract.mart_location(manifest.slug, name, year=None)
+                marts.append(entry)
+                continue
             year = max(manifest.years, default=None)
             if contract.mart_layout == "year" and year is None:
                 derive_errors.append(

--- a/toolkit/registry/layout.py
+++ b/toolkit/registry/layout.py
@@ -161,7 +161,17 @@ def load_manifest(yml_path: Path) -> DatasetManifest | None:
     except Exception:
         description = ""
 
-    tables = tuple({"name": t.name, "sql": t.sql} for t in cfg.mart.tables if t.name)
+    # years esplicite: tabella multi-anno → scritta flat dal runner (no
+    # dir anno); il builder le pubblica flat. years assente = per-anno.
+    tables = tuple(
+        {
+            "name": t.name,
+            "sql": t.sql,
+            **({"years": t.years} if t.years else {}),
+        }
+        for t in cfg.mart.tables
+        if t.name
+    )
     rules: dict[str, dict[str, Any]] = {}
     validate = cfg.mart.validate
     if validate is not None and validate.table_rules:

--- a/toolkit/registry/paths.py
+++ b/toolkit/registry/paths.py
@@ -64,12 +64,15 @@ class PathContract:
     # ── Mart ───────────────────────────────────────────────────────────────
 
     def mart_parquet_url(self, dataset: str, table: str, year: int | None = None) -> str:
-        """URL gs:// del parquet mart per dataset+tabella."""
+        """URL gs:// del parquet mart per dataset+tabella.
+
+        ``year=None`` = mart multi-anno (years esplicite nel config): il
+        runner lo scrive flat ``{dataset}/{table}.parquet`` (nessuna dir
+        anno) → anche con ``mart_layout="year"`` l'URL è flat.
+        """
         base = self._prefixed(MART_BUCKET)
-        if self.mart_layout == "flat":
+        if self.mart_layout == "flat" or year is None:
             return f"{base}/{dataset}/{table}.parquet"
-        if year is None:
-            raise ValueError("mart_layout='year' richiede year per l'URL mart")
         return f"{base}/{dataset}/{year}/{table}.parquet"
 
     def mart_location(self, dataset: str, table: str, year: int | None = None) -> dict[str, Any]:


### PR DESCRIPTION
## Tipo

**root fix** — chiusura issue #463: i mart multi-anno venivano pubblicati nel registry con path anno inesistente.

## Problema reale

Incoerenza tra 3 moduli:
1. **Runner** (`mart/run.py:115,179`): mart con `years` esplicite → scritti **flat** (`data/mart/{dataset}/{table}.parquet`, no dir anno)
2. **Sync GCS**: copia la struttura flat → `gs://.../{slug}/{table}.parquet`
3. **Builder** (`registry/builders.py:259`): location con `year = max(manifest.years)` → `gs://.../{slug}/{year}/{table}.parquet` — **path inesistente**

Evidenza in produzione: open-conto-annuale pubblica 14 `mart_trend` con path `.../anzianita/2024/mart_trend.parquet` ma il file reale sta in `.../anzianita/mart_trend.parquet`.

## Causa root

`load_manifest` scartava le `years` esplicite delle mart tables (`{name, sql}` soltanto) → il builder non poteva distinguere multi-anno da per-anno.

## Contratto riusato/sostituito

- **Riusato**: `MartTableConfig.years` (config model, già presente); il comportamento del runner (`t.get("years")` presenza = multi-anno).
- **Sostituito**: `PathContract.mart_parquet_url` con `year=None` → flat (era `ValueError` con `mart_layout="year"`).

## Implementazione (opzione A — builder)

| File | Cosa |
|---|---|
| `toolkit/registry/layout.py` | `load_manifest` include `years` esplicite in `mart_tables` |
| `toolkit/registry/builders.py` | Tabella con years → location flat (`year=None`); per-anno resta year |
| `toolkit/registry/paths.py` | `mart_parquet_url(year=None)` → flat anche con `mart_layout="year"` |
| `tests/test_registry_builder.py` | +1 contract: mart multi-anno flat, per-anno year |

## Verifica

- **Evidenza reale** (open-conto-annuale anzianita, layout year):
  - `mart_trend` (years [2020..2024]) → `gs://.../anzianita/mart_trend.parquet` **flat** ✅
  - `mart_sintesi` (no years) → `gs://.../anzianita/2024/mart_sintesi.parquet` **year** ✅
- Test protegge: fallisce senza fix (path anno), passa con fix
- **1346 test verdi**, mypy + ruff puliti

## Rischio residuo

- I registry già committati con path anno errato verranno corretti al prossimo aggiornamento post-merge (il file GCS flat esiste già, cambia solo il path dichiarato).
- Nessuna rottura contratti: fix additivo (flat solo per mart con years esplicite).

## Follow-up

Nessuno obbligatorio. Closes #463.