### PR TITLE
feat(registry): ordine canonico, comando build unico, drop legacy reader

### DIFF
--- a/tests/fixtures/di_candidate_mit_incidentalita/dataset.yml
+++ b/tests/fixtures/di_candidate_mit_incidentalita/dataset.yml
@@ -1,0 +1,70 @@
+root: "../../out"
+schema_version: 1
+
+dataset:
+  name: "mit_incidentalita_mensile"
+  source_id: "mit_opendata"
+  tags: [ambiente, mit, incidentalita]
+  category: ambiente
+  years: [2001]
+  time_coverage:
+    start_year: 2001
+    end_year: 2018
+
+raw:
+  sources:
+    - name: "mit_incidentalita_mensile_csv"
+      type: "http_file"
+      args:
+        url: "https://dati.mit.gov.it/catalog/dataset/f3336ae0-3a6b-4a25-9013-7df0c3750916/resource/121ad29a-1ec3-4f82-b93f-da65bed9e74e/download/incidenti-morti-feriti-ed-indicatori-dellincidentalita-stradale-per-mese-anni-2001-2018.csv"
+        filename: "mit_incidentalita_mensile_2001_2018.csv"
+      primary: true
+
+clean:
+  sql: "sql/clean.sql"
+  required_columns: [mese, anno]
+  read:
+    source: config_only
+    header: false
+    skip: 1
+    delim: ","
+    encoding: "utf-8"
+    null_padding: true
+    columns:
+      mese_raw: "VARCHAR"
+      anno_raw: "VARCHAR"
+      incidenti_raw: "VARCHAR"
+      morti_raw: "VARCHAR"
+      feriti_raw: "VARCHAR"
+      incidenti_mortali_raw: "VARCHAR"
+      perc_incidenti_raw: "VARCHAR"
+      perc_incidenti_mortali_raw: "VARCHAR"
+      perc_morti_raw: "VARCHAR"
+      perc_feriti_raw: "VARCHAR"
+      indice_mortalita_raw: "VARCHAR"
+      indice_gravita_raw: "VARCHAR"
+      indice_lesivita_raw: "VARCHAR"
+      indice_mortalita_spec_raw: "VARCHAR"
+      indice_incidentalita_spec_raw: "VARCHAR"
+  validate:
+    min_rows: 200
+    not_null:
+      - "mese"
+      - "anno"
+      - "incidenti"
+      - "morti"
+      - "feriti"
+
+mart:
+  tables:
+    - name: "mart_mensile"
+      sql: "sql/mart/mart_mensile.sql"
+  required_tables:
+    - "mart_mensile"
+  validate:
+    table_rules:
+      mart_mensile:
+        min_rows: 200
+
+validation:
+  fail_on_error: true

--- a/tests/test_catalog_ops.py
+++ b/tests/test_catalog_ops.py
@@ -739,7 +739,7 @@ class TestSemanticFind:
 
 
 class TestScanCommittedCatalogs:
-    """Scan semantico cross-repo: registry.json unico + fallback legacy.
+    """Scan semantico cross-repo: registry.json unico (fusion ADR).
 
     Regressione fusion ADR: prima leggeva solo ``clean_catalog.json``, quindi
     i repo migrati a ``registry.json`` (eurostat, dcl-bologna) sparivano dal
@@ -747,8 +747,8 @@ class TestScanCommittedCatalogs:
     GCS).
     """
 
-    def test_reads_fusion_registry_and_legacy(self, tmp_path: "Any") -> None:
-        """Repo migrato (registry.json) e legacy (clean_catalog.json) indicizzati."""
+    def test_reads_fusion_registries(self, tmp_path: "Any") -> None:
+        """Repo multipli con registry.json indicizzati."""
         # Repo migrato: registry.json unico con sezione datasets
         migrato = tmp_path / "eurostat"
         (migrato / "registry").mkdir(parents=True)
@@ -771,13 +771,14 @@ class TestScanCommittedCatalogs:
             ),
             encoding="utf-8",
         )
-        # Repo legacy: solo clean_catalog.json
-        legacy = tmp_path / "dataset-incubator"
-        (legacy / "registry").mkdir(parents=True)
-        (legacy / "registry" / "clean_catalog.json").write_text(
+        # Secondo repo: registry.json con un altro dataset
+        di = tmp_path / "dataset-incubator"
+        (di / "registry").mkdir(parents=True)
+        (di / "registry" / "registry.json").write_text(
             json.dumps(
                 {
                     "schema_version": 1,
+                    "repo": "dataset-incubator",
                     "datasets": [
                         {
                             "slug": "anac_bandi_gara",

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -1,0 +1,93 @@
+"""Test per `toolkit registry build` — generazione registry.json centralizzata.
+
+Il comando sostituisce i wrapper scripts/build_registry.py per-repo: scopre le
+sezioni dati per convenzione (repo_dataset_dirs), deriva source_repo dal git
+remote e preserva i run dei mart da existing (il fix del bug #465 che i wrapper
+legacy non passavano).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from toolkit.cli.app import app
+
+pytest.importorskip("duckdb")
+
+from tests.test_registry_builder import _make_repo  # noqa: E402
+
+runner = CliRunner()
+
+
+def _write_existing(out_dir: Path, with_mart_run: bool = True) -> None:
+    """Registry esistente con un mart con run storico (simula CI post-merge)."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    existing = {
+        "schema_version": 1,
+        "repo": "open-siope",
+        "source_repo": "dataciviclab/open-siope",
+        "updated_at": "2026-08-01",
+        "datasets": [],
+        "marts": [],
+        "signals": [],
+    }
+    if with_mart_run:
+        existing["marts"] = [
+            {
+                "slug": "my_dataset__mart_trend",
+                "dataset": "my_dataset",
+                "table": "mart_trend",
+                "run": {"run_id": "OLD", "year": 2025, "status": "SUCCESS"},
+            }
+        ]
+    (out_dir / "registry.json").write_text(
+        json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+@pytest.mark.pure_unit
+def test_build_dry_run_reports_counts(tmp_path: Path) -> None:
+    """Dry-run: stampa il riepilogo senza scrivere il file."""
+    _make_repo(tmp_path, with_run=True)
+    _write_existing(tmp_path / "registry")
+    out = tmp_path / "outreg"
+    result = runner.invoke(
+        app, ["registry", "build", "--repo", str(tmp_path), "--out", str(out)], obj={}
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "datasets 1" in result.stdout
+    assert "Dry-run" in result.stdout
+    assert not (out / "registry.json").is_file()
+
+
+@pytest.mark.pure_unit
+def test_build_write_preserves_mart_runs(tmp_path: Path) -> None:
+    """Il comando scrive registry.json e preserva i run dei mart da existing.
+
+    È il fix del bug #465: i wrapper legacy passavano existing_catalog senza
+    la sezione marts → i run dei mart sparivano a ogni rigenerazione CI.
+    with_run=False simula la CI (nessun run record locale → existing prevale).
+    """
+    _make_repo(tmp_path, with_run=False)
+    out = tmp_path / "outreg"
+    _write_existing(out, with_mart_run=True)
+    result = runner.invoke(
+        app, ["registry", "build", "--repo", str(tmp_path), "--write", "--out", str(out)], obj={}
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    payload = json.loads((out / "registry.json").read_text(encoding="utf-8"))
+    mart = next(m for m in payload["marts"] if m["slug"] == "my_dataset__mart_trend")
+    assert mart["run"]["run_id"] == "OLD"
+    assert payload["source_repo"] == "dataciviclab/toolkit" or payload["source_repo"]
+
+
+@pytest.mark.pure_unit
+def test_build_no_datasets_dir_fails(tmp_path: Path) -> None:
+    """Repo senza sezioni dati → errore pulito."""
+    result = runner.invoke(app, ["registry", "build", "--repo", str(tmp_path)], obj={})
+    assert result.exit_code != 0
+    assert "nessuna sezione dati" in result.stderr

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -695,3 +695,51 @@ def test_clean_read_default_mode_is_latest_when_undeclared(tmp_path: Path):
     read = cfg.clean.read
     assert read.mode is None  # default → _selection_params traduce in 'latest'
     assert read.include is None
+
+
+@pytest.mark.contract
+def test_di_candidate_real_config_loads_with_latest_default():
+    """Integrazione: un candidate DI reale si carica e il default read è latest.
+
+    Copia del config di dataset-incubator candidates/mit-incidentalita-
+    mensile-2001-2018 (read con columns esplicite, NESSUN mode/include).
+    Protegge il percorso che #435 rompeva: il refactor dataclass metteva
+    mode='explicit' + include=[] di default → 'No CLEAN input files matched
+    clean.read.include: []'. Il test sintetico in test_clean_read_default
+    *_latest copre il minimo; qui verifichiamo il candidate reale con
+    columns/config_only, che è il caso che ha colpito i run reali.
+    """
+    from pathlib import Path
+
+    from toolkit.clean.run import _selection_params
+
+    fixture = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "di_candidate_mit_incidentalita"
+        / "dataset.yml"
+    )
+    assert fixture.is_file(), f"fixture mancante: {fixture}"
+
+    cfg = load_config(fixture)
+    read = cfg.clean.read
+    # Il candidate reale non dichiara mode/include → default latest, non explicit.
+    assert read.mode is None
+    assert read.include is None
+    assert read.source == "config_only"
+    assert read.columns is not None and len(read.columns) == 15
+    assert read.header is False
+    assert read.skip == 1
+
+    # _selection_params (il punto dove #435 rompeva) traduce in 'latest'.
+    params = _selection_params(
+        {
+            "mode": read.mode,
+            "include": read.include,
+            "glob": read.glob,
+            "prefer_from_raw_run": read.prefer_from_raw_run,
+            "allow_ambiguous": read.allow_ambiguous,
+        },
+        logger=None,
+    )
+    assert params[0] == "latest"

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -468,6 +468,107 @@ class TestRegistryExistingRun:
         assert sig["run"]["run_id"] == "20260101T000000Z_abc123"  # run locale
 
 
+class TestCanonicalize:
+    """Ordine chiavi deterministico nelle entry (diff post-merge puliti).
+
+    Le entry derivano da path diversi (builder, existing, run restore):
+    l'ordine di inserimento del dict cambiava a ogni rigenerazione → diff
+    rumorosi. _canonicalize_registry finalizza un ordine canonico per sezione;
+    le chiavi extra vengono accodate, mai perse.
+    """
+
+    def _build_with_existing(self, tmp_path: Path) -> dict:
+        from toolkit.registry.builders import build_registry
+
+        layout = _make_repo(tmp_path, with_run=True)
+        existing = {
+            "datasets": [
+                {"slug": "my_dataset", "run": {"run_id": "OLD", "year": 2025, "status": "SUCCESS"}}
+            ],
+            "marts": [
+                {
+                    "slug": "my_dataset__mart_trend",
+                    "dataset": "my_dataset",
+                    "table": "mart_trend",
+                    "run": {"run_id": "OLD_mart", "year": 2025, "status": "SUCCESS"},
+                }
+            ],
+        }
+        result = build_registry(
+            layout,
+            existing_catalog=existing,
+            existing_signals={"signals": [{"id": "my_dataset", "run": {"run_id": "OLD_sig"}}]},
+        )
+        return result["registry"]
+
+    @pytest.mark.contract
+    def test_mart_run_position_before_location(self, tmp_path: Path) -> None:
+        """Il run ripristinato da existing va prima di location (canonico)."""
+        reg = self._build_with_existing(tmp_path)
+        mart = next(m for m in reg["marts"] if m["slug"] == "my_dataset__mart_trend")
+        keys = list(mart.keys())
+        assert keys.index("run") < keys.index("location")
+        assert keys[:4] == ["slug", "dataset", "table", "description"]
+
+    @pytest.mark.contract
+    def test_dataset_canonical_order(self, tmp_path: Path) -> None:
+        reg = self._build_with_existing(tmp_path)
+        ds = next(d for d in reg["datasets"] if d["slug"] == "my_dataset")
+        keys = list(ds.keys())
+        canonical = [
+            "slug",
+            "name",
+            "description",
+            "source",
+            "source_id",
+            "period",
+            "years",
+            "tags",
+            "category",
+            "columns",
+            "location",
+            "stage",
+            "registry_source",
+            "mart_refs",
+            "run",
+        ]
+        assert keys == canonical
+
+    @pytest.mark.contract
+    def test_extra_keys_preserved_at_end(self, tmp_path: Path) -> None:
+        """Chiavi non previste dal canonico vengono accodate, non perse."""
+        from toolkit.registry.builders import _canonicalize_entry
+
+        entry = {"z_key": 1, "slug": "a", "a_key": 2}
+        out = _canonicalize_entry(entry, ("slug", "name"))
+        assert list(out.keys()) == ["slug", "z_key", "a_key"]
+        assert out["z_key"] == 1 and out["a_key"] == 2
+
+    @pytest.mark.contract
+    def test_deterministic_across_regenerations(self, tmp_path: Path) -> None:
+        """Due build con existing diverso producono lo stesso ordine chiavi."""
+        from toolkit.registry.builders import build_registry
+
+        layout = _make_repo(tmp_path, with_run=True)
+        e1 = {
+            "datasets": [
+                {"slug": "my_dataset", "run": {"run_id": "OLD", "year": 2025, "status": "SUCCESS"}}
+            ],
+            "marts": [],
+        }
+        e2 = {
+            "datasets": [
+                {"slug": "my_dataset", "run": {"run_id": "NEW", "year": 2026, "status": "SUCCESS"}}
+            ],
+            "marts": [],
+        }
+        r1 = build_registry(layout, existing_catalog=e1)["registry"]
+        r2 = build_registry(layout, existing_catalog=e2)["registry"]
+        ds1 = next(d for d in r1["datasets"] if d["slug"] == "my_dataset")
+        ds2 = next(d for d in r2["datasets"] if d["slug"] == "my_dataset")
+        assert list(ds1.keys()) == list(ds2.keys())
+
+
 class TestEntityGraph:
     """build_entity_graph: entità + bridge dal clean_catalog (5° artifact)."""
 

--- a/tests/test_registry_graph.py
+++ b/tests/test_registry_graph.py
@@ -1,7 +1,7 @@
 """Test del grafo entità → dataset aggregato cross-repo.
 
 Fixture: mini-workspace con due repo, ognuno con la sezione entities nel
-registry (fusion e legacy).
+registry.json (fusion).
 
 Marker: contract (output pubblico del tool MCP toolkit_graph).
 """
@@ -18,57 +18,65 @@ from toolkit.registry.graph import DOMAIN_KEYWORDS, filter_graph, load_workspace
 
 @pytest.fixture
 def graph_workspace(tmp_path: Path) -> Path:
-    """Due repo con entities: DI (legacy entity_graph) + eurostat (fusion)."""
-    # DI legacy: entity_graph.json separato
+    """Due repo con entities: DI + eurostat (entrambi registry.json fusion)."""
+    # DI: registry.json unico con sezione entities
     di = tmp_path / "dataset-incubator" / "registry"
     di.mkdir(parents=True)
-    (di / "entity_graph.json").write_text(
+    (di / "registry.json").write_text(
         json.dumps(
             {
                 "schema_version": 1,
+                "repo": "dataset-incubator",
+                "datasets": [],
+                "marts": [],
+                "signals": [],
+                "codelists": {},
                 "entities": {
-                    "Comune": {
-                        "entity": "Comune",
-                        "label": "Comune (ISTAT)",
-                        "datasets": [
-                            {
-                                "slug": "irpef_comunale",
-                                "name": "Irpef Comunale",
-                                "column": "codice_istat_comune",
-                                "semantic_type": "municipality_code",
-                            }
-                        ],
-                        "types": {"municipality_code": 1},
-                    },
-                    "Gara": {
-                        "entity": "Gara",
-                        "label": "Gara / Appalto",
-                        "datasets": [
-                            {
-                                "slug": "anac_bandi_gara",
-                                "name": "Bandi ANAC",
-                                "column": "cig",
-                                "semantic_type": "cig_code",
-                            }
-                        ],
-                        "types": {"cig_code": 1},
-                    },
-                },
-                "bridges": [
-                    {
-                        "from": {
-                            "entity": "Gara",
-                            "dataset": "anac_aggiudicatari",
-                            "via": "cig_code",
-                        },
-                        "to": {
+                    "generated_from": "registry",
+                    "entities": {
+                        "Comune": {
                             "entity": "Comune",
-                            "bridge": "anac_bandi_gara",
-                            "on": "cig",
-                            "semantic_type": "municipality_code",
+                            "label": "Comune (ISTAT)",
+                            "datasets": [
+                                {
+                                    "slug": "irpef_comunale",
+                                    "name": "Irpef Comunale",
+                                    "column": "codice_istat_comune",
+                                    "semantic_type": "municipality_code",
+                                }
+                            ],
+                            "types": {"municipality_code": 1},
                         },
-                    }
-                ],
+                        "Gara": {
+                            "entity": "Gara",
+                            "label": "Gara / Appalto",
+                            "datasets": [
+                                {
+                                    "slug": "anac_bandi_gara",
+                                    "name": "Bandi ANAC",
+                                    "column": "cig",
+                                    "semantic_type": "cig_code",
+                                }
+                            ],
+                            "types": {"cig_code": 1},
+                        },
+                    },
+                    "bridges": [
+                        {
+                            "from": {
+                                "entity": "Gara",
+                                "dataset": "anac_aggiudicatari",
+                                "via": "cig_code",
+                            },
+                            "to": {
+                                "entity": "Comune",
+                                "bridge": "anac_bandi_gara",
+                                "on": "cig",
+                                "semantic_type": "municipality_code",
+                            },
+                        }
+                    ],
+                },
             }
         ),
         encoding="utf-8",

--- a/tests/test_registry_ops.py
+++ b/tests/test_registry_ops.py
@@ -20,21 +20,16 @@ def mini_workspace(tmp_path: Path) -> Path:
     """Workspace con due repo: uno con registry, uno senza."""
     euro = tmp_path / "eurostat"
     (euro / "registry").mkdir(parents=True)
-    (euro / "registry" / "clean_catalog.json").write_text(
+    (euro / "registry" / "registry.json").write_text(
         json.dumps(
             {
                 "schema_version": 1,
                 "datasets": [{"slug": "eurostat_gdp_nuts3", "name": "GDP"}],
+                "signals": [{"id": "x"}, {"id": "y"}],
             }
         ),
         encoding="utf-8",
     )
-    (euro / "registry" / "pipeline_signals.json").write_text(
-        json.dumps({"schema_version": "1", "signals": [{"id": "x"}, {"id": "y"}]}),
-        encoding="utf-8",
-    )
-    # Schema: escluso dalla vista
-    (euro / "registry" / "clean_catalog.schema.json").write_text("{}", encoding="utf-8")
 
     (tmp_path / "no-registry-repo").mkdir()
     return tmp_path
@@ -42,7 +37,7 @@ def mini_workspace(tmp_path: Path) -> Path:
 
 @pytest.mark.contract
 def test_list_registries(mini_workspace: Path) -> None:
-    """Lista i repo con artifact, escludendo gli schemi (contract)."""
+    """Lista i repo con artifact (contract)."""
     data = list_registries(mini_workspace)
     assert data["total_repos"] == 1
     repo = data["repos"][0]
@@ -50,7 +45,6 @@ def test_list_registries(mini_workspace: Path) -> None:
     assert len(repo["artifacts"]) == 1
     reg = repo["artifacts"][0]
     assert reg["name"] == "registry"
-    # mini_workspace legacy: clean_catalog (1 ds) + pipeline_signals
     assert reg["sections"]["datasets"] == 1
     assert reg["sections"]["signals"] == 2
 

--- a/toolkit/cli/cmd_registry.py
+++ b/toolkit/cli/cmd_registry.py
@@ -1,8 +1,8 @@
-"""toolkit registry — consulta gli artifact registry committati nel workspace.
+"""toolkit registry — consulta e genera gli artifact registry.
 
-Legge i cataloghi generati dal registry builder e committati nei repo
-(``{repo}/registry/*.json``): clean_catalog, mart_catalog, pipeline_signals,
-codelists. Cross-repo, senza riprogettare la discovery.
+Legge i registry.json committati nei repo (fusion ADR): sezioni datasets,
+marts, signals, codelists, entities. Cross-repo, senza riprogettare la
+discovery.
 
 Speculare al tool MCP toolkit_registry.
 """
@@ -26,8 +26,7 @@ def _print_list(data: dict[str, Any]) -> None:
             size_txt = f"  [{size // 1024} KB]" if size is not None else ""
             sections = art.get("sections") or {}
             counts = ", ".join(f"{k}: {v}" for k, v in sections.items() if v is not None)
-            legacy = " (legacy)" if art.get("legacy") else ""
-            typer.echo(f"    registry.json{size_txt}{legacy}  {counts}")
+            typer.echo(f"    registry.json{size_txt}  {counts}")
 
 
 def registry_list(json_output: bool = typer.Option(False, "--json", help="Output JSON")) -> None:

--- a/toolkit/cli/cmd_registry.py
+++ b/toolkit/cli/cmd_registry.py
@@ -10,6 +10,7 @@ Speculare al tool MCP toolkit_registry.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import typer
@@ -67,10 +68,130 @@ def registry_show(
     typer.echo(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
 
 
-def register(app: typer.Typer) -> None:
-    registry = typer.Typer(
-        no_args_is_help=True, help="Consulta gli artifact registry del workspace"
+def _git_source_repo(repo_root: Path) -> str:
+    """Deriva ``owner/repo`` dal git remote origin (fallback: repo name)."""
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        return repo_root.name
+    # Accetta ssh (git@host:owner/repo.git) e https (https://host/owner/repo.git)
+    url = out.rstrip("/").removesuffix(".git")
+    if "@" in url and ":" in url:
+        # git@host:owner/repo.git → owner/repo (toglie host: e porta).
+        rest = url.split("@", 1)[1].replace(":", "/")
+        parts = [p for p in rest.split("/") if p and p != "github.com"]
+        return "/".join(parts[-2:])
+    parts = [p for p in url.split("/") if p and p != "github.com"]
+    if len(parts) >= 2:
+        return "/".join(parts[-2:])
+    return repo_root.name
+
+
+def registry_build(
+    repo: str = typer.Option(None, "--repo", help="Root del repo (default: CWD)"),
+    prefix: str = typer.Option("", "--prefix", help="Prefisso GCS (es. 'eurostat')"),
+    flat: bool = typer.Option(False, "--flat", help="Layout flat per clean+mart (no year)"),
+    write: bool = typer.Option(False, "--write", help="Scrive registry.json (default: dry-run)"),
+    out: str = typer.Option("registry", "--out", help="Dir di output (default: registry)"),
+) -> None:
+    """Genera registry.json del repo (auto-discovery, fusion ADR).
+
+    Sostituisce i wrapper ``scripts/build_registry.py`` per-repo: scopre le
+    sezioni dati per convenzione (``repo_dataset_dirs``) e deriva ``source_repo``
+    dal git remote. Il PathContract si configura con i flag (default: root/year).
+
+    Uso:
+        toolkit registry build                     # dry-run sul repo corrente
+        toolkit registry build --write             # scrive registry/registry.json
+        toolkit registry build --prefix eurostat --flat --write
+    """
+    from toolkit.registry.builders import build_registry
+    from toolkit.registry.layout import RepoLayout, repo_dataset_dirs
+    from toolkit.registry.paths import PathContract
+
+    repo_root = Path(repo).resolve() if repo else Path.cwd()
+    sections = repo_dataset_dirs(repo_root)
+    if not sections:
+        typer.echo(
+            f"ERRORE: nessuna sezione dati in {repo_root} (nessuna dir con {{slug}}/dataset.yml)",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    layout = RepoLayout(
+        repo_root=repo_root,
+        dataset_dirs=sections,
+        source_repo=_git_source_repo(repo_root),
     )
+    contract = PathContract(
+        prefix=prefix,
+        clean_layout="flat" if flat else "year",
+        mart_layout="flat" if flat else "year",
+    )
+
+    out_dir = repo_root / out
+    existing_catalog = None
+    existing_signals = None
+    existing_path = out_dir / "registry.json"
+    if existing_path.is_file():
+        try:
+            existing = json.loads(existing_path.read_text(encoding="utf-8"))
+            existing_catalog = {
+                "datasets": existing.get("datasets", []),
+                "marts": existing.get("marts", []),
+            }
+            existing_signals = {"signals": existing.get("signals", [])}
+        except json.JSONDecodeError:
+            typer.echo("WARN: registry.json esistente illeggibile — riparto da zero", err=True)
+
+    result = build_registry(
+        layout,
+        path_contract=contract,
+        existing_catalog=existing_catalog,
+        existing_signals=existing_signals,
+    )
+
+    all_warnings: list[str] = []
+    all_real: list[str] = []
+    for artifact, errors in result["errors"].items():
+        all_warnings.extend(f"{artifact}: {e}" for e in errors["derive"])
+        all_real.extend(f"{artifact}: {e}" for e in errors["validation"])
+    for w in all_warnings:
+        typer.echo(f"WARN: {w}", err=True)
+    if all_real:
+        for e in all_real:
+            typer.echo(f"ERROR: {e}", err=True)
+        typer.echo("Artifact NON scritto: errori di validazione.", err=True)
+        raise typer.Exit(code=1)
+
+    registry = result["registry"]
+    s = registry["summary"]
+    typer.echo(
+        f"registry.json — datasets {s['datasets']}, marts {s['marts']}, "
+        f"signals {s['signals']} (repo: {layout.source_repo})"
+    )
+    if not write:
+        typer.echo("Dry-run: usa --write per scrivere il file.")
+        return
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "registry.json"
+    out_path.write_text(json.dumps(registry, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    typer.echo(f"scritto {out_path}")
+
+
+def register(app: typer.Typer) -> None:
+    registry = typer.Typer(no_args_is_help=True, help="Consulta e genera gli artifact registry")
     registry.command("list")(registry_list)
     registry.command("show")(registry_show)
+    registry.command("build")(registry_build)
     app.add_typer(registry, name="registry")

--- a/toolkit/domain/catalog.py
+++ b/toolkit/domain/catalog.py
@@ -332,7 +332,7 @@ def _gcs_files_from_registry(workspace: Path = WORKSPACE_ROOT) -> list[dict[str,
     if not workspace.is_dir():
         return files
     for repo_dir in sorted(p for p in workspace.iterdir() if p.is_dir()):
-        payload, _is_legacy = load_repo_registry(repo_dir)
+        payload = load_repo_registry(repo_dir)
         if payload is None:
             continue
         # clean: datasets → location
@@ -413,9 +413,8 @@ def _scan_committed_catalogs(workspace: Path = WORKSPACE_ROOT) -> dict[str, dict
     """Scansiona i cataloghi semantici committati nei repo del workspace.
 
     Usa ``load_repo_registry`` (lo stesso reader del resolver GCS): legge il
-    ``registry.json`` unico dei repo migrati (fusion ADR) e il fallback
-    ``clean_catalog.json`` dei repo legacy. Ritorna ``{slug: entry semantica}``
-    con ``_repo`` (nome dir) aggiunto.
+    ``registry.json`` unico dei repo (fusion ADR). Ritorna ``{slug: entry
+    semantica}`` con ``_repo`` (nome dir) aggiunto.
 
     La semantica (columns con role/semantic_type, description, tags, period)
     vive nei registry generati dal registry builder e committati nei repo:
@@ -427,7 +426,7 @@ def _scan_committed_catalogs(workspace: Path = WORKSPACE_ROOT) -> dict[str, dict
     if not workspace.is_dir():
         return result
     for repo_dir in sorted(p for p in workspace.iterdir() if p.is_dir()):
-        payload, _is_legacy = load_repo_registry(repo_dir)
+        payload = load_repo_registry(repo_dir)
         if payload is None:
             continue
         for ds in payload.get("datasets", []) or []:

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -354,7 +354,7 @@ def toolkit_sparql_query(
 @mcp.tool(
     description=(
         "Elenca gli artifact registry committati nei repo del workspace "
-        "(registry.json unico fusion, o fallback legacy clean_catalog/mart_catalog/...). "
+        "(registry.json unico fusion). "
         "Ogni repo con registry/ viene elencato con i suoi artifact, "
         "dimensione e conteggio entries per sezione "
         "(datasets, marts, signals, codelists, entities). "
@@ -370,8 +370,7 @@ def toolkit_registry_list() -> dict[str, Any]:
     description=(
         "Mostra un artifact registry committato di un repo del workspace "
         "(es. repo='eurostat', artifact='datasets'). Sezioni: datasets, marts, "
-        "signals, codelists, entities (o 'registry' per l'intero payload; "
-        "accetta anche i nomi legacy clean_catalog/mart_catalog/pipeline_signals/...). "
+        "signals, codelists, entities (o 'registry' per l'intero payload). "
         "Con slug filtra un'entry: dataset slug (datasets), mart slug in formato "
         "{dataset}__{mart} (marts), id (signals), codelist name (codelists). "
         "Il catalogo semantico contiene columns (role, semantic_type), "

--- a/toolkit/registry/builders.py
+++ b/toolkit/registry/builders.py
@@ -498,6 +498,12 @@ def build_registry(
         existing_signals=existing_signals,
     )
 
+    # Ordine chiavi deterministico: le entry derivano da path diversi
+    # (builder, existing, run restore) e l'ordine di inserimento del dict
+    # cambierebbe a ogni rigenerazione → diff rumorosi (v. PR post-merge
+    # #815/#817). Un UNICO pass finalizza l'ordine canonico per sezione.
+    registry = _canonicalize_registry(registry)
+
     registry_errors = validate_artifact(registry, "registry.schema.json")
     errors = {
         "datasets": cc_errors,
@@ -562,6 +568,75 @@ def _merge_existing_runs(
         if "run" not in s and s.get("id") in signals_run:
             s["run"] = signals_run[s["id"]]
 
+    return registry
+
+
+# Ordine canonico delle chiavi per sezione. Le chiavi non elencate vengono
+# accodate in ordine di arrivo (nessuna perdita).
+_CANONICAL_ORDER: dict[str, tuple[str, ...]] = {
+    "datasets": (
+        "slug",
+        "name",
+        "description",
+        "source",
+        "source_id",
+        "period",
+        "years",
+        "tags",
+        "category",
+        "columns",
+        "location",
+        "stage",
+        "registry_source",
+        "mart_refs",
+        "run",
+    ),
+    "marts": (
+        "slug",
+        "dataset",
+        "table",
+        "description",
+        "primary_key",
+        "required_columns",
+        "min_rows",
+        "run",
+        "location",
+    ),
+    "signals": (
+        "id",
+        "source_id",
+        "status",
+        "label",
+        "detail",
+        "action",
+        "years",
+        "run",
+    ),
+}
+
+
+def _canonicalize_entry(entry: dict[str, Any], order: tuple[str, ...]) -> dict[str, Any]:
+    """Riordina le chiavi di una entry secondo l'ordine canonico di sezione.
+
+    Chiavi note → ordine canonico; chiavi extra → accodate in ordine di
+    arrivo (preservate, niente perdite).
+    """
+    out: dict[str, Any] = {}
+    for key in order:
+        if key in entry:
+            out[key] = entry[key]
+    for key, value in entry.items():
+        if key not in out:
+            out[key] = value
+    return out
+
+
+def _canonicalize_registry(registry: dict[str, Any]) -> dict[str, Any]:
+    """Applica l'ordine chiavi canonico a tutte le entry delle sezioni."""
+    for section, order in _CANONICAL_ORDER.items():
+        entries = registry.get(section)
+        if isinstance(entries, list):
+            registry[section] = [_canonicalize_entry(e, order) for e in entries]
     return registry
 
 

--- a/toolkit/registry/graph.py
+++ b/toolkit/registry/graph.py
@@ -66,7 +66,7 @@ def load_workspace_graph(workspace: Path = WORKSPACE_ROOT) -> dict[str, Any]:
         return {"entities": {}, "bridges": [], "repos": []}
 
     for repo_dir in sorted(p for p in workspace.iterdir() if p.is_dir()):
-        payload, _is_legacy = load_repo_registry(repo_dir)
+        payload = load_repo_registry(repo_dir)
         repo_entities, repo_bridges = _entity_section(payload)
         if not repo_entities and not repo_bridges:
             continue

--- a/toolkit/registry/reader.py
+++ b/toolkit/registry/reader.py
@@ -4,10 +4,8 @@ Il registry builder (``toolkit.registry.builders``) genera e i repo committano
 il file unico ``{repo}/registry/registry.json`` (fusion ADR): sezioni
 ``datasets``, ``marts``, ``signals``, ``codelists``, ``entities``.
 
-Compatibilità: se il repo non ha ancora migrato (solo i vecchi
-clean_catalog/mart_catalog/pipeline_signals/codelists separati), il lettore
-cade sui file legacy. Esposizione all'agente (CLI e MCP) via
-``registry list`` / ``registry show <repo> <section>``.
+Esposizione all'agente (CLI e MCP) via ``registry list`` /
+``registry show <repo> <section>``.
 """
 
 from __future__ import annotations
@@ -18,19 +16,8 @@ from typing import Any
 
 from toolkit.core.paths import WORKSPACE_ROOT
 
-# Mappa: nome legacy → sezione del registry.json unico (per compatibilità).
-LEGACY_TO_SECTION = {
-    "clean_catalog": "datasets",
-    "mart_catalog": "marts",
-    "pipeline_signals": "signals",
-    "codelists": "codelists",
-    "entity_graph": "entities",
-}
-
 # Sezioni esposte (ordine stabile per list).
 SECTIONS = ("datasets", "marts", "signals", "codelists", "entities")
-
-EXCLUDED = (".schema.json", "README")
 
 
 def _section_count(section: str, payload: dict[str, Any]) -> int | None:
@@ -48,7 +35,7 @@ def _section_count(section: str, payload: dict[str, Any]) -> int | None:
     return None
 
 
-def _load_registry(repo_dir: Path) -> dict[str, Any] | None:
+def load_repo_registry(repo_dir: Path) -> dict[str, Any] | None:
     """Carica il registry unico del repo (registry.json), o None se assente."""
     path = repo_dir / "registry" / "registry.json"
     if not path.is_file():
@@ -59,88 +46,19 @@ def _load_registry(repo_dir: Path) -> dict[str, Any] | None:
         return None
 
 
-def _load_legacy(repo_dir: Path) -> tuple[dict[str, Any] | None, set[str]]:
-    """Fallback: carica i vecchi artifact separati come dict di sezioni.
-
-    Returns:
-        (payload sezioni, set delle sezioni effettivamente presenti nei file).
-    """
-    registry_dir = repo_dir / "registry"
-    if not registry_dir.is_dir():
-        return None, set()
-    payload: dict[str, Any] = {
-        "datasets": [],
-        "marts": [],
-        "signals": [],
-        "codelists": {},
-        "entities": {},
-    }
-    found_sections: set[str] = set()
-    legacy_files = {
-        "clean_catalog": "datasets",
-        "mart_catalog": "marts",
-        "pipeline_signals": "signals",
-        "codelists": "codelists",
-        "entity_graph": "entities",
-    }
-    for fname, section in legacy_files.items():
-        path = registry_dir / f"{fname}.json"
-        if not path.is_file():
-            continue
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            continue
-        if section == "datasets":
-            payload["datasets"] = data.get("datasets", [])
-        elif section == "marts":
-            payload["marts"] = data.get("marts", [])
-        elif section == "signals":
-            payload["signals"] = data.get("signals", [])
-        elif section == "codelists":
-            payload["codelists"] = data.get("codelists", {})
-        elif section == "entities":
-            payload["entities"] = data
-        found_sections.add(section)
-    if not found_sections:
-        return None, set()
-    return payload, found_sections
-
-
 def _scan_repo(repo_dir: Path) -> list[dict[str, Any]]:
     """Artifact del repo: registry unico (con conteggi per sezione)."""
-    payload = _load_registry(repo_dir)
-    if payload is not None:
-        counts = {section: _section_count(section, payload) for section in SECTIONS}
-        return [
-            {
-                "name": "registry",
-                "size_bytes": (repo_dir / "registry" / "registry.json").stat().st_size,
-                "sections": counts,
-            }
-        ]
-
-    legacy, _sections = _load_legacy(repo_dir)
-    if legacy is not None:
-        counts = {section: _section_count(section, legacy) for section in SECTIONS}
-        return [{"name": "registry", "size_bytes": None, "sections": counts, "legacy": True}]
-
-    return []
-
-
-def load_repo_registry(repo_dir: Path) -> tuple[dict[str, Any] | None, bool]:
-    """Carica il registry di un repo: formato unico o fallback legacy.
-
-    Returns:
-        (payload sezioni, is_legacy). None se il repo non ha registry.
-    """
-    payload = _load_registry(repo_dir)
-    if payload is not None:
-        return payload, False
-    payload, _sections = _load_legacy(repo_dir)
-    if payload is not None:
-        return payload, True
-    return None, False
+    payload = load_repo_registry(repo_dir)
+    if payload is None:
+        return []
+    counts = {section: _section_count(section, payload) for section in SECTIONS}
+    return [
+        {
+            "name": "registry",
+            "size_bytes": (repo_dir / "registry" / "registry.json").stat().st_size,
+            "sections": counts,
+        }
+    ]
 
 
 def list_registries(workspace: Path = WORKSPACE_ROOT) -> dict[str, Any]:
@@ -174,7 +92,6 @@ def show_registry(
         repo: Nome dir del repo (es. ``eurostat``).
         artifact: Sezione da mostrare (``datasets``, ``marts``, ``signals``,
             ``codelists``, ``entities``) o ``registry`` (intero).
-            Accetta anche i nomi legacy (``clean_catalog`` → ``datasets``).
         slug: Se fornito, filtra l'entry (dataset slug, mart slug, signal id,
             codelist name).
 
@@ -182,10 +99,7 @@ def show_registry(
         FileNotFoundError: se il repo/section non esiste nel workspace.
     """
     repo_dir = workspace / repo
-    payload = _load_registry(repo_dir)
-    legacy_sections: set[str] = set()
-    if payload is None:
-        payload, legacy_sections = _load_legacy(repo_dir)
+    payload = load_repo_registry(repo_dir)
 
     if payload is None:
         raise FileNotFoundError(
@@ -193,32 +107,28 @@ def show_registry(
             f"(usa 'toolkit registry list' per i repo disponibili)"
         )
 
-    section = LEGACY_TO_SECTION.get(artifact, artifact)
     if artifact == "registry":
         return {
             "repo": repo,
             "artifact": "registry",
-            "legacy": bool(legacy_sections),
             "data": payload,
         }
-    if section not in SECTIONS:
+    if artifact not in SECTIONS:
         raise FileNotFoundError(
             f"Sezione '{artifact}' non valida (usa una di: registry, " + ", ".join(SECTIONS) + ")"
         )
-    if legacy_sections and section not in legacy_sections:
-        raise FileNotFoundError(f"Sezione '{section}' non presente nel registry di {repo} (legacy)")
-    data = payload.get(section)
+    data = payload.get(artifact)
     if data is None:
-        raise FileNotFoundError(f"Sezione '{section}' non presente nel registry di {repo}")
+        raise FileNotFoundError(f"Sezione '{artifact}' non presente nel registry di {repo}")
 
     if slug:
         return {
             "repo": repo,
-            "artifact": section,
+            "artifact": artifact,
             "slug": slug,
-            "entry": _filter_entry(section, data, slug),
+            "entry": _filter_entry(artifact, data, slug),
         }
-    return {"repo": repo, "artifact": section, "data": data}
+    return {"repo": repo, "artifact": artifact, "data": data}
 
 
 def _filter_entry(section: str, data: Any, slug: str) -> dict[str, Any]:


### PR DESCRIPTION
## Sintesi

Tre cambi sull'artifact registry, tutti nello stesso dominio (fusion ADR):

1. **Ordine chiavi canonico** — `_canonicalize_registry` dopo `_merge_existing_runs`: il JSON viene scritto con ordine deterministico per datasets/marts/signals. Prima l'ordine di inserimento del dict variava a ogni rigenerazione → PR post-merge illeggibili (#815/#817).
2. **`toolkit registry build`** — comando unico che sostituisce i 6 `scripts/build_registry.py` per-repo: scopre le sezioni dati per convenzione (`repo_dataset_dirs`), deriva `source_repo` dal git remote, legge existing con `datasets+marts+signals`. **Fix del bug #465** negli altri 4 repo: i wrapper passavano existing senza `marts` → i run dei mart sparivano in CI.
3. **Drop fallback legacy reader** — rimossi `_load_legacy`, `LEGACY_TO_SECTION`, `EXCLUDED`; `load_repo_registry` ritorna solo `dict | None`. I repo hanno tutti `registry.json` dopo la #818, il fallback era codice morto.

## Contesto collegato

Vedi issue/PR del disallineamento wrapper (canonicalize, #465).

## Cosa cambia

- [x] Bug fix
- [x] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [x] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [x] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

- [ ] Struttura `dataset.yml`
- [ ] Path output
- [ ] Schema parquet
- [x] CLI o MCP tool (nuovo comando `registry build`)
- [x] API pubblica del toolkit (`load_repo_registry` cambia firma: tuple → `dict | None`)

> Se segnato, hai aggiornato downstream? [ ] `dataset-incubator` — [x] nessun consumer usa `load_repo_registry` esterno (verificato con `rg` sull'org)

## Verifica

```bash
pytest -q  # 1354 passed
ruff check .
mypy toolkit/registry/reader.py toolkit/domain/catalog.py toolkit/registry/graph.py
```

- [x] `pytest` passa (1354 passed)
- [x] `ruff check .` passa
- [x] `mypy` passa
- [x] Test aggiunti: `TestCanonicalize` (builder), `test_cli_registry.py` (comando), integrazione candidate reale (fixture mit-incidentalita)

## Checklist PR

- [x] Perimetro stretto: tre commit sullo stesso dominio (registry fusion)
- [ ] Nuovo plugin: n/a
- [x] Issue collegata o motivazione dell'assenza
- [x] **Rimozione funzione pubblica**: verificato con `rg` su tutta l'org che nessun consumer esterno usa `load_repo_registry`/legacy reader

## Note per chi revisiona

- `load_repo_registry` cambia firma (era `tuple[dict|None, bool]`, ora `dict | None`): nessun consumer esterno, ma è una breaking change del toolkit — da segnalare nel CHANGELOG.
- La migrazione dei 6 repo al comando `registry build` è additiva e si fa repo-per-repo (non in questa PR).
- `toolkit registry build --prefix <x> --flat --write` è il nuovo workflow per i repo con layout custom (es. eurostat).