### PR TITLE
feat(config): memory_limit DuckDB configurabile per dataset (blocco duckdb:)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -18,6 +18,7 @@ I path relativi sono sempre risolti rispetto alla directory che contiene `datase
 | `config` | `object` | no | policy parser config |
 | `validation` | `object` | no | solo opzioni globali del validation gate |
 | `output` | `object` | no | policy artefatti |
+| `duckdb` | `object` | no | configurazione motore DuckDB (es. `memory_limit`) |
 
 ## dataset
 
@@ -455,6 +456,23 @@ Campi supportati:
 |---|---|---|
 | `output.artifacts` | `str` | `standard` (accettato ma ignorato) |
 | `output.legacy_aliases` | — | rimosso, non ha più effetto |
+
+## duckdb
+
+Configurazione del motore DuckDB per il dataset (opzionale). Il valore viene
+passato a `safe_connect` nel layer clean. Gerarchia: default lab `2GB` →
+`duckdb.memory_limit` (per-dataset) → env `DUCKDB_MEMORY_LIMIT` (per ambiente).
+
+| Campo | Tipo | Default |
+|---|---|---|
+| `duckdb.memory_limit` | `string` | `None` (default lab `2GB`) |
+
+Esempio — dataset con join pesanti nel clean (OOM con il default):
+
+```yaml
+duckdb:
+    memory_limit: "4GB"
+```
 
 ## Legacy supportato
 

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -75,6 +75,27 @@ def test_load_config_ok(tmp_path: Path):
     assert cfg.root_source == "base_dir_fallback"
 
 
+@pytest.mark.contract
+def test_load_config_parses_duckdb_memory_limit(tmp_path: Path):
+    """duckdb.memory_limit viene letto e default assente → None."""
+    yml = tmp_path / "dataset.yml"
+    _yml(yml, years=[2024], duckdb={"memory_limit": "4GB"})
+
+    cfg = load_config(yml)
+    assert cfg.duckdb is not None
+    assert cfg.duckdb.memory_limit == "4GB"
+
+
+@pytest.mark.contract
+def test_load_config_duckdb_defaults_to_none(tmp_path: Path):
+    """Senza blocco duckdb: nessun override (default lab 2GB)."""
+    yml = tmp_path / "dataset.yml"
+    _yml(yml, years=[2024])
+
+    cfg = load_config(yml)
+    assert cfg.duckdb is None
+
+
 @pytest.mark.policy
 def test_load_config_parses_mart_transition_config(tmp_path: Path):
     yml = tmp_path / "dataset.yml"

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -18,6 +18,60 @@ from toolkit.raw.run import run_raw
 pytestmark = pytest.mark.policy
 
 
+def test_clean_propagates_duckdb_memory_limit(
+    project_example: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """memory_limit da duckdb.memory_limit arriva a safe_connect nel clean.
+
+    Prova del fuoco per la propagazione config → safe_connect (il parsing
+    è coperto altrove; qui la riga mancante in cmd_run farebbe fallire).
+    """
+    import toolkit.clean.sql_execute as sql_execute_mod
+
+    captured: dict = {}
+    real_safe_connect = sql_execute_mod.safe_connect
+
+    def _spy(*args, **kwargs):
+        captured["config"] = kwargs.get("config")
+        return real_safe_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sql_execute_mod, "safe_connect", _spy)
+
+    _simplify_sql_project(project_example)
+    config_path = project_example / "dataset.yml"
+    with config_path.open("a", encoding="utf-8") as fh:
+        fh.write("\nduckdb:\n")
+        fh.write('  memory_limit: "4GB"\n')
+
+    monkeypatch.chdir(project_example)
+    cfg = load_config(config_path)
+    year = cfg.years[0]
+    logger = NoopLogger()
+
+    run_raw(
+        cfg.dataset,
+        year,
+        cfg.root,
+        cfg.raw,
+        logger,
+        base_dir=cfg.base_dir,
+        output_cfg=cfg.output,
+        clean_cfg=cfg.clean,
+    )
+    run_clean(
+        cfg.dataset,
+        year,
+        cfg.root,
+        cfg.clean,
+        logger,
+        base_dir=cfg.base_dir,
+        output_cfg=cfg.output,
+        memory_limit=cfg.duckdb.memory_limit if cfg.duckdb else None,
+    )
+
+    assert captured.get("config") == {"memory_limit": "4GB"}
+
+
 def _append_output_cfg(config_path: Path, *, artifacts: str) -> None:
     with config_path.open("a", encoding="utf-8") as fh:
         fh.write("\noutput:\n")

--- a/toolkit/clean/run.py
+++ b/toolkit/clean/run.py
@@ -210,6 +210,7 @@ def run_clean(
     support_cfg: list[dict[str, Any]] | None = None,
     smoke: bool = False,
     raw_sources: list[dict[str, Any]] | None = None,
+    memory_limit: str | None = None,
 ):
     clean_cfg = ensure_dict(clean_cfg)
     output_cfg = ensure_dict(output_cfg)
@@ -270,6 +271,7 @@ def run_clean(
         read_mode=read_mode,
         logger=logger,
         sample_rows=sample_rows,
+        memory_limit=memory_limit,
     )
     output_profile = _normalize_output_profile(output_profile)
     output_bytes: int | None = output_path.stat().st_size if output_path.exists() else None

--- a/toolkit/clean/sql_execute.py
+++ b/toolkit/clean/sql_execute.py
@@ -61,6 +61,7 @@ def _run_sql(
     read_mode: str = "fallback",
     logger=None,
     sample_rows: int | None = None,
+    memory_limit: str | None = None,
 ) -> tuple[str, dict[str, Any], dict[str, Any]]:
     """Execute clean SQL against raw inputs and export result to Parquet.
 
@@ -70,10 +71,16 @@ def _run_sql(
     Standard toolkit macros (``normalize_italian_number``, ``decode_flag``,
     etc.) are automatically loaded at the start of the connection.
 
+    Args:
+        memory_limit: Override DuckDB memory_limit (es. "4GB") per dataset
+            con join pesanti (da ``duckdb.memory_limit`` del dataset.yml).
+            None = default lab (2GB o DUCKDB_MEMORY_LIMIT env).
+
     Returns:
         tuple of (source, params_used, output_profile)
     """
-    with safe_connect() as con:
+    duckdb_config = {"memory_limit": memory_limit} if memory_limit else None
+    with safe_connect(config=duckdb_config) as con:
         _load_standard_macros(con, logger)
         read_info = read_raw_to_relation(con, input_files, read_cfg, read_mode, logger)
         if sample_rows is not None:

--- a/toolkit/cli/cmd_run.py
+++ b/toolkit/cli/cmd_run.py
@@ -317,6 +317,7 @@ def run_year(
             support_cfg=dump_cfg_section(cfg.support),
             smoke=sampling_active,
             raw_sources=raw_sources,
+            memory_limit=cfg.duckdb.memory_limit if cfg.duckdb else None,
         ):
             # CLEAN fallito: skip mart per evitare output stale
             layers_to_run = [layer for layer in layers_to_run if layer != "mart"]

--- a/toolkit/core/config.py
+++ b/toolkit/core/config.py
@@ -219,10 +219,6 @@ class DuckDBConfig:
             return None
         return DuckDBConfig(memory_limit=d.get("memory_limit"))
 
-    @property
-    def is_set(self) -> bool:
-        return self.memory_limit is not None
-
 
 @dataclass
 class CleanReadConfig:

--- a/toolkit/core/config.py
+++ b/toolkit/core/config.py
@@ -204,6 +204,27 @@ class MartValidationSpec:
 
 
 @dataclass
+class DuckDBConfig:
+    """Configurazione motore DuckDB per il dataset (blocco ``duckdb:``).
+
+    Es. ``duckdb.memory_limit: "4GB"`` per dataset con join pesanti
+    (il default lab è 2GB via safe_connect).
+    """
+
+    memory_limit: str | None = None
+
+    @staticmethod
+    def from_dict(d: dict | None) -> DuckDBConfig | None:
+        if not d:
+            return None
+        return DuckDBConfig(memory_limit=d.get("memory_limit"))
+
+    @property
+    def is_set(self) -> bool:
+        return self.memory_limit is not None
+
+
+@dataclass
 class CleanReadConfig:
     source: str = "auto"
     mode: str | None = None
@@ -521,6 +542,9 @@ class PipelineConfig:
     mart: MartConfig = field(default_factory=MartConfig)
     support: list[dict] = field(default_factory=list)
 
+    # DuckDB engine settings (blocco ``duckdb:`` opzionale nel dataset.yml)
+    duckdb: DuckDBConfig | None = field(default_factory=DuckDBConfig)
+
     # Global settings
     validation: dict = field(default_factory=lambda: {"fail_on_error": True, "mode": "strict"})
     output: dict = field(default_factory=lambda: {"artifacts": "standard"})
@@ -794,6 +818,7 @@ def load_config(
         clean=CleanConfig.from_dict(data.get("clean")),
         mart=MartConfig.from_dict(data.get("mart")),
         support=support_objects,
+        duckdb=DuckDBConfig.from_dict(data.get("duckdb")),
         validation=data.get("validation", {"fail_on_error": True, "mode": "strict"}),
         output=data.get("output", {"artifacts": "standard"}),
     )


### PR DESCRIPTION
## Sintesi

Dataset con join pesanti nel clean (eurostat bd_hgnace2_r3: 4.4M righe, pop_nuts3: 5.9M righe) sforavano il default 2GB di `safe_connect` → **OOM** (`failed to pin block of size 256.0 KiB (1.8 GiB/1.8 GiB used)`) anche su runner CI con RAM abbondante. Il limite era fisso e non configurabile per dataset.

Introduce il blocco opzionale `duckdb:` nel dataset.yml:

```yaml
duckdb:
    memory_limit: "4GB"
```

`PipelineConfig` espone `duckdb.memory_limit`; il run lo propaga a `safe_connect(config={"memory_limit": ...})` nel clean (il punto dell'OOM).

## Cosa cambia

- [x] Nuova funzionalità del motore (override memoria DuckDB per dataset)
- [x] Modifica contratto pubblico (nuovo blocco `duckdb:` in dataset.yml)

## Impatto su contratti pubblici

- [x] Struttura `dataset.yml` (nuovo blocco opzionale `duckdb.memory_limit`)

> Downstream: nessun dataset esistente viene toccato (blocco opzionale, default invariato 2GB). eurostat #125 userà `duckdb.memory_limit` sui 2 dataset grossi.

## Gerarchia memoria DuckDB

`default lab 2GB` → `duckdb.memory_limit` (per-dataset) → `DUCKDB_MEMORY_LIMIT` env (per ambiente, PR lab-connectors #76)

## Verifica

```bash
pytest tests/ -q        # 1362 passed
ruff check toolkit/ tests/   # clean
mypy toolkit/           # success
```

- [x] `pytest` passa
- [x] `ruff` passa
- [x] `mypy` passa
- [x] Test: parsing `duckdb.memory_limit` + default None

Run reale: `bd_hgnace2_r3` passa con la sola config `duckdb.memory_limit: "4GB"` (qs=100, 4.4M righe, readiness 8/8), senza env.

## Checklist

- [x] Perimetro stretto: config + clean run + cmd_run
- [x] Ordine merge: lab-connectors #76 → questa PR → eurostat #125