### PR TITLE
refactor(registry): fallback run centralizzato in _merge_existing_runs (build_registry)

### DIFF
--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -403,95 +403,69 @@ def test_codelists_empty_without_dir(tmp_path: Path) -> None:
     assert payload["codelists"] == {}
 
 
-class TestSignalsExisting:
-    """existing_signals: preserva i run storici quando il run locale manca."""
+class TestRegistryExistingRun:
+    """build_registry preserva i run storici da existing quando il run locale manca (CI).
 
-    @pytest.mark.contract
-    def test_preserves_run_from_existing_signals(self, tmp_path: Path) -> None:
-        """CI: nessun run record locale → il run viene dal signals committato."""
-        layout = _make_repo(tmp_path, with_run=False)
-        existing = {
-            "schema_version": "1",
-            "signals": [
-                {
-                    "id": "my_dataset",
-                    "status": "ok",
-                    "run": {"run_id": "20260101T000000Z_abc123", "year": 2025, "status": "SUCCESS"},
-                }
-            ],
-        }
-        payload, errors = build_signals(layout, existing_signals=existing)
-        assert errors == {"derive": [], "validation": []}
-        sig = payload["signals"][0]
-        assert sig["id"] == "my_dataset"
-        assert sig["status"] == "ok"  # struttura derivata dal manifest
-        assert sig["run"]["run_id"] == "20260101T000000Z_abc123"  # run preservato
-        assert sig["run"]["status"] == "SUCCESS"
+    Unico pass centralizzato (_merge_existing_runs) per datasets/marts/signals:
+    in CI post-merge i dataset non rieseguiti non hanno run record locali.
+    """
 
-    @pytest.mark.contract
-    def test_local_run_wins_over_existing(self, tmp_path: Path) -> None:
-        """Run locale presente → vince su existing_signals (non lo sovrascrive)."""
-        layout = _make_repo(tmp_path, with_run=True)
-        existing = {
-            "schema_version": "1",
-            "signals": [
-                {
-                    "id": "my_dataset",
-                    "run": {"run_id": "OLD_run", "year": 2025, "status": "FAILED"},
-                }
-            ],
-        }
-        payload, _errors = build_signals(layout, existing_signals=existing)
-        sig = payload["signals"][0]
-        assert sig["run"]["run_id"] == "20260101T000000Z_abc123"  # run locale, non OLD
+    def _build(self, tmp_path, with_run):
+        from toolkit.registry.builders import build_registry
 
-
-class TestCleanCatalogExistingRun:
-    """existing: preserva il blocco run quando il run locale manca (CI)."""
-
-    @pytest.mark.contract
-    def test_preserves_run_from_existing(self, tmp_path: Path) -> None:
-        """CI: nessun run record locale → il run viene dall'entry editoriale."""
-        from toolkit.registry.builders import build_clean_catalog
-
-        layout = _make_repo(tmp_path, with_run=False)
+        layout = _make_repo(tmp_path, with_run=with_run)
         existing = {
             "datasets": [
                 {
                     "slug": "my_dataset",
-                    "name": "My Dataset",
-                    "description": "desc",
-                    "period": {"start": 2024, "end": 2025},
-                    "columns": [],
-                    "location": {"type": "gcs", "path": "gs://x"},
-                    "run": {"run_id": "20260101T000000Z_abc123", "year": 2025, "status": "SUCCESS"},
+                    "run": {"run_id": "OLD_dataset", "year": 2025, "status": "SUCCESS"},
                 }
+            ],
+            "marts": [
+                {
+                    "slug": "my_dataset__mart_trend",
+                    "dataset": "my_dataset",
+                    "table": "mart_trend",
+                    "run": {"run_id": "OLD_mart", "year": 2025, "status": "SUCCESS"},
+                }
+            ],
+        }
+        existing_signals = {
+            "signals": [
+                {
+                    "id": "my_dataset",
+                    "run": {"run_id": "OLD_signal", "year": 2025, "status": "SUCCESS"},
+                },
             ]
         }
-        catalog, errors = build_clean_catalog(layout, existing=existing)
-        assert not errors["derive"], errors["derive"]
-        ds = next(d for d in catalog["datasets"] if d["slug"] == "my_dataset")
-        assert ds["run"]["run_id"] == "20260101T000000Z_abc123"  # run preservato
+        result = build_registry(
+            layout,
+            existing_catalog=existing,
+            existing_signals=existing_signals,
+        )
+        return result["registry"]
+
+    @pytest.mark.contract
+    def test_preserves_runs_when_local_missing(self, tmp_path: Path) -> None:
+        """CI: nessun run locale → i run vengono da existing (tutte le sezioni)."""
+        reg = self._build(tmp_path, with_run=False)
+        ds = next(d for d in reg["datasets"] if d["slug"] == "my_dataset")
+        assert ds["run"]["run_id"] == "OLD_dataset"
+        mart = next(m for m in reg["marts"] if m["slug"] == "my_dataset__mart_trend")
+        assert mart["run"]["run_id"] == "OLD_mart"
+        sig = next(s for s in reg["signals"] if s["id"] == "my_dataset")
+        assert sig["run"]["run_id"] == "OLD_signal"
 
     @pytest.mark.contract
     def test_local_run_wins_over_existing(self, tmp_path: Path) -> None:
         """Run locale presente → vince su existing (non lo sovrascrive)."""
-        from toolkit.registry.builders import build_clean_catalog
-
-        layout = _make_repo(tmp_path, with_run=True)
-        existing = {
-            "datasets": [
-                {
-                    "slug": "my_dataset",
-                    "columns": [],
-                    "location": {"type": "gcs", "path": "gs://x"},
-                    "run": {"run_id": "OLD_run", "year": 2025, "status": "FAILED"},
-                }
-            ]
-        }
-        catalog, _errors = build_clean_catalog(layout, existing=existing)
-        ds = next(d for d in catalog["datasets"] if d["slug"] == "my_dataset")
+        reg = self._build(tmp_path, with_run=True)
+        ds = next(d for d in reg["datasets"] if d["slug"] == "my_dataset")
         assert ds["run"]["run_id"] == "20260101T000000Z_abc123"  # run locale, non OLD
+        mart = next(m for m in reg["marts"] if m["slug"] == "my_dataset__mart_trend")
+        assert mart["run"]["run_id"] == "20260101T000000Z_abc123"  # run locale
+        sig = next(s for s in reg["signals"] if s["id"] == "my_dataset")
+        assert sig["run"]["run_id"] == "20260101T000000Z_abc123"  # run locale
 
 
 class TestEntityGraph:

--- a/toolkit/registry/builders.py
+++ b/toolkit/registry/builders.py
@@ -152,15 +152,11 @@ def build_clean_catalog(
                 f"{manifest.slug}__{t.get('name')}" for t in manifest.mart_tables if t.get("name")
             ]
 
-        # Blocco run (ultimo run record del toolkit). Se il run record locale
-        # manca (CI post-merge senza parquet/run per i dataset non rieseguiti),
-        # preserva il run storico dall'entry editoriale — stesso pattern di
-        # build_signals (existing_signals).
+        # Blocco run (ultimo run record del toolkit). Il fallback sull'existing
+        # è centralizzato in _merge_existing_runs (build_registry).
         run_rec = latest_run_record(str(manifest.yml_path))
         if run_block(run_rec):
             entry["run"] = run_block(run_rec)
-        elif old and old.get("run"):
-            entry["run"] = old["run"]
 
         datasets.append(entry)
 
@@ -267,7 +263,6 @@ def build_mart_catalog(
 def build_signals(
     layout: RepoLayout,
     topic: str = "pipeline_state",
-    existing_signals: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], dict[str, list[str]]]:
     """Costruisce pipeline_signals per ACB (repo-signals standard).
 
@@ -275,19 +270,9 @@ def build_signals(
     mart; error = struttura rotta (clean.sql mancante per dataset non-compose).
     NOTA: status=ok NON significa pubblicato (vedi clean_catalog.stage).
 
-    ``existing_signals``: signals committato (pipeline_signals.json del repo).
-    Preserva il blocco ``run`` dei dataset che non hanno run record locale
-    (sempre il caso in CI post-merge: i parquet/run di chi non è stato
-    rieseguito non sono nel runner). Stesso pattern di ``existing_catalog``
-    per il clean: i run storici non devono sparire a ogni rigenerazione.
+    Il fallback sui run storici (run record locale mancante in CI) è
+    centralizzato in ``_merge_existing_runs`` (build_registry).
     """
-    # Index dei run storici dal signals committato (chiave: slug senza prefisso)
-    existing_runs: dict[str, dict[str, Any]] = {}
-    if existing_signals:
-        for s in existing_signals.get("signals", []) or []:
-            if s.get("run"):
-                existing_runs[str(s.get("id", "")).removeprefix("compose:")] = s["run"]
-
     signals: list[dict[str, Any]] = []
     compose_ids: set[str] = set()
 
@@ -328,9 +313,6 @@ def build_signals(
         run_rec = latest_run_record(str(manifest.yml_path))
         if run_block(run_rec):
             signal["run"] = run_block(run_rec)
-        elif manifest.slug in existing_runs:
-            # Nessun run locale (CI senza parquet) → preserva il run storico
-            signal["run"] = existing_runs[manifest.slug]
         signals.append(signal)
 
         # Prefisso "compose:" per i manifest in sezione compose del layout
@@ -484,7 +466,7 @@ def build_registry(
         slug=slug,
     )
     marts, mc_errors = build_mart_catalog(layout, path_contract=path_contract, slug=slug)
-    signals, ps_errors = build_signals(layout, existing_signals=existing_signals)
+    signals, ps_errors = build_signals(layout)
     codelists, cl_errors = build_codelists(layout)
     graph = build_entity_graph(catalog, semantic_types_path=semantic_types_path)
 
@@ -505,6 +487,17 @@ def build_registry(
         },
     }
 
+    # Preserva i run storici: in CI post-merge i dataset non rieseguiti non
+    # hanno run record locali, quindi i blocco run sparirebbero a ogni
+    # rigenerazione. Un UNICO pass centralizzato (dopo la costruzione delle
+    # sezioni) ripopola i run mancanti da existing — niente fallback duplicati
+    # nei singoli builder.
+    registry = _merge_existing_runs(
+        registry,
+        existing_catalog=existing_catalog,
+        existing_signals=existing_signals,
+    )
+
     registry_errors = validate_artifact(registry, "registry.schema.json")
     errors = {
         "datasets": cc_errors,
@@ -515,6 +508,61 @@ def build_registry(
         "registry": {"derive": [], "validation": registry_errors},
     }
     return {"registry": registry, "errors": errors}
+
+
+def _merge_existing_runs(
+    registry: dict[str, Any],
+    *,
+    existing_catalog: dict[str, Any] | None = None,
+    existing_signals: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Ripopola i blocco ``run`` mancanti dall'existing registry (CI).
+
+    Quando il run record locale manca (post-merge: i dataset non rieseguiti
+    non sono nel runner), le entry derivate non hanno ``run``. L'existing
+    (registry.json committato) preserva lo storico.
+
+    Chiavi:
+    - datasets: ``slug``
+    - marts: ``dataset`` (il run è per dataset, non per tabella)
+    - signals: ``id`` (con prefisso ``compose:`` per i compose)
+
+    Il run locale vince sempre; l'existing interviene solo dove manca.
+    """
+
+    def _index(
+        payload: dict | None, key: str, section: str = "datasets"
+    ) -> dict[str, dict[str, Any]]:
+        idx: dict[str, dict[str, Any]] = {}
+        if not payload:
+            return idx
+        for entry in payload.get(section, []) or []:
+            run = entry.get("run")
+            if run and entry.get(key):
+                idx[entry[key]] = run
+        return idx
+
+    datasets_run = _index(existing_catalog, "slug")
+    marts_run = _index(existing_catalog, "dataset", section="marts")
+    signals_run: dict[str, dict[str, Any]] = {}
+    if existing_signals:
+        for s in existing_signals.get("signals", []) or []:
+            if s.get("run") and s.get("id"):
+                signals_run[s["id"]] = s["run"]
+
+    for ds in registry.get("datasets", []) or []:
+        if "run" not in ds and ds.get("slug") in datasets_run:
+            ds["run"] = datasets_run[ds["slug"]]
+
+    for m in registry.get("marts", []) or []:
+        if "run" not in m and m.get("dataset") in marts_run:
+            m["run"] = marts_run[m["dataset"]]
+
+    for s in registry.get("signals", []) or []:
+        if "run" not in s and s.get("id") in signals_run:
+            s["run"] = signals_run[s["id"]]
+
+    return registry
 
 
 # Nomi display delle entità nel grafo (default: il nome entity dal vocabolario).


### PR DESCRIPTION
## Sintesi

**Fix strutturale** del fallback "preserva il run storico quando il run locale manca (CI)". Prima era **duplicato** in `build_signals` (`existing_signals`) e `build_clean_catalog` (`old.run`), e **mancava** in `build_mart_catalog` — a ogni rigenerazione i run dei mart sparivano.

Emerso dalla PR #813 (workflow_dispatch su comuni-master): **268 righe di run rimosse** dai mart nel registry generato.

## Problema reale

In CI post-merge i dataset non rieseguiti non hanno run record locali → il blocco `run` spariva a ogni rigenerazione. Il fallback esisteva in 2 builder su 3 (duplicazione), quindi ne restava sempre uno scoperto — patch sulla patch.

## Root cause e fix

**Causa**: la logica "preserva i run mancanti" era replicata nei singoli builder invece di essere un unico pass post-costruzione.

**Fix**: **UN solo `_merge_existing_runs`** in `build_registry`, chiamato dopo la costruzione di datasets/marts/signals. Ripopola i run mancanti da existing:
- datasets → per `slug`
- marts → per `dataset` (il run è per dataset, non per tabella)
- signals → per `id`

I 3 builder ora costruiscono **solo da stato locale** (niente fallback interni). Aggiungere un quarto artifact non richiederà più una quarta copia.

## Cosa cambia

- `toolkit/registry/builders.py`:
  - `build_registry`: chiama `_merge_existing_runs` (unico pass)
  - `build_signals`: **rimosso** `existing_signals` (fallback centralizzato)
  - `build_clean_catalog`: **rimosso** `old.run` (fallback centralizzato)
  - `build_mart_catalog`: invariato (nessun fallback locale) — ora coperto dal pass centrale
  - nuovo `_merge_existing_runs`
- `tests/test_registry_builder.py`: `TestRegistryExistingRun` (merge su datasets/marts/signals; run locale vince) sostituisce i 2 test per-proiezione

## Impatto su contratti pubblici

- [ ] Struttura `dataset.yml`
- [ ] Path output
- [ ] Schema parquet
- [ ] CLI o MCP tool
- [x] API pubblica del toolkit — **rimosso** `existing_signals` da `build_signals` (era per il fallback, ora centralizzato). Verificato: unico chiamante è `build_registry` (aggiornato) e i test. Il wrapper DI non passa `existing_signals` a `build_signals` direttamente (lo passa a `build_registry`).

## Verifica

```bash
python -m pytest tests/test_registry_builder.py tests/test_registry_ops.py \
  tests/test_registry_graph.py tests/test_catalog_ops.py -q   # 84 passed
ruff check toolkit/registry/builders.py                        # clean
mypy toolkit/registry/builders.py                              # ok
```

Simulazione CI con existing da main (dispatch simulato):
```
datasets: main=54 rigenerato=54
marts:    main=134 rigenerato=134
signals:  main=62 rigenerato=62
```

- [x] `pytest` 84 verdi, `ruff`/`mypy` puliti
- [x] **0 run persi** in simulazione CI (datasets/marts/signals)
- [x] Perimetro stretto: registry builder, nessun tocco ad altri moduli

## Note / rischi

- Questo è il refactor strutturale richiesto dalla review (il fallback era patch su patch). I run ora sono preservati da un punto solo.
- Serve un **nuovo tag toolkit** (v1.49.3) dopo il merge, e il bump del pin DI (se non già a v1.49.3).
- Il wrapper DI (`build_registry.py`) passa `existing_catalog` (con `marts` ora incluso) e `existing_signals` a `build_registry` — già compatibile col refactor (verificato con la simulazione).
