### PR TITLE
fix(clean): default read mode = latest (None), non explicit — regressione #435

### DIFF
--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -661,3 +661,37 @@ def test_dataset_tags_and_category_with_source_id(tmp_path: Path):
     assert cfg.source_id == "test_source"
     assert cfg.tags == ["tag1", "tag2"]
     assert cfg.category == "test-category"
+
+
+@pytest.mark.contract
+def test_clean_read_default_mode_is_latest_when_undeclared(tmp_path: Path):
+    """Senza clean.read.mode/include, il default deve essere latest (non explicit).
+
+    Regressione: il refactor dataclass (#435) aveva default mode='explicit' +
+    include=[] → ogni candidate senza read.mode falliva con 'No CLEAN input
+    files matched clean.read.include: []'.
+    """
+    (tmp_path / "dataset.yml").write_text(
+        "root: './out'\n"
+        "schema_version: 1\n"
+        "dataset:\n"
+        "  name: 'demo'\n"
+        "  source_id: 'src'\n"
+        "  years: [2024]\n"
+        "raw:\n"
+        "  sources:\n"
+        "    - name: 'demo_source'\n"
+        "      type: 'http_file'\n"
+        "      args:\n"
+        "        url: 'https://example.com/x.csv'\n"
+        "        filename: 'x.csv'\n"
+        "clean:\n"
+        "  read:\n"
+        "    delim: ','\n"
+        "  sql: 'sql/clean.sql'\n",
+        encoding="utf-8",
+    )
+    cfg = load_config(tmp_path / "dataset.yml")
+    read = cfg.clean.read
+    assert read.mode is None  # default → _selection_params traduce in 'latest'
+    assert read.include is None

--- a/toolkit/core/config.py
+++ b/toolkit/core/config.py
@@ -206,8 +206,8 @@ class MartValidationSpec:
 @dataclass
 class CleanReadConfig:
     source: str = "auto"
-    mode: str = "explicit"
-    include: list[str] = field(default_factory=list)
+    mode: str | None = None
+    include: list[str] | None = None
     glob: str = "*"
     prefer_from_raw_run: bool = True
     allow_ambiguous: bool = False


### PR DESCRIPTION
## Sintesi

Fix urgente: il default di `CleanReadConfig.mode` era `"explicit"` (con `include=[]`) — **qualsiasi candidate senza `clean.read.mode`/`include` espliciti fallisce** con `No CLEAN input files matched clean.read.include: []`. Emerso su `sai-strutture-italia` e `farmacie` (run rotti ovunque).

## Root cause

Il refactor dataclass (#435) ha introdotto `mode: str = "explicit"` e `include: list[str] = field(default_factory=list)` come default. Pre-refactor (pydantic) era `mode: Literal[...] | None = None` → `_selection_params` traduceva `None` in `"latest"`. Con `mode='explicit'` + `include=[]`, ogni config senza read.mode esplicito cercava match espliciti contro una lista vuota.

## Fix

`CleanReadConfig`:
- `mode: str | None = None` (default)
- `include: list[str] | None = None` (default)

`_selection_params` già traduce `mode=None` + `include=None` in `"latest"` (comportamento storico, coperto da `test_run_clean_default_mode_selects_latest`).

## Verifica

- Run reali: `sai-strutture-italia` e `farmacie` passano (raw→clean→mart)
- `pytest tests/` → **1346 passed, 22 deselected**
- Test nuovo: default mode latest quando non dichiarato

## Cosa cambia

- [x] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Note / rischi

- Nessun cambio di comportamento per i config con `mode`/`include` dichiarati: restano come configurato. Il default torna al comportamento pre-#435 (latest).
