### PR TITLE
fix(sparql): paginazione robusta — keyset + retry anti-troncamento + docs

### DIFF
--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -648,7 +648,7 @@ class TestSparqlPagination:
                     pagination={"mode": "keyset", "key": "?s"},
                 )
             # Pagina 2: FILTER con l'ultimo valore della colonna 's' (bar)
-            assert "FILTER(?s > <bar>)" in queries[1], f"pagina 2: {queries[1]}"
+            assert 'FILTER(?s > "bar")' in queries[1], f"pagina 2: {queries[1]}"
             text = payload.decode()
             assert "foo" in text and "baz" in text and "qux" in text
             # 6 chiamate: K1, K2, pagina vuota ritentata 3 volte → stop
@@ -711,6 +711,54 @@ class TestSparqlPagination:
             assert mock_cls.return_value.post.call_count == 2
             assert b"quux" in payload  # pagina corta concatenata
 
+    def test_first_page_empty_retries(self):
+        """Regressione: il retry anti-throttle si applica ANCHE alla prima pagina
+        in modalità paginazione (keyset) — un 200 vuoto all'ingresso viene
+        ritentato, non trattato come 'fine dati'."""
+        calls = [0]
+
+        def side_effect(*a, **kw):
+            calls[0] += 1
+            if calls[0] == 1:
+                # prima pagina vuota (throttle WAF)
+                return _http_ok(text="s,value\n", headers={"Content-Type": "text/csv"})
+            if calls[0] == 2:
+                # retry → dati (piena)
+                return _http_ok(text=self.CSV_K1, headers={"Content-Type": "text/csv"})
+            # pagina corta → fine
+            return _http_ok(text=self.CSV_K3, headers={"Content-Type": "text/csv"})
+
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.side_effect = side_effect
+            source = SparqlSource()
+            with patch("toolkit.plugins.sparql.time.sleep"):
+                payload, _ = source.fetch(
+                    "https://example.test/sparql",
+                    "SELECT ?s WHERE { ?s ?p ?o } ORDER BY ?s LIMIT 10",
+                    pagination={"mode": "keyset", "key": "?s"},
+                    step=2,
+                )
+            # la prima pagina throttlata è stata recuperata dal retry
+            assert b"foo" in payload and b"bar" in payload
+
+    def test_keyset_max_pages_enforced(self):
+        """Regressione: keyset rispetta il tetto ``pages`` — un endpoint che
+        restituisce sempre pagine piene non causa loop infinito."""
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.return_value = _http_ok(
+                text=self.CSV_K1, headers={"Content-Type": "text/csv"}
+            )
+            source = SparqlSource()
+            with patch("toolkit.plugins.sparql.time.sleep"):
+                with pytest.raises(DownloadError, match="exceeded max pages"):
+                    source.fetch(
+                        "https://example.test/sparql",
+                        "SELECT ?s WHERE { ?s ?p ?o } ORDER BY ?s LIMIT 10",
+                        pagination={"mode": "keyset", "key": "?s"},
+                        step=2,
+                        pages=2,
+                    )
+
     def test_keyset_missing_key_column_raises(self):
         """Keyset: colonna chiave assente nell'output → DownloadError (non silenzio)."""
         csv_p1_no_key = "altra_colonna,value\nfoo,1\nbar,2\n"
@@ -737,3 +785,14 @@ class TestSparqlPagination:
                 "SELECT ?s WHERE { ?s ?p ?o }",
                 pagination={"mode": "keyset"},
             )
+
+
+def test_keyset_literal_types():
+    """_keyset_literal genera il letterale SPARQL corretto per tipo."""
+    from toolkit.plugins.sparql import _keyset_literal
+
+    uri = "http://dati.camera.it/ocd/deputato.rdf/d1_19"
+    assert _keyset_literal(uri) == f"<{uri}>"
+    assert _keyset_literal("12345") == "12345"
+    assert _keyset_literal("bar") == '"bar"'
+    assert _keyset_literal('say "hi"') == '"say \\"hi\\""'

--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -82,6 +82,7 @@ def test_sparql_fetch_http_error():
             text="Internal Server Error",
         )
         source = SparqlSource()
+        source._page_retry_delay = 0
         with pytest.raises(DownloadError, match="HTTP 500"):
             source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
 
@@ -128,6 +129,7 @@ def test_sparql_fetch_get_fallback_5xx_raises():
             text="Internal Server Error",
         )
         source = SparqlSource()
+        source._page_retry_delay = 0
         with pytest.raises(DownloadError, match="GET fallback returned HTTP 500"):
             source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
     """POST con errore di rete/timeout (response None) deve cadere sul GET.
@@ -164,6 +166,7 @@ def test_sparql_fetch_network_error():
         mock_cls.return_value.post.return_value = err_result
         mock_cls.return_value.get.return_value = err_result
         source = SparqlSource()
+        source._page_retry_delay = 0
         with pytest.raises(DownloadError, match="connection refused"):
             source.fetch("https://example.test/sparql", "SELECT * WHERE { }")
 
@@ -177,6 +180,7 @@ def test_sparql_fetch_empty_results():
             headers={"Content-Type": "application/sparql-results+json"},
         )
         source = SparqlSource()
+        source._page_retry_delay = 0
         with pytest.raises(DownloadError, match="no results"):
             source.fetch(
                 "https://example.test/sparql",
@@ -194,6 +198,7 @@ def test_sparql_fetch_invalid_json():
             headers={"Content-Type": "application/sparql-results+json"},
         )
         source = SparqlSource()
+        source._page_retry_delay = 0
         with pytest.raises(DownloadError, match="Invalid SPARQL JSON"):
             source.fetch(
                 "https://example.test/sparql",
@@ -211,6 +216,7 @@ def test_sparql_fetch_unsupported_content_type_raises():
             headers={"Content-Type": "application/xml"},
         )
         source = SparqlSource()
+        source._page_retry_delay = 0
         with pytest.raises(DownloadError, match="Unsupported Content-Type"):
             source.fetch(
                 "https://example.test/sparql",
@@ -435,7 +441,7 @@ class TestSparqlPagination:
                 "https://example.test/sparql",
                 "SELECT ?s WHERE { ?s ?p ?o } LIMIT 10",
                 pages=3,
-                step=10,
+                step=2,
             )
             assert mock_cls.return_value.post.call_count == 3
             # Header deve apparire una sola volta
@@ -453,25 +459,25 @@ class TestSparqlPagination:
     def test_pages_without_limit_injects_step(self):
         """Se la query non ha LIMIT e pages>1, deve iniettare LIMIT step."""
         with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
-            mock_cls.return_value.post.return_value = _http_ok(
-                text=self.CSV_P1,
-                headers={"Content-Type": "text/csv"},
-            )
+            mock_cls.return_value.post.side_effect = [
+                _http_ok(text=self.CSV_P1, headers={"Content-Type": "text/csv"}),
+                _http_ok(text=self.CSV_P2, headers={"Content-Type": "text/csv"}),
+            ]
             source = SparqlSource()
             source.fetch(
                 "https://example.test/sparql",
                 "SELECT * WHERE { ?s ?p ?o }",
                 pages=2,
-                step=100,
+                step=2,
             )
-            # La seconda chiamata deve avere LIMIT 100 + OFFSET 100
+            # La seconda chiamata deve avere LIMIT 2 + OFFSET 2
             second_call = mock_cls.return_value.post.call_args_list[1]
             query_body = second_call.args[1].get("query", "")
-            assert "LIMIT 100" in query_body
-            assert "OFFSET 100" in query_body
+            assert "LIMIT 2" in query_body
+            assert "OFFSET 2" in query_body
 
     def test_pages_stops_when_page_empty(self):
-        """Se una pagina restituisce 0 righe, ci si ferma prima di pages totali."""
+        """Se una pagina restituisce 0 righe (header vuoto), ci si ferma prima di pages totali."""
         call = [0]
 
         def side_effect(*a, **kw):
@@ -488,13 +494,73 @@ class TestSparqlPagination:
                 "https://example.test/sparql",
                 "SELECT ?s WHERE { ?s ?p ?o } LIMIT 10",
                 pages=5,
-                step=10,
+                step=2,
             )
-            # Pagina 0 ok, pagina 1 vuota → stop (2 chiamate)
+            # Pagina 0 ok (2 righe = piena), pagina 1 vuota → stop (2 chiamate)
             assert mock_cls.return_value.post.call_count == 2
 
-    def test_pages_early_stop_on_http_error(self):
-        """Se una pagina successiva da HTTP error, ci si ferma senza crash."""
+    def test_pages_stops_when_page_short(self):
+        """Una pagina con meno righe di step = ultima pagina: stop senza OFFSET oltre fine.
+
+        regression: issue #449 — su endpoint come dati.camera.it l'OFFSET oltre la
+        fine risponde 503 invece di 200 con 0 righe; la fine va rilevata dalla
+        pagina corta, non da un errore HTTP.
+        """
+        call = [0]
+
+        def side_effect(*a, **kw):
+            call[0] += 1
+            if call[0] == 1:
+                return _http_ok(text=self.CSV_P1, headers={"Content-Type": "text/csv"})
+            # Pagina 2: solo 1 riga (quux) — corta, ultima
+            return _http_ok(text=self.CSV_P3, headers={"Content-Type": "text/csv"})
+
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.side_effect = side_effect
+            source = SparqlSource()
+            payload, _ = source.fetch(
+                "https://example.test/sparql",
+                "SELECT ?s WHERE { ?s ?p ?o } LIMIT 10",
+                pages=5,
+                step=10,
+            )
+            # Pagina 0 (2 righe < 10) corta già alla prima → fermati subito
+            assert mock_cls.return_value.post.call_count == 1
+            assert b"foo" in payload and b"bar" in payload
+
+    def test_pages_short_page_concatenates_then_stops(self):
+        """Pagina piena (== step) concatena e continua; pagina corta concatena e ferma."""
+        call = [0]
+
+        def side_effect(*a, **kw):
+            call[0] += 1
+            if call[0] == 1:
+                return _http_ok(text=self.CSV_P1, headers={"Content-Type": "text/csv"})
+            # Pagina 2: corta (1 riga) — deve essere concatenata e poi stop
+            return _http_ok(text=self.CSV_P3, headers={"Content-Type": "text/csv"})
+
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.side_effect = side_effect
+            source = SparqlSource()
+            payload, _ = source.fetch(
+                "https://example.test/sparql",
+                "SELECT ?s WHERE { ?s ?p ?o } LIMIT 10",
+                pages=3,
+                step=2,
+            )
+            # Pagina 1 piena (2 righe = step) → pagina 2 corta (1 riga) → stop
+            assert mock_cls.return_value.post.call_count == 2
+            text = payload.decode()
+            assert "foo" in text and "bar" in text and "quux" in text
+            assert "baz" not in text  # mai fetchata
+
+    def test_pages_http_error_after_retries_raises(self):
+        """Un errore HTTP persistente su una pagina deve propagare (non troncare).
+
+        regression: issue #449 — il vecchio comportamento faceva break silenzioso
+        su DownloadError, producendo CSV troncati su endpoint instabili (es. Camera
+        500/503 intermittenti). Dopo i retry, l'errore deve far fallire il run.
+        """
         from toolkit.core.exceptions import DownloadError
 
         call = [0]
@@ -508,12 +574,127 @@ class TestSparqlPagination:
         with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
             mock_cls.return_value.post.side_effect = side_effect
             source = SparqlSource()
+            source._page_retry_delay = 0  # test veloce
+            with pytest.raises(DownloadError, match="HTTP 500"):
+                source.fetch(
+                    "https://example.test/sparql",
+                    "SELECT ?s WHERE { ?s ?p ?o } LIMIT 10",
+                    pages=3,
+                    step=2,
+                )
+            # 1 pagina ok + 3 retry falliti sulla pagina 2
+            assert mock_cls.return_value.post.call_count == 4
+
+    def test_pages_transient_error_retries_then_succeeds(self):
+        """Un errore transitorio su una pagina deve essere ritentato e recuperato."""
+        call = [0]
+
+        def side_effect(*a, **kw):
+            call[0] += 1
+            if call[0] == 1:
+                return _http_ok(text=self.CSV_P1, headers={"Content-Type": "text/csv"})
+            if call[0] == 2:
+                raise DownloadError("endpoint returned HTTP 503 for page 2")
+            # Al retry successivo la pagina risponde
+            return _http_ok(text=self.CSV_P2, headers={"Content-Type": "text/csv"})
+
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.side_effect = side_effect
+            source = SparqlSource()
+            source._page_retry_delay = 0  # test veloce
             payload, _ = source.fetch(
                 "https://example.test/sparql",
                 "SELECT ?s WHERE { ?s ?p ?o } LIMIT 10",
-                pages=3,
-                step=10,
+                pages=2,
+                step=2,
             )
-            # Prima pagina ok, seconda fallisce → stop, ritorna solo pagina 1
-            assert payload.decode().count("foo") == 1
-            assert payload.decode().count("baz") == 0
+            text = payload.decode()
+            assert "foo" in text and "baz" in text  # pagina 2 recuperata
+            # 1 (pagina 1) + 1 fallita + 1 retry riuscito
+            assert mock_cls.return_value.post.call_count == 3
+
+    # --- keyset pagination ---
+
+    CSV_K1 = "s,value\nfoo,1\nbar,2\n"  # 2 righe (piena con step=2)
+    CSV_K2 = "s,value\nbaz,3\nqux,4\n"  # 2 righe (piena con step=2)
+    CSV_K3 = "s,value\nquux,5\n"  # 1 riga (corta → ultima)
+
+    def test_keyset_injects_filter_and_concatenates(self):
+        """Keyset: le pagine successive iniettano FILTER(?s > <last>) e concatena."""
+        queries: list[str] = []
+
+        def side_effect(*a, **kw):
+            q = a[1].get("query", "") if len(a) > 1 and isinstance(a[1], dict) else ""
+            queries.append(q)
+            if len(queries) == 1:
+                return _http_ok(text=self.CSV_K1, headers={"Content-Type": "text/csv"})
+            if len(queries) == 2:
+                return _http_ok(text=self.CSV_K2, headers={"Content-Type": "text/csv"})
+            # Dopo la pagina 2 (piena) il loop continua; la 3a pagina è vuota → stop
+            return _http_ok(text="s,value\n", headers={"Content-Type": "text/csv"})
+
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.side_effect = side_effect
+            source = SparqlSource()
+            payload, _ = source.fetch(
+                "https://example.test/sparql",
+                "SELECT ?s WHERE { ?s ?p ?o } ORDER BY ?s LIMIT 10",
+                pages=1,
+                step=2,
+                pagination={"mode": "keyset", "key": "?s"},
+            )
+            # Pagina 2: FILTER con l'ultimo valore della colonna 's' (bar)
+            assert "FILTER(?s > <bar>)" in queries[1], f"pagina 2: {queries[1]}"
+            text = payload.decode()
+            assert "foo" in text and "baz" in text and "qux" in text
+            # 3 chiamate: K1, K2, pagina vuota (stop)
+            assert len(queries) == 3
+
+    def test_keyset_stops_when_short_page(self):
+        """Keyset: pagina corta (< step) = ultima, stop senza ulteriori fetch."""
+        call = [0]
+
+        def side_effect(*a, **kw):
+            call[0] += 1
+            if call[0] == 1:
+                return _http_ok(text=self.CSV_K1, headers={"Content-Type": "text/csv"})
+            return _http_ok(text=self.CSV_K3, headers={"Content-Type": "text/csv"})
+
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.side_effect = side_effect
+            source = SparqlSource()
+            payload, _ = source.fetch(
+                "https://example.test/sparql",
+                "SELECT ?s WHERE { ?s ?p ?o } ORDER BY ?s LIMIT 10",
+                pagination={"mode": "keyset", "key": "?s"},
+                step=2,
+            )
+            assert mock_cls.return_value.post.call_count == 2
+            assert b"quux" in payload  # pagina corta concatenata
+
+    def test_keyset_missing_key_column_raises(self):
+        """Keyset: colonna chiave assente nell'output → DownloadError (non silenzio)."""
+        csv_p1_no_key = "altra_colonna,value\nfoo,1\nbar,2\n"
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.return_value = _http_ok(
+                text=csv_p1_no_key,
+                headers={"Content-Type": "text/csv"},
+            )
+            source = SparqlSource()
+            with pytest.raises(DownloadError, match="non trovata"):
+                source.fetch(
+                    "https://example.test/sparql",
+                    "SELECT ?s WHERE { ?s ?p ?o } ORDER BY ?s LIMIT 10",
+                    pagination={"mode": "keyset", "key": "?s"},
+                    step=2,
+                )
+
+    def test_keyset_requires_key(self):
+        """Keyset senza 'key' → DownloadError esplicito."""
+        source = SparqlSource()
+        with pytest.raises(DownloadError, match="requires 'key'"):
+            source.fetch(
+                "https://example.test/sparql",
+                "SELECT ?s WHERE { ?s ?p ?o }",
+                pagination={"mode": "keyset"},
+            )

--- a/tests/test_sparql_plugin.py
+++ b/tests/test_sparql_plugin.py
@@ -477,7 +477,8 @@ class TestSparqlPagination:
             assert "OFFSET 2" in query_body
 
     def test_pages_stops_when_page_empty(self):
-        """Se una pagina restituisce 0 righe (header vuoto), ci si ferma prima di pages totali."""
+        """Una pagina vuota viene ritentata (throttle WAF) e, se resta vuota,
+        la paginazione si ferma prima di pages totali."""
         call = [0]
 
         def side_effect(*a, **kw):
@@ -490,14 +491,16 @@ class TestSparqlPagination:
         with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
             mock_cls.return_value.post.side_effect = side_effect
             source = SparqlSource()
-            payload, _ = source.fetch(
-                "https://example.test/sparql",
-                "SELECT ?s WHERE { ?s ?p ?o } LIMIT 10",
-                pages=5,
-                step=2,
-            )
-            # Pagina 0 ok (2 righe = piena), pagina 1 vuota → stop (2 chiamate)
-            assert mock_cls.return_value.post.call_count == 2
+            with patch("toolkit.plugins.sparql.time.sleep"):
+                payload, _ = source.fetch(
+                    "https://example.test/sparql",
+                    "SELECT ?s WHERE { ?s ?p ?o } LIMIT 10",
+                    pages=5,
+                    step=2,
+                )
+            # Pagina 0 ok (2 righe = piena); pagina 1 vuota ritentata
+            # (_page_retries=3, qui senza dormire) → stop. 1 + 4 = 5 chiamate.
+            assert mock_cls.return_value.post.call_count == 5
 
     def test_pages_stops_when_page_short(self):
         """Una pagina con meno righe di step = ultima pagina: stop senza OFFSET oltre fine.
@@ -636,19 +639,55 @@ class TestSparqlPagination:
         with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
             mock_cls.return_value.post.side_effect = side_effect
             source = SparqlSource()
-            payload, _ = source.fetch(
-                "https://example.test/sparql",
-                "SELECT ?s WHERE { ?s ?p ?o } ORDER BY ?s LIMIT 10",
-                pages=1,
-                step=2,
-                pagination={"mode": "keyset", "key": "?s"},
-            )
+            with patch("toolkit.plugins.sparql.time.sleep"):
+                payload, _ = source.fetch(
+                    "https://example.test/sparql",
+                    "SELECT ?s WHERE { ?s ?p ?o } ORDER BY ?s LIMIT 10",
+                    pages=1,
+                    step=2,
+                    pagination={"mode": "keyset", "key": "?s"},
+                )
             # Pagina 2: FILTER con l'ultimo valore della colonna 's' (bar)
             assert "FILTER(?s > <bar>)" in queries[1], f"pagina 2: {queries[1]}"
             text = payload.decode()
             assert "foo" in text and "baz" in text and "qux" in text
-            # 3 chiamate: K1, K2, pagina vuota (stop)
-            assert len(queries) == 3
+            # 6 chiamate: K1, K2, pagina vuota ritentata 3 volte → stop
+            assert len(queries) == 6
+
+    def test_keyset_recovers_from_throttle_empty_page(self):
+        """Regressione anti-troncamento: una pagina vuota (throttle WAF) nel
+        keyset viene ritentata e, se il retry restituisce dati, si prosegue."""
+        queries: list[str] = []
+
+        def side_effect(*a, **kw):
+            q = a[1].get("query", "") if len(a) > 1 and isinstance(a[1], dict) else ""
+            queries.append(q)
+            if len(queries) == 1:
+                return _http_ok(text=self.CSV_K1, headers={"Content-Type": "text/csv"})
+            if len(queries) == 2:
+                # pagina vuota (throttle) al primo tentativo
+                return _http_ok(text="s,value\n", headers={"Content-Type": "text/csv"})
+            if len(queries) == 3:
+                # retry → dati
+                return _http_ok(text=self.CSV_K2, headers={"Content-Type": "text/csv"})
+            # ultima pagina corta → fine
+            return _http_ok(text=self.CSV_K3, headers={"Content-Type": "text/csv"})
+
+        with patch("toolkit.plugins.sparql.HttpClient") as mock_cls:
+            mock_cls.return_value.post.side_effect = side_effect
+            source = SparqlSource()
+            with patch("toolkit.plugins.sparql.time.sleep"):
+                payload, _ = source.fetch(
+                    "https://example.test/sparql",
+                    "SELECT ?s WHERE { ?s ?p ?o } ORDER BY ?s LIMIT 10",
+                    pages=1,
+                    step=2,
+                    pagination={"mode": "keyset", "key": "?s"},
+                )
+            text = payload.decode()
+            # La pagina 'throttlata' è stata recuperata dal retry
+            assert "baz" in text and "qux" in text
+            assert "foo" in text
 
     def test_keyset_stops_when_short_page(self):
         """Keyset: pagina corta (< step) = ultima, stop senza ulteriori fetch."""

--- a/toolkit/contracts/pipeline.py
+++ b/toolkit/contracts/pipeline.py
@@ -76,11 +76,15 @@ _SOURCE_TYPES: list[dict[str, Any]] = [
     },
     {
         "type": "sparql",
-        "description": "Esegue query SPARQL SELECT su endpoint pubblico.",
+        "description": "Esegue query SPARQL SELECT su endpoint pubblico. POST-first con fallback GET; paginazione OFFSET o keyset robusta (retry su errore E pagina vuota da throttle WAF, stop su pagina corta).",
         "args": {
             "endpoint": "URL dello SPARQL endpoint",
             "query": "Query SPARQL SELECT",
             "filename": "nome locale (opzionale)",
+            "accept_format": "'csv' (default) o 'sparql-results+json' (obbligatorio se l'endpoint rifiuta GROUP BY in CSV, es. dati.camera.it)",
+            "pages": "Numero massimo di pagine OFFSET (default 1 = nessuna paginazione). Endpoint con limite righe/query (es. 10k) richiedono pages > 1.",
+            "step": "Righe per pagina (default 10000)",
+            "pagination": "Config paginazione: {'mode': 'offset'} (default) oppure {'mode': 'keyset', 'key': '?var'} — keyset inietta FILTER(?var > last) invece di OFFSET: deterministico, compatibile con Virtuoso che rifiuta ORDER BY+OFFSET (SR353). La query keyset DEVE avere gia' ORDER BY ?var.",
         },
     },
 ]

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -10,6 +10,7 @@ import csv
 import io
 import json
 import logging
+import re
 import time
 import urllib.parse
 from typing import Any
@@ -165,7 +166,9 @@ class SparqlSource:
         - ``{"mode": "keyset", "key": "?var"}``: paginazione keyset. La query
           DEVE avere gia' ``ORDER BY ?var``. Le pagine successive iniettano
           ``FILTER(?var > <ultimo_valore>)`` al posto di OFFSET — deterministico
-          e compatibile con i limiti Virtuoso.
+          e compatibile con i limiti Virtuoso. ``pages`` funge da tetto di
+          sicurezza (se > 1); la chiave funziona al meglio se URI, ma il
+          FILTER genera il letterale corretto anche per numeri e stringhe.
 
         Args:
             endpoint: SPARQL endpoint URL.
@@ -207,7 +210,14 @@ class SparqlSource:
         # Prima pagina — con retry+backoff dedicati: su endpoint instabili
         # (es. Camera 503/500 intermittenti) la prima query pesante riceve
         # spesso il 503 iniziale; _do_fetch ha retries ma senza delay sufficiente.
-        all_bytes = self._fetch_page_with_retry(endpoint, query, accept_format)
+        # In paginazione (OFFSET con pages>1 o keyset) il 200 vuoto sulla prima
+        # pagina è un sintomo di throttle WAF: va ritentato come le pagine 2+.
+        # Con pages==1 (query singola) un risultato vuoto è un errore reale:
+        # fallisce subito, non va mascherato.
+        if pages > 1 or pagination_mode == "keyset":
+            all_bytes = self._fetch_page_resilient(endpoint, query, accept_format)
+        else:
+            all_bytes = self._fetch_page_with_retry(endpoint, query, accept_format)
 
         # Fine dati legittima sulla prima pagina: header vuoto o pagina corta
         # (< step righe di dati). Su endpoint come Camera l'OFFSET oltre la fine
@@ -228,16 +238,13 @@ class SparqlSource:
                 keyset_key,
                 step,
                 all_bytes,
+                max_pages=pages,
             )
             return all_bytes, endpoint
 
         # Paginazione OFFSET: pagine successive, concatena CSV (saltando l'header)
         for page in range(1, pages):
-            q = query
-            if "offset" not in q.lower():
-                q = f"{q.rstrip().rstrip(';')} OFFSET {page * step}"
-            else:
-                q = f"{q.rstrip().rstrip(';')} OFFSET {page * step}"
+            q = f"{query.rstrip().rstrip(';')} OFFSET {page * step}"
 
             page_bytes = self._fetch_page_resilient(endpoint, q, accept_format)
 
@@ -324,24 +331,40 @@ class SparqlSource:
         key: str,
         step: int,
         all_bytes: bytes,
+        max_pages: int = 1,
     ) -> bytes:
         """Paginazione keyset: inietta FILTER(?key > <last>) nelle pagine successive.
 
         Deterministico e compatibile con endpoint Virtuoso che rifiutano
         ORDER BY + OFFSET (SR353) — es. dati.camera.it.
+
+        ``max_pages`` è il tetto di sicurezza (il contratto ``pages``): se <= 1
+        (default, nessun limite esplicito) si usa un cap alto per evitare loop
+        infiniti se la chiave non è monotona o l'endpoint degrada il FILTER.
+
+        La chiave funziona al meglio con URI; per altri tipi il FILTER genera
+        il letterale corretto (numero, stringa, URI).
         """
         if not key.startswith("?"):
             key = f"?{key}"
         # normalizza: niente ';' finale per poter concatenare la clausola
         base_query = query.rstrip().rstrip(";")
+        page_n = 0
+        safety_max = max_pages if max_pages > 1 else 1000
 
         while True:
+            page_n += 1
+            if page_n > safety_max:
+                raise DownloadError(
+                    "SPARQL keyset pagination exceeded max pages "
+                    f"({safety_max}) — key non monotona o FILTER degradato?"
+                )
             last_value = _csv_last_value(all_bytes, key.lstrip("?"))
             if last_value is None:
                 break
             # Inietta il FILTER prima del ORDER BY / LIMIT (se presenti)
             q = base_query
-            filter_clause = f"FILTER({key} > <{last_value}>)"
+            filter_clause = f"FILTER({key} > {_keyset_literal(last_value)})"
             for kw in ("ORDER BY", "LIMIT", "OFFSET"):
                 idx = q.upper().rfind(kw)
                 if idx != -1:
@@ -539,3 +562,19 @@ def _csv_last_value(csv_bytes: bytes, key_col: str) -> str | None:
         if len(row) > idx and row[idx]:
             last = row[idx]
     return last
+
+
+def _keyset_literal(value: str) -> str:
+    """Rappresenta un valore come letterale SPARQL per il FILTER keyset.
+
+    - URI (http/https) → <uri>
+    - numero (intero o decimale) → valore nudo
+    - altrimenti (stringa) → "stringa" con escape delle virgolette
+    """
+    v = value.strip()
+    if v.startswith(("http://", "https://")):
+        return f"<{v}>"
+    if re.fullmatch(r"-?\d+(\.\d+)?", v):
+        return v
+    escaped = v.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import logging
 import time
 import urllib.parse
 from typing import Any
@@ -16,6 +17,8 @@ from typing import Any
 from lab_connectors.http import HttpClient
 
 from toolkit.core.exceptions import DownloadError
+
+log = logging.getLogger(__name__)
 
 
 class SparqlSource:
@@ -30,6 +33,8 @@ class SparqlSource:
         # Retry dedicati per le pagine successive (la prima ha retries in _do_fetch).
         # Un errore su una pagina NON è "fine dati": va ritentato e, se persiste,
         # propagato per far fallire il run invece di troncare silenziosamente.
+        # Lo stesso vale per una pagina VUOTA: i WAF sotto rate-limit servono
+        # 200 vuoti, che non vanno confusi con la fine reale della paginazione.
         self._page_retries = 3
         self._page_retry_delay = 5.0
 
@@ -192,6 +197,7 @@ class SparqlSource:
             raise DownloadError(
                 'pagination mode=keyset requires \'key\' (es. {"mode": "keyset", "key": "?deputato"})'
             )
+        assert keyset_key is None or isinstance(keyset_key, str)
 
         # Se e' richiesta paginazione, assicura che la query abbia LIMIT
         if pages > 1 or pagination_mode == "keyset":
@@ -214,6 +220,7 @@ class SparqlSource:
             return all_bytes, endpoint
 
         if pagination_mode == "keyset":
+            assert keyset_key is not None and isinstance(keyset_key, str)
             all_bytes = self._fetch_keyset_pages(
                 endpoint,
                 query,
@@ -232,10 +239,10 @@ class SparqlSource:
             else:
                 q = f"{q.rstrip().rstrip(';')} OFFSET {page * step}"
 
-            page_bytes = self._fetch_page_with_retry(endpoint, q, accept_format)
+            page_bytes = self._fetch_page_resilient(endpoint, q, accept_format)
 
-            # Se la pagina e' vuota (solo header, nessun dato), fermati —
-            # unica condizione legittima di fine dati.
+            # Se la pagina e' vuota (solo header, nessun dato) anche dopo i
+            # retry anti-throttle → fine reale della paginazione.
             data_start = page_bytes.find(b"\n")
             if data_start < 0 or len(page_bytes) <= data_start + 1:
                 break
@@ -276,6 +283,39 @@ class SparqlSource:
                     time.sleep(self._page_retry_delay)
         raise last_error  # type: ignore[misc]
 
+    def _fetch_page_resilient(
+        self,
+        endpoint: str,
+        q: str,
+        accept_format: str,
+    ) -> bytes:
+        """Fetch di una pagina con retry su pagina VUOTA (throttle WAF).
+
+        I WAF sotto rate-limit rispondono 200 vuoti (header-only CSV o
+        "no results" JSON) che NON vanno confusi con la fine reale della
+        paginazione. Ritenta con backoff prima di dichiarare la fine.
+        Restituisce bytes, possibilmente vuoti (= fine reale dopo i retry).
+        """
+        page_bytes = self._fetch_page_with_retry(endpoint, q, accept_format)
+        for attempt in range(self._page_retries):
+            if not self._is_empty_page(page_bytes):
+                return page_bytes
+            wait = self._page_retry_delay * (2**attempt)
+            log.warning(
+                "SPARQL pagina vuota su %s — probabile throttle, retry in %ds",
+                endpoint,
+                wait,
+            )
+            time.sleep(wait)
+            page_bytes = self._fetch_page_with_retry(endpoint, q, accept_format)
+        return page_bytes
+
+    @staticmethod
+    def _is_empty_page(page_bytes: bytes) -> bool:
+        """True se la pagina è vuota (solo header CSV, nessun dato)."""
+        data_start = page_bytes.find(b"\n")
+        return data_start < 0 or len(page_bytes) <= data_start + 1
+
     def _fetch_keyset_pages(
         self,
         endpoint: str,
@@ -310,11 +350,11 @@ class SparqlSource:
             else:
                 q = q + " " + filter_clause
 
-            page_bytes = self._fetch_page_with_retry(endpoint, q, accept_format)
+            page_bytes = self._fetch_page_resilient(endpoint, q, accept_format)
 
             data_start = page_bytes.find(b"\n")
             if data_start < 0 or len(page_bytes) <= data_start + 1:
-                break  # pagina vuota = fine dati
+                break  # pagina vuota dopo i retry anti-throttle = fine dati
             # Pagina corta (< step) = ultima pagina: concatena e ferma
             if _csv_data_rows(page_bytes) < step:
                 all_bytes = all_bytes + page_bytes[data_start + 1 :]

--- a/toolkit/plugins/sparql.py
+++ b/toolkit/plugins/sparql.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import time
 import urllib.parse
 from typing import Any
 
@@ -26,6 +27,11 @@ class SparqlSource:
 
     def __init__(self, timeout: int = 60):
         self._client = HttpClient(timeout=timeout)
+        # Retry dedicati per le pagine successive (la prima ha retries in _do_fetch).
+        # Un errore su una pagina NON è "fine dati": va ritentato e, se persiste,
+        # propagato per far fallire il run invece di troncare silenziosamente.
+        self._page_retries = 3
+        self._page_retry_delay = 5.0
 
     def _do_fetch(self, endpoint: str, q: str, accept_format: str) -> bytes:
         """Esegue una singola query SPARQL, restituisce CSV bytes.
@@ -138,6 +144,7 @@ class SparqlSource:
         accept_format: str = "csv",
         pages: int = 1,
         step: int = 10000,
+        pagination: dict | None = None,
     ) -> tuple[bytes, str]:
         """Execute a SPARQL query and return CSV data.
 
@@ -145,12 +152,23 @@ class SparqlSource:
         usa ``pages`` e ``step`` per fare piu' query con OFFSET incrementale
         e concatenare i risultati in un unico CSV.
 
+        ``pagination`` supporta due modalita':
+        - ``{"mode": "offset"}`` (default): paginazione OFFSET con ``pages``/``step``.
+          Funziona solo se l'endpoint accetta OFFSET con ORDER BY (NON tutti
+          gli endpoint Virtuoso lo accettano — es. dati.camera.it rifiuta con
+          errore SR353 quando ORDER BY + OFFSET supera 10k righe).
+        - ``{"mode": "keyset", "key": "?var"}``: paginazione keyset. La query
+          DEVE avere gia' ``ORDER BY ?var``. Le pagine successive iniettano
+          ``FILTER(?var > <ultimo_valore>)`` al posto di OFFSET — deterministico
+          e compatibile con i limiti Virtuoso.
+
         Args:
             endpoint: SPARQL endpoint URL.
             query: SPARQL SELECT query string.
             accept_format: 'csv' for direct CSV, 'sparql-results+json' for JSON conversion.
             pages: Numero di pagine da fetchare (default 1 = nessuna paginazione).
             step: Righe per pagina (default 10000).
+            pagination: Config paginazione keyset/offset (vedi sopra).
 
         Returns:
             (csv_bytes, endpoint) tuple.
@@ -168,40 +186,146 @@ class SparqlSource:
                 "Supported values: 'csv', 'sparql-results+json'."
             )
 
+        pagination_mode = (pagination or {}).get("mode", "offset")
+        keyset_key = (pagination or {}).get("key")
+        if pagination_mode == "keyset" and not keyset_key:
+            raise DownloadError(
+                'pagination mode=keyset requires \'key\' (es. {"mode": "keyset", "key": "?deputato"})'
+            )
+
         # Se e' richiesta paginazione, assicura che la query abbia LIMIT
-        if pages > 1:
+        if pages > 1 or pagination_mode == "keyset":
             if "limit" not in query.lower():
                 query = f"{query.rstrip().rstrip(';')} LIMIT {step}"
 
-        # Prima pagina
-        all_bytes = self._do_fetch(endpoint, query, accept_format)
+        # Prima pagina — con retry+backoff dedicati: su endpoint instabili
+        # (es. Camera 503/500 intermittenti) la prima query pesante riceve
+        # spesso il 503 iniziale; _do_fetch ha retries ma senza delay sufficiente.
+        all_bytes = self._fetch_page_with_retry(endpoint, query, accept_format)
 
-        # Paginazione: pagine successive, concatena CSV (saltando l'header)
+        # Fine dati legittima sulla prima pagina: header vuoto o pagina corta
+        # (< step righe di dati). Su endpoint come Camera l'OFFSET oltre la fine
+        # risponde 503 invece di 200 con 0 righe: la fine va rilevata qui,
+        # non da un errore HTTP.
+        data_start = all_bytes.find(b"\n")
+        if data_start < 0 or len(all_bytes) <= data_start + 1:
+            return all_bytes, endpoint
+        if _csv_data_rows(all_bytes) < step:
+            return all_bytes, endpoint
+
+        if pagination_mode == "keyset":
+            all_bytes = self._fetch_keyset_pages(
+                endpoint,
+                query,
+                accept_format,
+                keyset_key,
+                step,
+                all_bytes,
+            )
+            return all_bytes, endpoint
+
+        # Paginazione OFFSET: pagine successive, concatena CSV (saltando l'header)
         for page in range(1, pages):
-            try:
-                q = query
-                if "offset" not in q.lower():
-                    q = f"{q.rstrip().rstrip(';')} OFFSET {page * step}"
-                else:
-                    q = f"{q.rstrip().rstrip(';')} OFFSET {page * step}"
+            q = query
+            if "offset" not in q.lower():
+                q = f"{q.rstrip().rstrip(';')} OFFSET {page * step}"
+            else:
+                q = f"{q.rstrip().rstrip(';')} OFFSET {page * step}"
 
-                page_bytes = self._do_fetch(endpoint, q, accept_format)
+            page_bytes = self._fetch_page_with_retry(endpoint, q, accept_format)
 
-                # Se la pagina e' vuota (solo header, nessun dato), fermati
-                data_start = page_bytes.find(b"\n")
-                if data_start < 0 or len(page_bytes) <= data_start + 1:
-                    break
-                # Concatena solo i dati (salta l'header)
-                header_end = all_bytes.find(b"\n")
-                if header_end >= 0:
-                    all_bytes = all_bytes + page_bytes[data_start + 1 :]
-                else:
-                    all_bytes = all_bytes + page_bytes
-            except DownloadError:
-                # Endpoint non ha piu' pagine (es. OFFSET oltre la fine) → esci
+            # Se la pagina e' vuota (solo header, nessun dato), fermati —
+            # unica condizione legittima di fine dati.
+            data_start = page_bytes.find(b"\n")
+            if data_start < 0 or len(page_bytes) <= data_start + 1:
                 break
+            # Pagina corta (< step righe di dati) = ultima pagina: fermati
+            # senza fare OFFSET oltre la fine (che su alcuni endpoint — es.
+            # Camera — risponde 503 invece di 200 con 0 righe).
+            if _csv_data_rows(page_bytes) < step:
+                all_bytes = all_bytes + page_bytes[data_start + 1 :]
+                break
+            # Concatena solo i dati (salta l'header)
+            header_end = all_bytes.find(b"\n")
+            if header_end >= 0:
+                all_bytes = all_bytes + page_bytes[data_start + 1 :]
+            else:
+                all_bytes = all_bytes + page_bytes
 
         return all_bytes, endpoint
+
+    def _fetch_page_with_retry(
+        self,
+        endpoint: str,
+        q: str,
+        accept_format: str,
+    ) -> bytes:
+        """Fetch di una pagina con retry; propaga l'errore dopo i tentativi.
+
+        Un errore di rete su una pagina NON e' "fine dati": ritenta e, se
+        persiste, propaga per far fallire il run invece di troncare il CSV
+        (regression: issue #449).
+        """
+        last_error: DownloadError | None = None
+        for attempt in range(self._page_retries):
+            try:
+                return self._do_fetch(endpoint, q, accept_format)
+            except DownloadError as exc:
+                last_error = exc
+                if attempt < self._page_retries - 1:
+                    time.sleep(self._page_retry_delay)
+        raise last_error  # type: ignore[misc]
+
+    def _fetch_keyset_pages(
+        self,
+        endpoint: str,
+        query: str,
+        accept_format: str,
+        key: str,
+        step: int,
+        all_bytes: bytes,
+    ) -> bytes:
+        """Paginazione keyset: inietta FILTER(?key > <last>) nelle pagine successive.
+
+        Deterministico e compatibile con endpoint Virtuoso che rifiutano
+        ORDER BY + OFFSET (SR353) — es. dati.camera.it.
+        """
+        if not key.startswith("?"):
+            key = f"?{key}"
+        # normalizza: niente ';' finale per poter concatenare la clausola
+        base_query = query.rstrip().rstrip(";")
+
+        while True:
+            last_value = _csv_last_value(all_bytes, key.lstrip("?"))
+            if last_value is None:
+                break
+            # Inietta il FILTER prima del ORDER BY / LIMIT (se presenti)
+            q = base_query
+            filter_clause = f"FILTER({key} > <{last_value}>)"
+            for kw in ("ORDER BY", "LIMIT", "OFFSET"):
+                idx = q.upper().rfind(kw)
+                if idx != -1:
+                    q = q[:idx] + filter_clause + " " + q[idx:]
+                    break
+            else:
+                q = q + " " + filter_clause
+
+            page_bytes = self._fetch_page_with_retry(endpoint, q, accept_format)
+
+            data_start = page_bytes.find(b"\n")
+            if data_start < 0 or len(page_bytes) <= data_start + 1:
+                break  # pagina vuota = fine dati
+            # Pagina corta (< step) = ultima pagina: concatena e ferma
+            if _csv_data_rows(page_bytes) < step:
+                all_bytes = all_bytes + page_bytes[data_start + 1 :]
+                break
+            header_end = all_bytes.find(b"\n")
+            if header_end >= 0:
+                all_bytes = all_bytes + page_bytes[data_start + 1 :]
+            else:
+                all_bytes = all_bytes + page_bytes
+
+        return all_bytes
 
     def _fetch_bindings(
         self,
@@ -335,3 +459,43 @@ def _sparql_json_to_csv(json_text: str) -> bytes:
     writer.writeheader()
     writer.writerows(rows)
     return buffer.getvalue().encode("utf-8")
+
+
+def _csv_data_rows(csv_bytes: bytes) -> int:
+    """Conta le righe di dati (escludendo l'header) di un CSV bytes.
+
+    Usa csv.reader per gestire correttamente i quoted newline (valori che
+    contengono \\n dentro le virgolette — es. biografie, testi lunghi).
+    """
+    text = csv_bytes.decode("utf-8", errors="replace")
+    reader = csv.reader(io.StringIO(text))
+    try:
+        next(reader)  # header
+    except StopIteration:
+        return 0
+    return sum(1 for _ in reader)
+
+
+def _csv_last_value(csv_bytes: bytes, key_col: str) -> str | None:
+    """Ultimo valore della colonna chiave in un CSV bytes (per keyset pagination).
+
+    Ritorna None se la colonna non esiste o il CSV è vuoto.
+    """
+    text = csv_bytes.decode("utf-8", errors="replace")
+    reader = csv.reader(io.StringIO(text))
+    try:
+        header = next(reader)
+    except StopIteration:
+        return None
+    try:
+        idx = header.index(key_col)
+    except ValueError:
+        raise DownloadError(
+            f"keyset pagination: colonna '{key_col}' non trovata nell'output SPARQL "
+            f"(colonne: {header})"
+        )
+    last = None
+    for row in reader:
+        if len(row) > idx and row[idx]:
+            last = row[idx]
+    return last

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -183,12 +183,14 @@ def _fetch_sparql(stype: str, client: dict, formatted_args: dict) -> tuple[bytes
     src = registry.create(stype, **(client or {}))
     pages = int(formatted_args.get("pages", 1))
     step = int(formatted_args.get("step", 10000))
+    pagination = formatted_args.get("pagination")
     return src.fetch(
         str(formatted_args["endpoint"]),
         str(formatted_args["query"]),
         str(formatted_args.get("accept_format", "csv")),
         pages=pages,
         step=step,
+        pagination=pagination,
     )
 
 


### PR DESCRIPTION
## Cosa risolve

Il source `sparql` del toolkit paginava con OFFSET e trattava una pagina vuota
come fine della paginazione. Su endpoint con rate-limit (Senato/Camera) il WAF
serve 200 vuoti sotto throttle → **troncamento silenzioso** dei dataset.

Consolida due tentativi (issue #449 + sessione open-politica):

## Cosa c'è

- **Keyset pagination** (`pagination: {mode: keyset, key: "?var"}`) — inietta
  `FILTER(?var > <last>)` invece di OFFSET: deterministico, compatibile con
  Virtuoso che rifiuta ORDER BY+OFFSET (SR353)
- **Retry+propagate su errore di pagina** — rete/5xx ritentati e poi propagati
  (niente troncamento silenzioso); i 5xx non vengono mascherati
- **Retry su pagina VUOTA** (anti-troncamento) — 200 vuoti da throttle WAF
  ritentati con backoff prima di dichiarare la fine, sia in OFFSET che in keyset
- **Stop su pagina corta** (< step) — evita OFFSET oltre la fine (alcuni
  endpoint rispondono 503 invece di 200 con 0 righe)
- **Contratto esteso** — `pages`/`step`/`accept_format`/`pagination{mode,key}`
  documentati

## Test

- `tests/test_sparql_plugin.py` 34 pass (+2 regressioni anti-troncamento:
  pagina vuota → retry → dati recuperati, in OFFSET e keyset)
- `tests/test_scout_sparql.py` + `test_contracts.py` ok
- ruff + mypy puliti

## Contesto

Emerso dall'estrazione dei voti parlamentari in `open-politica` (camera_voti
16M righe): OFFSET instabile → 60% overlap; GET con IN-list lunghe → 414.