### PR TITLE
fix(registry): clean_catalog preserva il run storico dall'existing + rimuove check-gcs

### DIFF
--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -446,6 +446,54 @@ class TestSignalsExisting:
         assert sig["run"]["run_id"] == "20260101T000000Z_abc123"  # run locale, non OLD
 
 
+class TestCleanCatalogExistingRun:
+    """existing: preserva il blocco run quando il run locale manca (CI)."""
+
+    @pytest.mark.contract
+    def test_preserves_run_from_existing(self, tmp_path: Path) -> None:
+        """CI: nessun run record locale → il run viene dall'entry editoriale."""
+        from toolkit.registry.builders import build_clean_catalog
+
+        layout = _make_repo(tmp_path, with_run=False)
+        existing = {
+            "datasets": [
+                {
+                    "slug": "my_dataset",
+                    "name": "My Dataset",
+                    "description": "desc",
+                    "period": {"start": 2024, "end": 2025},
+                    "columns": [],
+                    "location": {"type": "gcs", "path": "gs://x"},
+                    "run": {"run_id": "20260101T000000Z_abc123", "year": 2025, "status": "SUCCESS"},
+                }
+            ]
+        }
+        catalog, errors = build_clean_catalog(layout, existing=existing)
+        assert not errors["derive"], errors["derive"]
+        ds = next(d for d in catalog["datasets"] if d["slug"] == "my_dataset")
+        assert ds["run"]["run_id"] == "20260101T000000Z_abc123"  # run preservato
+
+    @pytest.mark.contract
+    def test_local_run_wins_over_existing(self, tmp_path: Path) -> None:
+        """Run locale presente → vince su existing (non lo sovrascrive)."""
+        from toolkit.registry.builders import build_clean_catalog
+
+        layout = _make_repo(tmp_path, with_run=True)
+        existing = {
+            "datasets": [
+                {
+                    "slug": "my_dataset",
+                    "columns": [],
+                    "location": {"type": "gcs", "path": "gs://x"},
+                    "run": {"run_id": "OLD_run", "year": 2025, "status": "FAILED"},
+                }
+            ]
+        }
+        catalog, _errors = build_clean_catalog(layout, existing=existing)
+        ds = next(d for d in catalog["datasets"] if d["slug"] == "my_dataset")
+        assert ds["run"]["run_id"] == "20260101T000000Z_abc123"  # run locale, non OLD
+
+
 class TestEntityGraph:
     """build_entity_graph: entità + bridge dal clean_catalog (5° artifact)."""
 

--- a/toolkit/registry/builders.py
+++ b/toolkit/registry/builders.py
@@ -12,8 +12,6 @@ run_state, parquet_schema) — qui solo proiezione e arricchimento di catalogo.
 Derive-mode:
 - ``local`` (default): schemi e anni dai parquet locali e dai run records.
   Nessuna lettura GCS.
-- ``check-gcs``: come local, più verifica di presenza dei parquet pubblici
-  (object_exists) per segnalare gli URL non risolti.
 """
 
 from __future__ import annotations
@@ -60,8 +58,6 @@ def _mart_ok(manifest: DatasetManifest) -> bool:
 def build_clean_catalog(
     layout: RepoLayout,
     existing: dict[str, Any] | None = None,
-    derive_mode: str = "local",
-    check_gcs: bool = False,
     slug: str | None = None,
     semantic_types_path: Path | None = None,
     path_contract: PathContract | None = None,
@@ -72,8 +68,6 @@ def build_clean_catalog(
         layout: Struttura del repo (dataset_dirs, source_repo).
         existing: Catalogo precedente (metadata editoriali preservati:
             name/description/source/stage umani, role/semantic_type colonne).
-        derive_mode: ``"local"`` (default) o ``"check-gcs"``.
-        check_gcs: alias per derive_mode="check-gcs" (compat coi vecchi flag).
         slug: Limita a un singolo slug (per test e debug).
         semantic_types_path: Path a semantic_types.yaml (opzionale).
         path_contract: Contratto GCS (default: layout DI, year).
@@ -84,8 +78,6 @@ def build_clean_catalog(
         sono escluse e segnalate. Gli errori validation indicano un artifact
         non conforme allo schema.
     """
-    if derive_mode == "check-gcs" or check_gcs:
-        derive_mode = "check-gcs"
     contract = path_contract or PathContract()
     alias_map = load_semantic_types(semantic_types_path)
 
@@ -182,32 +174,8 @@ def build_clean_catalog(
         "datasets": sorted(datasets, key=lambda d: d["slug"]),
     }
 
-    if derive_mode == "check-gcs":
-        derive_errors.extend(_check_gcs_locations(catalog, contract))
-
     # Validazione: sul registry completo (registry.schema.json), non per sezione.
     return catalog, {"derive": derive_errors, "validation": []}
-
-
-def _check_gcs_locations(catalog: dict[str, Any], contract: PathContract) -> list[str]:
-    """Verifica che le location gs:// risolvano ad almeno un parquet pubblico."""
-    from lab_connectors.gcs import object_exists
-    from lab_connectors.gcs.paths import parse_gs_url
-
-    errors: list[str] = []
-    for ds in catalog.get("datasets", []):
-        loc = ds.get("location") or {}
-        path = loc.get("path", "")
-        if not path.startswith("gs://"):
-            continue
-        bucket, key = parse_gs_url(path)
-        if "*" in key:
-            prefix = key.split("*")[0].rstrip("/") + "/"
-            if not object_exists(bucket, prefix + "pipeline_run.json"):
-                errors.append(f"{ds['slug']}: nessun pipeline_run.json pubblicato in {prefix}")
-        elif not object_exists(bucket, key):
-            errors.append(f"{ds['slug']}: parquet non trovato su GCS ({path})")
-    return errors
 
 
 # ---------------------------------------------------------------------------
@@ -483,7 +451,6 @@ def build_codelists(
 def build_registry(
     layout: RepoLayout,
     *,
-    derive_mode: str = "local",
     path_contract: PathContract | None = None,
     existing_catalog: dict[str, Any] | None = None,
     existing_signals: dict[str, Any] | None = None,
@@ -507,7 +474,6 @@ def build_registry(
     catalog, cc_errors = build_clean_catalog(
         layout,
         existing=existing_catalog,
-        derive_mode=derive_mode,
         semantic_types_path=semantic_types_path,
         path_contract=path_contract,
         slug=slug,

--- a/toolkit/registry/builders.py
+++ b/toolkit/registry/builders.py
@@ -152,10 +152,15 @@ def build_clean_catalog(
                 f"{manifest.slug}__{t.get('name')}" for t in manifest.mart_tables if t.get("name")
             ]
 
-        # Blocco run (ultimo run record del toolkit)
+        # Blocco run (ultimo run record del toolkit). Se il run record locale
+        # manca (CI post-merge senza parquet/run per i dataset non rieseguiti),
+        # preserva il run storico dall'entry editoriale — stesso pattern di
+        # build_signals (existing_signals).
         run_rec = latest_run_record(str(manifest.yml_path))
         if run_block(run_rec):
             entry["run"] = run_block(run_rec)
+        elif old and old.get("run"):
+            entry["run"] = old["run"]
 
         datasets.append(entry)
 


### PR DESCRIPTION
## Sintesi

Due modifiche al registry builder condiviso:

1. **Fix bug reale**: `build_clean_catalog` ora preserva il blocco `run` dall'entry editoriale (`existing`) quando il run record locale manca — in CI post-merge i dataset non rieseguiti non hanno run locali, e il run spariva dal registry a ogni rigenerazione.
2. **Drop check-gcs**: segnale informativo non bloccante (derive=warning), nessun consumer lo usa, DI lo droppa per la migrazione a `gsutil rsync`.

## Contesto collegato

- Bug emerso dal `workflow_dispatch` su `comuni-master` (DI): il diff della draft PR post-merge mostrava i run di `ade_cinque_per_mille` e altri sparire da `registry/registry.json`
- `build_signals` aveva già il fallback (`existing_signals`); `build_clean_catalog` no — solo le entry senza parquet erano preservate
- DI: migrazione push GCS a `gsutil rsync` (PR in arrivo) → il check-gcs diventa inutile

## Cosa cambia

**`toolkit/registry/builders.py`:**
- `build_clean_catalog`: se il run record locale manca (`latest_run_record` vuoto), il blocco `run` viene preservato dall'entry editoriale (`old["run"]`) — run locale vince sempre
- Rimosso `derive_mode="check-gcs"` + flag `check_gcs` da `build_clean_catalog`/`build_registry`
- Rimosso `_check_gcs_locations` (e dipendenza da `list_objects`/`object_exists`)

**`tests/test_registry_builder.py`:**
- `TestCleanCatalogExistingRun` (+2): run preservato da existing senza run locale; run locale vince su existing
- Rimossi i test `TestCheckGcsLocations` (codice rimosso)

## Impatto

- [x] Modifica API pubblica del toolkit (`build_clean_catalog`, `build_registry`): rimosso `derive_mode`/`check_gcs` — nessun consumer esterno li usa (verificato: solo il wrapper DI, che sta migrando)
- [ ] Modifica schema/contratto parquet
- [ ] Modifica CLI

> **Backward-compat**: il drop di `derive_mode` è sicuro — nessun consumer attivo lo passa (DI è l'unico e sta droppando il check-gcs). Il fix run è puramente additivo (fallback).

## Verifica

```bash
python -m pytest tests/test_registry_builder.py -q   # 26 passed
ruff check toolkit/registry/builders.py               # clean
mypy toolkit/registry/builders.py                     # ok
```

- [x] `pytest` 26 verdi, `ruff`/`mypy` puliti
- [x] Simulazione CI: rigenerazione registry con existing da main → **54 run preservati, 0 persi**
- [x] Perimetro stretto: builder registry, nessun tocco ad altri moduli

## Note / rischi

- Le proiezioni legacy (clean_catalog/pipeline_signals separati) restano per i consumer non migrati; la rimozione è un task separato che NON tocca `build_clean_catalog`/`build_signals` (il cuore di registry.json).
