### PR TITLE
ci: usa composite action org python-ci nel job test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           test_dir: "tests"
           pytest_args: "-p pytest_cov -n auto -q -p no:cacheprovider -m \"not smoke\""
           cov_module: "toolkit"
-          cov_report: "term-missing --cov-report=xml"
+          cov_report: "term-missing xml"
           cov_threshold: "81"
       - name: Upload Coverage Artifact
         if: always() && hashFiles('coverage.xml') != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           extra-packages: -e ".[dev]"
-      - name: Ruff
-        run: python -m ruff check .
-      - name: Mypy
-        run: python -m mypy toolkit/
-      - name: Pytest
-        run: python -m pytest -p pytest_cov -n auto -q -p no:cacheprovider -m "not smoke" --cov=toolkit --cov-report=term-missing --cov-report=xml --cov-fail-under=81
+      - uses: dataciviclab/.github/actions/python-ci@main
+        with:
+          lint_paths: "."
+          mypy_paths: "toolkit/"
+          test_dir: "tests"
+          pytest_args: "-p pytest_cov -n auto -q -p no:cacheprovider -m \"not smoke\""
+          cov_module: "toolkit"
+          cov_report: "term-missing --cov-report=xml"
+          cov_threshold: "81"
       - name: Upload Coverage Artifact
         if: always() && hashFiles('coverage.xml') != ''
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Sintesi

Sostituisce i passi ruff/mypy/pytest inline del job `test` con la composite action condivisa `dataciviclab/.github/actions/python-ci` (ADR-001). Stessi comandi, stessa soglia coverage (81).

## Contesto collegato

ADR-001 in dataciviclab/.github PR #26.

## Cosa cambia

- [x] Dipendenze o CI

## Impatto su contratti pubblici

- [ ] Struttura `dataset.yml`
- [ ] Path output
- [ ] Schema parquet
- [ ] CLI o MCP tool
- [ ] API pubblica del toolkit
- [x] Nessun impatto sui contratti (solo CI)

## Verifica

- Comando pytest simulato dalla composite action: `pytest tests -p pytest_cov -n auto -q -p no:cacheprovider -m "not smoke" --cov=toolkit --cov-report=term-missing --cov-report=xml --cov-fail-under=81` — equivalente all'originale
- YAML validato; pre-commit passati

- [ ] `pytest -m core` passa — verrà eseguito dalla CI su questa PR (richiede il merge PR #26 per `python-ci@main`)
- [x] `ruff check .` passa — invariato (stesso comando via composite)
- [x] `mypy toolkit/` passa — invariato
- [ ] Modificato o aggiunto test con marker appropriato: N/A (nessuna logica)

## Checklist PR

- [x] Perimetro stretto: una PR = migrazione CI
- [x] Issue collegata o motivazione dell'assenza — ADR-001
- [x] Se rimuovo un modulo/funzione pubblica: N/A

## Note per chi revisiona

- **Dipendenza**: usa `python-ci@main` → mergeare dopo dataciviclab/.github#26.
- Il job `build` è invariato (build + twine check).