### PR TITLE
registry snello (catalogo puro) + column-values on-demand

### DIFF
--- a/tests/test_catalog_ops.py
+++ b/tests/test_catalog_ops.py
@@ -490,6 +490,40 @@ class TestDescribeSlug:
         with pytest.raises(FileNotFoundError):
             resolver.describe_slug("slug_che_non_esiste")
 
+    def test_describe_with_profile_on_demand(
+        self, resolver: CatalogResolver, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """describe_slug con profile=True aggiunge il profilo valori (on-demand)."""
+        fake_preview = {
+            "path": "s3://dataciviclab-clean/anac_bandi_gara/2024/anac_bandi_gara_2024_clean.parquet",
+            "column_count": 2,
+            "columns": [
+                {"name": "cig", "type": "VARCHAR"},
+                {"name": "importo", "type": "DOUBLE"},
+            ],
+            "row_count": 100,
+            "preview": [],
+            "truncated": False,
+            "slug": "anac_bandi_gara",
+            "year": 2024,
+        }
+        monkeypatch.setattr(
+            "toolkit.domain.catalog.parquet_preview", lambda path, limit=5: fake_preview
+        )
+        monkeypatch.setattr(
+            "toolkit.domain.column_values.build_column_values_profile",
+            lambda parquet, columns, top_n=20: {"n_rows": 100, "columns": {}},
+        )
+
+        # Default: nessun profilo (comportamento invariato)
+        result = resolver.describe_slug("anac_bandi_gara")
+        assert "values" not in result
+
+        # profile=True: sezione values presente
+        result_p = resolver.describe_slug("anac_bandi_gara", profile=True)
+        assert "values" in result_p
+        assert result_p["values"] == {"n_rows": 100, "columns": {}}
+
 
 # ---------------------------------------------------------------------------
 # Local workspace merge

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -65,12 +65,11 @@ def test_build_dry_run_reports_counts(tmp_path: Path) -> None:
 
 
 @pytest.mark.pure_unit
-def test_build_write_preserves_mart_runs(tmp_path: Path) -> None:
-    """Il comando scrive registry.json e preserva i run dei mart da existing.
+def test_build_write_keeps_registry_slim(tmp_path: Path) -> None:
+    """Il comando scrive registry.json snello: niente run su datasets/marts.
 
-    È il fix del bug #465: i wrapper legacy passavano existing_catalog senza
-    la sezione marts → i run dei mart sparivano a ogni rigenerazione CI.
-    with_run=False simula la CI (nessun run record locale → existing prevale).
+    Registry snello (ADR): il blocco run vive solo nei signals (usato dal
+    dashboard); datasets/marts non lo portano (nessun consumer lo legge).
     """
     _make_repo(tmp_path, with_run=False)
     out = tmp_path / "outreg"
@@ -81,7 +80,9 @@ def test_build_write_preserves_mart_runs(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.stdout + result.stderr
     payload = json.loads((out / "registry.json").read_text(encoding="utf-8"))
     mart = next(m for m in payload["marts"] if m["slug"] == "my_dataset__mart_trend")
-    assert mart["run"]["run_id"] == "OLD"
+    assert "run" not in mart  # registry snello: niente run sui marts
+    ds = next(d for d in payload["datasets"] if d["slug"] == "my_dataset")
+    assert "run" not in ds  # registry snello: niente run sui datasets
     assert payload["source_repo"] == "dataciviclab/toolkit" or payload["source_repo"]
 
 

--- a/tests/test_column_values.py
+++ b/tests/test_column_values.py
@@ -99,6 +99,19 @@ class TestColumnValuesProfile:
         assert len(profile["columns"]["regione"]["top_values"]) == 1
 
     @pytest.mark.contract
+    def test_top_not_truncated_when_exact_match(self, tmp_path: Path) -> None:
+        """Colonna con esattamente top_n valori distinti → NON troncata (edge case)."""
+        parquet = tmp_path / "clean.parquet"
+        _write_parquet(parquet)
+
+        # regione ha 2 valori distinti non-null (Lombardia, Piemonte): con
+        # top_n=2 il flag deve essere False (prima era falso positivo con >=).
+        profile = build_column_values_profile(parquet, _columns_fixture(), top_n=2)
+        regione = profile["columns"]["regione"]
+        assert regione["top_truncated"] is False
+        assert len(regione["top_values"]) == 2
+
+    @pytest.mark.contract
     def test_no_dimensions(self, tmp_path: Path) -> None:
         parquet = tmp_path / "clean.parquet"
         _write_parquet(parquet)

--- a/tests/test_column_values.py
+++ b/tests/test_column_values.py
@@ -1,0 +1,294 @@
+"""Test per ``toolkit column-values`` — profilo valori delle colonne dimensionali.
+
+Testa la logica di dominio (build_column_values_profile) e il layer CLI
+(comando ``column-values``). Fixture: parquet creato via DuckDB in tmp_path,
+nessuna rete.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from toolkit.cli.app import app
+from toolkit.domain.column_values import (
+    build_column_values_profile,
+    generate_workspace_column_values,
+)
+
+pytest.importorskip("duckdb")
+
+runner = CliRunner()
+
+
+def _write_parquet(path: Path) -> None:
+    import duckdb
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with duckdb.connect() as con:
+        con.execute(
+            "CREATE TABLE t (regione VARCHAR, provincia VARCHAR, "
+            "anno INTEGER, valore DOUBLE, attivo BOOLEAN)"
+        )
+        con.execute(
+            "INSERT INTO t VALUES "
+            "('Lombardia', 'MI', 2024, 10.5, true), "
+            "('Lombardia', 'MI', 2024, 12.0, true), "
+            "('Lombardia', 'BG', 2024, 9.5, false), "
+            "('Piemonte', 'TO', 2024, 7.0, true), "
+            "(NULL, NULL, 2024, 5.0, NULL)"
+        )
+        con.execute(f"COPY t TO '{path}' (FORMAT parquet)")
+
+
+def _columns_fixture() -> list[dict]:
+    return [
+        {"name": "regione", "type": "VARCHAR", "role": "dimension", "semantic_type": "region_code"},
+        {"name": "provincia", "type": "VARCHAR", "role": "dimension"},
+        {"name": "anno", "type": "INTEGER", "role": "dimension"},
+        {"name": "valore", "type": "DOUBLE", "role": "metric"},
+        {"name": "attivo", "type": "BOOLEAN", "role": "dimension"},
+    ]
+
+
+class TestColumnValuesProfile:
+    @pytest.mark.contract
+    def test_happy_path_dimensions_only(self, tmp_path: Path) -> None:
+        parquet = tmp_path / "clean.parquet"
+        _write_parquet(parquet)
+
+        profile = build_column_values_profile(parquet, _columns_fixture(), top_n=10)
+
+        assert profile["n_rows"] == 5
+        assert profile["count_distinct_mode"] == "approx"
+        assert profile["n_columns_profiled"] == 4  # regione, provincia, anno, attivo
+
+        # metriche escluse
+        assert "valore" not in profile["columns"]
+
+        # regione: 4 non-null, ~2 distinct (approx)
+        regione = profile["columns"]["regione"]
+        assert regione["role"] == "dimension"
+        assert regione["semantic_type"] == "region_code"
+        assert regione["n_null"] == 1
+        assert 2 <= regione["n_distinct"] <= 3
+        assert regione["top_values"][0] == {"value": "Lombardia", "n": 3, "pct": 60.0}
+        assert regione["top_truncated"] is False
+
+    @pytest.mark.contract
+    def test_boolean_and_date_values_json_safe(self, tmp_path: Path) -> None:
+        parquet = tmp_path / "clean.parquet"
+        _write_parquet(parquet)
+
+        profile = build_column_values_profile(parquet, _columns_fixture(), top_n=10)
+        # valore booleano serializzabile in JSON
+        attivo = profile["columns"]["attivo"]
+        assert attivo["n_distinct"] == 2
+        json.dumps(profile)  # non deve sollevare TypeError
+
+    @pytest.mark.contract
+    def test_top_truncated(self, tmp_path: Path) -> None:
+        parquet = tmp_path / "clean.parquet"
+        _write_parquet(parquet)
+
+        profile = build_column_values_profile(parquet, _columns_fixture(), top_n=1)
+        assert profile["columns"]["regione"]["top_truncated"] is True
+        assert len(profile["columns"]["regione"]["top_values"]) == 1
+
+    @pytest.mark.contract
+    def test_no_dimensions(self, tmp_path: Path) -> None:
+        parquet = tmp_path / "clean.parquet"
+        _write_parquet(parquet)
+
+        profile = build_column_values_profile(
+            parquet, [{"name": "valore", "type": "DOUBLE", "role": "metric"}]
+        )
+        assert profile["n_rows"] is None
+        assert profile["n_columns_profiled"] == 0
+        assert profile["columns"] == {}
+
+
+class TestColumnValuesBatch:
+    @pytest.mark.contract
+    def test_batch_generates_profiles_for_repo(self, tmp_path: Path) -> None:
+        # workspace/repo/section/slug/dataset.yml + parquet clean
+        repo_root = tmp_path / "repo-a"
+        parquet = repo_root / "out" / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
+        _write_parquet(parquet)
+        ds_dir = repo_root / "datasets" / "demo"
+        ds_dir.mkdir(parents=True)
+        yml = """
+root: "../../out"
+schema_version: 1
+dataset:
+  name: "demo"
+  source_id: "src1"
+  tags: [test]
+  category: demo
+  years: [2024]
+"""
+        (ds_dir / "dataset.yml").write_text(yml, encoding="utf-8")
+
+        out_dir = tmp_path / "_local" / "generated" / "column_values"
+        result = generate_workspace_column_values(tmp_path, out_dir, top_n=10)
+
+        assert result.processed == 1
+        assert result.written == 1
+        assert result.errors == []
+        assert (out_dir / "demo__column_values.json").is_file()
+
+    @pytest.mark.contract
+    def test_batch_dedup_slug_across_repos(self, tmp_path: Path) -> None:
+        # stesso slug in due repo: solo il primo viene scritto, il secondo skip
+        def _make_repo(name: str) -> None:
+            repo_root = tmp_path / name
+            parquet = (
+                repo_root / "out" / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
+            )
+            _write_parquet(parquet)
+            ds_dir = repo_root / "datasets" / "demo"
+            ds_dir.mkdir(parents=True)
+            yml = """
+root: "../../out"
+schema_version: 1
+dataset:
+  name: "demo"
+  source_id: "src1"
+  tags: [test]
+  category: demo
+  years: [2024]
+"""
+            (ds_dir / "dataset.yml").write_text(yml, encoding="utf-8")
+
+        _make_repo("aaa-first")
+        _make_repo("zzz-second")
+
+        out_dir = tmp_path / "_local" / "generated" / "column_values"
+        result = generate_workspace_column_values(tmp_path, out_dir, top_n=10)
+
+        assert result.written == 1
+        assert len(result.skipped) == 1
+        assert "duplicato" in result.skipped[0]
+
+    @pytest.mark.contract
+    def test_batch_skips_no_clean(self, tmp_path: Path) -> None:
+        # dataset senza parquet clean: skip, nessun errore
+        repo_root = tmp_path / "repo-a"
+        ds_dir = repo_root / "datasets" / "demo"
+        ds_dir.mkdir(parents=True)
+        yml = """
+root: "../../out"
+schema_version: 1
+dataset:
+  name: "demo"
+  source_id: "src1"
+  tags: [test]
+  category: demo
+  years: [2024]
+"""
+        (ds_dir / "dataset.yml").write_text(yml, encoding="utf-8")
+
+        out_dir = tmp_path / "_local" / "generated" / "column_values"
+        result = generate_workspace_column_values(tmp_path, out_dir, top_n=10)
+
+        assert result.processed == 1
+        assert result.written == 0
+        assert len(result.skipped) == 1
+        assert result.errors == []
+
+
+class TestColumnValuesCli:
+    @pytest.mark.contract
+    def test_requires_config(self) -> None:
+        result = runner.invoke(app, ["column-values"])
+        assert result.exit_code != 0
+        assert "config" in (result.stdout + result.stderr).lower()
+
+    @pytest.mark.contract
+    def test_json_output(self, tmp_path: Path) -> None:
+        parquet = tmp_path / "out" / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
+        _write_parquet(parquet)
+
+        # mini-repo: dataset.yml con root relativo che punta a out/
+        ds_dir = tmp_path / "datasets" / "demo"
+        ds_dir.mkdir(parents=True)
+        yml = """
+root: "../../out"
+schema_version: 1
+dataset:
+  name: "demo"
+  source_id: "src1"
+  tags: [test]
+  category: demo
+  years: [2024]
+"""
+        config_path = ds_dir / "dataset.yml"
+        config_path.write_text(yml, encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["column-values", "-c", str(config_path), "--json", "--top", "5"],
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(result.stdout)
+        assert data["dataset"] == "demo"
+        assert data["year"] == 2024
+        assert data["n_rows"] == 5
+        assert "regione" in data["columns"]
+
+    @pytest.mark.contract
+    def test_writes_json_file(self, tmp_path: Path) -> None:
+        parquet = tmp_path / "out" / "data" / "clean" / "demo" / "2024" / "demo_2024_clean.parquet"
+        _write_parquet(parquet)
+
+        ds_dir = tmp_path / "datasets" / "demo"
+        ds_dir.mkdir(parents=True)
+        yml = """
+root: "../../out"
+schema_version: 1
+dataset:
+  name: "demo"
+  source_id: "src1"
+  tags: [test]
+  category: demo
+  years: [2024]
+"""
+        config_path = ds_dir / "dataset.yml"
+        config_path.write_text(yml, encoding="utf-8")
+
+        out_dir = tmp_path / "_local" / "generated" / "column_values"
+        result = runner.invoke(
+            app,
+            ["column-values", "-c", str(config_path), "--out", str(out_dir)],
+        )
+        assert result.exit_code == 0, result.output
+
+        out_path = out_dir / "demo__column_values.json"
+        assert out_path.is_file()
+        data = json.loads(out_path.read_text(encoding="utf-8"))
+        assert data["dataset"] == "demo"
+
+    @pytest.mark.contract
+    def test_missing_parquet_errors(self, tmp_path: Path) -> None:
+        ds_dir = tmp_path / "datasets" / "demo"
+        ds_dir.mkdir(parents=True)
+        yml = """
+root: "../../out"
+schema_version: 1
+dataset:
+  name: "demo"
+  source_id: "src1"
+  tags: [test]
+  category: demo
+  years: [2024]
+"""
+        config_path = ds_dir / "dataset.yml"
+        config_path.write_text(yml, encoding="utf-8")
+
+        result = runner.invoke(app, ["column-values", "-c", str(config_path), "--json"])
+        assert result.exit_code != 0
+        assert "non trovato" in (result.stdout + result.stderr).lower()

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -164,9 +164,13 @@ def test_clean_catalog_contract(tmp_path: Path) -> None:
     assert ds["description"] == "Test dataset per il registry builder"  # da registry.description
     assert [c["name"] for c in ds["columns"]] == ["geo", "year", "value"]
     assert ds["mart_refs"] == ["my_dataset__mart_trend"]
-    assert ds["run"]["status"] == "SUCCESS"
-    assert ds["run"]["quality_score"] == {"raw": 100, "clean": 95, "mart": 100}
-    assert ds["run"]["output_bytes"] == {"raw": 6961784, "clean": 9757664}
+    # role derivato: year ha semantic_type → dimension (non metric)
+    roles = {c["name"]: c["role"] for c in ds["columns"]}
+    assert roles == {"geo": "dimension", "year": "dimension", "value": "metric"}
+    # blocco run NON presente (nessun consumer lo legge dai datasets)
+    assert "run" not in ds
+    assert "years" not in ds
+    assert "registry_source" not in ds
 
 
 @pytest.mark.policy
@@ -205,10 +209,13 @@ def test_mart_catalog_contract(tmp_path: Path) -> None:
     mart = catalog["marts"][0]
     assert mart["slug"] == "my_dataset__mart_trend"
     assert mart["dataset"] == "my_dataset"
-    assert mart["primary_key"] == ["year", "geo"]
-    assert mart["required_columns"] == ["year", "geo", "value"]
-    assert mart["min_rows"] == 10
-    assert mart["run"]["status"] == "SUCCESS"
+    assert mart["table"] == "mart_trend"
+    # registry snello: niente run/description/validation rules (non consumati)
+    assert "run" not in mart
+    assert "description" not in mart
+    assert "primary_key" not in mart
+    assert "required_columns" not in mart
+    assert "min_rows" not in mart
 
 
 @pytest.mark.pure_unit
@@ -255,8 +262,9 @@ def test_signals_contract(tmp_path: Path) -> None:
     sig = payload["signals"][0]
     assert sig["id"] == "my_dataset"
     assert sig["status"] == "ok"
-    assert sig["years"] == [2024, 2025]
     assert sig["run"]["run_id"] == "20260101T000000Z_abc123"
+    # registry snello: years del signal rimosso (non consumato)
+    assert "years" not in sig
 
 
 @pytest.mark.policy
@@ -349,7 +357,7 @@ def test_registry_builder_imports() -> None:
 
 @pytest.mark.contract
 def test_codelists_contract(tmp_path: Path) -> None:
-    """codelists.json espone i valori delle dimensioni dal repo (contract)."""
+    """codelists espone i NOMI dei codelist del repo (contract)."""
     from toolkit.registry.builders import build_codelists
 
     layout = _make_repo(tmp_path)
@@ -366,48 +374,26 @@ def test_codelists_contract(tmp_path: Path) -> None:
 
     payload, errors = build_codelists(layout)
     assert errors == {"derive": [], "validation": []}, f"errori inattesi: {errors}"
-    assert payload["codelists"]["units"] == [
-        {"unit": "EUR_HAB", "label_en": "EUR per inhabitant"},
-        {"unit": "PPS_HAB", "label_en": "PPS per inhabitant"},
-    ]
-    assert payload["codelists"]["geo"] == [
-        {"code": "ITC4", "label_en": "Lombardia", "nuts_level": "3", "parent_code": "ITH"}
-    ]
-
-
-@pytest.mark.pure_unit
-def test_codelists_large_external(tmp_path: Path) -> None:
-    """Codelist oltre la soglia → dichiarato in large, non embedded (policy)."""
-    from toolkit.registry.builders import build_codelists, MAX_CODELIST_ROWS
-
-    layout = _make_repo(tmp_path)
-    cl_dir = tmp_path / "codelists"
-    cl_dir.mkdir()
-    rows = "".join(f"code{i},label{i}\n" for i in range(MAX_CODELIST_ROWS + 5))
-    (cl_dir / "big.csv").write_text("code,label_en\n" + rows, encoding="utf-8")
-
-    payload, errors = build_codelists(layout)
-    assert errors == {"derive": [], "validation": []}
-    assert "big" not in payload["codelists"]
-    assert payload["large"] == ["big"]
+    assert payload["codelists"] == ["geo", "units"]
 
 
 @pytest.mark.pure_unit
 def test_codelists_empty_without_dir(tmp_path: Path) -> None:
-    """Senza dir codelists → payload vuoto, nessun errore (opzionale)."""
+    """Senza dir codelists → lista vuota, nessun errore (opzionale)."""
     from toolkit.registry.builders import build_codelists
 
     layout = _make_repo(tmp_path)
     payload, errors = build_codelists(layout)
     assert errors == {"derive": [], "validation": []}
-    assert payload["codelists"] == {}
+    assert payload["codelists"] == []
 
 
 class TestRegistryExistingRun:
-    """build_registry preserva i run storici da existing quando il run locale manca (CI).
+    """build_registry preserva i run storici dei signals da existing (CI).
 
-    Unico pass centralizzato (_merge_existing_runs) per datasets/marts/signals:
-    in CI post-merge i dataset non rieseguiti non hanno run record locali.
+    Unico pass centralizzato (_merge_existing_runs) sui signals: in CI
+    post-merge i dataset non rieseguiti non hanno run record locali. I
+    datasets/marts nel registry snello non hanno run (nessun consumer).
     """
 
     def _build(self, tmp_path, with_run):
@@ -446,26 +432,22 @@ class TestRegistryExistingRun:
         return result["registry"]
 
     @pytest.mark.contract
-    def test_preserves_runs_when_local_missing(self, tmp_path: Path) -> None:
-        """CI: nessun run locale → i run vengono da existing (tutte le sezioni)."""
+    def test_preserves_signals_run_when_local_missing(self, tmp_path: Path) -> None:
+        """CI: nessun run locale → il run dei signals viene da existing."""
         reg = self._build(tmp_path, with_run=False)
         ds = next(d for d in reg["datasets"] if d["slug"] == "my_dataset")
-        assert ds["run"]["run_id"] == "OLD_dataset"
+        assert "run" not in ds  # datasets snello: nessun run
         mart = next(m for m in reg["marts"] if m["slug"] == "my_dataset__mart_trend")
-        assert mart["run"]["run_id"] == "OLD_mart"
+        assert "run" not in mart  # marts snello: nessun run
         sig = next(s for s in reg["signals"] if s["id"] == "my_dataset")
         assert sig["run"]["run_id"] == "OLD_signal"
 
     @pytest.mark.contract
-    def test_local_run_wins_over_existing(self, tmp_path: Path) -> None:
+    def test_local_signal_run_wins_over_existing(self, tmp_path: Path) -> None:
         """Run locale presente → vince su existing (non lo sovrascrive)."""
         reg = self._build(tmp_path, with_run=True)
-        ds = next(d for d in reg["datasets"] if d["slug"] == "my_dataset")
-        assert ds["run"]["run_id"] == "20260101T000000Z_abc123"  # run locale, non OLD
-        mart = next(m for m in reg["marts"] if m["slug"] == "my_dataset__mart_trend")
-        assert mart["run"]["run_id"] == "20260101T000000Z_abc123"  # run locale
         sig = next(s for s in reg["signals"] if s["id"] == "my_dataset")
-        assert sig["run"]["run_id"] == "20260101T000000Z_abc123"  # run locale
+        assert sig["run"]["run_id"] == "20260101T000000Z_abc123"  # run locale, non OLD
 
 
 class TestCanonicalize:
@@ -502,13 +484,11 @@ class TestCanonicalize:
         return result["registry"]
 
     @pytest.mark.contract
-    def test_mart_run_position_before_location(self, tmp_path: Path) -> None:
-        """Il run ripristinato da existing va prima di location (canonico)."""
+    def test_mart_canonical_order(self, tmp_path: Path) -> None:
+        """Ordine canonico mart: slug, dataset, table, location."""
         reg = self._build_with_existing(tmp_path)
         mart = next(m for m in reg["marts"] if m["slug"] == "my_dataset__mart_trend")
-        keys = list(mart.keys())
-        assert keys.index("run") < keys.index("location")
-        assert keys[:4] == ["slug", "dataset", "table", "description"]
+        assert list(mart.keys()) == ["slug", "dataset", "table", "location"]
 
     @pytest.mark.contract
     def test_dataset_canonical_order(self, tmp_path: Path) -> None:
@@ -522,15 +502,12 @@ class TestCanonicalize:
             "source",
             "source_id",
             "period",
-            "years",
             "tags",
             "category",
             "columns",
             "location",
             "stage",
-            "registry_source",
             "mart_refs",
-            "run",
         ]
         assert keys == canonical
 
@@ -611,7 +588,6 @@ class TestEntityGraph:
         }
         graph = build_entity_graph(catalog)
 
-        assert graph["summary"]["total_entities"] >= 2
         entities = graph["entities"]
         assert "Gara" in entities  # cig_code → entity Gara
         assert "Comune" in entities  # municipality_code → entity Comune
@@ -622,6 +598,9 @@ class TestEntityGraph:
             for b in bridges
         )
         assert graph["schema_version"] == 1
+        # registry snello: niente summary/generated_from (non consumati)
+        assert "summary" not in graph
+        assert "generated_from" not in graph
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -193,6 +193,59 @@ def test_clean_catalog_missing_parquet_reported(tmp_path: Path) -> None:
     assert catalog["datasets"] == []
 
 
+@pytest.mark.contract
+def test_clean_catalog_slims_editorial_entry_without_parquet(tmp_path: Path) -> None:
+    """Entry editoriale (no parquet locale) preservata MA filtrata dalle chiavi morte.
+
+    La path editoriale è l'unico percorso dove le chiavi legacy dell'existing
+    (run, years, registry_source) potrebbero rientrare nel registry: senza
+    parquet locale l'entry non passa dal builder derivato. Il filtro
+    (_slim_dataset_entry) deve comunque applicarsi, così come il fix role
+    (year → dimension).
+    """
+    layout = _make_repo(tmp_path)
+    import shutil
+
+    shutil.rmtree(layout.repo_root / "out" / "data" / "clean")
+
+    existing = {
+        "datasets": [
+            {
+                "slug": "my_dataset",
+                "name": "My Dataset",
+                "description": "Editoriale",
+                "source_id": "src1",
+                "period": {"start": 2020, "end": 2024},
+                "columns": [
+                    {"name": "anno", "type": "INTEGER", "role": "metric", "semantic_type": "year"},
+                    {"name": "importo", "type": "DOUBLE", "role": "metric"},
+                ],
+                "location": {"type": "gcs", "path": "gs://dataciviclab-clean/my_dataset/"},
+                "stage": "published",
+                # chiavi morte legacy: non devono tornare nel registry
+                "run": {"run_id": "OLD", "year": 2025, "status": "SUCCESS"},
+                "years": [2025],
+                "registry_source": "editorial",
+            }
+        ]
+    }
+
+    catalog, errors = build_clean_catalog(layout, existing=existing)
+    assert errors == {"derive": [], "validation": []}, f"errori inattesi: {errors}"
+    ds = catalog["datasets"][0]
+    assert ds["slug"] == "my_dataset"
+    # chiavi morte filtrate
+    assert "run" not in ds
+    assert "years" not in ds
+    assert "registry_source" not in ds
+    # campi editoriali preservati
+    assert ds["stage"] == "published"
+    assert ds["description"] == "Editoriale"
+    # role corretto anche sull'entry editoriale (year → dimension)
+    roles = {c["name"]: c["role"] for c in ds["columns"]}
+    assert roles == {"anno": "dimension", "importo": "metric"}
+
+
 # ---------------------------------------------------------------------------
 # mart_catalog
 # ---------------------------------------------------------------------------

--- a/tests/test_registry_ops.py
+++ b/tests/test_registry_ops.py
@@ -90,5 +90,5 @@ def test_section_count_pure() -> None:
     assert _section_count("datasets", {"datasets": [1, 2]}) == 2
     assert _section_count("marts", {"marts": [1]}) == 1
     assert _section_count("signals", {"signals": [1, 2, 3]}) == 3
-    assert _section_count("codelists", {"codelists": {"geo": [], "units": []}}) == 2
+    assert _section_count("codelists", {"codelists": ["geo", "units"]}) == 2
     assert _section_count("entities", {"entities": {"entities": {}}}) == 0

--- a/toolkit/cli/app.py
+++ b/toolkit/cli/app.py
@@ -7,6 +7,7 @@ from toolkit.cli.cmd_inspect import register as register_inspect
 from toolkit.cli.cmd_contract import register as register_contract
 from toolkit.cli.cmd_scout import register as register_scout
 from toolkit.cli.cmd_registry import register as register_registry
+from toolkit.cli.cmd_column_values import register as register_column_values
 from toolkit.version import __version__
 
 app = typer.Typer(no_args_is_help=True, add_completion=False)
@@ -28,6 +29,7 @@ register_inspect(app)
 register_contract(app)
 register_scout(app)
 register_registry(app)
+register_column_values(app)
 
 
 def main():

--- a/toolkit/cli/cmd_column_values.py
+++ b/toolkit/cli/cmd_column_values.py
@@ -1,0 +1,135 @@
+"""toolkit column-values — profilo valori delle colonne dimensionali.
+
+Per un dataset clean, genera un JSON con gli aggregati di valore di ogni
+colonna dimensionale: cardinalita', null, top-N valori con percentuale.
+
+Prova locale (branch feat/column-values-profile): output in
+``<workspace>/_local/generated/column_values/`` o con ``--out``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+
+from toolkit.core.config import load_config
+from toolkit.core.io import write_json_atomic
+from toolkit.core.paths import WORKSPACE_ROOT
+from toolkit.domain.column_values import (
+    build_column_values_profile,
+    generate_workspace_column_values,
+)
+from toolkit.domain.path_resolver import payload_for_year
+from toolkit.registry.schema_reader import (
+    load_semantic_types,
+    parquet_columns,
+)
+
+
+def column_values(
+    config: str = typer.Option(None, "--config", "-c", help="Path or slug to dataset.yml"),
+    year: int | None = typer.Option(None, "--year", "-y", help="Dataset year"),
+    top: int = typer.Option(20, "--top", help="Max top values per column"),
+    out: str | None = typer.Option(
+        None, "--out", help="Output dir (default: <workspace>/_local/generated/column_values/)"
+    ),
+    all_datasets: bool = typer.Option(
+        False, "--all", help="Genera i profili per tutti i dataset clean locali del workspace"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Print JSON to stdout"),
+):
+    """Profilo valori delle colonne dimensionali di un dataset clean.
+
+    Esempi:
+        toolkit column-values -c dataset-incubator/candidates/camera-votazioni-sparql
+        toolkit column-values -c camera_votazioni_sparql --year 2024 --top 10
+        toolkit column-values --all
+    """
+    if all_datasets:
+        if config:
+            raise typer.BadParameter("--all non si combina con --config")
+        out_dir = (
+            Path(out).resolve()
+            if out
+            else WORKSPACE_ROOT / "_local" / "generated" / "column_values"
+        )
+        result = generate_workspace_column_values(
+            WORKSPACE_ROOT,
+            out_dir,
+            top_n=top,
+            latest_year_only=True,
+            log=lambda msg: typer.echo(msg),
+        )
+        typer.echo(
+            f"BATCH: processed={result.processed} written={result.written} "
+            f"skipped={len(result.skipped)} errors={len(result.errors)} "
+            f"in {result.duration_seconds}s"
+        )
+        if result.errors:
+            typer.echo("ERRORI:", err=True)
+            for e in result.errors[:20]:
+                typer.echo(f"  {e}", err=True)
+        return
+
+    if not config:
+        raise typer.BadParameter("Serve --config (path o slug a dataset.yml)")
+
+    cfg = load_config(config)
+    if year is None:
+        year = max(cfg.years) if cfg.years else 0
+
+    payload = payload_for_year(cfg, year)
+    clean_output = (payload.get("paths") or {}).get("clean", {}).get("output")
+    if not clean_output:
+        raise typer.BadParameter(f"Nessun output clean configurato per {cfg.dataset}/{year}")
+    parquet = Path(clean_output)
+    if not parquet.is_file():
+        typer.echo(f"ERRORE: parquet clean non trovato: {parquet}", err=True)
+        raise typer.Exit(code=1)
+
+    columns = parquet_columns(parquet, load_semantic_types())
+    if not columns:
+        typer.echo(f"ERRORE: nessuno schema leggibile da {parquet}", err=True)
+        raise typer.Exit(code=1)
+
+    profile = build_column_values_profile(parquet, columns, top_n=top)
+    profile.update(
+        {
+            "schema_version": 1,
+            "dataset": cfg.dataset,
+            "year": year,
+            "config_path": str(cfg.base_dir / "dataset.yml"),
+            "parquet": str(parquet),
+        }
+    )
+
+    if json_output:
+        typer.echo(json.dumps(profile, indent=2, ensure_ascii=False, default=str))
+        return
+
+    n_rows = profile.get("n_rows")
+    typer.echo(
+        f"{cfg.dataset}/{year} — {profile['n_columns_profiled']} colonne dimensionali "
+        f"(righe: {n_rows})"
+    )
+    for name, entry in profile["columns"].items():
+        top_preview = ", ".join(f"{tv['value']}={tv['n']}" for tv in entry["top_values"][:3])
+        suffix = "..." if entry["top_truncated"] else ""
+        typer.echo(
+            f"  {name}: distinct={entry['n_distinct']} null={entry['n_null']} "
+            f"[{top_preview}{suffix}]"
+        )
+
+    out_dir = (
+        Path(out).resolve() if out else WORKSPACE_ROOT / "_local" / "generated" / "column_values"
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{cfg.dataset}__column_values.json"
+    write_json_atomic(out_path, profile)
+    typer.echo(f"scritto {out_path}")
+
+
+def register(app: typer.Typer) -> None:
+    app.command("column-values")(column_values)

--- a/toolkit/cli/cmd_registry.py
+++ b/toolkit/cli/cmd_registry.py
@@ -173,10 +173,10 @@ def registry_build(
         raise typer.Exit(code=1)
 
     registry = result["registry"]
-    s = registry["summary"]
     typer.echo(
-        f"registry.json — datasets {s['datasets']}, marts {s['marts']}, "
-        f"signals {s['signals']} (repo: {layout.source_repo})"
+        f"registry.json — datasets {len(registry['datasets'])}, "
+        f"marts {len(registry['marts'])}, "
+        f"signals {len(registry['signals'])} (repo: {layout.source_repo})"
     )
     if not write:
         typer.echo("Dry-run: usa --write per scrivere il file.")

--- a/toolkit/domain/catalog.py
+++ b/toolkit/domain/catalog.py
@@ -817,6 +817,7 @@ class CatalogResolver:
         layer: str = "clean",
         year: int | None = None,
         source: str = "all",
+        profile: bool = False,
     ) -> dict[str, Any]:
         """Schema DuckDB + row count per slug.
 
@@ -825,6 +826,8 @@ class CatalogResolver:
             layer: ``"clean"`` (default) o ``"mart"``.
             year: Anno specifico o ``None`` (ultimo disponibile).
             source: ``"gcs"``, ``"workspace"``, ``"all"`` (default).
+            profile: Se True, profila i valori delle colonne dimensionali
+                (cardinalità, null, top-N) — on-demand, off di default.
 
         Raises:
             FileNotFoundError: se slug non trovato nella source richiesta.
@@ -875,6 +878,14 @@ class CatalogResolver:
                         if sc.get("description"):
                             col["description"] = sc["description"]
                 result["_repo"] = sem.get("_repo")
+            # Profilo valori delle colonne dimensionali (on-demand).
+            # Usa le colonne arricchite (role/semantic_type dal catalogo):
+            # il role è la base per decidere cosa profila.
+            if profile:
+                from toolkit.domain.column_values import build_column_values_profile
+
+                profile_data = build_column_values_profile(parquet_path, result.get("columns", []))
+                result["values"] = profile_data
             return result
         except Exception as exc:
             raise RuntimeError(

--- a/toolkit/domain/column_values.py
+++ b/toolkit/domain/column_values.py
@@ -53,13 +53,16 @@ def _build_summary_sql(parquet: Path, dims: list[dict[str, Any]]) -> str:
 
 def _build_top_sql(parquet: Path, col_name: str, top_n: int) -> str:
     ident = q_ident(col_name)
+    # LIMIT top_n + 1: serve a rilevare se ci sono PIÙ valori oltre il limite
+    # (top_truncated). Con LIMIT top_n, una colonna con esattamente top_n
+    # valori distinti risulterebbe falsamente troncata.
     return (
         f"SELECT {ident} AS value, COUNT(*) AS n\n"
         f"FROM read_parquet('{sql_path(parquet)}')\n"
         f"WHERE {ident} IS NOT NULL\n"
         f"GROUP BY {ident}\n"
         f"ORDER BY n DESC, value\n"
-        f"LIMIT {int(top_n)}"
+        f"LIMIT {int(top_n) + 1}"
     )
 
 
@@ -119,11 +122,15 @@ def build_column_values_profile(
             entry["distinct_ratio"] = round(n_distinct / n_rows, 6) if n_rows else None
 
             rows = con.execute(_build_top_sql(parquet, name, top_n)).fetchall()
+            # La query ritorna fino a top_n + 1: oltre top_n c'è sicuramente
+            # troncamento (l'ultimo valore è l'overflow marker).
+            truncated = len(rows) > top_n
+            rows = rows[:top_n]
             top_values = [{"value": _json_safe_value(r[0]), "n": int(r[1])} for r in rows]
             for tv in top_values:
                 tv["pct"] = round(tv["n"] * 100.0 / n_rows, 2) if n_rows else None
             entry["top_values"] = top_values
-            entry["top_truncated"] = len(top_values) >= top_n
+            entry["top_truncated"] = truncated
 
             result["columns"][name] = entry
 

--- a/toolkit/domain/column_values.py
+++ b/toolkit/domain/column_values.py
@@ -1,0 +1,251 @@
+"""Profilo valori delle colonne dimensionali di un parquet clean.
+
+Per ogni colonna con ``role=dimension`` calcola gli aggregati di valore:
+cardinalita' (n_distinct, distinct_ratio), null (n_null) e top-N valori
+con conteggio e percentuale. Output: dict JSON-serializzabile.
+
+I/O solo DuckDB (lettura parquet). Nessun side-effect su file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from lab_connectors.duckdb import safe_connect
+from toolkit.core.io import write_json_atomic
+from toolkit.core.sql_utils import q_ident, sql_path
+
+
+def _dimension_columns(columns: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [c for c in columns if c.get("role") == "dimension"]
+
+
+def _json_safe_value(value: Any) -> Any:
+    """Converte valori non-JSON (date, timestamp, ...) in stringa."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _build_summary_sql(parquet: Path, dims: list[dict[str, Any]]) -> str:
+    """SQL unico: n_rows + n_distinct (approx) + n_null per colonna dimensionale.
+
+    ``APPROX_COUNT_DISTINCT`` (HyperLogLog) tiene la memoria costante anche su
+    dataset grandi con molte dimensioni (es. anac_bandi_gara: 1.2M righe x 57
+    dimensioni): il COUNT(DISTINCT) esatto farebbe OOM nel memory limit 2GB.
+    Errore tipico ~1.6%; sufficiente per cardinalita' e distinct_ratio.
+    """
+    parts: list[str] = ["SELECT COUNT(*) AS n_rows"]
+    for col in dims:
+        ident = q_ident(col["name"])
+        alias_distinct = q_ident(f"d_{col['name']}")
+        alias_null = q_ident(f"nn_{col['name']}")
+        parts.append(f"  ,APPROX_COUNT_DISTINCT({ident}) AS {alias_distinct}")
+        parts.append(f"  ,SUM(CASE WHEN {ident} IS NULL THEN 1 ELSE 0 END) AS {alias_null}")
+    parts.append(f"FROM read_parquet('{sql_path(parquet)}')")
+    return "\n".join(parts)
+
+
+def _build_top_sql(parquet: Path, col_name: str, top_n: int) -> str:
+    ident = q_ident(col_name)
+    return (
+        f"SELECT {ident} AS value, COUNT(*) AS n\n"
+        f"FROM read_parquet('{sql_path(parquet)}')\n"
+        f"WHERE {ident} IS NOT NULL\n"
+        f"GROUP BY {ident}\n"
+        f"ORDER BY n DESC, value\n"
+        f"LIMIT {int(top_n)}"
+    )
+
+
+def build_column_values_profile(
+    parquet: Path,
+    columns: list[dict[str, Any]],
+    *,
+    top_n: int = 20,
+) -> dict[str, Any]:
+    """Aggregati di valore per le colonne dimensionali di un parquet clean.
+
+    Args:
+        parquet: Path al parquet clean.
+        columns: Colonne del catalogo (``name``, ``type``, ``role``,
+            ``semantic_type`` opzionale) — es. da ``registry.schema_reader``.
+        top_n: Numero massimo di top values per colonna (default 20).
+
+    Returns:
+        Dict JSON-serializzabile con sezioni ``n_rows`` e ``columns``
+        (una entry per colonna dimensionale: type, role, n_null, n_distinct,
+        distinct_ratio, top_values, top_truncated).
+    """
+    dims = _dimension_columns(columns)
+    result: dict[str, Any] = {
+        "n_rows": None,
+        "n_columns_profiled": len(dims),
+        "count_distinct_mode": "approx",
+        "columns": {},
+    }
+
+    if not dims:
+        return result
+
+    summary_sql = _build_summary_sql(parquet, dims)
+    with safe_connect() as con:
+        summary = con.execute(summary_sql).fetchone()
+        summary_names = [d[0] for d in con.description]
+
+        n_rows = int(summary[summary_names.index("n_rows")])
+        result["n_rows"] = n_rows
+
+        for col in dims:
+            name = col["name"]
+            d_idx = summary_names.index(f"d_{name}")
+            nn_idx = summary_names.index(f"nn_{name}")
+            n_distinct = int(summary[d_idx]) if summary[d_idx] is not None else 0
+            n_null = int(summary[nn_idx]) if summary[nn_idx] is not None else 0
+
+            entry: dict[str, Any] = {
+                "type": col.get("type"),
+                "role": col.get("role"),
+            }
+            if col.get("semantic_type"):
+                entry["semantic_type"] = col["semantic_type"]
+            entry["n_null"] = n_null
+            entry["n_distinct"] = n_distinct
+            entry["distinct_ratio"] = round(n_distinct / n_rows, 6) if n_rows else None
+
+            rows = con.execute(_build_top_sql(parquet, name, top_n)).fetchall()
+            top_values = [{"value": _json_safe_value(r[0]), "n": int(r[1])} for r in rows]
+            for tv in top_values:
+                tv["pct"] = round(tv["n"] * 100.0 / n_rows, 2) if n_rows else None
+            entry["top_values"] = top_values
+            entry["top_truncated"] = len(top_values) >= top_n
+
+            result["columns"][name] = entry
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Batch su workspace (discovery + generazione)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WorkspaceProfileResult:
+    """Esito della generazione batch su tutti i repo del workspace."""
+
+    processed: int = 0
+    written: int = 0
+    skipped: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    duration_seconds: float = 0.0
+
+
+def generate_workspace_column_values(
+    workspace_root: Path,
+    out_dir: Path,
+    *,
+    top_n: int = 20,
+    latest_year_only: bool = True,
+    log: Any | None = None,
+) -> WorkspaceProfileResult:
+    """Genera i profili valori per tutti i dataset clean locali del workspace.
+
+    Scopre i repo dati via ``repo_dataset_dirs`` + ``iter_manifests`` e per
+    ogni manifest risolve l'ultimo anno con parquet clean locale. Output:
+    ``<out_dir>/<slug>__column_values.json`` (uno per dataset).
+
+    Args:
+        workspace_root: Root del workspace (contiene i repo dati).
+        out_dir: Directory di output (creata se mancante).
+        top_n: Top values per colonna.
+        latest_year_only: True = solo ultimo anno con parquet; False = tutti
+            gli anni con parquet (nome file ``<slug>__<year>__column_values.json``).
+        log: Logger opzionale (usa ``print`` se None).
+
+    Returns:
+        Esito (processed/written/skipped/errors/duration).
+    """
+    from toolkit.registry.layout import RepoLayout, iter_manifests, repo_dataset_dirs
+    from toolkit.registry.schema_reader import (
+        clean_parquet_path,
+        load_semantic_types,
+        parquet_columns,
+    )
+
+    def _log(msg: str) -> None:
+        if log is not None:
+            log(msg)
+        else:
+            print(msg)
+
+    alias_map = load_semantic_types()
+    result = WorkspaceProfileResult()
+    started = datetime.now(UTC)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written_slugs: set[str] = set()
+
+    repos = sorted(p for p in workspace_root.iterdir() if p.is_dir())
+    for repo_dir in repos:
+        sections = repo_dataset_dirs(repo_dir)
+        if not sections:
+            continue
+        layout = RepoLayout(repo_root=repo_dir, dataset_dirs=sections)
+        for manifest in iter_manifests(layout):
+            result.processed += 1
+            slug = manifest.slug
+            if slug in written_slugs:
+                # Stesso slug presente in piu' repo (es. mirror dedicato):
+                # il primo repo in ordine alfabetico vince, il duplicato
+                # e' escluso per non sovrascrivere lo stesso file.
+                result.skipped.append(f"{slug} (duplicato in {repo_dir.name})")
+                continue
+            years = sorted(manifest.years, reverse=True)
+            if latest_year_only:
+                # Usa l'anno configurato più alto che ha un parquet clean locale.
+                selected = next(
+                    (y for y in years if clean_parquet_path(manifest.cfg, y) is not None), None
+                )
+                if selected is None:
+                    result.skipped.append(f"{slug} (nessun clean locale)")
+                    continue
+                years = [selected]
+            for year in years:
+                parquet = clean_parquet_path(manifest.cfg, year)
+                if parquet is None:
+                    result.skipped.append(f"{slug}:{year} (no clean locale)")
+                    continue
+                try:
+                    columns = parquet_columns(parquet, alias_map)
+                    if not columns:
+                        result.skipped.append(f"{slug}:{year} (schema non leggibile)")
+                        continue
+                    profile = build_column_values_profile(parquet, columns, top_n=top_n)
+                    profile.update(
+                        {
+                            "schema_version": 1,
+                            "dataset": slug,
+                            "year": year,
+                            "config_path": str(manifest.yml_path),
+                            "parquet": str(parquet),
+                        }
+                    )
+                    fname = (
+                        f"{slug}__column_values.json"
+                        if latest_year_only
+                        else f"{slug}__{year}__column_values.json"
+                    )
+                    out_path = out_dir / fname
+                    write_json_atomic(out_path, profile)
+                    result.written += 1
+                    written_slugs.add(slug)
+                except Exception as exc:  # noqa: BLE001 — un errore non blocca il batch
+                    result.errors.append(f"{slug}:{year}: {exc}")
+
+    result.duration_seconds = round((datetime.now(UTC) - started).total_seconds(), 2)
+    return result

--- a/toolkit/mcp/catalog_ops.py
+++ b/toolkit/mcp/catalog_ops.py
@@ -86,6 +86,7 @@ def mcp_dataset_overview(
     layer: str = "clean",
     year: int | None = None,
     source: str = "all",
+    profile: bool = False,
 ) -> dict[str, Any]:
     """Overview di un dataset: schema, row count e preview.
 
@@ -94,16 +95,19 @@ def mcp_dataset_overview(
         layer: ``"clean"`` (default) o ``"mart"``.
         year: Anno specifico o ``None`` (ultimo disponibile).
         source: ``"gcs"``, ``"workspace"``, ``"all"`` (default).
+        profile: Se True, profila i valori delle colonne dimensionali
+            (cardinalità, null, top-N) — on-demand, off di default.
 
     Returns:
-        Dict con slug, year, layer, columns, row_count, preview.
+        Dict con slug, year, layer, columns, row_count, preview (+ ``values``
+        se ``profile=True``).
 
     Raises:
         ToolkitClientError: se slug non trovato o errore DuckDB.
     """
     try:
         resolver = _get_resolver()
-        return resolver.describe_slug(slug, layer=layer, year=year, source=source)
+        return resolver.describe_slug(slug, layer=layer, year=year, source=source, profile=profile)
     except FileNotFoundError as exc:
         raise ToolkitClientError(
             str(exc),

--- a/toolkit/mcp/server.py
+++ b/toolkit/mcp/server.py
@@ -234,6 +234,9 @@ def toolkit_find(
 @mcp.tool(
     description="Overview di un dataset: schema colonne (DESCRIBE DuckDB), "
     "conteggio righe e preview dati. "
+    "Con profile=True (on-demand, default False) profila anche i valori delle "
+    "colonne dimensionali (cardinalità, null, top-N) — utile prima di scrivere "
+    "una query. "
     "Parametro source='gcs' (solo pubblicati), 'workspace' (solo sviluppo), "
     "'all' (default) — entrambi, preferisce locale.",
     structured_output=True,
@@ -243,6 +246,7 @@ def toolkit_dataset_overview(
     layer: str = "clean",
     year: int | None = None,
     source: str = "all",
+    profile: bool = False,
 ) -> dict[str, Any]:
     return guard_timed(
         dataset_overview_impl,
@@ -251,6 +255,7 @@ def toolkit_dataset_overview(
         layer=layer,
         year=year,
         source=source,
+        profile=profile,
     )
 
 

--- a/toolkit/registry/builders.py
+++ b/toolkit/registry/builders.py
@@ -469,11 +469,7 @@ def build_registry(
     # a ogni rigenerazione. Un UNICO pass centralizzato (dopo la costruzione
     # delle sezioni) ripopola i run mancanti da existing — niente fallback
     # duplicati nei singoli builder.
-    registry = _merge_existing_runs(
-        registry,
-        existing_catalog=existing_catalog,
-        existing_signals=existing_signals,
-    )
+    registry = _merge_existing_runs(registry, existing_signals=existing_signals)
 
     # Ordine chiavi deterministico: le entry derivano da path diversi
     # (builder, existing, run restore) e l'ordine di inserimento del dict
@@ -496,7 +492,6 @@ def build_registry(
 def _merge_existing_runs(
     registry: dict[str, Any],
     *,
-    existing_catalog: dict[str, Any] | None = None,
     existing_signals: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Ripopola i blocco ``run`` mancanti dei signals dall'existing (CI).
@@ -508,10 +503,6 @@ def _merge_existing_runs(
     Solo i signals hanno il blocco ``run`` nel registry snello (datasets/marts
     non lo portano più: nessun consumer lo legge). Il run locale vince sempre;
     l'existing interviene solo dove manca.
-
-    Args:
-        existing_catalog: Conservato per retro-compatibilità della firma;
-            non più usato (datasets/marts non hanno run).
     """
     signals_run: dict[str, dict[str, Any]] = {}
     if existing_signals:

--- a/toolkit/registry/builders.py
+++ b/toolkit/registry/builders.py
@@ -50,9 +50,54 @@ def _mart_ok(manifest: DatasetManifest) -> bool:
     return False
 
 
+def _dedup_tags(tags: Iterable[str]) -> list[str]:
+    """Dedup dei tag preservando l'ordine (i dataset.yml possono duplicarli)."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for tag in tags:
+        if tag and tag not in seen:
+            seen.add(tag)
+            out.append(tag)
+    return out
+
+
 # ---------------------------------------------------------------------------
 # clean_catalog
 # ---------------------------------------------------------------------------
+
+
+# Chiavi valide per una entry dataset (registry snello): il builder le deriva
+# da dataset.yml/parquet, le entry editoriali preservate (senza parquet locale)
+# vengono filtrate su questi campi — le chiavi morte (run, years,
+# registry_source) non devono tornare dall'existing.
+_DATASET_ENTRY_FIELDS: tuple[str, ...] = (
+    "slug",
+    "name",
+    "description",
+    "source",
+    "source_id",
+    "period",
+    "tags",
+    "category",
+    "columns",
+    "location",
+    "stage",
+    "mart_refs",
+)
+
+
+def _slim_dataset_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """Filtra una entry dataset (es. editoriale) sulle sole chiavi contratto.
+
+    Ricalcola anche ``role`` delle colonne con ``semantic_type`` → dimension:
+    l'existing storico può avere role sbagliati (es. ``year`` → metric) che il
+    builder deriva correttamente solo sulle entry con parquet locale.
+    """
+    slim = {k: v for k, v in entry.items() if k in _DATASET_ENTRY_FIELDS}
+    for col in slim.get("columns", []) or []:
+        if col.get("semantic_type") and col.get("role") != "dimension":
+            col["role"] = "dimension"
+    return slim
 
 
 def build_clean_catalog(
@@ -98,7 +143,7 @@ def build_clean_catalog(
             # Nessun parquet locale: possibile solo se l'entry è editoriale
             # (preservata) — altrimenti errore e skip.
             if manifest.slug in editorial:
-                datasets.append(editorial[manifest.slug])
+                datasets.append(_slim_dataset_entry(editorial[manifest.slug]))
                 continue
             derive_errors.append(
                 f"{manifest.slug}: nessun parquet clean locale "
@@ -119,17 +164,17 @@ def build_clean_catalog(
             "source": "",
             "source_id": manifest.source_id,
             "period": manifest.period or {"start": years_eff[0], "end": years_eff[-1]},
-            "years": years_eff,
-            "tags": list(manifest.tags),
+            "tags": _dedup_tags(manifest.tags),
             "category": manifest.category,
             "columns": columns,
             "location": contract.clean_location(manifest.slug, years_eff),
             "stage": "incubating",
-            "registry_source": "derive_auto",
         }
 
-        # Merge editoriale: i campi umani sovrascrivono; role/semantic_type
-        # delle colonne preservati se presenti.
+        # Merge editoriale: i campi umani sovrascrivono. role è SEMPRE
+        # derivato (semantic_type/type), mai dall'editoriale: l'existing
+        # storico può avere role sbagliati (es. year→metric) che bloccherebbero
+        # il fix. description e semantic_type restano editabili a mano.
         old = editorial.get(manifest.slug)
         if old:
             for field in ("name", "description", "source", "source_id", "stage", "period"):
@@ -141,8 +186,6 @@ def build_clean_catalog(
                 if oc:
                     if oc.get("description"):
                         col["description"] = oc["description"]
-                    if oc.get("role"):
-                        col["role"] = oc["role"]
                     if oc.get("semantic_type"):
                         col["semantic_type"] = oc["semantic_type"]
 
@@ -152,19 +195,13 @@ def build_clean_catalog(
                 f"{manifest.slug}__{t.get('name')}" for t in manifest.mart_tables if t.get("name")
             ]
 
-        # Blocco run (ultimo run record del toolkit). Il fallback sull'existing
-        # è centralizzato in _merge_existing_runs (build_registry).
-        run_rec = latest_run_record(str(manifest.yml_path))
-        if run_block(run_rec):
-            entry["run"] = run_block(run_rec)
-
         datasets.append(entry)
 
     # Preserva entry editoriali senza parquet locale né derive (es. adottati)
     derived_slugs = {d["slug"] for d in datasets}
     for ds_slug, ds in editorial.items():
         if ds_slug not in derived_slugs:
-            datasets.append(ds)
+            datasets.append(_slim_dataset_entry(ds))
 
     catalog: dict[str, Any] = {
         "schema_version": 1,
@@ -198,33 +235,19 @@ def build_mart_catalog(
     contract = path_contract or PathContract()
     marts: list[dict[str, Any]] = []
     derive_errors: list[str] = []
-    runs_cache: dict[str, dict[str, Any]] = {}
 
     for manifest in iter_manifests(layout):
         if slug and manifest.slug != slug:
             continue
-        run_rec = latest_run_record(str(manifest.yml_path))
-        if manifest.slug not in runs_cache:
-            runs_cache[manifest.slug] = run_block(run_rec) or {}
         for table in manifest.mart_tables:
             name = table.get("name")
             if not name:
                 continue
-            rule = manifest.mart_rules.get(name, {})
             entry: dict[str, Any] = {
                 "slug": f"{manifest.slug}__{name}",
                 "dataset": manifest.slug,
                 "table": name,
-                "description": f"{manifest.slug} — mart {name}",
             }
-            if rule.get("primary_key"):
-                entry["primary_key"] = list(rule["primary_key"])
-            if rule.get("required_columns"):
-                entry["required_columns"] = list(rule["required_columns"])
-            if rule.get("min_rows") is not None:
-                entry["min_rows"] = rule["min_rows"]
-            if runs_cache[manifest.slug]:
-                entry["run"] = runs_cache[manifest.slug]
             # Tabella con years esplicite = multi-anno: il runner la scrive
             # flat (data/mart/{dataset}/{table}.parquet, no dir anno) → la
             # location pubblicata deve essere flat. Tabella per-anno → year.
@@ -308,8 +331,6 @@ def build_signals(
             "detail": detail,
             "action": action,
         }
-        if manifest.years:
-            signal["years"] = list(manifest.years)
         run_rec = latest_run_record(str(manifest.yml_path))
         if run_block(run_rec):
             signal["run"] = run_block(run_rec)
@@ -348,85 +369,43 @@ def _years_label(years: Iterable[int]) -> str:
 
 
 # ---------------------------------------------------------------------------
-# codelists (valori delle dimensioni)
+# codelists (nomi delle dimensioni)
 # ---------------------------------------------------------------------------
-
-
-def _read_codelist_csv(path: Path) -> list[dict[str, Any]]:
-    """Legge un codelist CSV (header, prima riga) in lista di dict.
-
-    Preserva tutte le colonne (es. geo.csv: code, label_en, nuts_level,
-    parent_code). Righe vuote ignorate.
-    """
-    import csv
-
-    rows: list[dict[str, Any]] = []
-    with path.open(encoding="utf-8", newline="") as fh:
-        for row in csv.DictReader(fh):
-            if not row or not any((v or "").strip() for v in row.values()):
-                continue
-            cleaned = {k.strip(): (v or "").strip() for k, v in row.items()}
-            rows.append(cleaned)
-    return rows
-
-
-# Soglia righe per embedding nel JSON: oltre, il codelist è dichiarato in
-# ``large`` (il MCP lo legge dal CSV del repo, come faceva eurostat-mcp).
-MAX_CODELIST_ROWS = 1000
 
 
 def build_codelists(
     layout: RepoLayout,
     codelists_dir: Path | None = None,
 ) -> tuple[dict[str, Any], dict[str, list[str]]]:
-    """Costruisce codelists.json: i valori delle dimensioni del repo.
+    """Costruisce la sezione codelists del registry: i NOMI dei codelist.
 
     Legge ``{repo_root}/codelists/*.csv`` (convenzione eurostat: geo.csv,
-    units.csv, freq.csv, ...). I codelist piccoli (<= MAX_CODELIST_ROWS righe)
-    sono embedded come mappa ``nome → [righe]``; i grandi (es. geo, c_resid)
-    sono elencati in ``large`` — il consumatore li legge dal CSV del repo
-    (pattern del vecchio eurostat-mcp: embedded per i piccoli, file per i
-    grandi). Permette all'agente MCP di risolvere i codici (es. unit='EUR_HAB',
-    geo='ITC4' con parent_code) prima di scrivere le query.
+    units.csv, freq.csv, ...) e pubblica solo i nomi come lista. Il contenuto
+    (le righe) NON è embeddato: è letto dal CSV del repo dal consumer on-demand
+    (pattern eurostat-mcp). Embeddare le righe rendeva il registry enorme
+    (es. eurostat: codelists = 60% del file) senza che alcun consumer leggesse
+    i valori dal registry.
 
     Returns:
         Tuple (payload, errors) con errors = {"derive": [], "validation": [...]}.
-        Se la dir codelists non esiste, ritorna un payload vuoto senza errori
+        Se la dir codelists non esiste, ritorna una lista vuota senza errori
         (codelists è opzionale).
     """
     codelists_dir = codelists_dir or (layout.repo_root / "codelists")
-    codelists: dict[str, Any] = {}
-    large: list[str] = []
-    errors: list[str] = []
 
     if not codelists_dir.is_dir():
         return (
-            {"schema_version": 1, "source_repo": layout.source_repo, "codelists": {}},
+            {"schema_version": 1, "source_repo": layout.source_repo, "codelists": []},
             {"derive": [], "validation": []},
         )
 
-    for csv_path in sorted(codelists_dir.glob("*.csv")):
-        name = csv_path.stem
-        try:
-            rows = _read_codelist_csv(csv_path)
-        except Exception as exc:
-            errors.append(f"codelist {name}: {exc}")
-            continue
-        if not rows:
-            continue
-        if len(rows) > MAX_CODELIST_ROWS:
-            large.append(name)
-        else:
-            codelists[name] = rows
-
+    names = sorted(p.stem for p in codelists_dir.glob("*.csv"))
     payload: dict[str, Any] = {
         "schema_version": 1,
         "source_repo": layout.source_repo,
         "updated_at": str(datetime.now(UTC).date()),
-        "codelists": codelists,
+        "codelists": names,
     }
-    if large:
-        payload["large"] = sorted(large)
     return payload, {"derive": [], "validation": []}
 
 
@@ -478,20 +457,18 @@ def build_registry(
         "datasets": catalog.get("datasets", []),
         "marts": marts.get("marts", []),
         "signals": signals.get("signals", []),
-        "codelists": {k: v for k, v in codelists.items() if k != "schema_version"},
-        "entities": {k: v for k, v in graph.items() if k != "schema_version"},
-        "summary": {
-            "datasets": len(catalog.get("datasets", [])),
-            "marts": len(marts.get("marts", [])),
-            "signals": len(signals.get("signals", [])),
+        "codelists": codelists.get("codelists", []),
+        "entities": {
+            "entities": graph.get("entities", {}),
+            "bridges": graph.get("bridges", []),
         },
     }
 
-    # Preserva i run storici: in CI post-merge i dataset non rieseguiti non
-    # hanno run record locali, quindi i blocco run sparirebbero a ogni
-    # rigenerazione. Un UNICO pass centralizzato (dopo la costruzione delle
-    # sezioni) ripopola i run mancanti da existing — niente fallback duplicati
-    # nei singoli builder.
+    # Preserva i run storici dei signals: in CI post-merge i dataset non
+    # rieseguiti non hanno run record locali, quindi il blocco run sparirebbe
+    # a ogni rigenerazione. Un UNICO pass centralizzato (dopo la costruzione
+    # delle sezioni) ripopola i run mancanti da existing — niente fallback
+    # duplicati nei singoli builder.
     registry = _merge_existing_runs(
         registry,
         existing_catalog=existing_catalog,
@@ -522,47 +499,25 @@ def _merge_existing_runs(
     existing_catalog: dict[str, Any] | None = None,
     existing_signals: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Ripopola i blocco ``run`` mancanti dall'existing registry (CI).
+    """Ripopola i blocco ``run`` mancanti dei signals dall'existing (CI).
 
     Quando il run record locale manca (post-merge: i dataset non rieseguiti
-    non sono nel runner), le entry derivate non hanno ``run``. L'existing
+    non sono nel runner), i signals derivati non hanno ``run``. L'existing
     (registry.json committato) preserva lo storico.
 
-    Chiavi:
-    - datasets: ``slug``
-    - marts: ``dataset`` (il run è per dataset, non per tabella)
-    - signals: ``id`` (con prefisso ``compose:`` per i compose)
+    Solo i signals hanno il blocco ``run`` nel registry snello (datasets/marts
+    non lo portano più: nessun consumer lo legge). Il run locale vince sempre;
+    l'existing interviene solo dove manca.
 
-    Il run locale vince sempre; l'existing interviene solo dove manca.
+    Args:
+        existing_catalog: Conservato per retro-compatibilità della firma;
+            non più usato (datasets/marts non hanno run).
     """
-
-    def _index(
-        payload: dict | None, key: str, section: str = "datasets"
-    ) -> dict[str, dict[str, Any]]:
-        idx: dict[str, dict[str, Any]] = {}
-        if not payload:
-            return idx
-        for entry in payload.get(section, []) or []:
-            run = entry.get("run")
-            if run and entry.get(key):
-                idx[entry[key]] = run
-        return idx
-
-    datasets_run = _index(existing_catalog, "slug")
-    marts_run = _index(existing_catalog, "dataset", section="marts")
     signals_run: dict[str, dict[str, Any]] = {}
     if existing_signals:
         for s in existing_signals.get("signals", []) or []:
             if s.get("run") and s.get("id"):
                 signals_run[s["id"]] = s["run"]
-
-    for ds in registry.get("datasets", []) or []:
-        if "run" not in ds and ds.get("slug") in datasets_run:
-            ds["run"] = datasets_run[ds["slug"]]
-
-    for m in registry.get("marts", []) or []:
-        if "run" not in m and m.get("dataset") in marts_run:
-            m["run"] = marts_run[m["dataset"]]
 
     for s in registry.get("signals", []) or []:
         if "run" not in s and s.get("id") in signals_run:
@@ -581,25 +536,17 @@ _CANONICAL_ORDER: dict[str, tuple[str, ...]] = {
         "source",
         "source_id",
         "period",
-        "years",
         "tags",
         "category",
         "columns",
         "location",
         "stage",
-        "registry_source",
         "mart_refs",
-        "run",
     ),
     "marts": (
         "slug",
         "dataset",
         "table",
-        "description",
-        "primary_key",
-        "required_columns",
-        "min_rows",
-        "run",
         "location",
     ),
     "signals": (
@@ -609,7 +556,6 @@ _CANONICAL_ORDER: dict[str, tuple[str, ...]] = {
         "label",
         "detail",
         "action",
-        "years",
         "run",
     ),
 }
@@ -744,8 +690,6 @@ def build_entity_graph(
 
     return {
         "schema_version": 1,
-        "generated_from": "clean_catalog.json",
         "entities": {e: info for e, info in sorted(nodes.items())},
         "bridges": relations,
-        "summary": {"total_entities": len(nodes), "total_relations": len(relations)},
     }

--- a/toolkit/registry/reader.py
+++ b/toolkit/registry/reader.py
@@ -29,7 +29,7 @@ def _section_count(section: str, payload: dict[str, Any]) -> int | None:
     if section == "signals":
         return len(payload.get("signals") or [])
     if section == "codelists":
-        return len(payload.get("codelists") or {})
+        return len(payload.get("codelists") or [])
     if section == "entities":
         return len((payload.get("entities") or {}).get("entities") or {})
     return None
@@ -150,10 +150,10 @@ def _filter_entry(section: str, data: Any, slug: str) -> dict[str, Any]:
             raise FileNotFoundError(f"Signal '{slug}' non presente in signals")
         return hit
     if section == "codelists":
-        entries = data or {}
+        entries = data or []
         if slug not in entries:
             raise FileNotFoundError(f"Codelist '{slug}' non presente in codelists")
-        return entries[slug]
+        return {"name": slug}
     if section == "entities":
         entities = (data or {}).get("entities") or {}
         if slug not in entities:

--- a/toolkit/registry/schema_reader.py
+++ b/toolkit/registry/schema_reader.py
@@ -100,7 +100,13 @@ def parquet_columns(
     parquet_path: Path | None,
     alias_map: dict[str, str] | None = None,
 ) -> list[dict[str, Any]] | None:
-    """Schema del parquet (via reader runtime) → colonne del catalogo."""
+    """Schema del parquet (via reader runtime) → colonne del catalogo.
+
+    ``role`` è derivato — mai dal tipo DuckDB da solo:
+    - colonna con ``semantic_type`` → dimension (i tipi semantici del
+      vocabolario sono tutti entity/dimension: codici, anni, id, ...);
+    - altrimenti dal tipo DuckDB (VARCHAR/DATE/BOOLEAN → dimension).
+    """
     if parquet_path is None:
         return None
     alias_map = alias_map or {}
@@ -116,14 +122,17 @@ def parquet_columns(
         col_name = str(row.get("name", ""))
         raw_type = str(row.get("type", "")).lower()
         bq_type = DUCKDB_TO_CATALOG.get(raw_type, "VARCHAR")
-        role = "dimension" if bq_type in _DIMENSION_TYPES else "metric"
+        semantic_type = _assign_semantic_type(col_name, alias_map)
+        if semantic_type:
+            role = "dimension"
+        else:
+            role = "dimension" if bq_type in _DIMENSION_TYPES else "metric"
         col_entry: dict[str, Any] = {
             "name": col_name,
             "type": bq_type,
             "role": role,
             "description": "",
         }
-        semantic_type = _assign_semantic_type(col_name, alias_map)
         if semantic_type:
             col_entry["semantic_type"] = semantic_type
         columns.append(col_entry)

--- a/toolkit/registry/schemas/registry.schema.json
+++ b/toolkit/registry/schemas/registry.schema.json
@@ -46,19 +46,11 @@
       "description": "Health check operativo (ex pipeline_signals.signals)."
     },
     "codelists": {
-      "type": "object",
-      "properties": {
-        "large": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "codelists": {
-          "type": "object"
-        }
+      "type": "array",
+      "items": {
+        "type": "string"
       },
-      "description": "Valori delle dimensioni (ex codelists.json)."
+      "description": "Nomi dei codelist del repo (contenuto letto dal CSV in repo, non embeddato)."
     },
     "entities": {
       "type": "object",
@@ -68,26 +60,9 @@
         },
         "bridges": {
           "type": "array"
-        },
-        "summary": {
-          "type": "object"
         }
       },
       "description": "Grafo entità → dataset (ex entity_graph)."
-    },
-    "summary": {
-      "type": "object",
-      "properties": {
-        "datasets": {
-          "type": "integer"
-        },
-        "marts": {
-          "type": "integer"
-        },
-        "signals": {
-          "type": "integer"
-        }
-      }
     }
   },
   "additionalProperties": true,
@@ -140,10 +115,6 @@
           ],
           "description": "incubating = parquet su GCS ma non in DE; published = ha pagina su data-explorer; deprecated = non piu' mantenuto"
         },
-        "registry_source": {
-          "type": "string",
-          "description": "Origine dell'entry: derive_auto (dal builder) o editorial (mantenuta a mano)."
-        },
         "period": {
           "type": "object",
           "required": [
@@ -161,23 +132,12 @@
           "additionalProperties": false,
           "description": "Copertura temporale dei dati (da time_coverage del dataset.yml)."
         },
-        "years": {
-          "type": "array",
-          "items": {
-            "type": "integer"
-          },
-          "description": "Anni eseguiti dal run (da years del dataset.yml). Opzionale, distinto da period."
-        },
         "mart_refs": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "description": "Slug mart appartenenti al dataset, convention {dataset}__{mart} (vedi mart_catalog.schema.json). Opzionale."
-        },
-        "run": {
-          "$ref": "#/$defs/run",
-          "description": "Ultimo run record del toolkit (fonte canonica: run.schema.json). Opzionale — per la diagnostica dettagliata vedi pipeline_signals.json."
         },
         "columns": {
           "type": "array",
@@ -365,10 +325,6 @@
             "$ref": "#/$defs/column"
           },
           "description": "Schema colonne reale (dal parquet locale in derive_mode=local). Opzionale in v1."
-        },
-        "run": {
-          "$ref": "#/$defs/run",
-          "description": "Ultimo run record del toolkit per il layer mart. Opzionale."
         }
       },
       "additionalProperties": true
@@ -402,12 +358,6 @@
         },
         "action": {
           "type": "string"
-        },
-        "years": {
-          "type": "array",
-          "items": {
-            "type": "integer"
-          }
         },
         "run": {
           "$ref": "#/$defs/run"


### PR DESCRIPTION
## Sintesi

Due modifiche collegate, per la stessa diagnosi: il registry è un **catalogo di discovery**, non un report di esecuzione. Mappando tutti i consumer (MCP, data-explorer, lab-dashboard, agent-context-builder) risulta che metà del contenuto committato non è letto da nessuno — e genera diff rumorosi, buchi CI e file da centinaia di KB.

**1. Registry snello** — rimozione dei blocchi orfani e fix qualità dati:
- `datasets[].run` e `marts[].run`: lo stato operativo vive in `signals[].run` (unico punto usato dal dashboard). I run qui causavano i 60 buchi CI e il churn dei diff post-merge.
- `datasets[].years`, `registry_source`, `marts[].description/primary_key/required_columns/min_rows`, `summary` top-level, `entities.generated_from/summary`: nessun consumer.
- `codelists` embeddato (le righe): 60% del file eurostat, nessuno legge le entry dal registry. Resta la lista dei nomi; il contenuto si legge dal CSV del repo on-demand.
- **role colonne derivato da `semantic_type`** → `year` diventa `dimension` (prima era `metric`, bug). Applicato anche alle entry editoriali preservate via `_slim_dataset_entry`.
- dedup tags; reader: fix conteggio `codelists` (da dict a lista).

**2. Column-values on-demand** — il completamento del catalogo, senza peso committato:
- Nuovo dominio `build_column_values_profile`: per ogni colonna dimensionale calcola cardinalità (HyperLogLog), null e top-N valori con percentuale. I/O solo DuckDB.
- CLI: `toolkit column-values` (singolo dataset o `--all` batch sul workspace).
- MCP senza nuovo tool: flag `profile` (default `False`, on-demand) su `toolkit_dataset_overview`. Risposta arricchita con la sezione `values`. Riutilizza la risoluzione `slug/year/source` e le colonne già arricchite di `describe_slug`.

## Contesto collegato

Nessuna issue pre-esistente (verificato). Nasce dalla diagnosi dell'audit del registry.

## Cosa cambia

- [x] Refactor / performance
- [x] Modifica contratto pubblico (schema registry.json, firma `describe_slug`/`toolkit_dataset_overview`)
- [x] Nuova funzionalità del motore (column-values)

## Impatto su contratti pubblici

- [x] CLI o MCP tool (nuovo flag `profile` su `toolkit_dataset_overview`; nuovo comando `column-values`)
- [x] API pubblica del toolkit (firma `describe_slug`/`mcp_dataset_overview` con `profile`)

> Downstream: `dataset-incubator` e gli altri repo dati NON usano i campi rimossi (verificato con `rg` su tutto il workspace). I registry dei 6 repo verranno rigenerati dal CI al prossimo post-merge con il toolkit nuovo.

## Verifica

```bash
pytest tests/                 # 1365 passed
ruff check toolkit/ tests/    # All checks passed
mypy toolkit/                 # Success, no issues
```

- [x] `pytest` passa (1365)
- [x] `ruff check` passa
- [x] `mypy` passa
- [x] Test aggiunti/aggiornati (registry builder, reader, describe_slug profile, column_values domain+CLI)

Rigenerazione reale dei registry (solo verifica locale, non committata):
- eurostat: 498KB → 155KB (-69%, era il codelists embeddato)
- dataset-incubator: 861KB → 716KB
- open-conto-annuale: 176KB → 107KB, dcl-bologna: 69KB → 53KB
- Determinismo: doppia rigenerazione = file identico

Verifica end-to-end `profile=True` su `rna_aiuti_stato` (2.1M righe): 29 colonne profiliate, top-N corretti.

## Checklist PR

- [x] Perimetro stretto: registry snello + column-values on-demand (telemetry esclusa, resta in branch locale come WIP non collegato)
- [x] Nessun consumer org usa i campi rimossi (verificato con `rg` su tutto il workspace)
- [x] Test con marker appropriati

## Note per chi revisiona

- Il registry snello è un cambio di contratto: i 6 repo dati hanno ancora il formato vecchio committato, finché il CI non li rigenera col toolkit nuovo (post-merge). Il reader è retro-compatibile (legge dict `codelists` vecchi senza crash).
- Il flag `profile` su `toolkit_dataset_overview` richiede il riavvio del server MCP per essere attivo (processo separato).
- telemetry.py resta nel branch come WIP non collegato: decisione di escluderlo da questa PR (perimetro stretto).