### PR TITLE
fix(script source): timeout configurabile via client + iniezione client appiattito

### DIFF
--- a/tests/test_script_source.py
+++ b/tests/test_script_source.py
@@ -11,6 +11,7 @@ Verifica che _fetch_script:
 """
 
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -97,27 +98,29 @@ def test_script_year_placeholder_through_format_args(script_dir: Path):
 
 
 def test_script_client_timeout_applied(script_dir: Path):
-    """client.timeout > default permette script più lunghi di 600s di default.
+    """client.timeout è letto e applicato al subprocess.
 
     Regressione: il timeout era hardcoded a 600s — harvest lunghi (es. inPA,
-    ~17 min) venivano uccisi. Con client.timeout alto il subprocess termina.
+    ~17 min) venivano uccisi anche con client.timeout dichiarato perché il
+    client non arrivava a _fetch_script (appiattito dal config).
+
+    Prova del fuoco: se il timeout NON fosse letto, il subprocess userebbe il
+    default 600s e un `sleep 5` completerebbe senza errore → il test fallirebbe.
+    Con client.timeout=1 il subprocess viene ucciso dopo ~1s → TimeoutExpired.
     """
-    output_file = script_dir / "output.csv"
     script = _make_script(
         script_dir,
-        output_file,
-        f'echo "anno,valore" > {output_file}\necho "2023,42.5" >> {output_file}',
+        script_dir / "never.csv",
+        'echo "inizio" > never.csv\nsleep 5\n',
     )
 
-    payload, origin = _fetch_payload(
-        "script",
-        {"timeout": 1},  # 1s: se non letto, subprocess.run userebbe default 600
-        {"command": f"bash {script}", "output": str(output_file)},
-        base_dir=script_dir,
-    )
-
-    assert payload == b"anno,valore\n2023,42.5\n"
-    assert origin == str(output_file)
+    with pytest.raises(subprocess.TimeoutExpired):
+        _fetch_payload(
+            "script",
+            {"timeout": 1},
+            {"command": f"bash {script}", "output": "never.csv"},
+            base_dir=script_dir,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_script_source.py
+++ b/tests/test_script_source.py
@@ -96,6 +96,30 @@ def test_script_year_placeholder_through_format_args(script_dir: Path):
     assert origin == str(output_file)
 
 
+def test_script_client_timeout_applied(script_dir: Path):
+    """client.timeout > default permette script più lunghi di 600s di default.
+
+    Regressione: il timeout era hardcoded a 600s — harvest lunghi (es. inPA,
+    ~17 min) venivano uccisi. Con client.timeout alto il subprocess termina.
+    """
+    output_file = script_dir / "output.csv"
+    script = _make_script(
+        script_dir,
+        output_file,
+        f'echo "anno,valore" > {output_file}\necho "2023,42.5" >> {output_file}',
+    )
+
+    payload, origin = _fetch_payload(
+        "script",
+        {"timeout": 1},  # 1s: se non letto, subprocess.run userebbe default 600
+        {"command": f"bash {script}", "output": str(output_file)},
+        base_dir=script_dir,
+    )
+
+    assert payload == b"anno,valore\n2023,42.5\n"
+    assert origin == str(output_file)
+
+
 # ---------------------------------------------------------------------------
 # Error handling
 # ---------------------------------------------------------------------------

--- a/toolkit/core/config.py
+++ b/toolkit/core/config.py
@@ -487,6 +487,38 @@ class RawSourceConfig:
             headers=client.get("headers") if isinstance(client, dict) else None,
         )
 
+    def to_dict(self) -> dict[str, Any]:
+        """Replacement for old Pydantic model_dump().
+
+        Ricostruisce il blocco ``client`` annidato (timeout/retries/user_agent/
+        headers) invece di appiattirlo a livello source — così i plugin che
+        leggono ``source.get("client")`` vedono il client del dataset.yml.
+        """
+        result: dict[str, Any] = {
+            "name": self.name,
+            "type": self.type,
+            "args": self.args,
+        }
+        if self.year is not None:
+            result["year"] = self.year
+        if self.primary:
+            result["primary"] = True
+        if self.inject_column is not None:
+            result["inject_column"] = self.inject_column
+        client = {
+            k: v
+            for k, v in (
+                ("timeout", self.timeout),
+                ("retries", self.retries),
+                ("user_agent", self.user_agent),
+                ("headers", self.headers),
+            )
+            if v is not None
+        }
+        if client:
+            result["client"] = client
+        return result
+
 
 @dataclass
 class RawConfig:

--- a/toolkit/core/config.py
+++ b/toolkit/core/config.py
@@ -527,6 +527,21 @@ class RawConfig:
     extractor: dict | None = None
     extra: dict[str, Any] = field(default_factory=dict)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Replacement for old Pydantic model_dump().
+
+        I source sono dumpati col loro ``to_dict()`` (che ricostruisce il blocco
+        ``client`` annidato), non con ``asdict`` che li appiattisce.
+        """
+        result: dict[str, Any] = {
+            "sources": [s.to_dict() for s in self.sources],
+        }
+        if self.output_policy != "versioned":
+            result["output_policy"] = self.output_policy
+        if self.extractor is not None:
+            result["extractor"] = self.extractor
+        return result
+
     @staticmethod
     def from_dict(d: dict | None) -> RawConfig:
         if not d:

--- a/toolkit/raw/_fetch_utils.py
+++ b/toolkit/raw/_fetch_utils.py
@@ -267,7 +267,7 @@ def _fetch_script(stype: str, client: dict, formatted_args: dict) -> tuple[bytes
         shell=True,
         capture_output=True,
         text=True,
-        timeout=600,
+        timeout=(client or {}).get("timeout", 600),
         cwd=candidate_root,
     )
     if result.returncode != 0:

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -81,15 +81,6 @@ def run_raw(
     for i, source in enumerate(sources):
         stype = source.get("type") or source.get("plugin") or "http_file"
         client = source.get("client", {}) or {}
-        # I campi client appiattiti a livello source (timeout, retries, ...) da
-        # RawSourceConfig.to_dict() vanno iniettati nel client se il blocco
-        # `client:` non è presente nel dataset.yml (backward-compat).
-        if not client and "client" not in source:
-            client = {
-                k: v
-                for k, v in source.items()
-                if k in ("timeout", "retries", "user_agent", "headers") and v is not None
-            }
         args = source.get("args", {}) or {}
         name = source.get("name") or source.get("id") or f"source_{i + 1}"
         source_written: list[str] = []

--- a/toolkit/raw/run.py
+++ b/toolkit/raw/run.py
@@ -81,6 +81,15 @@ def run_raw(
     for i, source in enumerate(sources):
         stype = source.get("type") or source.get("plugin") or "http_file"
         client = source.get("client", {}) or {}
+        # I campi client appiattiti a livello source (timeout, retries, ...) da
+        # RawSourceConfig.to_dict() vanno iniettati nel client se il blocco
+        # `client:` non è presente nel dataset.yml (backward-compat).
+        if not client and "client" not in source:
+            client = {
+                k: v
+                for k, v in source.items()
+                if k in ("timeout", "retries", "user_agent", "headers") and v is not None
+            }
         args = source.get("args", {}) or {}
         name = source.get("name") or source.get("id") or f"source_{i + 1}"
         source_written: list[str] = []


### PR DESCRIPTION
## Sintesi

Rende configurabile il timeout del source type `script` (era hardcoded a 600s) e sistema l'iniezione del client per i plugin quando il `dataset.yml` non dichiara il blocco `client:`.

Necessario per gli harvest lunghi via script (es. candidate `inpa-bandi` in dataset-incubator: OPEN ~13 min, CLOSED ~17 min), che venivano uccisi dal limite di 10 minuti.

## Contesto collegato

Collegata a intake di dataset-incubator: `inpa-bandi` e `inpa-comunicazioni` (reclutamento PA dal Portale inPA).

## Cosa cambia

- [x] Bug fix
- [ ] Nuova funzionalità del motore
- [ ] Nuovo plugin sorgente
- [ ] Modifica contratto pubblico (dataset.yml, path output, schema parquet)
- [ ] Refactor / performance
- [ ] Documentazione
- [ ] Dipendenze o CI

## Impatto su contratti pubblici

- [x] Struttura `dataset.yml` — `raw.sources[].client.timeout` ora letto dal source `script` (campo già usato da http_file/http_post_file, quindi coerente)
- [ ] Path output
- [ ] Schema parquet
- [ ] CLI o MCP tool
- [ ] API pubblica del toolkit

> Backward-compatible: default invariato (600s); il campo `client.timeout` era già documentato per altri source.

## Verifica

```bash
python -m pytest -q                     # 1379 passed (1401 collected, 22 deselected)
ruff check toolkit/raw/_fetch_utils.py toolkit/raw/run.py
```

Test aggiunto: `tests/test_script_source.py::test_script_client_timeout_applied` verifica che `client.timeout` venga letto dal subprocess.